### PR TITLE
fix: prevent fanart overwrite when numbering gaps exist

### DIFF
--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -975,8 +975,8 @@ func (r *Router) processAndAppendFanart(ctx context.Context, dir string, data []
 
 	primary := r.getActiveFanartPrimary(ctx)
 	kodi := r.isKodiNumbering(ctx)
-	existing := img.DiscoverFanart(dir, primary)
-	nextIndex := len(existing)
+	maxIdx := img.MaxFanartIndex(dir, primary)
+	nextIndex := maxIdx + 1
 	nextName := img.FanartFilename(primary, nextIndex, kodi)
 
 	saved, err := img.Save(dir, "fanart", resized, []string{nextName}, r.logger)

--- a/internal/image/fanart_test.go
+++ b/internal/image/fanart_test.go
@@ -106,6 +106,37 @@ func TestDiscoverFanart_MixedCase(t *testing.T) {
 	}
 }
 
+func TestMaxFanartIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   []string
+		primary string
+		want    int
+	}{
+		{"empty dir", nil, "backdrop.jpg", -1},
+		{"primary only", []string{"backdrop.jpg"}, "backdrop.jpg", 0},
+		{"primary plus numbered", []string{"backdrop.jpg", "backdrop2.jpg", "backdrop3.jpg"}, "backdrop.jpg", 3},
+		{"gap in numbering", []string{"backdrop.jpg", "backdrop5.jpg"}, "backdrop.jpg", 5},
+		{"only high numbered", []string{"fanart3.jpg"}, "fanart.jpg", 3},
+		{"unrelated files only", []string{"logo.png", "folder.jpg"}, "backdrop.jpg", -1},
+		{"mixed case", []string{"Backdrop.jpg", "BACKDROP2.png"}, "backdrop.jpg", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, name := range tt.files {
+				if err := os.WriteFile(filepath.Join(dir, name), []byte("fake"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := MaxFanartIndex(dir, tt.primary)
+			if got != tt.want {
+				t.Errorf("MaxFanartIndex() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDiscoverFanart_AlternateExtension(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- Replace `len(DiscoverFanart(...))` with `MaxFanartIndex(...)` for next-index calculation so that gaps in the numbering sequence (e.g., fanart1 deleted but fanart2 present) do not cause an existing file to be overwritten
- Add `MaxFanartIndex` function with full test coverage

Addresses Copilot feedback from closed PR #244. Stacked on #253.

## Test plan
- [x] `go test ./...` passes (including new MaxFanartIndex table-driven tests)
- [x] `go build` succeeds

Generated with [Claude Code](https://claude.com/claude-code)