### PR TITLE
fix: use reviews API for dependabot auto-merge check

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -72,12 +72,14 @@ jobs:
           # This works regardless of whether branch protection requires
           # pull request reviews (which controls the reviewDecision field).
           for i in $(seq 1 10); do
-            # Use --paginate and take the latest review per user to avoid
-            # counting stale approvals that were superseded by later reviews.
+            # Slurp all pages into one array, sort, group by user, and take
+            # only the latest review per user to avoid stale approvals.
             APPROVED=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate \
-              --jq '
-                group_by(.user.login)
-                | map(sort_by(.submitted_at) | last)
+              | jq -s '
+                add
+                | sort_by(.user.login, .submitted_at)
+                | group_by(.user.login)
+                | map(last)
                 | map(select(.state == "APPROVED"))
                 | length
               ') || {


### PR DESCRIPTION
## Summary
- Replace `gh pr view --json reviewDecision` with direct reviews API query
- `reviewDecision` is only populated when branch protection requires PR reviews
- The reviews API correctly reports approvals regardless of branch protection config
- This fixes dependabot PRs being approved but never auto-merged

## Test plan
- [x] Workflow syntax valid (YAML structure unchanged)
- [x] No command injection risk (all inputs from env vars, not user content)
- [x] Logic matches: checks for any APPROVED review via `gh api repos/$REPO/pulls/$PR_NUMBER/reviews`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency merge checks to aggregate PR reviews (handles paginated results and per-user latest reviews), count approvals, and require an explicit APPROVED outcome before merging.
  * Enhanced reliability with retry and warning behavior on fetch failures, clearer log messages, and updated gating logic to prevent premature merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->