### PR TITLE
fix: normalize date fields before pushing to Emby/Jellyfin

### DIFF
--- a/internal/connection/date.go
+++ b/internal/connection/date.go
@@ -1,0 +1,76 @@
+package connection
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Compiled regexps for structured date detection.
+var (
+	reISO8601  = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T`)
+	reYMD      = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+	reYM       = regexp.MustCompile(`^\d{4}-\d{2}$`)
+	reYear     = regexp.MustCompile(`^\d{4}$`)
+	reInSuffix = regexp.MustCompile(`(?i)\s+in\s+.*$`)
+	reExtract  = regexp.MustCompile(`\b(1\d{3}|20\d{2})\b`)
+)
+
+// Named-month layouts to try after stripping location suffixes.
+var namedMonthLayouts = []string{
+	"January 2, 2006",
+	"Jan 2, 2006",
+	"2 January 2006",
+	"January 2006",
+	"Jan 2006",
+}
+
+// NormalizeDateForPlatform converts a free-form date string to yyyy-MM-dd
+// format suitable for Emby/Jellyfin PremiereDate and EndDate fields. It
+// returns the original string for values already in ISO 8601 format, pads
+// partial dates (yyyy or yyyy-MM), parses named-month formats, and falls
+// back to extracting the first 4-digit year. Returns "" for completely
+// unparseable input.
+func NormalizeDateForPlatform(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+
+	// Already full ISO 8601 with time component -- pass through.
+	if reISO8601.MatchString(s) {
+		return s
+	}
+
+	// Already yyyy-MM-dd -- pass through.
+	if reYMD.MatchString(s) {
+		return s
+	}
+
+	// yyyy-MM -- pad day.
+	if reYM.MatchString(s) {
+		return s + "-01"
+	}
+
+	// yyyy -- pad month and day.
+	if reYear.MatchString(s) {
+		return s + "-01-01"
+	}
+
+	// Strip " in <location>" suffix and try named-month layouts.
+	cleaned := reInSuffix.ReplaceAllString(s, "")
+	cleaned = strings.TrimSpace(cleaned)
+
+	for _, layout := range namedMonthLayouts {
+		if t, err := time.Parse(layout, cleaned); err == nil {
+			return t.Format("2006-01-02")
+		}
+	}
+
+	// Last resort: extract first 4-digit year (1000-2099).
+	if m := reExtract.FindString(s); m != "" {
+		return m + "-01-01"
+	}
+
+	return ""
+}

--- a/internal/connection/date_test.go
+++ b/internal/connection/date_test.go
@@ -1,0 +1,36 @@
+package connection
+
+import "testing"
+
+func TestNormalizeDateForPlatform(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"year only", "1991", "1991-01-01"},
+		{"year-month", "1991-05", "1991-05-01"},
+		{"full date", "1991-05-27", "1991-05-27"},
+		{"ISO 8601 full precision", "1985-01-01T00:00:00.0000000Z", "1985-01-01T00:00:00.0000000Z"},
+		{"ISO 8601 short", "2006-06-15T00:00:00Z", "2006-06-15T00:00:00Z"},
+		{"named month day year", "October 14, 1946", "1946-10-14"},
+		{"named month with location", "October 14, 1946 in Abingdon, England", "1946-10-14"},
+		{"year with location", "2006 in Cardiff, CA", "2006-01-01"},
+		{"month year", "January 2006", "2006-01-01"},
+		{"unparseable", "not a date", ""},
+		{"year in text", "some text 1987 more text", "1987-01-01"},
+		{"whitespace padded", "   1991   ", "1991-01-01"},
+		{"short month name", "Oct 14, 1946", "1946-10-14"},
+		{"day month year", "14 October 1946", "1946-10-14"},
+		{"short month year", "Jan 2006", "2006-01-01"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeDateForPlatform(tt.input)
+			if got != tt.want {
+				t.Errorf("NormalizeDateForPlatform(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/connection/emby/client_test.go
+++ b/internal/connection/emby/client_test.go
@@ -443,3 +443,86 @@ func TestPost_ErrorBodyLimited(t *testing.T) {
 		t.Errorf("error message length = %d, want bounded (body should be limited to 1024 bytes)", len(errMsg))
 	}
 }
+
+func TestPushMetadata_DateNormalization(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         connection.ArtistPushData
+		wantPremiere string
+		wantEnd      string
+	}{
+		{
+			name:         "year-only born",
+			data:         connection.ArtistPushData{Name: "Test", Born: "1985"},
+			wantPremiere: "1985-01-01",
+		},
+		{
+			name:         "year-month formed",
+			data:         connection.ArtistPushData{Name: "Test", Formed: "1991-05"},
+			wantPremiere: "1991-05-01",
+		},
+		{
+			name:         "full date born",
+			data:         connection.ArtistPushData{Name: "Test", Born: "1946-10-14"},
+			wantPremiere: "1946-10-14",
+		},
+		{
+			name:         "ISO 8601 passthrough",
+			data:         connection.ArtistPushData{Name: "Test", Formed: "1985-01-01T00:00:00.0000000Z"},
+			wantPremiere: "1985-01-01T00:00:00.0000000Z",
+		},
+		{
+			name:         "unparseable date omitted",
+			data:         connection.ArtistPushData{Name: "Test", Born: "not a date"},
+			wantPremiere: "",
+		},
+		{
+			name:         "born takes precedence over formed",
+			data:         connection.ArtistPushData{Name: "Test", Born: "1946", Formed: "1985"},
+			wantPremiere: "1946-01-01",
+		},
+		{
+			name:    "died year-only",
+			data:    connection.ArtistPushData{Name: "Test", Died: "2016"},
+			wantEnd: "2016-01-01",
+		},
+		{
+			name:    "disbanded year-only",
+			data:    connection.ArtistPushData{Name: "Test", Disbanded: "2003"},
+			wantEnd: "2003-01-01",
+		},
+		{
+			name:    "died takes precedence over disbanded",
+			data:    connection.ArtistPushData{Name: "Test", Died: "2016", Disbanded: "2003"},
+			wantEnd: "2016-01-01",
+		},
+		{
+			name:         "named month with location",
+			data:         connection.ArtistPushData{Name: "Test", Born: "October 14, 1946 in Abingdon, England"},
+			wantPremiere: "1946-10-14",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody itemUpdateBody
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Fatalf("decoding body: %v", err)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer srv.Close()
+
+			c := NewWithHTTPClient(srv.URL, "key", srv.Client(), testLogger())
+			if err := c.PushMetadata(context.Background(), "emby-001", tt.data); err != nil {
+				t.Fatalf("PushMetadata failed: %v", err)
+			}
+			if gotBody.PremiereDate != tt.wantPremiere {
+				t.Errorf("PremiereDate = %q, want %q", gotBody.PremiereDate, tt.wantPremiere)
+			}
+			if gotBody.EndDate != tt.wantEnd {
+				t.Errorf("EndDate = %q, want %q", gotBody.EndDate, tt.wantEnd)
+			}
+		})
+	}
+}

--- a/internal/connection/emby/push.go
+++ b/internal/connection/emby/push.go
@@ -45,16 +45,21 @@ func (c *Client) PushMetadata(ctx context.Context, platformArtistID string, data
 		}
 	}
 	// Use Born for persons, Formed for groups as premiere date.
-	if data.Born != "" {
-		body.PremiereDate = data.Born
-	} else if data.Formed != "" {
-		body.PremiereDate = data.Formed
+	// Normalize to yyyy-MM-dd so Emby does not silently discard partial dates.
+	if raw := data.Born; raw != "" {
+		body.PremiereDate = connection.NormalizeDateForPlatform(raw)
+		c.logDateNormalization("premiere_date", raw, body.PremiereDate, platformArtistID)
+	} else if raw := data.Formed; raw != "" {
+		body.PremiereDate = connection.NormalizeDateForPlatform(raw)
+		c.logDateNormalization("premiere_date", raw, body.PremiereDate, platformArtistID)
 	}
 	// Use Died for persons, Disbanded for groups as end date.
-	if data.Died != "" {
-		body.EndDate = data.Died
-	} else if data.Disbanded != "" {
-		body.EndDate = data.Disbanded
+	if raw := data.Died; raw != "" {
+		body.EndDate = connection.NormalizeDateForPlatform(raw)
+		c.logDateNormalization("end_date", raw, body.EndDate, platformArtistID)
+	} else if raw := data.Disbanded; raw != "" {
+		body.EndDate = connection.NormalizeDateForPlatform(raw)
+		c.logDateNormalization("end_date", raw, body.EndDate, platformArtistID)
 	}
 
 	payload, err := json.Marshal(body)
@@ -115,6 +120,17 @@ func (c *Client) UploadImage(ctx context.Context, platformArtistID string, image
 
 	c.logger.Debug("image uploaded to emby", "artist_id", platformArtistID, "type", embyType)
 	return nil
+}
+
+// logDateNormalization logs the result of normalizing a date field for push.
+func (c *Client) logDateNormalization(field, raw, normalized, artistID string) {
+	if normalized == "" {
+		c.logger.Warn("unparseable date dropped from push",
+			"field", field, "raw", raw, "artist_id", artistID)
+	} else if normalized != raw {
+		c.logger.Debug("date normalized for push",
+			"field", field, "raw", raw, "normalized", normalized, "artist_id", artistID)
+	}
 }
 
 // mapImageType converts a Stillwater image type to an Emby image type.

--- a/internal/connection/jellyfin/client_test.go
+++ b/internal/connection/jellyfin/client_test.go
@@ -437,3 +437,86 @@ func TestPost_ErrorBodyLimited(t *testing.T) {
 		t.Errorf("error message length = %d, want bounded (body should be limited to 1024 bytes)", len(errMsg))
 	}
 }
+
+func TestPushMetadata_DateNormalization(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         connection.ArtistPushData
+		wantPremiere string
+		wantEnd      string
+	}{
+		{
+			name:         "year-only born",
+			data:         connection.ArtistPushData{Name: "Test", Born: "1985"},
+			wantPremiere: "1985-01-01",
+		},
+		{
+			name:         "year-month formed",
+			data:         connection.ArtistPushData{Name: "Test", Formed: "1991-05"},
+			wantPremiere: "1991-05-01",
+		},
+		{
+			name:         "full date born",
+			data:         connection.ArtistPushData{Name: "Test", Born: "1946-10-14"},
+			wantPremiere: "1946-10-14",
+		},
+		{
+			name:         "ISO 8601 passthrough",
+			data:         connection.ArtistPushData{Name: "Test", Formed: "1985-01-01T00:00:00.0000000Z"},
+			wantPremiere: "1985-01-01T00:00:00.0000000Z",
+		},
+		{
+			name:         "unparseable date omitted",
+			data:         connection.ArtistPushData{Name: "Test", Born: "not a date"},
+			wantPremiere: "",
+		},
+		{
+			name:         "born takes precedence over formed",
+			data:         connection.ArtistPushData{Name: "Test", Born: "1946", Formed: "1985"},
+			wantPremiere: "1946-01-01",
+		},
+		{
+			name:    "died year-only",
+			data:    connection.ArtistPushData{Name: "Test", Died: "2016"},
+			wantEnd: "2016-01-01",
+		},
+		{
+			name:    "disbanded year-only",
+			data:    connection.ArtistPushData{Name: "Test", Disbanded: "2003"},
+			wantEnd: "2003-01-01",
+		},
+		{
+			name:    "died takes precedence over disbanded",
+			data:    connection.ArtistPushData{Name: "Test", Died: "2016", Disbanded: "2003"},
+			wantEnd: "2016-01-01",
+		},
+		{
+			name:         "named month with location",
+			data:         connection.ArtistPushData{Name: "Test", Born: "October 14, 1946 in Abingdon, England"},
+			wantPremiere: "1946-10-14",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody itemUpdateBody
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Fatalf("decoding body: %v", err)
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer srv.Close()
+
+			c := NewWithHTTPClient(srv.URL, "key", srv.Client(), testLogger())
+			if err := c.PushMetadata(context.Background(), "jf-001", tt.data); err != nil {
+				t.Fatalf("PushMetadata failed: %v", err)
+			}
+			if gotBody.PremiereDate != tt.wantPremiere {
+				t.Errorf("PremiereDate = %q, want %q", gotBody.PremiereDate, tt.wantPremiere)
+			}
+			if gotBody.EndDate != tt.wantEnd {
+				t.Errorf("EndDate = %q, want %q", gotBody.EndDate, tt.wantEnd)
+			}
+		})
+	}
+}

--- a/internal/connection/jellyfin/push.go
+++ b/internal/connection/jellyfin/push.go
@@ -44,15 +44,20 @@ func (c *Client) PushMetadata(ctx context.Context, platformArtistID string, data
 			"MusicBrainzArtist": data.MusicBrainzID,
 		}
 	}
-	if data.Born != "" {
-		body.PremiereDate = data.Born
-	} else if data.Formed != "" {
-		body.PremiereDate = data.Formed
+	// Normalize to yyyy-MM-dd so Jellyfin does not silently discard partial dates.
+	if raw := data.Born; raw != "" {
+		body.PremiereDate = connection.NormalizeDateForPlatform(raw)
+		c.logDateNormalization("premiere_date", raw, body.PremiereDate, platformArtistID)
+	} else if raw := data.Formed; raw != "" {
+		body.PremiereDate = connection.NormalizeDateForPlatform(raw)
+		c.logDateNormalization("premiere_date", raw, body.PremiereDate, platformArtistID)
 	}
-	if data.Died != "" {
-		body.EndDate = data.Died
-	} else if data.Disbanded != "" {
-		body.EndDate = data.Disbanded
+	if raw := data.Died; raw != "" {
+		body.EndDate = connection.NormalizeDateForPlatform(raw)
+		c.logDateNormalization("end_date", raw, body.EndDate, platformArtistID)
+	} else if raw := data.Disbanded; raw != "" {
+		body.EndDate = connection.NormalizeDateForPlatform(raw)
+		c.logDateNormalization("end_date", raw, body.EndDate, platformArtistID)
 	}
 
 	payload, err := json.Marshal(body)
@@ -113,6 +118,17 @@ func (c *Client) UploadImage(ctx context.Context, platformArtistID string, image
 
 	c.logger.Debug("image uploaded to jellyfin", "artist_id", platformArtistID, "type", jfType)
 	return nil
+}
+
+// logDateNormalization logs the result of normalizing a date field for push.
+func (c *Client) logDateNormalization(field, raw, normalized, artistID string) {
+	if normalized == "" {
+		c.logger.Warn("unparseable date dropped from push",
+			"field", field, "raw", raw, "artist_id", artistID)
+	} else if normalized != raw {
+		c.logger.Debug("date normalized for push",
+			"field", field, "raw", raw, "normalized", normalized, "artist_id", artistID)
+	}
 }
 
 // mapImageType converts a Stillwater image type to a Jellyfin image type.


### PR DESCRIPTION
## Summary

Closes #355.

- Add `NormalizeDateForPlatform()` in `internal/connection/date.go` that converts free-form date strings to `yyyy-MM-dd` format at the push boundary, handling: ISO 8601 passthrough, year-only (`"1985"` -> `"1985-01-01"`), year-month (`"1991-05"` -> `"1991-05-01"`), named-month formats (`"October 14, 1946"` -> `"1946-10-14"`), location suffix stripping (`"... in Nashville, TN"`), and year extraction as fallback
- Apply normalization in both `emby/push.go` and `jellyfin/push.go` with debug/warn logging for transformed or unparseable dates
- Stored data (database, NFO files) is not changed; normalization only at the push boundary
- 16 unit tests for the normalizer, 10 integration subtests per platform (Emby + Jellyfin)

## Test plan

- [x] `go test ./internal/connection/... -v` -- all date normalization and push tests pass
- [x] `go test ./...` -- no regressions across the full suite
- [x] `gofmt -d .` -- no formatting issues
- [x] Pre-commit hooks pass (gofmt, go build, golangci-lint, govulncheck)
- [x] Docker UAT: pushed artist with year-only born (`"1932"`) and free-text died (`"September 12, 2003 in Nashville, TN"`) to both Emby and Jellyfin; debug logs confirm normalization to `"1932-01-01"` and `"2003-09-12"` respectively

## Wiki update checklist

- [ ] No provider/event/interface changes (Architecture -- N/A)
- [ ] No linting/hook/workflow changes (Contributing -- N/A)
- [ ] No new package or tech stack change (Developer Guide -- N/A)
- [ ] No user-facing behavior change (internal fix, no UI impact -- N/A)


Generated with [Claude Code](https://claude.com/claude-code)