### PR TITLE
docs: add milestone 26.5 plan

### DIFF
--- a/docs/plans/m26.5-plan.md
+++ b/docs/plans/m26.5-plan.md
@@ -1,0 +1,99 @@
+# Milestone 26.5 -- Database Normalization and Repository Abstraction
+
+## Goal
+
+Introduce repository interfaces for the artist service, normalize provider IDs and
+image metadata into separate tables, and update all affected documentation. The API
+JSON contract does not change.
+
+## Acceptance Criteria
+
+- [ ] Repository interfaces defined and implemented for the artist service
+- [ ] Provider IDs extracted from artists table into `artist_provider_ids`
+- [ ] Image metadata extracted from artists table into `artist_images`
+- [ ] All wiki pages and architecture docs updated
+- [ ] API JSON contract unchanged across all changes
+- [ ] All tests pass after each issue
+
+## Dependency Map
+
+```
+#371 (dbutil extraction) [DONE]
+  |
+  v
+#372 (repository interfaces)
+  |
+  +------+------+
+  v             v
+#373 (provider  #374 (image
+ IDs)            metadata)
+  |             |
+  +------+------+
+         v
+       #375 (documentation)
+         |
+         v
+       cleanup: remove this plan file
+```
+
+## Checklist
+
+### Issue #371 -- Extract shared database helpers into internal/dbutil
+- [x] Implementation
+- [x] Tests
+- [x] Merged
+
+### Issue #372 -- Introduce repository interfaces for the artist service
+- [ ] Implementation
+- [ ] Tests pass without modification
+- [ ] Docs updated (if applicable)
+- [ ] Merged
+
+### Issue #373 -- Normalize provider IDs into artist_provider_ids table
+- [ ] Migration created
+- [ ] Data migrated from existing columns
+- [ ] Old columns dropped
+- [ ] ProviderIDRepository implementation updated
+- [ ] Tests pass
+- [ ] Merged
+
+### Issue #374 -- Normalize image metadata into artist_images table
+- [ ] Migration created
+- [ ] Data migrated from existing columns
+- [ ] Old columns dropped
+- [ ] ImageRepository implementation updated
+- [ ] Tests pass
+- [ ] Merged
+
+### Issue #375 -- Update documentation for normalized schema
+- [ ] Architecture wiki updated
+- [ ] Developer Guide wiki updated
+- [ ] Contributing wiki updated
+- [ ] CLAUDE.md Architecture section updated
+- [ ] Architecture docs (emby/jellyfin) updated
+- [ ] Plan file removed (`git rm docs/plans/m26.5-plan.md`)
+- [ ] Merged
+
+## Worktrees
+
+| Directory | Branch | Issue | Status |
+|-----------|--------|-------|--------|
+| stillwater-m26.5-plan | docs/m26.5-plan | plan | pending |
+| stillwater-372 | feat/372-repo-interfaces | #372 | pending |
+| stillwater-373 | feat/373-provider-ids | #373 | pending |
+| stillwater-374 | feat/374-image-metadata | #374 | pending |
+| stillwater-375 | feat/375-docs-update | #375 | pending |
+
+## UAT / Merge Order
+
+1. #372 (base: main) -- no schema changes, pure refactor
+2. #373 (base: main, after #372 merged) -- schema migration
+3. #374 (base: main, after #372 merged, parallel with #373) -- schema migration
+4. #375 (base: main, after #373 and #374 merged) -- docs only, includes plan file cleanup
+
+## Notes
+
+- #371 (dbutil extraction) merged 2026-03-03 as commit a189bb2
+- ImageRepository is intentionally empty in #372; #374 populates it
+- After #373/#374, the Artist struct keeps its provider ID and image fields for
+  API compatibility; they are hydrated from the new tables by the Service layer


### PR DESCRIPTION
## Summary
- Adds `docs/plans/m26.5-plan.md` covering database normalization and repository abstraction
- Tracks #371 (done), #372, #373, #374, #375 with dependency map and merge order

## Test plan
- [ ] Plan file renders correctly on GitHub

Generated with [Claude Code](https://claude.com/claude-code)