### PR TITLE
feat: add NFO roundtrip smoke tests and Emby platform ID guard

### DIFF
--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -943,7 +943,7 @@ if [[ "$ROUNDTRIP" -eq 1 ]]; then
 
     if [[ "$RT_SETUP_OK" -eq 1 ]]; then
 
-    RT_ARTIST_TYPE=$(echo "$sw_artist_orig" | jq -r '.artist.type // "Group"' 2>/dev/null || echo "Group")
+    RT_ARTIST_TYPE=$(echo "$sw_artist_orig" | jq -r '.artist.type // "group"' 2>/dev/null || echo "group")
     orig_bio=$(echo "$sw_artist_orig" | jq -r '.artist.biography // empty' 2>/dev/null || true)
     orig_formed=$(echo "$sw_artist_orig" | jq -r '.artist.formed // empty' 2>/dev/null || true)
     orig_disbanded=$(echo "$sw_artist_orig" | jq -r '.artist.disbanded // empty' 2>/dev/null || true)
@@ -1076,10 +1076,10 @@ if [[ "$ROUNDTRIP" -eq 1 ]]; then
         echo "[SKIP] $platform roundtrip MBID -- no MBID in Stillwater"
       fi
 
-      # Formed/Disbanded -> PremiereDate/EndDate (Groups only).
-      # Person-type artists use Born/Died which are not standard Items API fields.
-      if [[ "$RT_ARTIST_TYPE" == "Person" ]]; then
-        echo "[SKIP] $platform roundtrip formed/disbanded -- Person type (no PremiereDate/EndDate)"
+      # Formed/Disbanded -> PremiereDate/EndDate (group types only).
+      # Non-group artists use Born/Died which are not standard Items API fields.
+      if [[ "$RT_ARTIST_TYPE" != "group" && "$RT_ARTIST_TYPE" != "orchestra" && "$RT_ARTIST_TYPE" != "choir" ]]; then
+        echo "[SKIP] $platform roundtrip formed/disbanded -- $RT_ARTIST_TYPE type (uses born/died, not PremiereDate/EndDate)"
       else
         local p_date_short="${p_date:0:10}"
         assert_json_value "$platform roundtrip formed->PremiereDate" "$RT_FORMED" "$p_date_short"


### PR DESCRIPTION
## Summary

- **Tier 5 roundtrip tests** (`--roundtrip` flag): End-to-end verification of metadata fidelity between Stillwater and Emby/Jellyfin
  - **Direction 1** (Stillwater -> Platform): Sets synthetic test data, pushes via API, fetches from platform API, compares biography, MBID, dates, genres, and tags field-by-field
  - **Direction 2** (Platform -> NFO -> Stillwater): Modifies biography directly on platform, polls for NFO mtime change, verifies Stillwater's diff and conflict detection endpoints
  - Both directions restore original values after testing
  - Multi-layer skip guards prevent false failures when env vars, platform IDs, or connectivity are missing
- **Emby push/images platform ID guard**: Checks for stored platform ID before calling push endpoint, emitting `[SKIP]` instead of false `[FAIL]`
- Helper functions: `platform_get_item`, `platform_modify_overview`, `wait_for_nfo_change`, `assert_json_value`

Closes #416

## Test plan
- [x] `bash scripts/smoke.sh` -- 58/58 pass (standard tiers)
- [x] `bash scripts/smoke.sh --roundtrip` -- 80/80 pass (all tiers including roundtrip)
- [x] Emby Direction 1: biography, MBID, formed, disbanded, genres, tags all verified
- [x] Jellyfin Direction 1: same fields verified
- [x] Emby Direction 2: NFO mtime change detected, diff and conflict endpoints confirmed
- [x] Jellyfin Direction 2: same verification confirmed

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Quality Assurance**
  * Enhanced smoke testing for artist metadata sync across platforms with improved push/image handling and per-platform skip logic.
  * Added opt-in roundtrip testing mode to validate end-to-end data integrity, conflict detection, and automatic restoration.

* **Tests**
  * Introduced extensive tiered roundtrip test flows covering cross-platform field comparisons (dates, genres, tags, IDs) and post-test cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->