### PR TITLE
fix: prevent deleted library artists from re-populating on scan

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -159,8 +159,9 @@ func (s *Service) runScan(ctx context.Context, result *ScanResult) {
 			targets = append(targets, scanTarget{path: lib.Path, libraryID: lib.ID})
 		}
 	}
-	// Fallback: if no libraries found, use the legacy single path.
-	if len(targets) == 0 && s.libraryPath != "" {
+	// Fallback: if no library lister is configured, use the legacy single path.
+	// When a lister IS set but returns empty, the user has no libraries -- do not fall back.
+	if len(targets) == 0 && s.libraryLister == nil && s.libraryPath != "" {
 		targets = append(targets, scanTarget{path: s.libraryPath, libraryID: s.defaultLibraryID})
 	}
 


### PR DESCRIPTION
## Summary
- The scanner's legacy `libraryPath` fallback in `runScan()` fired whenever the library lister returned an empty list, re-scanning the default `/music` path and re-creating artists with dangling `library_id` foreign keys
- Restricted the fallback to only trigger when no library lister is configured (`s.libraryLister == nil`), preserving backward compatibility for legacy/test setups while preventing ghost re-population in normal multi-library operation
- Added two regression tests: `TestScan_NoLibraries_NoFallback` and `TestScan_DeletedLibrary_NoRepopulate`

## Test plan
- [x] New tests pass: `go test ./internal/scanner/ -run "TestScan_NoLibraries_NoFallback|TestScan_DeletedLibrary_NoRepopulate" -v`
- [x] All existing scanner tests pass: `go test ./internal/scanner/ -v` (17/17)
- [ ] Full suite: `make test`
- [ ] UAT: delete a library, click Scan Library, verify no artists re-appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)