### PR TITLE
fix: log level and UI text improvements (#70)

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -287,7 +287,7 @@ func resolveEncryptionKey(cfg *config.Config, logger *slog.Logger) (string, erro
 	if err == nil {
 		key := strings.TrimSpace(string(data))
 		if key != "" {
-			logger.Info("loaded encryption key from file", slog.String("path", keyFile))
+			logger.Debug("loaded encryption key from file", slog.String("path", keyFile))
 			return key, nil
 		}
 	}

--- a/web/templates/settings.templ
+++ b/web/templates/settings.templ
@@ -301,7 +301,7 @@ templ ProviderKeyCard(pk provider.ProviderKeyStatus) {
 				} else if pk.HasKey {
 					<div class="text-xs text-gray-500 dark:text-gray-400">Key configured</div>
 				} else {
-					<div class="text-xs text-amber-600 dark:text-amber-400">Subscription required</div>
+					<div class="text-xs text-amber-600 dark:text-amber-400">API key required</div>
 				}
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

Two small code quality improvements from Copilot review on PR #60.

- **Log level:** Encryption key file path is now logged at Debug level instead of Info, avoiding exposure of filesystem structure in production logs.
- **UI text:** Changed the missing API key message from "Subscription required" to "API key required". Most providers (Last.fm, Fanart.tv) offer free API keys with registration, so "subscription required" was misleading.

Closes #70.

## Test plan

- [ ] `go build ./...` compiles cleanly
- [ ] Verify settings page shows "API key required" for unconfigured providers
- [ ] Verify encryption key path only appears in debug logs

Generated with [Claude Code](https://claude.com/claude-code)