### PR TITLE
fix: scope MBID-to-name retry to NameLookupProvider

### DIFF
--- a/internal/provider/genius/genius.go
+++ b/internal/provider/genius/genius.go
@@ -48,6 +48,10 @@ func (a *Adapter) Name() provider.ProviderName { return provider.NameGenius }
 // RequiresAuth returns whether this provider needs an API key.
 func (a *Adapter) RequiresAuth() bool { return true }
 
+// SupportsNameLookup returns true because Genius GetArtist can accept an
+// artist name (non-numeric, non-UUID) and will search by name automatically.
+func (a *Adapter) SupportsNameLookup() bool { return true }
+
 // SearchArtist searches Genius for artists matching the given name.
 // Genius search returns song hits; we extract and deduplicate primary_artist entries.
 func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.ArtistSearchResult, error) {

--- a/internal/provider/genius/genius_test.go
+++ b/internal/provider/genius/genius_test.go
@@ -50,6 +50,11 @@ func loadFixture(t *testing.T, name string) []byte {
 func newTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Validate the Authorization header to catch regressions that drop it.
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		path := r.URL.Path
 		switch {

--- a/internal/provider/lastfm/lastfm.go
+++ b/internal/provider/lastfm/lastfm.go
@@ -47,6 +47,10 @@ func (a *Adapter) Name() provider.ProviderName { return provider.NameLastFM }
 // RequiresAuth returns whether this provider needs an API key.
 func (a *Adapter) RequiresAuth() bool { return true }
 
+// SupportsNameLookup returns true because Last.fm GetArtist can accept an
+// artist name and will use it as the "artist" parameter instead of "mbid".
+func (a *Adapter) SupportsNameLookup() bool { return true }
+
 // SearchArtist searches Last.fm for artists matching the given name.
 func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.ArtistSearchResult, error) {
 	apiKey, err := a.getAPIKey(ctx)

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -220,15 +220,18 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 	if id != "" {
 		meta, err := p.GetArtist(ctx, id)
 		// If we used an MBID and the provider returned not-found, retry with
-		// the artist name. Name-based providers (e.g. Genius) cannot interpret
-		// MBIDs, so the name fallback lets them participate in the fallback chain.
+		// the artist name -- but only for providers that support name lookups
+		// (e.g. Genius, Last.fm). Other providers only accept provider-specific
+		// IDs, so retrying with a name would waste an HTTP call.
 		if err != nil && mbid != "" && artistName != "" {
 			var notFound *ErrNotFound
 			if errors.As(err, &notFound) {
-				o.logger.Debug("retrying with artist name after MBID not-found",
-					slog.String("provider", string(name)),
-					slog.String("name", artistName))
-				meta, err = p.GetArtist(ctx, artistName)
+				if nlp, ok := p.(NameLookupProvider); ok && nlp.SupportsNameLookup() {
+					o.logger.Debug("retrying with artist name after MBID not-found",
+						slog.String("provider", string(name)),
+						slog.String("name", artistName))
+					meta, err = p.GetArtist(ctx, artistName)
+				}
 			}
 		}
 		if err != nil {

--- a/internal/provider/orchestrator_test.go
+++ b/internal/provider/orchestrator_test.go
@@ -45,6 +45,14 @@ func (m *mockProvider) GetImages(ctx context.Context, id string) ([]ImageResult,
 	return nil, nil
 }
 
+// mockNameLookupProvider wraps mockProvider and implements NameLookupProvider
+// so the MBID-to-name retry logic can detect it via type assertion.
+type mockNameLookupProvider struct {
+	mockProvider
+}
+
+func (m *mockNameLookupProvider) SupportsNameLookup() bool { return true }
+
 func setupOrchestratorTest(t *testing.T) (*Registry, *SettingsService) {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
@@ -250,19 +258,22 @@ func TestOrchestratorMBIDFallbackToName(t *testing.T) {
 	}
 
 	// Genius returns ErrNotFound for MBID, then succeeds with name.
+	// Uses mockNameLookupProvider so the NameLookupProvider type assertion succeeds.
 	geniusCalls := 0
-	registry.Register(&mockProvider{
-		name: NameGenius,
-		getArtFn: func(_ context.Context, id string) (*ArtistMetadata, error) {
-			geniusCalls++
-			if id == "mbid-uuid-1234" {
-				return nil, &ErrNotFound{Provider: NameGenius, ID: id}
-			}
-			// Called with artist name on retry
-			return &ArtistMetadata{
-				Name:      "Radiohead",
-				Biography: "From Genius",
-			}, nil
+	registry.Register(&mockNameLookupProvider{
+		mockProvider: mockProvider{
+			name: NameGenius,
+			getArtFn: func(_ context.Context, id string) (*ArtistMetadata, error) {
+				geniusCalls++
+				if id == "mbid-uuid-1234" {
+					return nil, &ErrNotFound{Provider: NameGenius, ID: id}
+				}
+				// Called with artist name on retry
+				return &ArtistMetadata{
+					Name:      "Radiohead",
+					Biography: "From Genius",
+				}, nil
+			},
 		},
 	})
 	registry.Register(&mockProvider{
@@ -291,6 +302,42 @@ func TestOrchestratorMBIDFallbackToName(t *testing.T) {
 	// Genius should have been called twice: once with MBID (not-found), once with name.
 	if geniusCalls != 2 {
 		t.Errorf("expected 2 Genius GetArtist calls (MBID + name retry), got %d", geniusCalls)
+	}
+}
+
+// TestOrchestratorMBIDNoRetryWithoutNameLookup verifies that the MBID-to-name
+// retry does NOT fire for providers that do not implement NameLookupProvider.
+func TestOrchestratorMBIDNoRetryWithoutNameLookup(t *testing.T) {
+	registry, settings := setupOrchestratorTest(t)
+
+	// Discogs requires auth; store a dummy key so it passes availability check.
+	if err := settings.SetAPIKey(context.Background(), NameDiscogs, "test-token"); err != nil {
+		t.Fatalf("SetAPIKey: %v", err)
+	}
+
+	// Use a plain mockProvider (no NameLookupProvider) that returns ErrNotFound.
+	discogsCalls := 0
+	registry.Register(&mockProvider{
+		name:    NameDiscogs,
+		authReq: true,
+		getArtFn: func(_ context.Context, id string) (*ArtistMetadata, error) {
+			discogsCalls++
+			return nil, &ErrNotFound{Provider: NameDiscogs, ID: id}
+		},
+	})
+
+	if err := settings.SetPriority(context.Background(), "biography", []ProviderName{NameDiscogs}); err != nil {
+		t.Fatalf("SetPriority: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	orch := NewOrchestrator(registry, settings, logger)
+
+	_, _ = orch.FetchMetadata(context.Background(), "mbid-uuid-1234", "Radiohead")
+
+	// Discogs should only be called once (MBID attempt). No name retry.
+	if discogsCalls != 1 {
+		t.Errorf("expected 1 Discogs GetArtist call (no name retry), got %d", discogsCalls)
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -256,6 +256,16 @@ type TestableProvider interface {
 	TestConnection(ctx context.Context) error
 }
 
+// NameLookupProvider is an optional interface for providers whose GetArtist
+// method can accept an artist name in addition to a provider-specific ID.
+// Providers that implement this are eligible for the MBID-to-name retry:
+// when an MBID-based GetArtist call returns ErrNotFound, the caller retries
+// with the artist name only for providers that support name lookups.
+type NameLookupProvider interface {
+	Provider
+	SupportsNameLookup() bool
+}
+
 // MirrorableProvider is an optional interface for providers that support
 // pointing at a self-hosted mirror (e.g. MusicBrainz).
 type MirrorableProvider interface {

--- a/internal/scraper/executor.go
+++ b/internal/scraper/executor.go
@@ -188,15 +188,18 @@ func (e *Executor) getProviderResult(
 	if id != "" {
 		meta, err := p.GetArtist(ctx, id)
 		// If we used an MBID and the provider returned not-found, retry with
-		// the artist name. Name-based providers (e.g. Genius) cannot interpret
-		// MBIDs, so the name fallback lets them participate in the fallback chain.
+		// the artist name -- but only for providers that support name lookups
+		// (e.g. Genius, Last.fm). Other providers only accept provider-specific
+		// IDs, so retrying with a name would waste an HTTP call.
 		if err != nil && mbid != "" && artistName != "" {
 			var notFound *provider.ErrNotFound
 			if errors.As(err, &notFound) {
-				e.logger.Debug("retrying with artist name after MBID not-found",
-					slog.String("provider", string(name)),
-					slog.String("name", artistName))
-				meta, err = p.GetArtist(ctx, artistName)
+				if nlp, ok := p.(provider.NameLookupProvider); ok && nlp.SupportsNameLookup() {
+					e.logger.Debug("retrying with artist name after MBID not-found",
+						slog.String("provider", string(name)),
+						slog.String("name", artistName))
+					meta, err = p.GetArtist(ctx, artistName)
+				}
 			}
 		}
 		if err != nil {


### PR DESCRIPTION
## Summary

Addresses three unresolved Copilot review comments from PRs #333 and #334 (both already merged):

- **NameLookupProvider interface** (`provider.go`): New optional interface so the MBID-not-found retry in `orchestrator.go` and `executor.go` only fires for providers whose `GetArtist` supports name-based lookups (Genius, Last.fm). Previously, every provider returning `ErrNotFound` triggered a name retry, wasting HTTP calls on providers that only accept provider-specific IDs (Discogs, MusicBrainz, AudioDB, Wikidata).
- **Auth header validation** (`genius_test.go`): Test server now validates `Authorization: Bearer <token>` header, matching the Discogs test pattern. Catches regressions that drop the header.
- **Negative test** (`orchestrator_test.go`): `TestOrchestratorMBIDNoRetryWithoutNameLookup` verifies the retry does NOT fire for a plain `mockProvider` that lacks the `NameLookupProvider` interface.

Copilot comment refs:
- [orchestrator.go:233](https://github.com/sydlexius/stillwater/pull/334#discussion_r2870334390)
- [executor.go:201](https://github.com/sydlexius/stillwater/pull/334#discussion_r2870334429)
- [genius_test.go:68](https://github.com/sydlexius/stillwater/pull/334#discussion_r2870334447)

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `TestOrchestratorMBIDFallbackToName` still passes (Genius mock uses `mockNameLookupProvider`)
- [x] `TestOrchestratorMBIDNoRetryWithoutNameLookup` verifies no retry for non-name-lookup providers
- [x] Genius test server rejects requests missing `Authorization: Bearer test-token`
- [x] Pre-commit hooks pass (gofmt, go build, golangci-lint, govulncheck)

Generated with [Claude Code](https://claude.com/claude-code)