### PR TITLE
feat(security): add CSP and HSTS headers (#64)

### DIFF
--- a/internal/api/middleware/security.go
+++ b/internal/api/middleware/security.go
@@ -10,6 +10,7 @@ const cspHeader = "default-src 'self'; " +
 	"script-src 'self' 'unsafe-inline'; " +
 	"style-src 'self' 'unsafe-inline'; " +
 	"img-src 'self' data:; " +
+	"connect-src 'self'; " +
 	"object-src 'none'; " +
 	"base-uri 'self'; " +
 	"frame-ancestors 'none'; " +
@@ -24,7 +25,7 @@ func SecurityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("X-XSS-Protection", "0")
 		w.Header().Set("Content-Security-Policy", cspHeader)
 
-		if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
+		if isSecureRequest(r) {
 			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		}
 

--- a/internal/api/middleware/security_test.go
+++ b/internal/api/middleware/security_test.go
@@ -18,9 +18,9 @@ func TestSecurityHeaders_Present(t *testing.T) {
 
 	expected := map[string]string{
 		"X-Content-Type-Options": "nosniff",
-		"X-Frame-Options":       "DENY",
-		"Referrer-Policy":       "strict-origin-when-cross-origin",
-		"X-XSS-Protection":     "0",
+		"X-Frame-Options":        "DENY",
+		"Referrer-Policy":        "strict-origin-when-cross-origin",
+		"X-XSS-Protection":       "0",
 	}
 
 	for header, want := range expected {
@@ -82,6 +82,7 @@ func TestSecurityHeaders_CSPPresent(t *testing.T) {
 		"default-src 'self'",
 		"script-src",
 		"style-src",
+		"connect-src 'self'",
 		"object-src 'none'",
 		"frame-ancestors 'none'",
 	}


### PR DESCRIPTION
## Summary

- Add Content-Security-Policy header tuned for HTMX, Cropper.js, and Chart.js compatibility (`unsafe-inline` required for inline scripts and `hx-on::` handlers)
- Add Strict-Transport-Security header conditionally when request arrives over TLS or via HTTPS reverse proxy

Fixes #64

## Test plan

- [ ] Verify CSP header present in responses (`curl -I`)
- [ ] Verify HSTS header present only when accessed via HTTPS
- [ ] Check browser dev tools console for CSP violations on all pages (dashboard, artists, settings, image search)
- [ ] Confirm HTMX interactions still work (search, pagination, form submissions)
- [ ] Confirm Chart.js renders on dashboard
- [ ] Confirm Cropper.js works on image search page

Generated with [Claude Code](https://claude.com/claude-code)