### PR TITLE
docs: update milestone plans with new issues and remove PR tracking

### DIFF
--- a/docs/plans/m27-plan.md
+++ b/docs/plans/m27-plan.md
@@ -8,9 +8,9 @@ where only push direction works but pull does not.
 
 ## Acceptance Criteria
 
-- [ ] Library populate imports biography, genres, and dates from Emby/Jellyfin
+- [x] Library populate imports biography, genres, and dates from Emby/Jellyfin
 - [ ] Library populate downloads Primary/Backdrop/Logo/Banner images from platforms
-- [ ] Image download skips if local image already exists
+- [x] Image download skips if local image already exists
 - [ ] Artist detail page shows platform state with side-by-side comparison
 - [ ] Users can delete individual images from Emby/Jellyfin via the UI
 - [ ] Both Emby and Jellyfin clients support all new methods
@@ -21,9 +21,11 @@ where only push direction works but pull does not.
 #230 (metadata import) --\
                           +--> #232 (view platform state) --> #233 (delete images)
 #231 (image import)   --/
+  \--> #357 (multiple backdrops)
 ```
 
 #230 and #231 are independent of each other.
+#231 blocks #357 (backdrops use the image download infrastructure from #231).
 #232 depends on #230 and #231 (uses expanded fields and image methods).
 #233 depends on #232 (delete button lives in the platform state view).
 
@@ -38,21 +40,27 @@ where only push direction works but pull does not.
 - [x] Investigate additional fields (Tags, SortName) from real server data
 - [x] Switch from `/Artists` to `/Artists/AlbumArtists` endpoint (matches folder structure)
 - [x] Tests
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
+- [x] Done (merged)
 
 ### Issue #231 -- Emby/Jellyfin images not downloaded during import
-- [ ] Add `GetArtistImage(ctx, artistID, imageType) ([]byte, string, error)` to Emby client
-- [ ] Add same method to Jellyfin client
-- [ ] Download images during populate for each artist
-- [ ] Save using active naming config via `image.Save()`
-- [ ] Skip download if local image already exists
-- [ ] Update artist image flags in database after download
+- [x] Add `GetArtistImage(ctx, artistID, imageType) ([]byte, string, error)` to Emby client
+- [x] Add same method to Jellyfin client
+- [x] Download images during populate for each artist
+- [x] Save using active naming config via `image.Save()`
+- [x] Skip download if local image already exists
+- [x] Update artist image flags in database after download
+- [x] Add image cache directory fallback for artists without filesystem paths
+- [x] Backfill MusicBrainzID from platform ProviderIds onto existing artists
+- [x] Tests
+- [ ] Done (in review)
+
+### Issue #357 -- Support multiple backdrop images from Emby/Jellyfin
+- [ ] Add `BackdropImageTags []string` to `ArtistItem` in both `emby/types.go` and `jellyfin/types.go`
+- [ ] Update `downloadPlatformImages` to handle `BackdropImageTags` separately from `ImageTags`
+- [ ] Construct indexed URLs (`/Images/Backdrop/0`, `/Images/Backdrop/1`, etc.)
+- [ ] Save with correct naming (fanart.jpg, fanart1.jpg, fanart2.jpg, ...)
+- [ ] Update `FanartCount` on artist records
 - [ ] Tests
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #232 -- View platform state on artist detail page
 - [ ] Add `GetArtistDetail(ctx, artistID) (*ArtistDetail, error)` to Emby client
@@ -62,9 +70,6 @@ where only push direction works but pull does not.
 - [ ] Visual indicators for mismatched fields
 - [ ] Push/pull action buttons per field
 - [ ] Tests
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #233 -- Delete images from Emby/Jellyfin
 - [ ] Add `delete()` HTTP helper to Emby client (alongside `get()` and `post()`)
@@ -74,19 +79,19 @@ where only push direction works but pull does not.
 - [ ] Add `DELETE /api/v1/artists/{id}/push/images/{type}` endpoint
 - [ ] Add delete button to platform state view from #232
 - [ ] Tests
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ## UAT / Merge Order
 
 Session 1 (import):
-1. PR for #230 (base: main) -- metadata import
-2. PR for #231 (base: main) -- image import
+1. #230 -- metadata import -- MERGED
+2. #231 -- image import (Primary, Logo, Banner; no backdrops)
 
-Session 2 (platform state + delete):
-3. PR for #232 (base: main, after #230 and #231 merge)
-4. PR for #233 (base: main or stacked on #232)
+Session 2 (backdrops):
+3. #357 -- multiple backdrop images (after #231 merges)
+
+Session 3 (platform state + delete):
+4. #232 -- view platform state (after #230 and #231 merge)
+5. #233 -- delete platform images (after #232)
 
 ## Notes
 
@@ -94,6 +99,7 @@ Session 2 (platform state + delete):
 - Jellyfin API uses the same endpoint pattern
 - Import policy: never overwrite existing local images (user changes take priority)
 - `delete()` HTTP helper needed because only `get()` and `post()` exist in current clients
+- Backdrops are in `BackdropImageTags` (array), not `ImageTags` (map) -- discovered during #231 UAT
 
 ### #230 investigation findings (2026-03-02)
 
@@ -111,3 +117,13 @@ Session 2 (platform state + delete):
 - Follow-up idea: add a tooltip or info indicator on the Platform Profile page
   showing which metadata fields can be written to each platform (Emby, Jellyfin, Kodi).
 - #355 opened for date format normalization (free-text dates silently dropped by Emby).
+
+### #231 implementation findings (2026-03-02)
+
+- Emby does not return a `Path` field for artists via the AlbumArtists endpoint.
+  All Emby-sourced artists have empty `Path`. Image cache dir is the fallback.
+- `ProviderIds` must be explicitly requested in `Fields=` query parameter.
+- MBID backfill added: when an existing artist lacks an MBID but the platform provides
+  one, the local record is updated during populate.
+- Image cache directory (`/data/cache/images/{artistID}/`) created automatically when
+  `artist.Path` is empty. Uses `imageDir(a)` helper throughout handlers.

--- a/docs/plans/m28-plan.md
+++ b/docs/plans/m28-plan.md
@@ -49,9 +49,6 @@ rule execution.
 - [ ] Collapsible group headers with count badges
 - [ ] Default grouping: artist then rule category
 - [ ] Tests
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #286 -- Bliss-like actionable fix options on Notifications page
 - [ ] Collapsible inline fix panels below each violation row
@@ -61,9 +58,6 @@ rule execution.
 - [ ] Fix recommendation badges with highest-confidence option
 - [ ] Global "Fix All" button for bulk application
 - [ ] Tests
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #287 -- Image deduplication rule using perceptual hashing
 - [ ] Hashing module in `internal/image/` (SHA-256 exact + pHash/dHash perceptual)
@@ -72,9 +66,6 @@ rule execution.
 - [ ] Scope options: per-artist, per-library, or global
 - [ ] Violation display with thumbnails, similarity score, and file paths
 - [ ] Tests
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 - [ ] Docs updated (Architecture wiki: new rule type)
 
 ### Issue #313 -- Artist directory rename rule (directory_name_mismatch)
@@ -84,9 +75,6 @@ rule execution.
 - [ ] Safety: verify no file locks, atomic rename with copy+delete fallback
 - [ ] Update all internal database references to old path
 - [ ] Tests
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 - [ ] Docs updated (Architecture wiki: new rule type)
 
 ### Issue #314 -- Per-artist Run Rules button on artist detail page
@@ -96,9 +84,6 @@ rule execution.
 - [ ] Spinner/progress indicator while running
 - [ ] Result count and link to filtered Notifications view
 - [ ] Tests
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #353 -- Remove redundant Disabled option from rule automation mode dropdown
 - [ ] Remove `AutomationModeDisabled` constant from `internal/rule/model.go`
@@ -107,9 +92,6 @@ rule execution.
 - [ ] Migration to convert existing `automation_mode = 'disabled'` rows
 - [ ] Update tests referencing AutomationModeDisabled
 - [ ] Add test: PATCH with `automation_mode: "disabled"` returns 400
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ## UAT / Merge Order
 

--- a/docs/plans/m29-plan.md
+++ b/docs/plans/m29-plan.md
@@ -32,9 +32,6 @@ release note quality with grouped, user-friendly summaries.
 - [ ] Auto-generate release notes from PR labels/commit messages
 - [ ] CHANGELOG.md generation or accumulation strategy
 - [ ] Tests (workflow syntax validation, dry-run)
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ## UAT / Merge Order
 

--- a/docs/plans/m30-plan.md
+++ b/docs/plans/m30-plan.md
@@ -21,6 +21,7 @@ code reuse issues.
 - [ ] SQL migrations consolidated into single baseline file; fresh installs work cleanly
 - [ ] High-severity runtime safety issues (races, leaks, deadlocks) fixed
 - [ ] High-impact code duplication reduced (connection clients, handler params, body decoding)
+- [ ] Image caching system with settings UI; "degraded" concept removed
 
 ## Dependency Map
 
@@ -33,14 +34,14 @@ code reuse issues.
 #350 (SQL squash) -----------> independent, merge early (foundation)
 #351 (runtime safety) -------> independent audit + fixes
 #352 (refactoring audit) ----> independent audit + refactoring
+#360 (image caching) --------> depends on #352 (shared write path abstraction)
 ```
 
-All seven issues are independent -- no blocking relationships. #322 (universal editing)
-informs #321 (history) since history needs to track edits on newly-editable fields, but
-they can be implemented in parallel as long as history hooks are added to the existing
-`UpdateField`/`ClearField` paths which both issues share. #350 (SQL squash) should merge
-early since it touches the migration foundation. #351 and #352 are audit-style work that
-can proceed in any order.
+Most issues are independent. #322 (universal editing) informs #321 (history) since
+history needs to track edits on newly-editable fields. #350 (SQL squash) should merge
+early since it touches the migration foundation. #360 (image caching) benefits from
+#352 (refactoring) landing first since both touch image write paths and handler structure.
+#351 and #352 are audit-style work that can proceed in any order.
 
 ## Checklist
 
@@ -55,9 +56,6 @@ can proceed in any order.
 - [ ] Rollback action per change entry
 - [ ] Band member and provider ID change tracking
 - [ ] Tests
-- [ ] PR opened (#324)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #322 -- Make all metadata fields editable/fetchable and always visible
 - [ ] Extend `fieldColumnMap` with name, sort_name, disambiguation, musicbrainz_id, audiodb_id, discogs_id, wikidata_id, deezer_id
@@ -67,9 +65,6 @@ can proceed in any order.
 - [ ] Update artist detail template to always show all fields (not hidden when empty)
 - [ ] Provider fetch support for disambiguation (MusicBrainz), provider IDs (respective providers)
 - [ ] Tests
-- [ ] PR opened (#325)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #323 -- Run code analysis, document findings, and improve test coverage
 - [ ] Document current coverage numbers per package
@@ -78,18 +73,12 @@ can proceed in any order.
 - [ ] Add tests for auth, config, database, encryption packages
 - [ ] Improve filesystem and middleware coverage
 - [ ] Tests pass with race detector
-- [ ] PR opened (#326)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #349 -- Add sort controls to Artists page grid and table views
 - [ ] Sort dropdown in toolbar (name, sort_name, health_score, updated_at, created_at)
 - [ ] Asc/desc toggle button
 - [ ] Clickable column headers in table view
 - [ ] Handler test for sort/order param passthrough
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #350 -- Consolidate SQL migrations into single baseline file
 - [ ] Merge ALTER TABLE / CREATE TABLE from 002-012 into 001_initial.sql
@@ -97,9 +86,6 @@ can proceed in any order.
 - [ ] Verify goose handles existing databases gracefully
 - [ ] Fresh-start UAT (delete DB, restart, verify clean single-migration startup)
 - [ ] All existing tests pass with consolidated migration
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #351 -- Audit codebase for memory leaks, race conditions, deadlocks, and dead code
 - [ ] Fix watcher map race condition (lock released between reads)
@@ -111,9 +97,6 @@ can proceed in any order.
 - [ ] Fix router state accessed with inconsistent locking
 - [ ] Document medium-severity findings as follow-up issues
 - [ ] go test -race ./... passes
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #352 -- Audit and improve code reuse and maintainability
 - [ ] Extract shared BaseClient for connection clients (emby, jellyfin, lidarr)
@@ -121,24 +104,34 @@ can proceed in any order.
 - [ ] Extract DecodeBody helper for JSON/form body decoding
 - [ ] Document medium-impact findings (Phase 2) for follow-up
 - [ ] Tests
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
+
+### Issue #360 -- Image caching strategy for platform-sourced artists
+- [ ] Remove "degraded" concept (`IsDegraded()`, all UI references, conditional logic)
+- [ ] Add System settings tab (move Behavior and Logging from General)
+- [ ] Add Cache settings section with connection source cache and provider image cache
+- [ ] Unify image write path: local save + platform push via single abstraction
+- [ ] Image upload/replace pushes to connected platform automatically
+- [ ] Cache path defaults to `/data/cache/images`, configurable via settings
+- [ ] Connection source cache mandatory when no filesystem path
+- [ ] Provider image cache toggle-able with configurable size
+- [ ] Tests
 
 ## UAT / Merge Order
 
-1. PR for #350 (SQL squash) -- foundation change, merge first
-2. PR #326 for #323 (code analysis) -- no runtime changes
-3. PR for #351 (runtime safety) -- fixes across multiple packages
-4. PR for #352 (refactoring) -- structural improvements
-5. PR for #349 (artist sort) -- UI feature
-6. PR #325 for #322 (universal field editing) -- extends existing field system
-7. PR #324 for #321 (history tab) -- builds on final field set from #322
+1. #350 (SQL squash) -- foundation change, merge first
+2. #323 (code analysis) -- no runtime changes
+3. #351 (runtime safety) -- fixes across multiple packages
+4. #352 (refactoring) -- structural improvements
+5. #349 (artist sort) -- UI feature
+6. #322 (universal field editing) -- extends existing field system
+7. #321 (history tab) -- builds on final field set from #322
+8. #360 (image caching) -- after #352 refactoring lands
 
 ## Notes
 
-- 2026-03-01: Plan file created. Issues and PR numbers reserved; implementation PRs are not yet opened and will start as design/analysis docs only.
+- 2026-03-01: Plan file created.
 - 2026-03-02: Added #349 (artist sort), #350 (SQL squash), #351 (runtime safety), #352 (refactoring audit) to milestone scope.
+- 2026-03-02: Added #360 (image caching) to milestone scope. Depends on #352 for shared write path abstraction.
 - #321 is `scope: large` with `[mode: plan] [model: opus]`; #322 is `scope: medium` with `[mode: plan] [model: sonnet]`; #323 is `scope: medium` with `[mode: direct] [model: sonnet]`.
 - #349 is `scope: small` with `[mode: direct] [model: sonnet]`; #350 is `scope: medium` with `[mode: plan] [model: sonnet]`; #351 is `scope: medium` with `[mode: direct] [model: opus]`; #352 is `scope: medium` with `[mode: plan] [model: sonnet]`.
 - Existing `nfo_snapshots` table tracks full NFO XML; new `metadata_changes` table tracks individual field-level changes -- these are complementary, not replacements.

--- a/docs/plans/m31-plan.md
+++ b/docs/plans/m31-plan.md
@@ -33,9 +33,6 @@ Enhance the metadata provider pipeline with web scraping capabilities, new image
 - [ ] Add targeted image fetching (filter by needed image types)
 - [ ] Add debug logging for skipped provider calls
 - [ ] Tests (call count verification)
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #339 -- Convert Last.fm provider from API to web scraper
 - [ ] Add `goquery` dependency for HTML parsing
@@ -48,9 +45,6 @@ Enhance the metadata provider pipeline with web scraping capabilities, new image
 - [ ] Update OOBE UI (remove Last.fm API key step)
 - [ ] Update `providerRequiresKey()` in settings
 - [ ] Tests with mocked HTML responses (metadata + image search)
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #340 -- Add Wikidata as image source via Wikimedia Commons
 - [ ] Extend SPARQL query to fetch P18 (image) and P154 (logo)
@@ -58,9 +52,6 @@ Enhance the metadata provider pipeline with web scraping capabilities, new image
 - [ ] Update `GetImages()` to return thumb/logo from Commons
 - [ ] Add Wikidata to image field priorities (thumb, logo)
 - [ ] Tests with mocked SPARQL and Commons API responses
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #341 -- Add Wikipedia as metadata provider via MediaWiki API
 - [ ] Create `internal/provider/wikipedia/` package
@@ -70,9 +61,6 @@ Enhance the metadata provider pipeline with web scraping capabilities, new image
 - [ ] Register provider and add to field priorities
 - [ ] Update rate limiting, Settings UI, OOBE
 - [ ] Tests (infobox parser, API mocks, integration)
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ## Worktrees
 

--- a/docs/plans/m32-plan.md
+++ b/docs/plans/m32-plan.md
@@ -29,9 +29,6 @@ All four issues are independent and can be worked in parallel.
 - [ ] Link to `/api/v1/docs` (opens in new tab)
 - [ ] Dark mode compatible styling
 - [ ] Update user guide if API/integration section exists
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #344 -- Audit and update user guide for current features
 - [ ] Audit provider documentation (all 10 providers listed)
@@ -44,9 +41,6 @@ All four issues are independent and can be worked in parallel.
 - [ ] Audit settings documentation
 - [ ] Verify OOBE steps match current implementation
 - [ ] Update `web/templates/guide.templ`
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #345 -- Audit and update developer documentation and wiki
 - [ ] Audit Architecture wiki page
@@ -55,9 +49,6 @@ All four issues are independent and can be worked in parallel.
 - [ ] Audit `docs/dev-setup.md`
 - [ ] Audit `CLAUDE.md` for accuracy
 - [ ] Push wiki updates
-- [ ] PR opened (#?) for repo file changes
-- [ ] CI passing
-- [ ] PR merged
 
 ### Issue #346 -- Post-OOBE guided tour with tooltip walkthrough
 - [ ] Evaluate and vendor Driver.js (~5KB gzip, MIT, zero deps)
@@ -67,9 +58,6 @@ All four issues are independent and can be worked in parallel.
 - [ ] Dark mode styling
 - [ ] Cache-bust vendored assets via StaticAssets
 - [ ] Manual testing: OOBE -> tour -> dismissal -> no re-trigger
-- [ ] PR opened (#?)
-- [ ] CI passing
-- [ ] PR merged
 - [ ] Docs updated
 
 ## Worktrees


### PR DESCRIPTION
## Summary

- Add #357 (multiple backdrops from Emby/Jellyfin) to m27 plan with implementation details discovered during #231 work
- Add #360 (image caching strategy) to m30 plan with implementation checklist
- Remove PR number tracking from checklist items across all plan files (m27-m32) to avoid double-commit problem
- Remove CI passing/PR merged boilerplate lines from all checklists
- Add #231 implementation findings to m27 notes (BackdropImageTags, ProviderIds, MBID backfill, image cache dir)

## Test plan

- [x] No code changes -- documentation only
- [x] All plan files have valid markdown structure
- [x] No PR number references remain in any plan file

Generated with [Claude Code](https://claude.com/claude-code)