### PR TITLE
refactor: extract shared database helpers into internal/dbutil

### DIFF
--- a/internal/artist/alias.go
+++ b/internal/artist/alias.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
 )
 
 // prefixedArtistColumns returns artistColumns with each column prefixed by the given table alias.
@@ -96,7 +97,7 @@ func (s *Service) ListAliases(ctx context.Context, artistID string) ([]Alias, er
 		if err := rows.Scan(&a.ID, &a.ArtistID, &a.Alias, &a.Source, &createdAt); err != nil {
 			return nil, fmt.Errorf("scanning alias: %w", err)
 		}
-		a.CreatedAt = parseTime(createdAt)
+		a.CreatedAt = dbutil.ParseTime(createdAt)
 		aliases = append(aliases, a)
 	}
 	return aliases, rows.Err()
@@ -305,27 +306,27 @@ func scanArtistWithExtra(row interface{ Scan(...any) error }, n int) (*artistWit
 	a.IsClassical = isClassical == 1
 	a.MetadataSources = UnmarshalStringMap(metadataSources)
 	if audiodbFetchedAt.Valid {
-		t := parseTime(audiodbFetchedAt.String)
+		t := dbutil.ParseTime(audiodbFetchedAt.String)
 		a.AudioDBIDFetchedAt = &t
 	}
 	if discogsFetchedAt.Valid {
-		t := parseTime(discogsFetchedAt.String)
+		t := dbutil.ParseTime(discogsFetchedAt.String)
 		a.DiscogsIDFetchedAt = &t
 	}
 	if wikidataFetchedAt.Valid {
-		t := parseTime(wikidataFetchedAt.String)
+		t := dbutil.ParseTime(wikidataFetchedAt.String)
 		a.WikidataIDFetchedAt = &t
 	}
 	if lastfmFetchedAt.Valid {
-		t := parseTime(lastfmFetchedAt.String)
+		t := dbutil.ParseTime(lastfmFetchedAt.String)
 		a.LastFMFetchedAt = &t
 	}
 	if lastScannedAt.Valid {
-		t := parseTime(lastScannedAt.String)
+		t := dbutil.ParseTime(lastScannedAt.String)
 		a.LastScannedAt = &t
 	}
-	a.CreatedAt = parseTime(createdAt)
-	a.UpdatedAt = parseTime(updatedAt)
+	a.CreatedAt = dbutil.ParseTime(createdAt)
+	a.UpdatedAt = dbutil.ParseTime(updatedAt)
 
 	return &artistWithExtra{artist: a, extra: extra}, nil
 }

--- a/internal/artist/platform_ids.go
+++ b/internal/artist/platform_ids.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/sydlexius/stillwater/internal/dbutil"
 )
 
 // ErrPlatformIDNotFound is returned when a platform ID mapping does not exist.
@@ -75,8 +77,8 @@ func (s *Service) GetPlatformIDs(ctx context.Context, artistID string) ([]Platfo
 		if err := rows.Scan(&p.ArtistID, &p.ConnectionID, &p.PlatformArtistID, &createdAt, &updatedAt); err != nil {
 			return nil, fmt.Errorf("scanning platform id: %w", err)
 		}
-		p.CreatedAt = parseTime(createdAt)
-		p.UpdatedAt = parseTime(updatedAt)
+		p.CreatedAt = dbutil.ParseTime(createdAt)
+		p.UpdatedAt = dbutil.ParseTime(updatedAt)
 		ids = append(ids, p)
 	}
 	return ids, rows.Err()

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
 )
 
 // artistColumns is the ordered list of columns for SELECT queries.
@@ -60,16 +61,16 @@ func (s *Service) Create(ctx context.Context, a *Artist) error {
 		a.MusicBrainzID, a.AudioDBID, a.DiscogsID, a.WikidataID, a.DeezerID, a.SpotifyID,
 		MarshalStringSlice(a.Genres), MarshalStringSlice(a.Styles), MarshalStringSlice(a.Moods),
 		a.YearsActive, a.Born, a.Formed, a.Died, a.Disbanded, a.Biography,
-		a.Path, nullableString(a.LibraryID), boolToInt(a.NFOExists), boolToInt(a.ThumbExists),
-		boolToInt(a.FanartExists), a.FanartCount, boolToInt(a.LogoExists), boolToInt(a.BannerExists),
-		boolToInt(a.ThumbLowRes), boolToInt(a.FanartLowRes),
-		boolToInt(a.LogoLowRes), boolToInt(a.BannerLowRes),
+		a.Path, dbutil.NullableString(a.LibraryID), dbutil.BoolToInt(a.NFOExists), dbutil.BoolToInt(a.ThumbExists),
+		dbutil.BoolToInt(a.FanartExists), a.FanartCount, dbutil.BoolToInt(a.LogoExists), dbutil.BoolToInt(a.BannerExists),
+		dbutil.BoolToInt(a.ThumbLowRes), dbutil.BoolToInt(a.FanartLowRes),
+		dbutil.BoolToInt(a.LogoLowRes), dbutil.BoolToInt(a.BannerLowRes),
 		a.ThumbPlaceholder, a.FanartPlaceholder, a.LogoPlaceholder, a.BannerPlaceholder,
-		a.HealthScore, boolToInt(a.IsExcluded), a.ExclusionReason, boolToInt(a.IsClassical),
+		a.HealthScore, dbutil.BoolToInt(a.IsExcluded), a.ExclusionReason, dbutil.BoolToInt(a.IsClassical),
 		MarshalStringMap(a.MetadataSources),
-		formatNullableTime(a.AudioDBIDFetchedAt), formatNullableTime(a.DiscogsIDFetchedAt),
-		formatNullableTime(a.WikidataIDFetchedAt), formatNullableTime(a.LastFMFetchedAt),
-		formatNullableTime(a.LastScannedAt),
+		dbutil.FormatNullableTime(a.AudioDBIDFetchedAt), dbutil.FormatNullableTime(a.DiscogsIDFetchedAt),
+		dbutil.FormatNullableTime(a.WikidataIDFetchedAt), dbutil.FormatNullableTime(a.LastFMFetchedAt),
+		dbutil.FormatNullableTime(a.LastScannedAt),
 		now.Format(time.RFC3339), now.Format(time.RFC3339),
 	)
 	if err != nil {
@@ -254,17 +255,17 @@ func (s *Service) Update(ctx context.Context, a *Artist) error {
 		a.MusicBrainzID, a.AudioDBID, a.DiscogsID, a.WikidataID, a.DeezerID, a.SpotifyID,
 		MarshalStringSlice(a.Genres), MarshalStringSlice(a.Styles), MarshalStringSlice(a.Moods),
 		a.YearsActive, a.Born, a.Formed, a.Died, a.Disbanded, a.Biography,
-		a.Path, nullableString(a.LibraryID),
-		boolToInt(a.NFOExists), boolToInt(a.ThumbExists),
-		boolToInt(a.FanartExists), a.FanartCount, boolToInt(a.LogoExists), boolToInt(a.BannerExists),
-		boolToInt(a.ThumbLowRes), boolToInt(a.FanartLowRes),
-		boolToInt(a.LogoLowRes), boolToInt(a.BannerLowRes),
+		a.Path, dbutil.NullableString(a.LibraryID),
+		dbutil.BoolToInt(a.NFOExists), dbutil.BoolToInt(a.ThumbExists),
+		dbutil.BoolToInt(a.FanartExists), a.FanartCount, dbutil.BoolToInt(a.LogoExists), dbutil.BoolToInt(a.BannerExists),
+		dbutil.BoolToInt(a.ThumbLowRes), dbutil.BoolToInt(a.FanartLowRes),
+		dbutil.BoolToInt(a.LogoLowRes), dbutil.BoolToInt(a.BannerLowRes),
 		a.ThumbPlaceholder, a.FanartPlaceholder, a.LogoPlaceholder, a.BannerPlaceholder,
-		a.HealthScore, boolToInt(a.IsExcluded), a.ExclusionReason, boolToInt(a.IsClassical),
+		a.HealthScore, dbutil.BoolToInt(a.IsExcluded), a.ExclusionReason, dbutil.BoolToInt(a.IsClassical),
 		MarshalStringMap(a.MetadataSources),
-		formatNullableTime(a.AudioDBIDFetchedAt), formatNullableTime(a.DiscogsIDFetchedAt),
-		formatNullableTime(a.WikidataIDFetchedAt), formatNullableTime(a.LastFMFetchedAt),
-		formatNullableTime(a.LastScannedAt),
+		dbutil.FormatNullableTime(a.AudioDBIDFetchedAt), dbutil.FormatNullableTime(a.DiscogsIDFetchedAt),
+		dbutil.FormatNullableTime(a.WikidataIDFetchedAt), dbutil.FormatNullableTime(a.LastFMFetchedAt),
+		dbutil.FormatNullableTime(a.LastScannedAt),
 		a.UpdatedAt.Format(time.RFC3339),
 		a.ID,
 	)
@@ -512,7 +513,7 @@ func (s *Service) CreateMember(ctx context.Context, m *BandMember) error {
 	`,
 		m.ID, m.ArtistID, m.MemberName, m.MemberMBID,
 		MarshalStringSlice(m.Instruments), m.VocalType,
-		m.DateJoined, m.DateLeft, boolToInt(m.IsOriginalMember), m.SortOrder,
+		m.DateJoined, m.DateLeft, dbutil.BoolToInt(m.IsOriginalMember), m.SortOrder,
 		now.Format(time.RFC3339), now.Format(time.RFC3339),
 	)
 	if err != nil {
@@ -569,7 +570,7 @@ func (s *Service) UpsertMembers(ctx context.Context, artistID string, members []
 		`,
 			m.ID, m.ArtistID, m.MemberName, m.MemberMBID,
 			MarshalStringSlice(m.Instruments), m.VocalType,
-			m.DateJoined, m.DateLeft, boolToInt(m.IsOriginalMember), m.SortOrder,
+			m.DateJoined, m.DateLeft, dbutil.BoolToInt(m.IsOriginalMember), m.SortOrder,
 			now.Format(time.RFC3339), now.Format(time.RFC3339),
 		); err != nil {
 			return fmt.Errorf("inserting member %s: %w", m.MemberName, err)
@@ -632,27 +633,27 @@ func scanArtist(row interface{ Scan(...any) error }) (*Artist, error) {
 	a.IsExcluded = isExcluded == 1
 	a.IsClassical = isClassical == 1
 	a.MetadataSources = UnmarshalStringMap(metadataSources)
-	a.CreatedAt = parseTime(createdAt)
-	a.UpdatedAt = parseTime(updatedAt)
+	a.CreatedAt = dbutil.ParseTime(createdAt)
+	a.UpdatedAt = dbutil.ParseTime(updatedAt)
 
 	if audiodbFetchedAt.Valid {
-		t := parseTime(audiodbFetchedAt.String)
+		t := dbutil.ParseTime(audiodbFetchedAt.String)
 		a.AudioDBIDFetchedAt = &t
 	}
 	if discogsFetchedAt.Valid {
-		t := parseTime(discogsFetchedAt.String)
+		t := dbutil.ParseTime(discogsFetchedAt.String)
 		a.DiscogsIDFetchedAt = &t
 	}
 	if wikidataFetchedAt.Valid {
-		t := parseTime(wikidataFetchedAt.String)
+		t := dbutil.ParseTime(wikidataFetchedAt.String)
 		a.WikidataIDFetchedAt = &t
 	}
 	if lastfmFetchedAt.Valid {
-		t := parseTime(lastfmFetchedAt.String)
+		t := dbutil.ParseTime(lastfmFetchedAt.String)
 		a.LastFMFetchedAt = &t
 	}
 	if lastScannedAt.Valid {
-		t := parseTime(lastScannedAt.String)
+		t := dbutil.ParseTime(lastScannedAt.String)
 		a.LastScannedAt = &t
 	}
 
@@ -678,8 +679,8 @@ func scanMember(row interface{ Scan(...any) error }) (*BandMember, error) {
 
 	m.Instruments = UnmarshalStringSlice(instruments)
 	m.IsOriginalMember = isOriginal == 1
-	m.CreatedAt = parseTime(createdAt)
-	m.UpdatedAt = parseTime(updatedAt)
+	m.CreatedAt = dbutil.ParseTime(createdAt)
+	m.UpdatedAt = dbutil.ParseTime(updatedAt)
 
 	return &m, nil
 }
@@ -735,36 +736,4 @@ func buildWhereClause(params ListParams) (string, []any) {
 		return "", nil
 	}
 	return " WHERE " + strings.Join(conditions, " AND "), args
-}
-
-func nullableString(s string) any {
-	if s == "" {
-		return nil
-	}
-	return s
-}
-
-func boolToInt(b bool) int {
-	if b {
-		return 1
-	}
-	return 0
-}
-
-func formatNullableTime(t *time.Time) any {
-	if t == nil {
-		return nil
-	}
-	return t.Format(time.RFC3339)
-}
-
-// parseTime parses a time string, handling both RFC3339 and SQLite datetime formats.
-func parseTime(s string) time.Time {
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t
-	}
-	if t, err := time.Parse("2006-01-02 15:04:05", s); err == nil {
-		return t
-	}
-	return time.Time{}
 }

--- a/internal/connection/service.go
+++ b/internal/connection/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
 	"github.com/sydlexius/stillwater/internal/encryption"
 )
 
@@ -58,10 +59,10 @@ func (s *Service) Create(ctx context.Context, c *Connection) error {
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		c.ID, c.Name, c.Type, c.URL, encKey,
-		boolToInt(c.Enabled), c.Status, c.StatusMessage,
-		formatNullableTime(c.LastCheckedAt),
+		dbutil.BoolToInt(c.Enabled), c.Status, c.StatusMessage,
+		dbutil.FormatNullableTime(c.LastCheckedAt),
 		now.Format(time.RFC3339), now.Format(time.RFC3339),
-		boolToInt(c.FeatureLibraryImport), boolToInt(c.FeatureNFOWrite), boolToInt(c.FeatureImageWrite),
+		dbutil.BoolToInt(c.FeatureLibraryImport), dbutil.BoolToInt(c.FeatureNFOWrite), dbutil.BoolToInt(c.FeatureImageWrite),
 	)
 	if err != nil {
 		return fmt.Errorf("creating connection: %w", err)
@@ -195,10 +196,10 @@ func (s *Service) Update(ctx context.Context, c *Connection) error {
 			feature_library_import = ?, feature_nfo_write = ?, feature_image_write = ?
 		WHERE id = ?
 	`,
-		c.Name, c.Type, c.URL, encKey, boolToInt(c.Enabled),
+		c.Name, c.Type, c.URL, encKey, dbutil.BoolToInt(c.Enabled),
 		c.Status, c.StatusMessage,
 		c.UpdatedAt.Format(time.RFC3339),
-		boolToInt(c.FeatureLibraryImport), boolToInt(c.FeatureNFOWrite), boolToInt(c.FeatureImageWrite),
+		dbutil.BoolToInt(c.FeatureLibraryImport), dbutil.BoolToInt(c.FeatureNFOWrite), dbutil.BoolToInt(c.FeatureImageWrite),
 		c.ID,
 	)
 	if err != nil {
@@ -243,7 +244,7 @@ func (s *Service) UpdateFeatures(ctx context.Context, id string, libImport, nfoW
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE connections SET feature_library_import = ?, feature_nfo_write = ?, feature_image_write = ?, updated_at = ?
 		WHERE id = ?
-	`, boolToInt(libImport), boolToInt(nfoWrite), boolToInt(imageWrite), now.Format(time.RFC3339), id)
+	`, dbutil.BoolToInt(libImport), dbutil.BoolToInt(nfoWrite), dbutil.BoolToInt(imageWrite), now.Format(time.RFC3339), id)
 	if err != nil {
 		return fmt.Errorf("updating connection features: %w", err)
 	}
@@ -287,37 +288,13 @@ func (s *Service) scanConnection(row interface{ Scan(...any) error }) (*Connecti
 	c.FeatureLibraryImport = featLibImport == 1
 	c.FeatureNFOWrite = featNFOWrite == 1
 	c.FeatureImageWrite = featImageWrite == 1
-	c.CreatedAt = parseTime(createdAt)
-	c.UpdatedAt = parseTime(updatedAt)
+	c.CreatedAt = dbutil.ParseTime(createdAt)
+	c.UpdatedAt = dbutil.ParseTime(updatedAt)
 
 	if lastCheckedAt.Valid {
-		t := parseTime(lastCheckedAt.String)
+		t := dbutil.ParseTime(lastCheckedAt.String)
 		c.LastCheckedAt = &t
 	}
 
 	return &c, nil
-}
-
-func boolToInt(b bool) int {
-	if b {
-		return 1
-	}
-	return 0
-}
-
-func formatNullableTime(t *time.Time) any {
-	if t == nil {
-		return nil
-	}
-	return t.Format(time.RFC3339)
-}
-
-func parseTime(s string) time.Time {
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t
-	}
-	if t, err := time.Parse("2006-01-02 15:04:05", s); err == nil {
-		return t
-	}
-	return time.Time{}
 }

--- a/internal/dbutil/dbutil.go
+++ b/internal/dbutil/dbutil.go
@@ -1,0 +1,58 @@
+package dbutil
+
+import "time"
+
+// BoolToInt converts a boolean to an integer (1 for true, 0 for false)
+// for storage in SQLite, which has no native boolean type.
+func BoolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// IntToBool converts an integer to a boolean (non-zero is true).
+func IntToBool(i int) bool {
+	return i != 0
+}
+
+// ParseTime attempts to parse a time string using common database formats.
+// It tries RFC3339, "2006-01-02 15:04:05", and "2006-01-02T15:04:05" in order,
+// returning the zero time if none match.
+func ParseTime(s string) time.Time {
+	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05", "2006-01-02T15:04:05"} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+// FormatNullableTime formats a nullable time pointer as an RFC3339 string
+// for SQL insertion. Returns nil (untyped) when t is nil so the database
+// driver stores NULL.
+func FormatNullableTime(t *time.Time) any {
+	if t == nil {
+		return nil
+	}
+	return t.Format(time.RFC3339)
+}
+
+// NullableString returns nil (untyped) for an empty string so the database
+// driver stores NULL, or returns the string itself otherwise.
+func NullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// NilableTime converts a nullable time pointer to a nullable RFC3339 string
+// pointer, suitable for JSON serialization where omitempty applies.
+func NilableTime(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.Format(time.RFC3339)
+	return &s
+}

--- a/internal/dbutil/dbutil_test.go
+++ b/internal/dbutil/dbutil_test.go
@@ -1,0 +1,135 @@
+package dbutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBoolToInt(t *testing.T) {
+	tests := []struct {
+		name string
+		in   bool
+		want int
+	}{
+		{"true", true, 1},
+		{"false", false, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BoolToInt(tt.in); got != tt.want {
+				t.Errorf("BoolToInt(%v) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIntToBool(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want bool
+	}{
+		{"zero", 0, false},
+		{"one", 1, true},
+		{"negative", -1, true},
+		{"large", 42, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IntToBool(tt.in); got != tt.want {
+				t.Errorf("IntToBool(%d) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTime(t *testing.T) {
+	ref := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		in   string
+		want time.Time
+	}{
+		{"RFC3339", "2024-06-15T10:30:00Z", ref},
+		{"space-separated", "2024-06-15 10:30:00", ref},
+		{"T-separated no zone", "2024-06-15T10:30:00", ref},
+		{"empty string", "", time.Time{}},
+		{"garbage", "not-a-time", time.Time{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseTime(tt.in)
+			if !got.Equal(tt.want) {
+				t.Errorf("ParseTime(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatNullableTime(t *testing.T) {
+	ref := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
+
+	t.Run("nil", func(t *testing.T) {
+		if got := FormatNullableTime(nil); got != nil {
+			t.Errorf("FormatNullableTime(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("non-nil", func(t *testing.T) {
+		got := FormatNullableTime(&ref)
+		s, ok := got.(string)
+		if !ok {
+			t.Fatalf("FormatNullableTime returned %T, want string", got)
+		}
+		if s != "2024-06-15T10:30:00Z" {
+			t.Errorf("FormatNullableTime = %q, want %q", s, "2024-06-15T10:30:00Z")
+		}
+	})
+}
+
+func TestNullableString(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantNil bool
+	}{
+		{"empty", "", true},
+		{"non-empty", "hello", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NullableString(tt.in)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("NullableString(%q) = %v, want nil", tt.in, got)
+				}
+			} else {
+				s, ok := got.(string)
+				if !ok || s != tt.in {
+					t.Errorf("NullableString(%q) = %v, want %q", tt.in, got, tt.in)
+				}
+			}
+		})
+	}
+}
+
+func TestNilableTime(t *testing.T) {
+	ref := time.Date(2024, 6, 15, 10, 30, 0, 0, time.UTC)
+
+	t.Run("nil", func(t *testing.T) {
+		if got := NilableTime(nil); got != nil {
+			t.Errorf("NilableTime(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("non-nil", func(t *testing.T) {
+		got := NilableTime(&ref)
+		if got == nil {
+			t.Fatal("NilableTime returned nil, want non-nil")
+		}
+		if *got != "2024-06-15T10:30:00Z" {
+			t.Errorf("NilableTime = %q, want %q", *got, "2024-06-15T10:30:00Z")
+		}
+	})
+}

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
 )
 
 const libraryColumns = `id, name, path, type, source, connection_id, external_id, fs_watch, fs_poll_interval, created_at, updated_at`
@@ -62,7 +63,7 @@ func (s *Service) Create(ctx context.Context, lib *Library) error {
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		lib.ID, lib.Name, lib.Path, lib.Type,
-		lib.Source, nullableString(lib.ConnectionID), lib.ExternalID,
+		lib.Source, dbutil.NullableString(lib.ConnectionID), lib.ExternalID,
 		lib.FSWatch, lib.FSPollInterval,
 		now.Format(time.RFC3339), now.Format(time.RFC3339),
 	)
@@ -172,7 +173,7 @@ func (s *Service) Update(ctx context.Context, lib *Library) error {
 		WHERE id = ?
 	`,
 		lib.Name, lib.Path, lib.Type,
-		lib.Source, nullableString(lib.ConnectionID), lib.ExternalID,
+		lib.Source, dbutil.NullableString(lib.ConnectionID), lib.ExternalID,
 		lib.FSWatch, lib.FSPollInterval,
 		lib.UpdatedAt.Format(time.RFC3339),
 		lib.ID,
@@ -321,17 +322,10 @@ func scanLibrary(row interface{ Scan(...any) error }) (*Library, error) {
 	if connectionID.Valid {
 		lib.ConnectionID = connectionID.String
 	}
-	lib.CreatedAt = parseTime(createdAt)
-	lib.UpdatedAt = parseTime(updatedAt)
+	lib.CreatedAt = dbutil.ParseTime(createdAt)
+	lib.UpdatedAt = dbutil.ParseTime(updatedAt)
 
 	return &lib, nil
-}
-
-func nullableString(s string) any {
-	if s == "" {
-		return nil
-	}
-	return s
 }
 
 // isValidSource reports whether s is one of the allowed library source values.
@@ -342,15 +336,4 @@ func isValidSource(s string) bool {
 	default:
 		return false
 	}
-}
-
-// parseTime parses a time string, handling both RFC3339 and SQLite datetime formats.
-func parseTime(s string) time.Time {
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t
-	}
-	if t, err := time.Parse("2006-01-02 15:04:05", s); err == nil {
-		return t
-	}
-	return time.Time{}
 }

--- a/internal/nfo/snapshot.go
+++ b/internal/nfo/snapshot.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
 )
 
 // Snapshot represents a saved copy of an artist's NFO file content.
@@ -92,16 +93,6 @@ func scanSnapshot(row interface{ Scan(...any) error }) (*Snapshot, error) {
 	if err != nil {
 		return nil, err
 	}
-	snap.CreatedAt = parseTime(createdAt)
+	snap.CreatedAt = dbutil.ParseTime(createdAt)
 	return &snap, nil
-}
-
-func parseTime(s string) time.Time {
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t
-	}
-	if t, err := time.Parse("2006-01-02 15:04:05", s); err == nil {
-		return t
-	}
-	return time.Time{}
 }

--- a/internal/platform/service.go
+++ b/internal/platform/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
 )
 
 // Service provides platform profile data operations.
@@ -131,8 +132,8 @@ func (s *Service) Create(ctx context.Context, p *Profile) error {
 		INSERT INTO platform_profiles (id, name, is_builtin, is_active, nfo_enabled, nfo_format, image_naming, use_symlinks, created_at, updated_at)
 		VALUES (?, ?, 0, ?, ?, ?, ?, ?, ?, ?)
 	`,
-		p.ID, p.Name, boolToInt(p.IsActive), boolToInt(p.NFOEnabled), p.NFOFormat,
-		MarshalImageNaming(p.ImageNaming), boolToInt(p.UseSymlinks),
+		p.ID, p.Name, dbutil.BoolToInt(p.IsActive), dbutil.BoolToInt(p.NFOEnabled), p.NFOFormat,
+		MarshalImageNaming(p.ImageNaming), dbutil.BoolToInt(p.UseSymlinks),
 		now.Format(time.RFC3339), now.Format(time.RFC3339),
 	)
 	if err != nil {
@@ -150,8 +151,8 @@ func (s *Service) Update(ctx context.Context, p *Profile) error {
 			name = ?, nfo_enabled = ?, nfo_format = ?, image_naming = ?, use_symlinks = ?, updated_at = ?
 		WHERE id = ?
 	`,
-		p.Name, boolToInt(p.NFOEnabled), p.NFOFormat,
-		MarshalImageNaming(p.ImageNaming), boolToInt(p.UseSymlinks),
+		p.Name, dbutil.BoolToInt(p.NFOEnabled), p.NFOFormat,
+		MarshalImageNaming(p.ImageNaming), dbutil.BoolToInt(p.UseSymlinks),
 		p.UpdatedAt.Format(time.RFC3339),
 		p.ID,
 	)
@@ -194,25 +195,8 @@ func scanProfile(row interface{ Scan(...any) error }) (*Profile, error) {
 	p.NFOEnabled = nfoEnabled == 1
 	p.UseSymlinks = useSymlinks == 1
 	p.ImageNaming = UnmarshalImageNaming(imageNaming)
-	p.CreatedAt = parseTime(createdAt)
-	p.UpdatedAt = parseTime(updatedAt)
+	p.CreatedAt = dbutil.ParseTime(createdAt)
+	p.UpdatedAt = dbutil.ParseTime(updatedAt)
 
 	return &p, nil
-}
-
-func boolToInt(b bool) int {
-	if b {
-		return 1
-	}
-	return 0
-}
-
-func parseTime(s string) time.Time {
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t
-	}
-	if t, err := time.Parse("2006-01-02 15:04:05", s); err == nil {
-		return t
-	}
-	return time.Time{}
 }

--- a/internal/rule/bulk_service.go
+++ b/internal/rule/bulk_service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
 )
 
 // BulkService provides persistence for bulk jobs.
@@ -145,7 +146,7 @@ func (s *BulkService) ListItems(ctx context.Context, jobID string) ([]BulkJobIte
 		if message.Valid {
 			item.Message = message.String
 		}
-		item.CreatedAt = parseTime(createdAt)
+		item.CreatedAt = dbutil.ParseTime(createdAt)
 		items = append(items, item)
 	}
 	return items, rows.Err()
@@ -171,13 +172,13 @@ func scanBulkJob(row interface{ Scan(...any) error }) (*BulkJob, error) {
 	if errStr.Valid {
 		job.Error = errStr.String
 	}
-	job.CreatedAt = parseTime(createdAt)
+	job.CreatedAt = dbutil.ParseTime(createdAt)
 	if startedAt.Valid {
-		t := parseTime(startedAt.String)
+		t := dbutil.ParseTime(startedAt.String)
 		job.StartedAt = &t
 	}
 	if completedAt.Valid {
-		t := parseTime(completedAt.String)
+		t := dbutil.ParseTime(completedAt.String)
 		job.CompletedAt = &t
 	}
 

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
 )
 
 // Built-in rule IDs.
@@ -193,7 +194,7 @@ func (s *Service) SeedDefaults(ctx context.Context) error {
 				name        = excluded.name,
 				description = excluded.description,
 				updated_at  = excluded.updated_at
-		`, r.ID, r.Name, r.Description, r.Category, boolToInt(r.Enabled),
+		`, r.ID, r.Name, r.Description, r.Category, dbutil.BoolToInt(r.Enabled),
 			autoMode, MarshalConfig(r.Config), now, now)
 		if err != nil {
 			return fmt.Errorf("seeding rule %s: %w", r.ID, err)
@@ -245,7 +246,7 @@ func (s *Service) Update(ctx context.Context, r *Rule) error {
 	r.UpdatedAt = time.Now().UTC()
 	_, err := s.db.ExecContext(ctx, `
 		UPDATE rules SET enabled = ?, automation_mode = ?, config = ?, updated_at = ? WHERE id = ?
-	`, boolToInt(r.Enabled), r.AutomationMode, MarshalConfig(r.Config),
+	`, dbutil.BoolToInt(r.Enabled), r.AutomationMode, MarshalConfig(r.Config),
 		r.UpdatedAt.Format(time.RFC3339), r.ID)
 	if err != nil {
 		return fmt.Errorf("updating rule: %w", err)
@@ -340,8 +341,8 @@ func (s *Service) UpsertViolation(ctx context.Context, v *RuleViolation) error {
 			resolved_at = excluded.resolved_at,
 			updated_at = excluded.updated_at
 	`, v.ID, v.RuleID, v.ArtistID, v.ArtistName, v.Severity, v.Message,
-		boolToInt(v.Fixable), v.Status, marshalCandidates(v.Candidates),
-		nilableTime(v.DismissedAt), nilableTime(v.ResolvedAt),
+		dbutil.BoolToInt(v.Fixable), v.Status, marshalCandidates(v.Candidates),
+		dbutil.NilableTime(v.DismissedAt), dbutil.NilableTime(v.ResolvedAt),
 		v.CreatedAt.Format(time.RFC3339), v.UpdatedAt.Format(time.RFC3339))
 	if err != nil {
 		return fmt.Errorf("upserting violation: %w", err)
@@ -503,7 +504,7 @@ func scanHealthSnapshot(row interface{ Scan(...any) error }) (*HealthSnapshot, e
 	if err != nil {
 		return nil, err
 	}
-	snap.RecordedAt = parseTime(recordedAt)
+	snap.RecordedAt = dbutil.ParseTime(recordedAt)
 	return &snap, nil
 }
 
@@ -522,14 +523,14 @@ func scanViolation(row interface{ Scan(...any) error }) (*RuleViolation, error) 
 
 	v.Fixable = fixable == 1
 	v.Candidates = unmarshalCandidates(candidates)
-	v.CreatedAt = parseTime(createdAt.String)
-	v.UpdatedAt = parseTime(updatedAt.String)
+	v.CreatedAt = dbutil.ParseTime(createdAt.String)
+	v.UpdatedAt = dbutil.ParseTime(updatedAt.String)
 	if dismissedAt.Valid {
-		t := parseTime(dismissedAt.String)
+		t := dbutil.ParseTime(dismissedAt.String)
 		v.DismissedAt = &t
 	}
 	if resolvedAt.Valid {
-		t := parseTime(resolvedAt.String)
+		t := dbutil.ParseTime(resolvedAt.String)
 		v.ResolvedAt = &t
 	}
 
@@ -551,35 +552,10 @@ func scanRule(row interface{ Scan(...any) error }) (*Rule, error) {
 
 	r.Enabled = enabled == 1
 	r.Config = UnmarshalConfig(config)
-	r.CreatedAt = parseTime(createdAt)
-	r.UpdatedAt = parseTime(updatedAt)
+	r.CreatedAt = dbutil.ParseTime(createdAt)
+	r.UpdatedAt = dbutil.ParseTime(updatedAt)
 
 	return &r, nil
-}
-
-func boolToInt(b bool) int {
-	if b {
-		return 1
-	}
-	return 0
-}
-
-func nilableTime(t *time.Time) *string {
-	if t == nil {
-		return nil
-	}
-	s := t.Format(time.RFC3339)
-	return &s
-}
-
-func parseTime(s string) time.Time {
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t
-	}
-	if t, err := time.Parse("2006-01-02 15:04:05", s); err == nil {
-		return t
-	}
-	return time.Time{}
 }
 
 func joinStrings(ss []string, sep string) string {

--- a/internal/scraper/service.go
+++ b/internal/scraper/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
 )
 
 // Service provides CRUD operations for scraper configuration.
@@ -132,8 +133,8 @@ func (s *Service) loadConfig(ctx context.Context, scope string) (*ScraperConfig,
 	}
 	cfg.ID = id
 	cfg.Scope = scope
-	cfg.CreatedAt = parseTime(createdAt)
-	cfg.UpdatedAt = parseTime(updatedAt)
+	cfg.CreatedAt = dbutil.ParseTime(createdAt)
+	cfg.UpdatedAt = dbutil.ParseTime(updatedAt)
 	return cfg, nil
 }
 
@@ -154,8 +155,8 @@ func (s *Service) loadConfigWithOverrides(ctx context.Context, scope string) (*S
 	}
 	cfg.ID = id
 	cfg.Scope = scope
-	cfg.CreatedAt = parseTime(createdAt)
-	cfg.UpdatedAt = parseTime(updatedAt)
+	cfg.CreatedAt = dbutil.ParseTime(createdAt)
+	cfg.UpdatedAt = dbutil.ParseTime(updatedAt)
 
 	var overrides Overrides
 	if overridesJSON != "" && overridesJSON != "{}" {
@@ -244,14 +245,4 @@ func mergeConfigs(global, conn *ScraperConfig, overrides *Overrides) *ScraperCon
 	}
 
 	return merged
-}
-
-func parseTime(s string) time.Time {
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t
-	}
-	if t, err := time.Parse("2006-01-02 15:04:05", s); err == nil {
-		return t
-	}
-	return time.Time{}
 }

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
 )
 
 // Service manages webhook CRUD operations.
@@ -177,8 +178,8 @@ func scanWebhookFromScanner(s scanner) (*Webhook, error) {
 	if err := json.Unmarshal([]byte(eventsJSON), &w.Events); err != nil {
 		w.Events = []string{}
 	}
-	w.CreatedAt = parseTime(createdAt)
-	w.UpdatedAt = parseTime(updatedAt)
+	w.CreatedAt = dbutil.ParseTime(createdAt)
+	w.UpdatedAt = dbutil.ParseTime(updatedAt)
 
 	return &w, nil
 }
@@ -189,13 +190,4 @@ func scanWebhook(row *sql.Row) (*Webhook, error) {
 
 func scanWebhookRow(rows *sql.Rows) (*Webhook, error) {
 	return scanWebhookFromScanner(rows)
-}
-
-func parseTime(s string) time.Time {
-	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05", "2006-01-02T15:04:05"} {
-		if t, err := time.Parse(layout, s); err == nil {
-			return t
-		}
-	}
-	return time.Time{}
 }


### PR DESCRIPTION
## Summary

Closes #371.

- Create `internal/dbutil` package with 6 exported helpers: `BoolToInt`, `IntToBool`, `ParseTime`, `FormatNullableTime`, `NullableString`, `NilableTime`
- Remove duplicated local definitions of `boolToInt`, `parseTime`, `formatNullableTime`, `nullableString`, `nilableTime` from 8 packages (11 files)
- `ParseTime` uses the 3-format superset from the webhook package (RFC3339, space-separated, T-separated without zone) -- no behavior change since the extra format only matches if the others fail
- `IntToBool` is new (requested in the issue) with no existing callers yet
- Net reduction of ~133 lines of duplicated code

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./...` all pass (existing tests exercise all refactored call sites)
- [x] `gofmt -d` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint` passes (pre-commit hook)
- [x] Grep confirms zero remaining local definitions of the 5 extracted functions
- [x] New `internal/dbutil/dbutil_test.go` covers all 6 functions with table-driven tests

## Wiki update checklist

- [ ] Does this PR add, remove, or change a provider, event type, or core interface? **No**
- [x] Does this PR add a package, change the tech stack, or alter a design principle? **Yes** -- new `internal/dbutil` package. Update [Developer Guide](https://github.com/sydlexius/stillwater/wiki/Developer-Guide)
- [ ] Does this PR change linting, hooks, test patterns, or contribution workflow? **No**
- [ ] Does this PR change user-facing behavior, settings, or setup? **No**

Generated with [Claude Code](https://claude.com/claude-code)