### PR TITLE
docs: add milestone plan files for M31 and M32

### DIFF
--- a/docs/plans/m31-plan.md
+++ b/docs/plans/m31-plan.md
@@ -1,0 +1,107 @@
+# Milestone 31 (v0.31.0) -- Provider Pipeline & Scraping
+
+## Goal
+
+Enhance the metadata provider pipeline with web scraping capabilities, new image and metadata sources, and optimized fallback behavior. Convert Last.fm from API to scraper, add Wikidata as an image source via Wikimedia Commons, introduce Wikipedia as a metadata provider via the MediaWiki API, and ensure fallback providers are only called when actually needed.
+
+## Acceptance Criteria
+
+- [ ] Last.fm provider works without an API key (web scraper)
+- [ ] Last.fm implements `WebImageProvider` and appears in Web Image Search settings
+- [ ] Wikidata returns images from Wikimedia Commons (P18/P154)
+- [ ] Wikipedia provider supplies biography, members, years active, genres, and origin
+- [ ] Fallback providers are not called unless the primary provider fails or returns empty
+- [ ] No regression in metadata completeness or image quality
+
+## Dependency Map
+
+```
+#342 (fallback optimization) -- no deps, can start first
+#339 (Last.fm scraper)       -- no deps, parallel with #342
+#340 (Wikidata images)       -- no deps, parallel with #339/#342
+#341 (Wikipedia metadata)    -- loosely depends on #340 (Wikidata supplies Wikipedia URL)
+```
+
+#342 is the foundational optimization that ensures new providers do not add unnecessary API calls. #339 and #340 are independent and can proceed in parallel. #341 benefits from #340 (Wikidata SPARQL changes to extract Wikipedia sitelinks) but can also work independently via Wikipedia API search.
+
+## Checklist
+
+### Issue #342 -- Optimize fallback provider call strategy in orchestrator
+- [ ] Audit orchestrator `FetchMetadata` and `FetchImages` call patterns
+- [ ] Audit scraper executor `ScrapeAll` for redundant calls
+- [ ] Implement lazy provider evaluation (only call when needed for unfilled field)
+- [ ] Add targeted image fetching (filter by needed image types)
+- [ ] Add debug logging for skipped provider calls
+- [ ] Tests (call count verification)
+- [ ] PR opened (#?)
+- [ ] CI passing
+- [ ] PR merged
+
+### Issue #339 -- Convert Last.fm provider from API to web scraper
+- [ ] Add `goquery` dependency for HTML parsing
+- [ ] Rewrite `SearchArtist` to scrape search results page
+- [ ] Rewrite `GetArtist` to scrape artist page + wiki subpage
+- [ ] Remove API key dependency (`RequiresAuth() false`)
+- [ ] Implement `WebImageProvider` interface (`SearchImages`) for web image search
+- [ ] Add Last.fm to `AllWebSearchProviderNames()` and register in `WebSearchRegistry`
+- [ ] Update Settings: remove from API key panel, add to Web Image Search section
+- [ ] Update OOBE UI (remove Last.fm API key step)
+- [ ] Update `providerRequiresKey()` in settings
+- [ ] Tests with mocked HTML responses (metadata + image search)
+- [ ] PR opened (#?)
+- [ ] CI passing
+- [ ] PR merged
+
+### Issue #340 -- Add Wikidata as image source via Wikimedia Commons
+- [ ] Extend SPARQL query to fetch P18 (image) and P154 (logo)
+- [ ] Implement Wikimedia Commons URL resolution
+- [ ] Update `GetImages()` to return thumb/logo from Commons
+- [ ] Add Wikidata to image field priorities (thumb, logo)
+- [ ] Tests with mocked SPARQL and Commons API responses
+- [ ] PR opened (#?)
+- [ ] CI passing
+- [ ] PR merged
+
+### Issue #341 -- Add Wikipedia as metadata provider via MediaWiki API
+- [ ] Create `internal/provider/wikipedia/` package
+- [ ] Implement `SearchArtist` via MediaWiki opensearch
+- [ ] Implement `GetArtist` via extracts API (biography) + wikitext parse (infobox)
+- [ ] Implement infobox parser for members, years active, genres, origin
+- [ ] Register provider and add to field priorities
+- [ ] Update rate limiting, Settings UI, OOBE
+- [ ] Tests (infobox parser, API mocks, integration)
+- [ ] PR opened (#?)
+- [ ] CI passing
+- [ ] PR merged
+
+## Worktrees
+
+| Directory | Branch | Issue | Status |
+|-----------|--------|-------|--------|
+| stillwater-342 | feat/342-fallback-optimization | #342 | pending |
+| stillwater-339 | feat/339-lastfm-scraper | #339 | pending |
+| stillwater-340 | feat/340-wikidata-images | #340 | pending |
+| stillwater-341 | feat/341-wikipedia-provider | #341 | pending |
+
+## UAT / Merge Order
+
+1. PR for #342 (base: main) -- fallback optimization first to establish clean baseline
+2. PR for #339 (base: main) -- Last.fm scraper, independent
+3. PR for #340 (base: main) -- Wikidata images, independent
+4. PR for #341 (base: main) -- Wikipedia provider, may reference Wikidata SPARQL changes from #340
+
+## New Dependencies
+
+- `github.com/PuerkitoBio/goquery` -- HTML parsing for Last.fm scraper (#339) and potentially Wikipedia infobox fallback
+
+## Wiki Pages Affected
+
+- [Architecture](https://github.com/sydlexius/stillwater/wiki/Architecture) -- new Wikipedia provider, updated Last.fm and Wikidata descriptions
+- [Developer Guide](https://github.com/sydlexius/stillwater/wiki/Developer-Guide) -- new `goquery` dependency, `internal/provider/wikipedia/` package
+
+## Notes
+
+- 2026-03-02: Milestone created. Last.fm currently provides biography, genres, similar artists, and URLs via API. Scraper will extract the same fields from HTML pages. Last.fm will also implement `WebImageProvider` to serve as a web image search source (appears in the Web Image Search section of Providers settings alongside DuckDuckGo).
+- 2026-03-02: Wikidata images will use P18 (photo) mapped to thumb and P154 (logo) mapped to logo. Wikimedia Commons API resolves filenames to downloadable URLs.
+- 2026-03-02: Wikipedia provider will use MediaWiki API for biography text. Structured fields (members, years active, genres, origin) come from wikitext infobox parsing.
+- 2026-03-02: Provider ID population and URL enrichment scoped into existing #322 (M30).

--- a/docs/plans/m32-plan.md
+++ b/docs/plans/m32-plan.md
@@ -1,0 +1,108 @@
+# Milestone 32 (v0.32.0) -- Documentation & Guided Tour
+
+## Goal
+
+Improve application discoverability and documentation accuracy. Add an OpenAPI reference link in Settings, audit and update both user-facing and developer documentation, and implement a post-OOBE guided tour to introduce users to the application workflow.
+
+## Acceptance Criteria
+
+- [ ] Settings page links to interactive API documentation
+- [ ] User guide reflects all current features and providers
+- [ ] Developer documentation and wiki pages are accurate and current
+- [ ] Post-OOBE guided tour walks users through key UI elements
+
+## Dependency Map
+
+```
+#343 (OpenAPI in Settings) -- no deps, standalone
+#344 (user guide audit)    -- no deps, standalone
+#345 (developer docs audit)-- no deps, standalone
+#346 (guided tour)         -- no deps, standalone (OOBE already stable)
+```
+
+All four issues are independent and can be worked in parallel.
+
+## Checklist
+
+### Issue #343 -- Add OpenAPI documentation reference to Settings page
+- [ ] Add "API Documentation" card to Settings General tab
+- [ ] Link to `/api/v1/docs` (opens in new tab)
+- [ ] Dark mode compatible styling
+- [ ] Update user guide if API/integration section exists
+- [ ] PR opened (#?)
+- [ ] CI passing
+- [ ] PR merged
+
+### Issue #344 -- Audit and update user guide for current features
+- [ ] Audit provider documentation (all 10 providers listed)
+- [ ] Audit platform profiles documentation
+- [ ] Audit scanner behavior documentation
+- [ ] Audit image management documentation
+- [ ] Audit server connections documentation
+- [ ] Audit rule engine documentation
+- [ ] Audit automation documentation
+- [ ] Audit settings documentation
+- [ ] Verify OOBE steps match current implementation
+- [ ] Update `web/templates/guide.templ`
+- [ ] PR opened (#?)
+- [ ] CI passing
+- [ ] PR merged
+
+### Issue #345 -- Audit and update developer documentation and wiki
+- [ ] Audit Architecture wiki page
+- [ ] Audit Developer Guide wiki page
+- [ ] Audit Contributing wiki page
+- [ ] Audit `docs/dev-setup.md`
+- [ ] Audit `CLAUDE.md` for accuracy
+- [ ] Push wiki updates
+- [ ] PR opened (#?) for repo file changes
+- [ ] CI passing
+- [ ] PR merged
+
+### Issue #346 -- Post-OOBE guided tour with tooltip walkthrough
+- [ ] Evaluate and vendor Driver.js (~5KB gzip, MIT, zero deps)
+- [ ] Create tour configuration (5-8 steps covering key UI elements)
+- [ ] Implement auto-trigger after OOBE completion
+- [ ] Implement manual restart from user guide
+- [ ] Dark mode styling
+- [ ] Cache-bust vendored assets via StaticAssets
+- [ ] Manual testing: OOBE -> tour -> dismissal -> no re-trigger
+- [ ] PR opened (#?)
+- [ ] CI passing
+- [ ] PR merged
+- [ ] Docs updated
+
+## Worktrees
+
+| Directory | Branch | Issue | Status |
+|-----------|--------|-------|--------|
+| stillwater-343 | feat/343-openapi-settings | #343 | pending |
+| stillwater-344 | feat/344-user-guide-audit | #344 | pending |
+| stillwater-345 | feat/345-developer-docs-audit | #345 | pending |
+| stillwater-346 | feat/346-guided-tour | #346 | pending |
+
+## UAT / Merge Order
+
+All PRs are independent. Merge order does not matter, but a suggested sequence:
+
+1. PR for #343 (base: main) -- smallest change, quick win
+2. PR for #344 (base: main) -- user guide audit
+3. PR for #345 (base: main) -- developer docs audit
+4. PR for #346 (base: main) -- guided tour (largest scope)
+
+## New Dependencies
+
+- [Driver.js](https://driverjs.com/) v1.x -- lightweight tooltip tour library (~5KB gzip, MIT license, zero dependencies). Vendored into `web/static/js/` and `web/static/css/` per project conventions.
+
+## Wiki Pages Affected
+
+- [Architecture](https://github.com/sydlexius/stillwater/wiki/Architecture) -- updated during #345
+- [Developer Guide](https://github.com/sydlexius/stillwater/wiki/Developer-Guide) -- updated during #345
+- [Contributing](https://github.com/sydlexius/stillwater/wiki/Contributing) -- updated during #345
+- User-facing wiki pages -- updated during #344 if applicable
+
+## Notes
+
+- 2026-03-02: Milestone created. OpenAPI docs already exist at `/api/v1/docs` (Scalar API Reference); this milestone adds discoverability from within the app.
+- 2026-03-02: Driver.js chosen over Shepherd.js for guided tour due to smaller bundle size (5KB vs 25KB) and zero dependencies, aligning with the project's minimal JS philosophy.
+- 2026-03-02: User guide audit scope covers all features added since the guide was last updated, including: Genius, Spotify, Deezer, DuckDuckGo providers; scraper configuration; rule engine; MusicBrainz mirror support; image cropping; API tokens.


### PR DESCRIPTION
## Summary

- Add `docs/plans/m31-plan.md` for Milestone 31 (v0.31.0 -- Provider Pipeline & Scraping)
- Add `docs/plans/m32-plan.md` for Milestone 32 (v0.32.0 -- Documentation & Guided Tour)

### Milestone 31 Issues
- #339: Convert Last.fm provider from API to web scraper (includes Web Image Search)
- #340: Add Wikidata as image source via Wikimedia Commons
- #341: Add Wikipedia as metadata provider via MediaWiki API
- #342: Optimize fallback provider call strategy in orchestrator

### Milestone 32 Issues
- #343: Add OpenAPI documentation reference to Settings page
- #344: Audit and update user guide for current features
- #345: Audit and update developer documentation and wiki
- #346: Post-OOBE guided tour with tooltip walkthrough

### Existing Issue Updated
- #322: Scoped in provider ID population and URL enrichment (Section 7)

## Test plan

- [ ] Plan files render correctly in GitHub markdown
- [ ] Issue cross-references resolve correctly
- [ ] No stale references to non-existent issues

## Wiki update checklist
- [ ] Does this PR add, remove, or change a provider, event type, or core interface? **No** (plan files only)
- [ ] Does this PR change linting, hooks, test patterns, or contribution workflow? **No**
- [ ] Does this PR add a package, change the tech stack, or alter a design principle? **No**
- [ ] Does this PR change user-facing behavior, settings, or setup? **No**

Generated with [Claude Code](https://claude.com/claude-code)