### PR TITLE
fix: case-insensitive matching in existingImageFileNames

### DIFF
--- a/internal/image/cleanup.go
+++ b/internal/image/cleanup.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -15,27 +16,104 @@ var conflictingExtensions = map[string][]string{
 	".webp": {".jpg", ".jpeg", ".png"},
 }
 
-// CleanupConflictingFormats deletes existing files that share the same base name
-// but have a different image format extension. For example, when saving "folder.png",
-// this function deletes "folder.jpg" and "folder.jpeg" if they exist.
+// CleanupConflictingFormats removes existing files that share the same base name
+// (case-insensitive) but have a different image format extension, or the same
+// format with different casing. This prevents duplicate files on case-sensitive
+// filesystems when the canonical filename differs in case from what is on disk.
+//
+// For example, when saving "folder.jpg", this function:
+//   - deletes "folder.png" (conflicting format, same case)
+//   - renames "Folder.JPG" to "folder.jpg" (same format, different case)
+//   - deletes "Folder.PNG" (conflicting format, different case)
+//
+// Same-format case mismatches are renamed rather than deleted so that if the
+// subsequent WriteFileAtomic fails, the original image content is preserved
+// under the canonical name. Conflicting formats are deleted outright since
+// the content is being replaced.
+//
+// The file being written (exact match on fileName) is skipped, since
+// WriteFileAtomic handles overwriting it.
 func CleanupConflictingFormats(dir string, fileName string, logger *slog.Logger) error {
 	ext := strings.ToLower(filepath.Ext(fileName))
 	base := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+	lowerBase := strings.ToLower(base)
 
 	conflicts, ok := conflictingExtensions[ext]
 	if !ok {
 		return nil
 	}
 
-	for _, altExt := range conflicts {
-		altPath := filepath.Join(dir, base+altExt)
-		if _, err := os.Stat(altPath); err == nil {
-			if err := os.Remove(altPath); err != nil {
+	conflictSet := make(map[string]struct{}, len(conflicts))
+	for _, c := range conflicts {
+		conflictSet[c] = struct{}{}
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("reading directory %s: %w", dir, err)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if name == fileName {
+			continue // exact match: WriteFileAtomic will handle overwrite
+		}
+
+		entryExt := strings.ToLower(filepath.Ext(name))
+		entryBase := strings.TrimSuffix(name, filepath.Ext(name))
+		if strings.ToLower(entryBase) != lowerBase {
+			continue // different base name entirely
+		}
+
+		_, isConflict := conflictSet[entryExt]
+		isSameFormat := entryExt == ext
+
+		oldPath := filepath.Join(dir, name)
+		newPath := filepath.Join(dir, fileName)
+
+		if isSameFormat {
+			// Same format, different casing (e.g., "Folder.JPG" -> "folder.jpg").
+			// If the canonical file already exists as a separate file (case-
+			// sensitive FS with both present), delete the duplicate to avoid
+			// overwriting the canonical content. Otherwise rename so the
+			// content survives if the subsequent WriteFileAtomic fails.
+			//
+			// We use os.SameFile to distinguish: on case-insensitive
+			// filesystems, Stat("folder.jpg") resolves to "Folder.JPG"
+			// (same file), so we must rename rather than delete.
+			canonicalIsSeparateFile := false
+			if oldInfo, err := os.Stat(oldPath); err == nil {
+				if newInfo, err := os.Stat(newPath); err == nil {
+					canonicalIsSeparateFile = !os.SameFile(oldInfo, newInfo)
+				}
+			}
+			if canonicalIsSeparateFile {
+				// Both files exist as separate inodes: delete the duplicate.
+				if err := os.Remove(oldPath); err != nil {
+					return err
+				}
+				logger.Info("deleted duplicate case-mismatched image file",
+					slog.String("deleted", oldPath),
+					slog.String("canonical", newPath))
+			} else {
+				if err := os.Rename(oldPath, newPath); err != nil {
+					return err
+				}
+				logger.Info("renamed case-mismatched image file",
+					slog.String("from", oldPath),
+					slog.String("to", newPath))
+			}
+		} else if isConflict {
+			// Different format (e.g., .png when writing .jpg): delete.
+			if err := os.Remove(oldPath); err != nil {
 				return err
 			}
 			logger.Info("deleted conflicting image format",
-				slog.String("deleted", altPath),
-				slog.String("replaced_by", filepath.Join(dir, fileName)))
+				slog.String("deleted", oldPath),
+				slog.String("replaced_by", newPath))
 		}
 	}
 

--- a/internal/image/cleanup_test.go
+++ b/internal/image/cleanup_test.go
@@ -91,3 +91,61 @@ func TestCleanupConflictingFormats_UnknownExtension(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestCleanupConflictingFormats_CaseMismatchSameFormat(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Create a differently-cased file of the same format
+	if err := os.WriteFile(filepath.Join(dir, "Folder.JPG"), []byte("old jpeg"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cleaning up for "folder.jpg" should rename "Folder.JPG" to "folder.jpg"
+	// (preserving content in case the subsequent write fails)
+	if err := CleanupConflictingFormats(dir, "folder.jpg", logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The canonical name should now exist with the original content
+	data, err := os.ReadFile(filepath.Join(dir, "folder.jpg"))
+	if err != nil {
+		t.Fatalf("folder.jpg should exist after rename: %v", err)
+	}
+	if string(data) != "old jpeg" {
+		t.Errorf("content = %q, want %q", string(data), "old jpeg")
+	}
+
+	// Verify only one file in the directory (no duplicate)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("expected 1 file, got %d: %v", len(entries), names)
+	}
+}
+
+func TestCleanupConflictingFormats_CaseMismatchConflictFormat(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Create a differently-cased file of a conflicting format
+	oldPath := filepath.Join(dir, "Folder.PNG")
+	if err := os.WriteFile(oldPath, []byte("old png"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cleaning up for "folder.jpg" should remove "Folder.PNG"
+	if err := CleanupConflictingFormats(dir, "folder.jpg", logger); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Error("Folder.PNG should have been deleted")
+	}
+}

--- a/internal/image/save_test.go
+++ b/internal/image/save_test.go
@@ -284,6 +284,58 @@ func TestSave_Symlinks_ExtensionCoercionDuplicate(t *testing.T) {
 	}
 }
 
+func TestSave_OverwritesCaseMismatchedFile(t *testing.T) {
+	dir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Create a differently-cased file on disk (simulates case-sensitive filesystem)
+	if err := os.WriteFile(filepath.Join(dir, "Folder.JPG"), []byte("old data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save with the canonical (lowercase) name
+	jpegData := makeJPEG(t, 100, 100)
+	saved, err := Save(dir, "thumb", jpegData, []string{"folder.jpg"}, false, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(saved) != 1 || saved[0] != "folder.jpg" {
+		t.Errorf("saved = %v, want [folder.jpg]", saved)
+	}
+
+	// The canonical file should exist with valid content
+	newData, err := os.ReadFile(filepath.Join(dir, "folder.jpg"))
+	if err != nil {
+		t.Fatalf("folder.jpg should exist: %v", err)
+	}
+	format, _, err := DetectFormat(bytesReader(newData))
+	if err != nil {
+		t.Fatalf("DetectFormat: %v", err)
+	}
+	if format != FormatJPEG {
+		t.Errorf("format = %q, want %q", format, FormatJPEG)
+	}
+
+	// Verify exactly one file in the directory, named "folder.jpg".
+	// We use ReadDir instead of os.Stat because Stat follows the underlying
+	// filesystem's lookup rules, which are typically case-insensitive on
+	// Windows and default macOS volumes and would treat "folder.jpg" and
+	// "Folder.JPG" as the same file.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("expected 1 file, got %d: %v", len(entries), names)
+	} else if entries[0].Name() != "folder.jpg" {
+		t.Errorf("expected file named folder.jpg, got %s", entries[0].Name())
+	}
+}
+
 func TestSave_Symlinks_SingleFile(t *testing.T) {
 	dir := t.TempDir()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/internal/rule/fixer_test.go
+++ b/internal/rule/fixer_test.go
@@ -706,6 +706,24 @@ func TestExistingImageFileNames_OnlyWritesExistingFiles(t *testing.T) {
 	}
 }
 
+func TestExistingImageFileNames_CaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create file with non-canonical casing
+	if err := os.WriteFile(filepath.Join(dir, "Folder.JPG"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	got := existingImageFileNames(context.Background(), dir, "thumb", nil)
+	if len(got) != 1 {
+		t.Fatalf("want 1 match, got %d: %v", len(got), got)
+	}
+	// Should return the canonical name so img.Save uses a consistent extension
+	if got[0] != "folder.jpg" {
+		t.Errorf("existingImageFileNames = %q; want folder.jpg (canonical name)", got[0])
+	}
+}
+
 func TestExistingImageFileNames_FallsBackToPrimary(t *testing.T) {
 	dir := t.TempDir() // empty -- no existing files
 

--- a/internal/rule/fixers.go
+++ b/internal/rule/fixers.go
@@ -487,9 +487,22 @@ func existingImageFileNames(ctx context.Context, dir, imageType string, platform
 	if len(all) == 0 {
 		all = img.FileNamesForType(img.DefaultFileNames, imageType)
 	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if len(all) > 0 {
+			return all[:1]
+		}
+		return nil
+	}
+	lowerNames := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			lowerNames[strings.ToLower(e.Name())] = struct{}{}
+		}
+	}
 	var found []string
 	for _, name := range all {
-		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+		if _, ok := lowerNames[strings.ToLower(name)]; ok {
 			found = append(found, name)
 		}
 	}


### PR DESCRIPTION
## Summary
- Replace `os.Stat` with `os.ReadDir` + lowercase map lookup in `existingImageFileNames()` so files with non-canonical casing (e.g. `Folder.JPG` vs `folder.jpg`) are found on case-sensitive filesystems (Linux)
- Returns the canonical name (from the naming config), not the on-disk name, since `CleanupConflictingFormats` now handles removing stale differently-cased files before `WriteFileAtomic` writes the canonical name
- Refactor `CleanupConflictingFormats` to scan the directory instead of constructing exact paths, so it catches case-mismatched files (e.g. `Folder.JPG` when writing `folder.jpg`) and conflicting formats with any casing (e.g. `Folder.PNG` when writing `folder.jpg`)

Closes #319

## Test plan
- [x] Existing `TestExistingImageFileNames_OnlyWritesExistingFiles` still passes
- [x] Existing `TestExistingImageFileNames_FallsBackToPrimary` still passes
- [x] New `TestExistingImageFileNames_CaseInsensitive` passes
- [x] New `TestCleanupConflictingFormats_CaseMismatchSameFormat` passes
- [x] New `TestCleanupConflictingFormats_CaseMismatchConflictFormat` passes
- [x] New `TestSave_OverwritesCaseMismatchedFile` end-to-end test passes
- [x] Full `internal/image` test suite passes
- [x] Full `internal/rule` test suite passes
- [x] Pre-commit hooks pass (gofmt, build, lint, govulncheck)

Generated with [Claude Code](https://claude.com/claude-code)