### PR TITLE
docs: add issue templates and effort hint to agent workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,38 @@
+---
+name: Bug Report
+about: Something is broken or behaving incorrectly
+labels: bug
+---
+
+<!-- Agent hints: set all three before submitting -->
+[mode: direct] <!-- plan | direct -->
+[model: sonnet] <!-- opus | sonnet | haiku -->
+[effort: medium] <!-- high | medium | low -->
+
+## Description
+
+<!-- What is broken? What did you expect to happen? -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What should happen -->
+
+## Actual Behavior
+
+<!-- What actually happens -->
+
+## Environment
+
+- Stillwater version:
+- Platform (Docker / bare metal):
+- Browser (if UI bug):
+
+## Additional Context
+
+<!-- Logs, screenshots, related issues, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,32 @@
+---
+name: Feature Request
+about: New feature or enhancement
+labels: enhancement
+---
+
+<!-- Agent hints: set all three before submitting -->
+[mode: plan] <!-- plan | direct -->
+[model: sonnet] <!-- opus | sonnet | haiku -->
+[effort: medium] <!-- high | medium | low -->
+
+## Summary
+
+<!-- One sentence: what does this add or change? -->
+
+## Problem / Motivation
+
+<!-- Why is this needed? What pain does it solve? -->
+
+## Proposed Solution
+
+<!-- How should it work? Include any relevant design notes. -->
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+- [ ]
+
+## Additional Context
+
+<!-- Screenshots, references, related issues, etc. -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,23 @@
+---
+name: Task / Chore
+about: Refactor, cleanup, docs, config, or other non-feature work
+labels: chore
+---
+
+<!-- Agent hints: set all three before submitting -->
+[mode: direct] <!-- plan | direct -->
+[model: haiku] <!-- opus | sonnet | haiku -->
+[effort: low] <!-- high | medium | low -->
+
+## Description
+
+<!-- What needs to be done and why? -->
+
+## Acceptance Criteria
+
+- [ ]
+- [ ]
+
+## Additional Context
+
+<!-- References, related issues, etc. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,27 @@ When working on a GitHub issue, look for these tags in the issue body:
 - **`[model: opus]`** - Use Opus for this task. Indicates complex architecture, multi-file changes, or nuanced design decisions.
 - **`[model: sonnet]`** - Use Sonnet for this task. Good balance of capability and speed for standard feature work.
 - **`[model: haiku]`** - Use Haiku for this task. Indicates simple, well-defined changes (typo fixes, small additions, config changes).
+- **`[effort: high]`** - Enable extended thinking. Use for complex architectural decisions, multi-system design, ambiguous requirements, or security-sensitive analysis.
+- **`[effort: medium]`** - Standard reasoning. Default for most feature and bug work.
+- **`[effort: low]`** - Minimal reasoning. Use for simple, fully-specified tasks with no ambiguity (config tweaks, typo fixes, docs).
 
-If no hint is present, default to: Sonnet with Plan Mode for new features, Sonnet direct for bug fixes, Haiku for documentation-only changes.
+If no hint is present, default to: Sonnet + Plan Mode + medium effort for new features, Sonnet + direct + medium effort for bug fixes, Haiku + direct + low effort for documentation-only changes.
+
+When a model or effort hint differs from the current session state, pause before starting work and ask the user to run the appropriate command:
+
+- Model mismatch: "This issue requests `[model: opus]`. Please run `/model claude-opus-4-6` before I proceed."
+- Effort high: "This issue requests `[effort: high]`. Please run `/think` to enable extended thinking before I proceed."
+
+Do not start implementation until the user confirms or explicitly waives the hint.
+
+### Creating Issues via CLI
+
+When creating a GitHub issue with `gh issue create`, do NOT write a freeform body. Instead:
+
+1. Choose the appropriate template from `.github/ISSUE_TEMPLATE/` (`feature.md`, `bug.md`, or `task.md`).
+2. Read the template file to get its structure.
+3. Fill in all sections, including the `[mode:]`, `[model:]`, and `[effort:]` hints at the top.
+4. Pass the populated content as the `--body` argument.
 
 ## Architectural Decisions
 


### PR DESCRIPTION
## Summary

- Adds GitHub issue templates (feature, bug, task) with `[mode:]`, `[model:]`, and `[effort:]` hints pre-populated and commented with options
- Defines `[effort: high|medium|low]` semantics in CLAUDE.md: high = extended thinking (`/think`), medium = standard, low = minimal
- Adds a rule requiring agents to read and follow templates when creating issues via `gh issue create` (no freeform bodies)
- Agents seeing a model or effort mismatch will pause and ask the user to run `/model` or `/think` before proceeding

## Test plan

- [ ] Open a new issue on GitHub -- all three templates should appear as options
- [ ] Verify hint comments show available values inline
- [ ] Confirm CLAUDE.md hint table reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)