### PR TITLE
chore: update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -15,12 +15,12 @@ repos:
       - id: typos
 
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.22.1
+    rev: v8.30.0
     hooks:
       - id: gitleaks
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.10.1
+    rev: v2.11.2
     hooks:
       - id: golangci-lint
 
@@ -33,7 +33,7 @@ repos:
         types: [go]
 
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]


### PR DESCRIPTION
## Summary
- Update pre-commit-hooks v5.0.0 -> v6.0.0
- Update gitleaks v8.22.1 -> v8.30.0
- Update golangci-lint v2.10.1 -> v2.11.2
- Update conventional-pre-commit v4.1.0 -> v4.4.0

Dependabot does not manage pre-commit hook versions (no native ecosystem support), so these were updated manually via `pre-commit autoupdate`.

## Test plan
- [ ] Pre-commit hooks run successfully on a test commit
- [ ] CI passes (lint, test, build)

Generated with [Claude Code](https://claude.com/claude-code)