### PR TITLE
fix: finalize SWAG reverse proxy configs (#32)

### DIFF
--- a/build/swag/stillwater.subdomain.conf.sample
+++ b/build/swag/stillwater.subdomain.conf.sample
@@ -1,4 +1,4 @@
-## Version 2026/02/19
+## Version 2026/02/20
 # Make sure that your stillwater container is named stillwater
 # Make sure that your DNS has a CNAME set for stillwater
 
@@ -10,7 +10,7 @@ server {
 
     include /config/nginx/ssl.conf;
 
-    client_max_body_size 0;
+    client_max_body_size 25m;
 
     # enable for ldap auth (requires ldap-location.conf in the location block)
     #include /config/nginx/ldap-server.conf;
@@ -48,8 +48,7 @@ server {
         set $upstream_proto http;
         proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-        # WebSocket support
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $http_connection;
+        # longer timeout for scanner and bulk operations
+        proxy_read_timeout 600s;
     }
 }

--- a/build/swag/stillwater.subfolder.conf.sample
+++ b/build/swag/stillwater.subfolder.conf.sample
@@ -1,4 +1,4 @@
-## Version 2026/02/19
+## Version 2026/02/20
 # Make sure that your stillwater container is named stillwater
 # Make sure that the SW_BASE_PATH environment variable is set to /stillwater on the stillwater container
 
@@ -30,16 +30,8 @@ location ^~ /stillwater/ {
     set $upstream_proto http;
     proxy_pass $upstream_proto://$upstream_app:$upstream_port;
 
-    # WebSocket support
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection $http_connection;
-}
+    client_max_body_size 25m;
 
-location ^~ /stillwater/api {
-    include /config/nginx/proxy.conf;
-    include /config/nginx/resolver.conf;
-    set $upstream_app stillwater;
-    set $upstream_port 1973;
-    set $upstream_proto http;
-    proxy_pass $upstream_proto://$upstream_app:$upstream_port;
+    # longer timeout for scanner and bulk operations
+    proxy_read_timeout 600s;
 }


### PR DESCRIPTION
## Summary
- Set `client_max_body_size 25m` in both subdomain and subfolder configs (was unlimited/missing; matches 25MB image upload limit)
- Add `proxy_read_timeout 600s` for long-running scanner and bulk operations (SWAG default is 240s)
- Remove WebSocket proxy headers (Stillwater does not use WebSockets)
- Remove redundant `/stillwater/api` location block from subfolder config (already covered by `^~ /stillwater/`)
- Bump version date to 2026/02/20
- No additional headers needed: `X-Real-IP`, `X-Forwarded-Proto`, etc. are already set by SWAG's `proxy.conf` include

## Test plan
- [ ] Subdomain config: all routes accessible, image uploads work, scanner/bulk ops don't timeout
- [ ] Subfolder config with `SW_BASE_PATH=/stillwater`: all routes work under prefix
- [ ] Static assets load with cache-busted URLs through proxy
- [ ] HTMX requests proxy correctly (no header stripping)

Closes #32

Generated with [Claude Code](https://claude.com/claude-code)