### PR TITLE
feat: add --music-path parameter to smoke.sh

### DIFF
--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -41,6 +41,10 @@ while [[ $# -gt 0 ]]; do
         echo "ERROR: --music-path requires a value"
         exit 1
       fi
+      if [[ "${2:-}" == --* ]]; then
+        echo "ERROR: --music-path value looks like a flag: $2"
+        exit 1
+      fi
       MUSIC_PATHS+=("$2")
       shift 2
       ;;


### PR DESCRIPTION
## Summary
- Adds `--music-path PATH` CLI argument (supports multiple) to `smoke.sh` for scoping roundtrip tests to specific music directories
- Adds `SW_MUSIC_PATH` env var fallback (colon-separated paths)
- Precedence: CLI arg > env var > API query (existing behavior)
- Unknown arguments now error instead of being silently ignored

## Test plan
- [ ] `bash scripts/smoke.sh --roundtrip --music-path /music` uses specified path
- [ ] `SW_MUSIC_PATH=/music bash scripts/smoke.sh --roundtrip` uses env var
- [ ] `bash scripts/smoke.sh --roundtrip` falls back to API discovery (existing behavior)
- [ ] `bash scripts/smoke.sh --music_path /music` errors on unknown arg (typo protection)
- [ ] `bash scripts/smoke.sh --full --roundtrip` existing flags still work

Closes #524

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repeatable --music-path CLI flag and SW_MUSIC_PATH env var to filter artist selection by filesystem directories during roundtrip runs.
  * When filters are active, the tool now prints the active music-path filter.

* **Bug Fixes**
  * Unknown or missing CLI arguments now report usage errors and fail fast.
  * Path handling normalized to ensure reliable filtering of candidate selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->