### PR TITLE
fix: document and test extraneous image rule sequencing awareness

### DIFF
--- a/internal/rule/checkers.go
+++ b/internal/rule/checkers.go
@@ -651,7 +651,7 @@ func expectedImageFiles(profile *platform.Profile, artistPath string) map[string
 // extension variants are considered expected.
 //
 // Responsibility boundary: this checker flags files with non-standard names
-// (e.g., "backdrop_old.png", "cover.png"). It does NOT flag valid numbered
+// (e.g., "backdrop_old.png"). It does NOT flag valid numbered
 // fanart variants even if their indices have gaps (e.g., backdrop.jpg +
 // backdrop3.jpg with no backdrop2.jpg). Gap detection is handled by the
 // backdrop_sequencing rule (#519).

--- a/internal/rule/checkers_test.go
+++ b/internal/rule/checkers_test.go
@@ -506,7 +506,7 @@ func TestCheckExtraneousImages_BackdropNaming(t *testing.T) {
 }
 
 func TestCheckExtraneousImages_NonStandardNameFlagged(t *testing.T) {
-	// Non-standard names like "backdrop_old.png" should be flagged even
+	// Non-standard names like "backdrop_old.jpg" should be flagged even
 	// when valid numbered backdrops are present.
 	dir := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir, "folder.jpg"), 500, 500)


### PR DESCRIPTION
## Summary
- Audit confirms extraneous images rule already handles numbered fanart/backdrop variants correctly
- Add responsibility boundary documentation: extraneous = non-standard names, NOT sequencing gaps (that is #519)
- Add 3 new tests: gaps are whitelisted, backdrop naming works, non-standard names are flagged

Closes #520

## Test plan
- [x] `go test ./...` passes on all packages
- [x] `TestCheckExtraneousImages_NumberedFanartWithGaps` verifies gaps are not false positives
- [x] `TestCheckExtraneousImages_BackdropNaming` verifies Emby/Jellyfin naming
- [x] `TestCheckExtraneousImages_NonStandardNameFlagged` verifies bad names are caught


Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarification of image filename validation logic and exception handling boundaries.

* **Tests**
  * Enhanced test coverage for image filename validation with additional scenarios for numbered variants and non-standard naming patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->