### PR TITLE
fix: add SSRF protection with connection-time IP validation

### DIFF
--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -136,6 +136,31 @@ func TestRequireArtistPath_Degraded(t *testing.T) {
 	}
 }
 
+func TestIsPrivateURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"loopback ipv4", "http://127.0.0.1/image.jpg", true},
+		{"loopback ipv6", "http://[::1]/image.jpg", true},
+		{"private 10.x", "http://10.0.0.1/image.jpg", true},
+		{"private 172.16.x", "http://172.16.0.1/image.jpg", true},
+		{"private 192.168.x", "http://192.168.1.1/image.jpg", true},
+		{"link-local", "http://169.254.1.1/image.jpg", true},
+		{"unspecified ipv4", "http://0.0.0.0/image.jpg", true},
+		{"invalid url", "://bad", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPrivateURL(context.Background(), tt.url)
+			if got != tt.want {
+				t.Errorf("isPrivateURL(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSetArtistImageFlag_UnreadableFile(t *testing.T) {
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- Add `isPrivateURL` pre-check that rejects loopback, private, link-local, and unspecified addresses before image fetch
- Add `ssrfSafeTransport` with a custom `DialContext` that validates resolved IPs at connection time, preventing TOCTOU / DNS-rebinding attacks where the hostname resolves to a safe address during pre-check but to a private address when the actual connection is made
- Add unit tests for `isPrivateURL` covering loopback, private, link-local, unspecified, and invalid URLs

Addresses Copilot feedback from closed PR #245, including the valid TOCTOU/DNS-rebinding concern and missing test coverage. Stacked on #254.

## Test plan
- [x] `go test ./internal/api/ -run TestIsPrivateURL` passes
- [x] Full test suite passes
- [x] `go build` succeeds

Generated with [Claude Code](https://claude.com/claude-code)