### PR TITLE
fix: address Copilot review bugs (#65, #66, #67)

### DIFF
--- a/internal/api/handlers_report.go
+++ b/internal/api/handlers_report.go
@@ -32,7 +32,7 @@ type violationSummary struct {
 }
 
 // handleReportHealth returns the current library health summary.
-// Uses stored health_score values from the database for performance.
+// Evaluates all artists against active rules and records a health snapshot.
 // GET /api/v1/reports/health
 func (r *Router) handleReportHealth(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
@@ -59,7 +59,9 @@ func (r *Router) handleReportHealth(w http.ResponseWriter, req *http.Request) {
 		params.Page++
 		more, _, err := r.artistService.List(ctx, params)
 		if err != nil {
-			break
+			r.logger.Error("listing artists for health report (page)", "page", params.Page, "error", err)
+			writeError(w, req, http.StatusInternalServerError, "failed to generate health report")
+			return
 		}
 		allArtists = append(allArtists, more...)
 	}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -453,11 +453,11 @@ func TestScan_HealthScoreIntegration(t *testing.T) {
 	if a.HealthScore <= 0 {
 		t.Errorf("HealthScore = %v, want > 0", a.HealthScore)
 	}
-	// Missing: logo, thumb quality checks (no valid image data) -- should not be 100
-	// But thumb_square and thumb_min_res will fail to read dimensions (fake jpg), so they
-	// just skip. We have 8 rules, pass: nfo_exists, nfo_has_mbid, thumb_exists, fanart_exists, bio_exists = 5
-	// fail: logo_exists = 1, thumb_square skips (returns nil), thumb_min_res skips (returns nil)
-	// So 7 pass out of 8 = 87.5%
+	// Missing: logo -- should not be 100
+	// thumb_square and thumb_min_res cannot read dimensions from the fake jpg data,
+	// so they return nil (no violation), which counts as a pass in the health score.
+	// 8 rules total: 7 pass (nfo_exists, nfo_has_mbid, thumb_exists, fanart_exists,
+	// bio_exists, thumb_square, thumb_min_res), 1 fail (logo_exists) = 7/8 = 87.5%
 	if a.HealthScore < 50 {
 		t.Errorf("HealthScore = %v, expected at least 50 for an artist with most assets", a.HealthScore)
 	}

--- a/web/templates/nfo_diff.templ
+++ b/web/templates/nfo_diff.templ
@@ -128,10 +128,11 @@ templ NFODiffFragment(diff nfo.DiffResult) {
 }
 
 func truncateStr(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
 		return s
 	}
-	return s[:maxLen] + "..."
+	return string(runes[:maxLen]) + "..."
 }
 
 templ diffStatusBadge(status string) {


### PR DESCRIPTION
## Summary

Addresses bug-related Copilot review comments from PRs #52 and #55.

- **Health report pagination (#65):** Pagination loop now returns HTTP 500 with a logged error instead of silently breaking and computing reports from partial data. Also corrects the misleading handler comment.
- **UTF-8 truncation (#66):** `truncateStr` in NFO diff display now uses rune-aware slicing so multi-byte characters (accented names, CJK text) are not split mid-character.
- **Test comment (#67):** Clarifies that `thumb_square` and `thumb_min_res` return nil (counted as pass) on unreadable images, not "skip". The 87.5% score (7/8) was already correct.

Closes #65, closes #66, closes #67.

## Test plan

- [ ] `go build ./...` compiles cleanly
- [ ] `go test ./internal/api/...` passes
- [ ] `go test ./internal/scanner/...` passes
- [ ] Health report returns 500 on DB errors instead of partial data

Generated with [Claude Code](https://claude.com/claude-code)