### PR TITLE
test: add smoke tests for fix-undo route and NFO lockdata

### DIFF
--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1128,9 +1128,6 @@ if [[ "$ROUNDTRIP" -eq 1 ]]; then
     # the platform to overwrite the NFO before we can check it. The real
     # protection happens when the platform next reads the locked NFO and imports
     # the lock into its internal DB (confirmed in platform behavior tests).
-    # This check re-writes the NFO by patching a field with auto-push disabled
-    # (using a no-op biography re-set) so we can read it before any platform
-    # interference.
     if [[ -n "$RT_ARTIST_PATH" ]]; then
       nfo_target="$RT_ARTIST_PATH/artist.nfo"
       if [[ -f "$nfo_target" ]]; then


### PR DESCRIPTION
## Summary

- Tier 3: verify POST /api/v1/fix-undo/{undoId} returns 404/400/410 for
  nonexistent undo ID (proves renamed route is registered)
- Tier 5 roundtrip: verify artist.nfo contains `<lockdata>true</lockdata>`
  after Stillwater writes it (platform overwrite protection)

## Test plan

- [x] `bash scripts/smoke.sh` -- 55 passed, 0 failed (native, no roundtrip)
- [ ] `bash scripts/smoke.sh --roundtrip` -- lockdata check validated


Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automated API smoke check that verifies the system returns the expected "gone" (410) response for missing undo entries.
  * Added a local validation step that inspects artist metadata for a required lock flag: it marks passes, emits warnings when the flag exists but isn't set, fails when the flag is absent, and skips when metadata or local path is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->