### PR TITLE
docs: remove PR number references from plan file template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ Create `docs/plans/m<N>-plan.md` (e.g. `docs/plans/m14-plan.md`) before starting
 - Sub-issue dependency map (which issues block which)
 - A checklist for every sub-issue: use `- [ ]` for pending, `- [x]` for done
 - A notes/observations section for decisions, blockers, and findings discovered during work
-- The UAT and merge order (which issues land first, which are stacked)
+- The UAT and merge order (which issues are implemented/merged first, which are stacked)
 
 **Do NOT include PR numbers in plan files.** Referencing PR numbers forces a
 commit-then-update cycle every time a PR is created, which wastes time and


### PR DESCRIPTION
## Summary

- Remove `PR opened (#?)` and `CI passing` checklist items from the plan file template
- Replace `PR #?` references in UAT/Merge Order with issue numbers only
- Add explicit guidance: do not include PR numbers in plan files

PR numbers in plan files cause a commit-then-update cycle every time a PR is
created, wasting time and resources. Issue numbers are sufficient for tracking;
the PR-to-issue linkage lives in GitHub.

## Test plan

- [x] Docs-only change, no runtime impact

Generated with [Claude Code](https://claude.com/claude-code)