### PR TITLE
feat: import Emby/Jellyfin metadata fields during library scan

### DIFF
--- a/docs/plans/m27-plan.md
+++ b/docs/plans/m27-plan.md
@@ -30,13 +30,14 @@ where only push direction works but pull does not.
 ## Checklist
 
 ### Issue #230 -- Emby/Jellyfin metadata not imported during library populate
-- [ ] Expand `ArtistItem` struct in `emby/types.go` (Overview, Genres, PremiereDate, EndDate)
-- [ ] Update `GetArtists()` query fields in `emby/client.go`
-- [ ] Update `populateFromEmbyCtx()` in `handlers_connection_library.go`
-- [ ] Mirror changes in `jellyfin/types.go` and `jellyfin/client.go`
-- [ ] Update `populateFromJellyfinCtx()` in `handlers_connection_library.go`
-- [ ] Investigate additional fields (Tags, SortName) from real server data
-- [ ] Tests
+- [x] Expand `ArtistItem` struct in `emby/types.go` (Overview, Genres, Tags, SortName, PremiereDate, EndDate)
+- [x] Update `GetArtists()` query fields in `emby/client.go`
+- [x] Update `populateFromEmbyCtx()` in `handlers_connection_library.go`
+- [x] Mirror changes in `jellyfin/types.go` and `jellyfin/client.go`
+- [x] Update `populateFromJellyfinCtx()` in `handlers_connection_library.go`
+- [x] Investigate additional fields (Tags, SortName) from real server data
+- [x] Switch from `/Artists` to `/Artists/AlbumArtists` endpoint (matches folder structure)
+- [x] Tests
 - [ ] PR opened (#?)
 - [ ] CI passing
 - [ ] PR merged
@@ -93,3 +94,20 @@ Session 2 (platform state + delete):
 - Jellyfin API uses the same endpoint pattern
 - Import policy: never overwrite existing local images (user changes take priority)
 - `delete()` HTTP helper needed because only `get()` and `post()` exist in current clients
+
+### #230 investigation findings (2026-03-02)
+
+- Switched from `/Artists` to `/Artists/AlbumArtists` endpoint. AlbumArtists matches
+  folder structure and excludes featured/track-only artists.
+- The AlbumArtists list endpoint returns Overview when present but does not return
+  Tags, PremiereDate, or EndDate even when requested via the Fields parameter.
+  Full metadata is only available via per-item queries (`/Users/{userId}/Items/{itemId}`).
+- Genres from the list endpoint are aggregated from audio file tags (child items),
+  not from the artist item's own metadata. This is still useful data.
+- Emby's NFO reader may not map `<biography>` to Overview for artist items, or
+  requires a manual metadata refresh to pick up NFO data for existing artists.
+- NFO date fields (born, formed, died, disbanded) often contain free-text strings
+  like "2006 in Cardiff, CA" which Emby cannot parse as dates (expects yyyy-MM-dd).
+- Follow-up idea: add a tooltip or info indicator on the Platform Profile page
+  showing which metadata fields can be written to each platform (Emby, Jellyfin, Kodi).
+- #355 opened for date format normalization (free-text dates silently dropped by Emby).

--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -487,11 +487,20 @@ func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, l
 				}
 			}
 
+			sortName := item.Name
+			if item.SortName != "" {
+				sortName = item.SortName
+			}
 			a := &artist.Artist{
 				Name:          item.Name,
-				SortName:      item.Name,
+				SortName:      sortName,
 				MusicBrainzID: mbid,
 				LibraryID:     lib.ID,
+				Biography:     item.Overview,
+				Genres:        item.Genres,
+				Styles:        item.Tags,
+				Formed:        item.PremiereDate,
+				Disbanded:     item.EndDate,
 			}
 			if err := r.artistService.Create(ctx, a); err != nil {
 				r.logger.Warn("creating artist from emby", "name", item.Name, "error", err)
@@ -546,11 +555,20 @@ func (r *Router) populateFromJellyfinCtx(ctx context.Context, client *jellyfin.C
 				}
 			}
 
+			sortName := item.Name
+			if item.SortName != "" {
+				sortName = item.SortName
+			}
 			a := &artist.Artist{
 				Name:          item.Name,
-				SortName:      item.Name,
+				SortName:      sortName,
 				MusicBrainzID: mbid,
 				LibraryID:     lib.ID,
+				Biography:     item.Overview,
+				Genres:        item.Genres,
+				Styles:        item.Tags,
+				Formed:        item.PremiereDate,
+				Disbanded:     item.EndDate,
 			}
 			if err := r.artistService.Create(ctx, a); err != nil {
 				r.logger.Warn("creating artist from jellyfin", "name", item.Name, "error", err)

--- a/internal/api/handlers_connection_library_test.go
+++ b/internal/api/handlers_connection_library_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
+	"github.com/sydlexius/stillwater/internal/connection/emby"
+	"github.com/sydlexius/stillwater/internal/connection/jellyfin"
 	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/library"
@@ -263,6 +265,154 @@ func TestScheduleOpCleanup_SkipsNewerOp(t *testing.T) {
 	r.libraryOpsMu.Unlock()
 	if !exists {
 		t.Error("expected newer operation to be preserved, but it was deleted")
+	}
+}
+
+func TestPopulateFromEmby_ImportsMetadataFields(t *testing.T) {
+	// Stand up a fake Emby server returning one artist with full metadata.
+	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"Items":[{
+				"Name":"Radiohead",
+				"SortName":"Radiohead, The",
+				"Id":"emby-001",
+				"Path":"/music/Radiohead",
+				"Overview":"English rock band formed in Abingdon.",
+				"Genres":["Rock","Alternative"],
+				"Tags":["Experimental","Art Rock"],
+				"PremiereDate":"1985-01-01T00:00:00.0000000Z",
+				"EndDate":"",
+				"ProviderIds":{"MusicBrainzArtist":"a74b1b7f-71a5-4011-9441-d0b5e4122711"},
+				"ImageTags":{"Primary":"abc"}
+			}],
+			"TotalRecordCount":1
+		}`))
+	}))
+	defer embySrv.Close()
+
+	r := testRouterForLibraryOps(t)
+	ctx := context.Background()
+
+	// Create a library to populate into.
+	lib := &library.Library{
+		Name:       "Test Music",
+		Type:       library.TypeRegular,
+		Source:     connection.TypeEmby,
+		ExternalID: "emby-lib-1",
+	}
+	if err := r.libraryService.Create(ctx, lib); err != nil {
+		t.Fatalf("creating library: %v", err)
+	}
+
+	// Run populate using the fake Emby server.
+	client := emby.NewWithHTTPClient(embySrv.URL, "key", embySrv.Client(),
+		slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+	var result populateResult
+	if err := r.populateFromEmbyCtx(ctx, client, lib, &result); err != nil {
+		t.Fatalf("populateFromEmbyCtx: %v", err)
+	}
+
+	if result.Created != 1 {
+		t.Fatalf("created = %d, want 1", result.Created)
+	}
+
+	// Retrieve the artist and verify metadata was mapped.
+	a, err := r.artistService.GetByNameAndLibrary(ctx, "Radiohead", lib.ID)
+	if err != nil {
+		t.Fatalf("looking up artist: %v", err)
+	}
+	if a == nil {
+		t.Fatal("artist not found after populate")
+	}
+	if a.SortName != "Radiohead, The" {
+		t.Errorf("SortName = %q, want %q", a.SortName, "Radiohead, The")
+	}
+	if a.Biography != "English rock band formed in Abingdon." {
+		t.Errorf("Biography = %q, want expected text", a.Biography)
+	}
+	if len(a.Genres) != 2 || a.Genres[0] != "Rock" {
+		t.Errorf("Genres = %v, want [Rock Alternative]", a.Genres)
+	}
+	if len(a.Styles) != 2 || a.Styles[0] != "Experimental" {
+		t.Errorf("Styles = %v, want [Experimental Art Rock]", a.Styles)
+	}
+	if a.Formed != "1985-01-01T00:00:00.0000000Z" {
+		t.Errorf("Formed = %q, want 1985 date", a.Formed)
+	}
+	if a.Disbanded != "" {
+		t.Errorf("Disbanded = %q, want empty", a.Disbanded)
+	}
+	if a.MusicBrainzID != "a74b1b7f-71a5-4011-9441-d0b5e4122711" {
+		t.Errorf("MusicBrainzID = %q, want expected MBID", a.MusicBrainzID)
+	}
+}
+
+func TestPopulateFromJellyfin_ImportsMetadataFields(t *testing.T) {
+	// Stand up a fake Jellyfin server returning one artist with full metadata.
+	jfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"Items":[{
+				"Name":"Bjork",
+				"SortName":"Bjork",
+				"Id":"jf-001",
+				"Path":"/music/Bjork",
+				"Overview":"Icelandic singer and songwriter.",
+				"Genres":["Electronic","Art Pop"],
+				"Tags":["Avant-Garde"],
+				"PremiereDate":"1965-11-21T00:00:00.0000000Z",
+				"EndDate":"",
+				"ProviderIds":{"MusicBrainzArtist":"87c5dedd-371d-4571-9e1c-45f6e0ed3fce"},
+				"ImageTags":{}
+			}],
+			"TotalRecordCount":1
+		}`))
+	}))
+	defer jfSrv.Close()
+
+	r := testRouterForLibraryOps(t)
+	ctx := context.Background()
+
+	lib := &library.Library{
+		Name:       "Test Music JF",
+		Type:       library.TypeRegular,
+		Source:     connection.TypeJellyfin,
+		ExternalID: "jf-lib-1",
+	}
+	if err := r.libraryService.Create(ctx, lib); err != nil {
+		t.Fatalf("creating library: %v", err)
+	}
+
+	client := jellyfin.NewWithHTTPClient(jfSrv.URL, "key", jfSrv.Client(),
+		slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+	var result populateResult
+	if err := r.populateFromJellyfinCtx(ctx, client, lib, &result); err != nil {
+		t.Fatalf("populateFromJellyfinCtx: %v", err)
+	}
+
+	if result.Created != 1 {
+		t.Fatalf("created = %d, want 1", result.Created)
+	}
+
+	a, err := r.artistService.GetByNameAndLibrary(ctx, "Bjork", lib.ID)
+	if err != nil {
+		t.Fatalf("looking up artist: %v", err)
+	}
+	if a == nil {
+		t.Fatal("artist not found after populate")
+	}
+	if a.Biography != "Icelandic singer and songwriter." {
+		t.Errorf("Biography = %q, want expected text", a.Biography)
+	}
+	if len(a.Genres) != 2 || a.Genres[0] != "Electronic" {
+		t.Errorf("Genres = %v, want [Electronic Art Pop]", a.Genres)
+	}
+	if len(a.Styles) != 1 || a.Styles[0] != "Avant-Garde" {
+		t.Errorf("Styles = %v, want [Avant-Garde]", a.Styles)
+	}
+	if a.Formed != "1965-11-21T00:00:00.0000000Z" {
+		t.Errorf("Formed = %q, want 1965 date", a.Formed)
 	}
 }
 

--- a/internal/connection/emby/client.go
+++ b/internal/connection/emby/client.go
@@ -79,9 +79,9 @@ func (c *Client) CheckNFOWriterEnabled(ctx context.Context) (bool, string, error
 	return false, "", nil
 }
 
-// GetArtists returns artists from a specific library (by parent ID) with pagination.
+// GetArtists returns album artists from a specific library (by parent ID) with pagination.
 func (c *Client) GetArtists(ctx context.Context, libraryID string, startIndex, limit int) (*ItemsResponse, error) {
-	path := fmt.Sprintf("/Artists?ParentId=%s&StartIndex=%d&Limit=%d&Recursive=true&Fields=ImageTags", libraryID, startIndex, limit)
+	path := fmt.Sprintf("/Artists/AlbumArtists?ParentId=%s&StartIndex=%d&Limit=%d&Recursive=true&Fields=ImageTags,Overview,Genres,Tags,SortName,PremiereDate,EndDate", libraryID, startIndex, limit)
 	var resp ItemsResponse
 	if err := c.get(ctx, path, &resp); err != nil {
 		return nil, fmt.Errorf("getting artists: %w", err)

--- a/internal/connection/emby/client_test.go
+++ b/internal/connection/emby/client_test.go
@@ -72,12 +72,16 @@ func TestGetMusicLibraries(t *testing.T) {
 
 func TestGetArtists(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/Artists" {
+		if r.URL.Path != "/Artists/AlbumArtists" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
 		parentID := r.URL.Query().Get("ParentId")
 		if parentID != "lib-001" {
 			t.Errorf("ParentId = %q, want lib-001", parentID)
+		}
+		fields := r.URL.Query().Get("Fields")
+		if fields != "ImageTags,Overview,Genres,Tags,SortName,PremiereDate,EndDate" {
+			t.Errorf("Fields = %q, want expanded field list", fields)
 		}
 		http.ServeFile(w, r, "testdata/artists.json")
 	}))
@@ -95,11 +99,31 @@ func TestGetArtists(t *testing.T) {
 	if len(resp.Items) != 2 {
 		t.Fatalf("got %d items, want 2", len(resp.Items))
 	}
-	if resp.Items[0].Name != "Radiohead" {
-		t.Errorf("first artist = %q, want Radiohead", resp.Items[0].Name)
+
+	rh := resp.Items[0]
+	if rh.Name != "Radiohead" {
+		t.Errorf("first artist = %q, want Radiohead", rh.Name)
 	}
-	if resp.Items[0].ProviderIDs.MusicBrainzArtist != "a74b1b7f-71a5-4011-9441-d0b5e4122711" {
-		t.Errorf("unexpected MBID: %s", resp.Items[0].ProviderIDs.MusicBrainzArtist)
+	if rh.SortName != "Radiohead" {
+		t.Errorf("SortName = %q, want Radiohead", rh.SortName)
+	}
+	if rh.ProviderIDs.MusicBrainzArtist != "a74b1b7f-71a5-4011-9441-d0b5e4122711" {
+		t.Errorf("unexpected MBID: %s", rh.ProviderIDs.MusicBrainzArtist)
+	}
+	if rh.Overview != "English rock band formed in 1985." {
+		t.Errorf("Overview = %q, want biography text", rh.Overview)
+	}
+	if len(rh.Genres) != 2 || rh.Genres[0] != "Rock" {
+		t.Errorf("Genres = %v, want [Rock Alternative]", rh.Genres)
+	}
+	if len(rh.Tags) != 2 || rh.Tags[0] != "Experimental" {
+		t.Errorf("Tags = %v, want [Experimental Art Rock]", rh.Tags)
+	}
+	if rh.PremiereDate != "1985-01-01T00:00:00.0000000Z" {
+		t.Errorf("PremiereDate = %q, want 1985 date", rh.PremiereDate)
+	}
+	if rh.ImageTags["Primary"] != "abc123" {
+		t.Errorf("ImageTags[Primary] = %q, want abc123", rh.ImageTags["Primary"])
 	}
 }
 

--- a/internal/connection/emby/testdata/artists.json
+++ b/internal/connection/emby/testdata/artists.json
@@ -2,19 +2,35 @@
   "Items": [
     {
       "Name": "Radiohead",
+      "SortName": "Radiohead",
       "Id": "emby-001",
       "Path": "/music/Radiohead",
+      "Overview": "English rock band formed in 1985.",
+      "Genres": ["Rock", "Alternative"],
+      "Tags": ["Experimental", "Art Rock"],
+      "PremiereDate": "1985-01-01T00:00:00.0000000Z",
+      "EndDate": "",
       "ProviderIds": {
         "MusicBrainzArtist": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
+      },
+      "ImageTags": {
+        "Primary": "abc123"
       }
     },
     {
       "Name": "Bjork",
+      "SortName": "Bjork",
       "Id": "emby-002",
       "Path": "/music/Bjork",
+      "Overview": "Icelandic singer and songwriter.",
+      "Genres": ["Electronic", "Art Pop"],
+      "Tags": ["Avant-Garde"],
+      "PremiereDate": "1965-11-21T00:00:00.0000000Z",
+      "EndDate": "",
       "ProviderIds": {
         "MusicBrainzArtist": "87c5dedd-371d-4571-9e1c-45f6e0ed3fce"
-      }
+      },
+      "ImageTags": {}
     }
   ],
   "TotalRecordCount": 2

--- a/internal/connection/emby/types.go
+++ b/internal/connection/emby/types.go
@@ -21,13 +21,19 @@ type VirtualFolder struct {
 	LibraryOptions LibraryOptions `json:"LibraryOptions"`
 }
 
-// ArtistItem represents an artist from the Items endpoint.
+// ArtistItem represents an artist from the AlbumArtists endpoint.
 type ArtistItem struct {
-	Name        string            `json:"Name"`
-	ID          string            `json:"Id"`
-	Path        string            `json:"Path"`
-	ProviderIDs ProviderIDs       `json:"ProviderIds"`
-	ImageTags   map[string]string `json:"ImageTags"`
+	Name         string            `json:"Name"`
+	SortName     string            `json:"SortName"`
+	ID           string            `json:"Id"`
+	Path         string            `json:"Path"`
+	Overview     string            `json:"Overview"`
+	Genres       []string          `json:"Genres"`
+	Tags         []string          `json:"Tags"`
+	PremiereDate string            `json:"PremiereDate"`
+	EndDate      string            `json:"EndDate"`
+	ProviderIDs  ProviderIDs       `json:"ProviderIds"`
+	ImageTags    map[string]string `json:"ImageTags"`
 }
 
 // ProviderIDs contains external provider identifiers.

--- a/internal/connection/jellyfin/client.go
+++ b/internal/connection/jellyfin/client.go
@@ -79,9 +79,9 @@ func (c *Client) CheckNFOWriterEnabled(ctx context.Context) (bool, string, error
 	return false, "", nil
 }
 
-// GetArtists returns artists from a specific library with pagination.
+// GetArtists returns album artists from a specific library with pagination.
 func (c *Client) GetArtists(ctx context.Context, libraryID string, startIndex, limit int) (*ItemsResponse, error) {
-	path := fmt.Sprintf("/Artists?ParentId=%s&StartIndex=%d&Limit=%d&Recursive=true&Fields=ImageTags", libraryID, startIndex, limit)
+	path := fmt.Sprintf("/Artists/AlbumArtists?ParentId=%s&StartIndex=%d&Limit=%d&Recursive=true&Fields=ImageTags,Overview,Genres,Tags,SortName,PremiereDate,EndDate", libraryID, startIndex, limit)
 	var resp ItemsResponse
 	if err := c.get(ctx, path, &resp); err != nil {
 		return nil, fmt.Errorf("getting artists: %w", err)

--- a/internal/connection/jellyfin/client_test.go
+++ b/internal/connection/jellyfin/client_test.go
@@ -89,9 +89,28 @@ func TestGetMusicLibraries(t *testing.T) {
 
 func TestGetArtists(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Artists/AlbumArtists" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		fields := r.URL.Query().Get("Fields")
+		if fields != "ImageTags,Overview,Genres,Tags,SortName,PremiereDate,EndDate" {
+			t.Errorf("Fields = %q, want expanded field list", fields)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
-			"Items":[{"Name":"Radiohead","Id":"jf-001","Path":"/music/Radiohead","ProviderIds":{"MusicBrainzArtist":"mbid-001"}}],
+			"Items":[{
+				"Name":"Radiohead",
+				"SortName":"Radiohead",
+				"Id":"jf-001",
+				"Path":"/music/Radiohead",
+				"Overview":"English rock band formed in 1985.",
+				"Genres":["Rock","Alternative"],
+				"Tags":["Experimental"],
+				"PremiereDate":"1985-01-01T00:00:00.0000000Z",
+				"EndDate":"",
+				"ProviderIds":{"MusicBrainzArtist":"mbid-001"},
+				"ImageTags":{"Primary":"tag1"}
+			}],
 			"TotalRecordCount":1
 		}`))
 	}))
@@ -104,6 +123,29 @@ func TestGetArtists(t *testing.T) {
 	}
 	if resp.TotalRecordCount != 1 {
 		t.Errorf("TotalRecordCount = %d, want 1", resp.TotalRecordCount)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("got %d items, want 1", len(resp.Items))
+	}
+
+	rh := resp.Items[0]
+	if rh.Name != "Radiohead" {
+		t.Errorf("Name = %q, want Radiohead", rh.Name)
+	}
+	if rh.SortName != "Radiohead" {
+		t.Errorf("SortName = %q, want Radiohead", rh.SortName)
+	}
+	if rh.Overview != "English rock band formed in 1985." {
+		t.Errorf("Overview = %q, want biography text", rh.Overview)
+	}
+	if len(rh.Genres) != 2 || rh.Genres[0] != "Rock" {
+		t.Errorf("Genres = %v, want [Rock Alternative]", rh.Genres)
+	}
+	if len(rh.Tags) != 1 || rh.Tags[0] != "Experimental" {
+		t.Errorf("Tags = %v, want [Experimental]", rh.Tags)
+	}
+	if rh.PremiereDate != "1985-01-01T00:00:00.0000000Z" {
+		t.Errorf("PremiereDate = %q, want 1985 date", rh.PremiereDate)
 	}
 }
 

--- a/internal/connection/jellyfin/types.go
+++ b/internal/connection/jellyfin/types.go
@@ -21,13 +21,19 @@ type VirtualFolder struct {
 	LibraryOptions LibraryOptions `json:"LibraryOptions"`
 }
 
-// ArtistItem represents an artist from the Items endpoint.
+// ArtistItem represents an artist from the AlbumArtists endpoint.
 type ArtistItem struct {
-	Name        string            `json:"Name"`
-	ID          string            `json:"Id"`
-	Path        string            `json:"Path"`
-	ProviderIDs ProviderIDs       `json:"ProviderIds"`
-	ImageTags   map[string]string `json:"ImageTags"`
+	Name         string            `json:"Name"`
+	SortName     string            `json:"SortName"`
+	ID           string            `json:"Id"`
+	Path         string            `json:"Path"`
+	Overview     string            `json:"Overview"`
+	Genres       []string          `json:"Genres"`
+	Tags         []string          `json:"Tags"`
+	PremiereDate string            `json:"PremiereDate"`
+	EndDate      string            `json:"EndDate"`
+	ProviderIDs  ProviderIDs       `json:"ProviderIds"`
+	ImageTags    map[string]string `json:"ImageTags"`
 }
 
 // ProviderIDs contains external provider identifiers.


### PR DESCRIPTION
## Summary

- Expand Emby and Jellyfin client `ArtistItem` structs with `Overview`, `Genres`, `Tags`, `SortName`, `PremiereDate`, and `EndDate` fields
- Switch both clients from `/Artists` to `/Artists/AlbumArtists` and request the expanded `Fields` query parameter
- Map new fields in `populateFromEmbyCtx` and `populateFromJellyfinCtx`: Overview->Biography, Genres->Genres, Tags->Styles, SortName->SortName (when non-empty), PremiereDate->Formed, EndDate->Disbanded

## UAT Findings

- The AlbumArtists list endpoint returns `Overview` when present but does NOT return `Tags`, `PremiereDate`, or `EndDate`. Full metadata requires per-item queries (future enhancement tracked in backlog).
- `Genres` from the list endpoint are aggregated from audio file tags, not artist-level metadata. Still useful for populating the Genres field.
- Free-text date values (e.g., "2006 in Cardiff, CA") are silently dropped by Emby. Tracked in #355.
- Only 1/69 artists had `Overview` populated in UAT -- most metadata comes from NFO files or external providers, not from Emby's own database.

## Test plan

- [x] `go test ./internal/connection/emby/...` -- client parses expanded fields from fixture
- [x] `go test ./internal/connection/jellyfin/...` -- client parses expanded fields
- [x] `go test ./internal/api/...` -- handler-level tests verify Emby and Jellyfin populate paths map all new fields correctly
- [x] Docker UAT confirmed genres import correctly from live Emby library

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)