### PR TITLE
feat(providers): update TheAudioDB to paid tier with official pricing link

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -45,8 +45,8 @@ func ProviderCapabilities() map[ProviderName]ProviderCapability {
 			RateLimit: &RateLimitInfo{RequestsPerSecond: 3},
 		},
 		NameAudioDB: {
-			Tier:      TierFreemium,
-			HelpURL:   "https://www.patreon.com/thedatadb",
+			Tier:      TierPaid,
+			HelpURL:   "https://www.theaudiodb.com/pricing",
 			RateLimit: &RateLimitInfo{RequestsPerSecond: 2},
 		},
 		NameDiscogs: {


### PR DESCRIPTION
## Summary
- Changes TheAudioDB `HelpURL` from the Patreon page to the official pricing page (`https://www.theaudiodb.com/pricing`)
- Updates tier from `TierFreemium` to `TierPaid` so the UI renders "Purchase access" instead of "Get free key"

## Test plan
- [ ] Settings > Providers: TheAudioDB row shows "Purchase access" link pointing to `https://www.theaudiodb.com/pricing`

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)