### PR TITLE
fix: use immutable profile ID for Kodi numbering check

### DIFF
--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -962,7 +962,7 @@ func (r *Router) isKodiNumbering(ctx context.Context) bool {
 	if err != nil || profile == nil {
 		return false
 	}
-	return strings.EqualFold(profile.Name, "Kodi")
+	return strings.EqualFold(profile.ID, "kodi")
 }
 
 // processAndAppendFanart processes image data and saves it as the next


### PR DESCRIPTION
## Summary
- Change `isKodiNumbering` to compare `profile.ID` instead of `profile.Name`, which is user-editable and could break the Kodi-specific fanart numbering logic after a rename

Addresses Copilot feedback from closed PR #243. Stacked on #252.

## Test plan
- [x] `go test ./...` passes
- [x] `go build` succeeds

Generated with [Claude Code](https://claude.com/claude-code)