### PR TITLE
fix: set HX-Trigger header on image upload with sync warnings

### DIFF
--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -189,6 +189,7 @@ func (r *Router) handleImageUpload(w http.ResponseWriter, req *http.Request) {
 	if imageType == "fanart" {
 		resp["count"] = a.FanartCount
 	}
+	setSyncWarningTrigger(w, warnings)
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -572,6 +572,18 @@ func TestHandleImageUpload_SyncWarnings_PlatformFailure(t *testing.T) {
 	if !strings.Contains(warnings[0], "image upload failed") {
 		t.Errorf("warning should mention upload failure, got %q", warnings[0])
 	}
+
+	hxTrigger := w.Header().Get("HX-Trigger")
+	if hxTrigger == "" {
+		t.Fatal("HX-Trigger header not set when sync warnings present")
+	}
+	var triggerPayload map[string][]string
+	if err := json.Unmarshal([]byte(hxTrigger), &triggerPayload); err != nil {
+		t.Fatalf("HX-Trigger is not valid JSON: %v -- value: %s", err, hxTrigger)
+	}
+	if len(triggerPayload["syncWarning"]) == 0 {
+		t.Error("HX-Trigger syncWarning payload is empty")
+	}
 }
 
 func TestHandleDeleteImage_SyncWarnings_PlatformFailure(t *testing.T) {


### PR DESCRIPTION
## Summary

- `handleImageUpload` collected sync warnings from `syncImageToPlatforms` but never called `setSyncWarningTrigger`, so HTMX clients received no `HX-Trigger` header and toast notifications were never shown for upload sync failures
- All other image handlers (fetch, crop, trim, delete) already called `setSyncWarningTrigger` correctly; this patch closes the gap for upload
- Extends `TestHandleImageUpload_SyncWarnings_PlatformFailure` to assert the `HX-Trigger` header is present and contains a valid `syncWarning` payload

The three early-exit warning paths in `syncImageToPlatforms` and `deleteImageFromPlatforms` were already addressed in #420 (#426). Four pre-existing silent failure issues identified during review were filed separately as #431, #432, #433, #434.

## Test plan
- [ ] `go test ./...` passes
- [ ] `TestHandleImageUpload_SyncWarnings_PlatformFailure` asserts `HX-Trigger` header is set and contains `syncWarning` payload
- [ ] OpenAPI spec verified -- no changes required (header is HTMX-internal, not part of the API contract)

Closes #427

Generated with [Claude Code](https://claude.com/claude-code)