### PR TITLE
Design: universal field editing for all metadata fields

### DIFF
--- a/docs/plans/m30-universal-field-editing.md
+++ b/docs/plans/m30-universal-field-editing.md
@@ -50,7 +50,7 @@ New `validateFieldUpdate(field, value string) error` function:
 - `name`: must not be empty after trimming
 - `musicbrainz_id`: if non-empty, must be a valid UUID
 - `audiodb_id`, `discogs_id`, `deezer_id`: if non-empty, must be numeric
-- `wikidata_id`: if non-empty, must match `Q\d+` pattern
+- `wikidata_id`: if non-empty, value is trimmed and must match the anchored, case-sensitive pattern `^Q[0-9]+$` (uppercase `Q` followed immediately by one or more digits, no leading/trailing whitespace)
 - Other fields: no additional validation (existing behavior)
 
 Call `validateFieldUpdate` in `handleFieldUpdate` before `UpdateField`.


### PR DESCRIPTION
## Summary

- Design plan for making all 19 metadata fields editable via the field API
- Covers validation rules for name, provider IDs (MBID UUID, numeric IDs, Wikidata Q-numbers)
- Documents sort_name auto-update logic and template changes

Refs #322

## Test plan

- [ ] Plan file review -- verify all 8 new fields are accounted for
- [ ] Confirm validation rules match external ID format requirements
- [ ] Verify NFO write-back considerations are accurate


Generated with [Claude Code](https://claude.com/claude-code)