### PR TITLE
refactor: consolidate image save with platform-aware naming

### DIFF
--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -548,6 +548,9 @@ func (r *Router) getActiveNamingConfig(ctx context.Context, imageType string) []
 // getActiveNamingAndSymlinks returns the filenames for the given image type and
 // the UseSymlinks flag from the active platform profile.
 func (r *Router) getActiveNamingAndSymlinks(ctx context.Context, imageType string) ([]string, bool) {
+	if r.platformService == nil {
+		return img.FileNamesForType(img.DefaultFileNames, imageType), false
+	}
 	profile, err := r.platformService.GetActive(ctx)
 	if err != nil || profile == nil {
 		return img.FileNamesForType(img.DefaultFileNames, imageType), false

--- a/internal/api/handlers_notifications.go
+++ b/internal/api/handlers_notifications.go
@@ -354,7 +354,8 @@ func (r *Router) handleApplyViolationCandidate(w http.ResponseWriter, req *http.
 	// Download and save the chosen image using platform-aware naming
 	naming, useSymlinks := r.getActiveNamingAndSymlinks(req.Context(), body.ImageType)
 	if _, err := rule.SaveImageFromURL(req.Context(), a, body.ImageType, body.URL, naming, useSymlinks, r.platformService, r.logger); err != nil {
-		writeError(w, req, http.StatusInternalServerError, fmt.Sprintf("applying candidate: %v", err))
+		r.logger.Error("applying image candidate", "artist_id", a.ID, "image_type", body.ImageType, "error", err)
+		writeError(w, req, http.StatusInternalServerError, "failed to apply image candidate")
 		return
 	}
 

--- a/internal/rule/bulk_executor.go
+++ b/internal/rule/bulk_executor.go
@@ -338,10 +338,11 @@ func (e *BulkExecutor) saveBestImage(ctx context.Context, a *artist.Artist, imag
 		return (candidates[i].Width * candidates[i].Height) > (candidates[j].Width * candidates[j].Height)
 	})
 
-	// Try each candidate using the shared save pipeline (platform-aware naming)
+	// Pre-resolve naming and symlink config once (does not depend on candidate URL).
 	useSymlinks := activeUseSymlinks(ctx, e.platformService)
+	naming := existingImageFileNames(ctx, a.Path, imageType, e.platformService)
 	for _, c := range candidates {
-		if _, err := SaveImageFromURL(ctx, a, imageType, c.URL, nil, useSymlinks, e.platformService, e.logger); err != nil {
+		if _, err := SaveImageFromURL(ctx, a, imageType, c.URL, naming, useSymlinks, e.platformService, e.logger); err != nil {
 			e.logger.Debug("image candidate failed", "url", c.URL, "error", err)
 			continue
 		}

--- a/internal/rule/fixers.go
+++ b/internal/rule/fixers.go
@@ -499,7 +499,7 @@ func SaveImageFromURL(ctx context.Context, a *artist.Artist, imageType, rawURL s
 // the downloaded data (e.g. post-download dimension checks) can do so before
 // committing the save.
 //
-// When naming is non-nil, it overrides the platform-aware resolution.
+// When naming is non-empty, it overrides the platform-aware resolution.
 // Returns the list of saved filenames on success.
 func SaveImageFromData(ctx context.Context, a *artist.Artist, imageType string, data []byte, naming []string, useSymlinks bool, platformService *platform.Service, logger *slog.Logger) ([]string, error) {
 	converted, _, err := img.ConvertFormat(bytes.NewReader(data))


### PR DESCRIPTION
## Summary
- Extracts `SaveImageFromURL` and `SaveImageFromData` shared helpers in `internal/rule/fixers.go` for the download-convert-save-flag pipeline
- Refactors `BulkExecutor.fixImageForArtist` and `ImageFixer.Fix` to use the shared helpers, eliminating duplicated logic
- Fixes bulk executor using `img.DefaultFileNames` (hardcoded) instead of platform-aware naming
- Apply-candidate handler now passes resolved naming through instead of discarding it

## Test plan
- [ ] `go test ./internal/rule/...` passes (fixer pipeline tests)
- [ ] `go test ./internal/api/...` passes (notification handler tests)
- [ ] Full test suite passes: `go test ./...`
- [ ] Bulk fix-all operations use correct platform-specific filenames

Closes #545

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined image candidate processing and platform-aware saving to reduce duplication and make image handling more consistent.
* **Bug Fixes**
  * Improved resilience when platform configuration is unavailable (falls back to sensible defaults).
  * Standardized error handling and logging for image save failures to avoid leaking internal error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->