### PR TITLE
docs: update m27 plan -- unified CRUD direction, new issues #408-#410

### DIFF
--- a/docs/plans/m27-plan.md
+++ b/docs/plans/m27-plan.md
@@ -131,3 +131,11 @@ Session 4 (unified CRUD):
   one, the local record is updated during populate.
 - Image cache directory (`/data/cache/images/{artistID}/`) created automatically when
   `artist.Path` is empty. Uses `imageDir(a)` helper throughout handlers.
+
+## Cleanup
+
+When all checklist items are complete and all PRs are merged:
+1. Post a summary comment on each completed issue and close it.
+2. `git rm docs/plans/m27-plan.md` and commit directly to `main`.
+3. Remove all M27 worktrees and delete their branches (remote and local).
+4. Update `memory/worktrees.md`.


### PR DESCRIPTION
## Summary

- Updates M27 plan to reflect the new unified CRUD direction
- Closes #385 (wontfix) reference and removes it from the checklist
- Adds #408 (unified image CRUD), #409 (auto-push metadata), #410 (remove Platform State section), #411 (debug panel -- moved to M32)
- Updates goal paragraph and acceptance criteria
- Adds self-delete clause

## Test plan

- [ ] Plan file reads correctly and reflects current M27 state
- [ ] No broken issue references

🤖 Generated with [Claude Code](https://claude.com/claude-code)