### PR TITLE
refactor: extract PipelineRunner interface (#475)

### DIFF
--- a/internal/api/handlers_run_artist_rules_stub_test.go
+++ b/internal/api/handlers_run_artist_rules_stub_test.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"log/slog"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/auth"
+	"github.com/sydlexius/stillwater/internal/connection"
+	"github.com/sydlexius/stillwater/internal/database"
+	"github.com/sydlexius/stillwater/internal/encryption"
+	"github.com/sydlexius/stillwater/internal/rule"
+)
+
+// stubPipeline is a test double for rule.PipelineRunner that returns
+// preconfigured results without requiring a real Engine or Service.
+type stubPipeline struct {
+	runForArtistFn func(ctx context.Context, a *artist.Artist) (*rule.RunResult, error)
+}
+
+func (s *stubPipeline) RunForArtist(ctx context.Context, a *artist.Artist) (*rule.RunResult, error) {
+	if s.runForArtistFn != nil {
+		return s.runForArtistFn(ctx, a)
+	}
+	return &rule.RunResult{}, nil
+}
+
+func (s *stubPipeline) RunRule(_ context.Context, _ string) (*rule.RunResult, error) {
+	return &rule.RunResult{}, nil
+}
+
+func (s *stubPipeline) RunAll(_ context.Context) (*rule.RunResult, error) {
+	return &rule.RunResult{}, nil
+}
+
+// testRouterWithStubPipeline creates a Router backed by a stubPipeline,
+// avoiding the need for a real Engine, rule seeding, and rule service.
+func testRouterWithStubPipeline(t *testing.T, stub *stubPipeline) (*Router, *artist.Service) {
+	t.Helper()
+
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("opening test db: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("running migrations: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	enc, _, err := encryption.NewEncryptor("")
+	if err != nil {
+		t.Fatalf("creating encryptor: %v", err)
+	}
+
+	authSvc := auth.NewService(db)
+	artistSvc := artist.NewService(db)
+	connSvc := connection.NewService(db, enc)
+
+	r := NewRouter(RouterDeps{
+		AuthService:       authSvc,
+		ArtistService:     artistSvc,
+		ConnectionService: connSvc,
+		Pipeline:          stub,
+		DB:                db,
+		Logger:            logger,
+		StaticDir:         "../../web/static",
+	})
+
+	return r, artistSvc
+}
+
+func TestStub_RunArtistRules_ViolationsFound_JSON(t *testing.T) {
+	stub := &stubPipeline{
+		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
+			return &rule.RunResult{
+				ArtistsProcessed: 1,
+				ViolationsFound:  3,
+				FixesAttempted:   1,
+				FixesSucceeded:   1,
+			}, nil
+		},
+	}
+	r, artistSvc := testRouterWithStubPipeline(t, stub)
+	a := addTestArtist(t, artistSvc, "Stub Violations Artist")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/run-rules", nil)
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+
+	r.handleRunArtistRules(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if got, ok := resp["violations_found"]; !ok {
+		t.Error("response missing violations_found field")
+	} else if got != float64(3) {
+		t.Errorf("violations_found = %v, want 3", got)
+	}
+}
+
+func TestStub_RunArtistRules_ViolationsFound_HTMX(t *testing.T) {
+	stub := &stubPipeline{
+		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
+			return &rule.RunResult{
+				ArtistsProcessed: 1,
+				ViolationsFound:  5,
+			}, nil
+		},
+	}
+	r, artistSvc := testRouterWithStubPipeline(t, stub)
+	a := addTestArtist(t, artistSvc, "Stub HTMX Violations Artist")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/run-rules", nil)
+	req.Header.Set("HX-Request", "true")
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+
+	r.handleRunArtistRules(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "5 violation(s).") {
+		t.Errorf("HTMX body = %q, want '5 violation(s).'", body)
+	}
+	if !strings.Contains(body, "/notifications") {
+		t.Errorf("HTMX body = %q, want /notifications link", body)
+	}
+}
+
+func TestStub_RunArtistRules_PipelineError_JSON(t *testing.T) {
+	stub := &stubPipeline{
+		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
+			return nil, fmt.Errorf("engine exploded")
+		},
+	}
+	r, artistSvc := testRouterWithStubPipeline(t, stub)
+	a := addTestArtist(t, artistSvc, "Stub Error Artist")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/run-rules", nil)
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+
+	r.handleRunArtistRules(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d; body: %s", w.Code, http.StatusInternalServerError, w.Body.String())
+	}
+}
+
+func TestStub_RunArtistRules_PipelineError_HTMX(t *testing.T) {
+	stub := &stubPipeline{
+		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
+			return nil, fmt.Errorf("engine exploded")
+		},
+	}
+	r, artistSvc := testRouterWithStubPipeline(t, stub)
+	a := addTestArtist(t, artistSvc, "Stub HTMX Error Artist")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/run-rules", nil)
+	req.Header.Set("HX-Request", "true")
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+
+	r.handleRunArtistRules(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Failed") {
+		t.Errorf("HTMX body = %q, want failure message containing 'Failed'", body)
+	}
+	if strings.Contains(body, "engine exploded") {
+		t.Error("HTMX body leaked internal error message to client")
+	}
+}
+
+func TestStub_RunArtistRules_NoViolations_HTMX(t *testing.T) {
+	stub := &stubPipeline{
+		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
+			return &rule.RunResult{ArtistsProcessed: 1}, nil
+		},
+	}
+	r, artistSvc := testRouterWithStubPipeline(t, stub)
+	a := addTestArtist(t, artistSvc, "Stub Clean Artist")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/run-rules", nil)
+	req.Header.Set("HX-Request", "true")
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+
+	r.handleRunArtistRules(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "No violations found.") {
+		t.Errorf("HTMX body = %q, want 'No violations found.'", body)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -41,7 +41,7 @@ type RouterDeps struct {
 	Orchestrator       *provider.Orchestrator
 	RuleService        *rule.Service
 	RuleEngine         *rule.Engine
-	Pipeline           *rule.Pipeline
+	Pipeline           rule.PipelineRunner
 	BulkService        *rule.BulkService
 	BulkExecutor       *rule.BulkExecutor
 	NFOSnapshotService *nfo.SnapshotService
@@ -76,7 +76,7 @@ type Router struct {
 	orchestrator       *provider.Orchestrator
 	ruleService        *rule.Service
 	ruleEngine         *rule.Engine
-	pipeline           *rule.Pipeline
+	pipeline           rule.PipelineRunner
 	bulkService        *rule.BulkService
 	bulkExecutor       *rule.BulkExecutor
 	nfoSnapshotService *nfo.SnapshotService

--- a/internal/rule/bulk_executor.go
+++ b/internal/rule/bulk_executor.go
@@ -22,7 +22,7 @@ type BulkExecutor struct {
 	bulkService     *BulkService
 	artistService   *artist.Service
 	orchestrator    *provider.Orchestrator
-	pipeline        *Pipeline
+	pipeline        PipelineRunner
 	snapshotService *nfo.SnapshotService
 	platformService *platform.Service
 	logger          *slog.Logger
@@ -39,7 +39,7 @@ func (e *BulkExecutor) SetEventBus(bus *event.Bus) {
 }
 
 // NewBulkExecutor creates a BulkExecutor.
-func NewBulkExecutor(bulkService *BulkService, artistService *artist.Service, orchestrator *provider.Orchestrator, pipeline *Pipeline, snapshotService *nfo.SnapshotService, platformService *platform.Service, logger *slog.Logger) *BulkExecutor {
+func NewBulkExecutor(bulkService *BulkService, artistService *artist.Service, orchestrator *provider.Orchestrator, pipeline PipelineRunner, snapshotService *nfo.SnapshotService, platformService *platform.Service, logger *slog.Logger) *BulkExecutor {
 	return &BulkExecutor{
 		bulkService:     bulkService,
 		artistService:   artistService,

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -43,6 +43,17 @@ type RunResult struct {
 	Results          []FixResult `json:"results"`
 }
 
+// PipelineRunner abstracts the rule pipeline so consumers can be tested
+// with stubs instead of requiring a full Engine, Service, and Fixer chain.
+type PipelineRunner interface {
+	RunForArtist(ctx context.Context, a *artist.Artist) (*RunResult, error)
+	RunRule(ctx context.Context, ruleID string) (*RunResult, error)
+	RunAll(ctx context.Context) (*RunResult, error)
+}
+
+// Compile-time assertion: *Pipeline implements PipelineRunner.
+var _ PipelineRunner = (*Pipeline)(nil)
+
 // Pipeline orchestrates rule evaluation and auto-fixing across artists.
 type Pipeline struct {
 	engine        *Engine

--- a/internal/rule/scheduler.go
+++ b/internal/rule/scheduler.go
@@ -9,13 +9,13 @@ import (
 // Scheduler periodically runs enabled rules via the pipeline, respecting
 // each rule's automation mode.
 type Scheduler struct {
-	pipeline    *Pipeline
+	pipeline    PipelineRunner
 	ruleService *Service
 	logger      *slog.Logger
 }
 
 // NewScheduler creates a rule scheduler.
-func NewScheduler(pipeline *Pipeline, ruleService *Service, logger *slog.Logger) *Scheduler {
+func NewScheduler(pipeline PipelineRunner, ruleService *Service, logger *slog.Logger) *Scheduler {
 	return &Scheduler{
 		pipeline:    pipeline,
 		ruleService: ruleService,


### PR DESCRIPTION
## Summary
- Extract `PipelineRunner` interface from concrete `*Pipeline` in `internal/rule/fixer.go`
- Update all consumers (`Router`, `Scheduler`, `BulkExecutor`) to depend on the interface instead of the concrete type
- Add stub-based handler tests covering violations-found, no-violations, and pipeline-error paths for both JSON and HTMX responses
- No changes to `cmd/stillwater/main.go` needed -- concrete `*Pipeline` satisfies the interface

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New stub-based tests verify handler behavior without requiring a real Engine/Service chain
- [x] `go build ./...` compiles cleanly
- [x] Pre-commit hooks (gofmt, golangci-lint, govulncheck) pass

Closes #475

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the Run Artist Rules HTTP handler, including scenarios for violations found, no violations, and error handling across both JSON and HTMX response formats.

* **Refactor**
  * Updated internal pipeline abstraction to use interface-based dependency injection, improving flexibility and testability of the rules execution system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->