### PR TITLE
ci: add workflow to auto-merge Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,6 +23,9 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    concurrency:
+      group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - name: Fetch Dependabot metadata
         id: metadata


### PR DESCRIPTION
## Summary
- Add `.github/workflows/dependabot-auto-merge.yml` that auto-approves and squash-merges Dependabot PRs for patch and minor dependency updates
- Major version bumps are excluded and require manual review
- Workflow waits for all required CI status checks (Lint, Test, Build) to pass before merging

## Prerequisites
- [ ] Enable "Allow auto-merge" in repo settings (Settings > General > Pull Requests)
- [ ] Branch protection rules on `main` require CI status checks

Closes #395

## Test plan
- [ ] Verify YAML is valid and workflow syntax is correct
- [ ] Confirm workflow triggers on Dependabot PRs only (`github.actor == 'dependabot[bot]'`)
- [ ] Confirm patch/minor updates are auto-approved and auto-merged
- [ ] Confirm major updates are skipped (no approval, no auto-merge)

Generated with [Claude Code](https://claude.com/claude-code)