### PR TITLE
fix(ci): GoReleaser pre-release tagging and Dockerfile (#69)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,11 +74,13 @@ docker_manifests:
       - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
 
   - name_template: "ghcr.io/sydlexius/stillwater:{{ .Major }}.{{ .Minor }}"
+    skip_push: "{{ .Prerelease }}"
     image_templates:
       - "ghcr.io/sydlexius/stillwater:{{ .Version }}-amd64"
       - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
 
   - name_template: "ghcr.io/sydlexius/stillwater:latest"
+    skip_push: "{{ .Prerelease }}"
     image_templates:
       - "ghcr.io/sydlexius/stillwater:{{ .Version }}-amd64"
       - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
@@ -116,4 +118,4 @@ release:
     owner: sydlexius
     name: stillwater
   prerelease: auto
-  make_latest: true
+  make_latest: auto

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -7,6 +7,8 @@ RUN addgroup -g 1000 stillwater && \
 
 RUN mkdir -p /data /music && chown stillwater:stillwater /data /music
 
+WORKDIR /app
+
 COPY stillwater /usr/local/bin/stillwater
 COPY web/static /app/web/static
 COPY build/docker/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## Summary

Three GoReleaser configuration fixes from Copilot review on PR #54.

- **Pre-release Docker tags:** Added `skip_push` for pre-release versions on `major.minor` and `latest` Docker manifest tags. Previously, a tag like `v0.2.0-rc1` would incorrectly update the `0.2` and `latest` tags.
- **make_latest:** Changed from `true` to `auto` so only stable releases are marked as "latest" on GitHub.
- **Dockerfile WORKDIR:** Added `WORKDIR /app` to `Dockerfile.goreleaser` so the application can find static files at the expected `web/static` relative path.

Closes #69.

## Test plan

- [ ] GoReleaser config validates: `goreleaser check` (if available)
- [ ] Stable release tags push all manifests (version, major.minor, latest)
- [ ] Pre-release tags only push the exact version manifest

Generated with [Claude Code](https://claude.com/claude-code)