### PR TITLE
feat(ci): add GoReleaser release automation and fix CI version ldflags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,14 @@ jobs:
         run: templ generate
 
       - name: Build binary
-        run: CGO_ENABLED=0 go build -ldflags="-s -w" -o stillwater ./cmd/stillwater
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "0.1.0-dev")
+          COMMIT=$(git rev-parse --short HEAD)
+          DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          PKG=github.com/sydlexius/stillwater/internal/version
+          CGO_ENABLED=0 go build \
+            -ldflags="-s -w -X ${PKG}.Version=${VERSION} -X ${PKG}.Commit=${COMMIT} -X ${PKG}.Date=${DATE}" \
+            -o stillwater ./cmd/stillwater
 
   docker:
     name: Docker Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,119 @@
+version: 2
+
+before:
+  hooks:
+    - go install github.com/a-h/templ/cmd/templ@latest
+    - templ generate
+    - >-
+      sh -c 'curl -sL
+      https://github.com/tailwindlabs/tailwindcss/releases/download/v4.2.0/tailwindcss-linux-x64
+      -o /tmp/tailwindcss && chmod +x /tmp/tailwindcss &&
+      /tmp/tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minify'
+
+builds:
+  - id: stillwater
+    main: ./cmd/stillwater
+    binary: stillwater
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+      - -X github.com/sydlexius/stillwater/internal/version.Version={{ .Version }}
+      - -X github.com/sydlexius/stillwater/internal/version.Commit={{ .ShortCommit }}
+      - -X github.com/sydlexius/stillwater/internal/version.Date={{ .Date }}
+
+archives:
+  - id: default
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+dockers:
+  - id: amd64
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-amd64"
+    dockerfile: build/docker/Dockerfile.goreleaser
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    extra_files:
+      - web/static
+      - build/docker/entrypoint.sh
+
+  - id: arm64
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
+    dockerfile: build/docker/Dockerfile.goreleaser
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    extra_files:
+      - web/static
+      - build/docker/entrypoint.sh
+
+docker_manifests:
+  - name_template: "ghcr.io/sydlexius/stillwater:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-amd64"
+      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
+
+  - name_template: "ghcr.io/sydlexius/stillwater:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-amd64"
+      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
+
+  - name_template: "ghcr.io/sydlexius/stillwater:latest"
+    image_templates:
+      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-amd64"
+      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
+
+changelog:
+  sort: asc
+  use: github
+  groups:
+    - title: Features
+      regexp: '^feat(\(.+\))?:'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^fix(\(.+\))?:'
+      order: 1
+    - title: Performance
+      regexp: '^perf(\(.+\))?:'
+      order: 2
+    - title: Refactoring
+      regexp: '^refactor(\(.+\))?:'
+      order: 3
+    - title: Other
+      order: 999
+  filters:
+    exclude:
+      - '^chore:'
+      - '^docs:'
+      - '^ci:'
+      - '^style:'
+      - '^test:'
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: sydlexius
+    name: stillwater
+  prerelease: auto
+  make_latest: true

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -1,0 +1,20 @@
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata su-exec
+
+RUN addgroup -g 1000 stillwater && \
+    adduser -u 1000 -G stillwater -s /bin/sh -D stillwater
+
+RUN mkdir -p /data /music && chown stillwater:stillwater /data /music
+
+COPY stillwater /usr/local/bin/stillwater
+COPY web/static /app/web/static
+COPY build/docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8080
+
+VOLUME ["/data", "/music"]
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["stillwater"]

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -139,3 +139,30 @@ make clean          Remove build artifacts
 ```
 
 When `make` is not available, run the equivalent commands directly as shown in the sections above.
+
+## Releasing
+
+Releases are automated with [GoReleaser](https://goreleaser.com/). Pushing a semver tag triggers the release workflow, which builds multi-platform binaries, pushes Docker images to GHCR with semver tags, and creates a GitHub Release with auto-generated notes from conventional commit history.
+
+### Tag and push
+
+```bash
+git tag -a v0.2.0 -m "Release v0.2.0"
+git push origin v0.2.0
+```
+
+The release workflow creates the GitHub Release automatically. Pre-release tags (e.g. `v0.2.0-rc1`) are marked as pre-release on GitHub.
+
+### Local dry run (no publish)
+
+```bash
+goreleaser release --snapshot --clean
+```
+
+This builds all artifacts locally without creating a release or pushing images. Useful for verifying the config before tagging.
+
+### Validate config
+
+```bash
+goreleaser check
+```


### PR DESCRIPTION
## Summary

- Add `.goreleaser.yml` with multi-platform builds, Docker multi-arch images, and conventional commit changelog grouping
- Add `.github/workflows/release.yml` triggered on `v*.*.*` tag push
- Add `build/docker/Dockerfile.goreleaser` for GoReleaser Docker builds (existing Dockerfile unchanged)
- Fix CI build job to inject version ldflags matching the Makefile
- Document release process in `docs/dev-setup.md`

Closes #53

## Test plan

- [ ] Verify `goreleaser check` passes
- [ ] Run `goreleaser release --snapshot --clean` locally to confirm artifacts build
- [ ] Push a test tag (e.g. `v0.2.0-rc1`) to verify the release workflow runs and creates a pre-release
- [ ] Confirm GHCR images are tagged with semver (`v0.2.0-rc1`, `0.2`, `latest`)
- [ ] Confirm CI build job still passes with the updated ldflags

🤖 Generated with [Claude Code](https://claude.com/claude-code)