### PR TITLE
docs: update M27 and M30 plan files

### DIFF
--- a/docs/plans/m27-plan.md
+++ b/docs/plans/m27-plan.md
@@ -84,7 +84,7 @@ where only push direction works but pull does not.
 ## UAT / Merge Order
 
 Session 1 (import):
-1. #230 (base: main) -- metadata import -- MERGED
+1. #230 (base: main) -- metadata import -- merged
 2. #231 (base: main) -- image import
 
 Session 2 (backdrops):

--- a/docs/plans/m30-plan.md
+++ b/docs/plans/m30-plan.md
@@ -38,8 +38,9 @@ code reuse issues.
 
 Most issues are independent. #322 (universal editing) informs #321 (history) since
 history needs to track edits on newly-editable fields. #350 (SQL squash) should merge
-early since it touches the migration foundation. #360 (image caching) benefits from
-#352 (refactoring) landing first since both touch image write paths and handler structure.
+early since it touches the migration foundation. #360 (image caching) depends on
+#352 (refactoring) since it uses the shared write path abstraction and both touch
+image write paths and handler structure.
 #351 and #352 are audit-style work that can proceed in any order.
 
 ## Checklist


### PR DESCRIPTION
## Summary

- Mark #230 as merged in M27 plan, update #231 checklist items
- Add #357 (multiple backdrop images) as new M27 sub-issue with dependency on #231
- Add #360 (image caching strategy) as new M30 sub-issue with dependency on #352
- Update dependency maps and merge order in both plans
- Strip PR number references from plan checklists to avoid commit churn

Generated with [Claude Code](https://claude.com/claude-code)