### PR TITLE
test: add shared-filesystem smoke checks to Tier 3

### DIFF
--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -937,20 +937,11 @@ if [[ "$shared_fs_code" == "200" ]]; then
       FAILURES+=("shared-fs image_fetcher_warnings -- array missing or wrong type when overlaps detected")
     fi
 
-    # Validate warning structure when warnings exist.
+    # Validate warning structure when warnings exist. Only risk_level and
+    # message are required; platform is optional (degraded warnings may omit it).
     if [[ "$shared_fs_warnings_ok" == "true" && "$shared_fs_warnings" -gt 0 ]]; then
-      first_warning_platform=$(echo "$shared_fs_body" | jq -r '.image_fetcher_warnings[0].platform' 2>/dev/null || echo "null")
       first_warning_risk=$(echo "$shared_fs_body" | jq -r '.image_fetcher_warnings[0].risk_level' 2>/dev/null || echo "null")
       first_warning_message=$(echo "$shared_fs_body" | jq -r '.image_fetcher_warnings[0].message' 2>/dev/null || echo "null")
-      # Validate platform is present.
-      if [[ "$first_warning_platform" != "null" && -n "$first_warning_platform" ]]; then
-        echo "[PASS]   image_fetcher_warnings[0] has platform=$first_warning_platform"
-        PASS=$((PASS + 1))
-      else
-        echo "[FAIL]   image_fetcher_warnings[0] -- missing platform field"
-        FAIL=$((FAIL + 1))
-        FAILURES+=("image_fetcher_warnings[0] -- missing platform field")
-      fi
       # Validate risk_level is one of the expected values.
       if [[ "$first_warning_risk" == "warn" || "$first_warning_risk" == "critical" ]]; then
         echo "[PASS]   image_fetcher_warnings[0] has risk_level=$first_warning_risk"


### PR DESCRIPTION
## Summary

- Add smoke tests for shared-filesystem detection endpoints to Tier 3 (Feature Coverage)
- Verify `GET /api/v1/shared-filesystem/status` response shape: `has_overlaps` boolean, `libraries` array, `image_fetcher_warnings` when overlaps are detected, and warning structure validation
- Add `GET /api/v1/connections/clobber-check` to Tier 3 (previously only exercised in Tier 5 roundtrip)

## Test plan

- [ ] Run `bash scripts/smoke.sh` against a running instance with no shared-FS overlaps -- new checks should PASS with `has_overlaps=false` and SKIP the warnings section
- [ ] Run against an instance with shared-FS overlaps (Emby/Jellyfin sharing music dirs) -- new checks should validate `image_fetcher_warnings` array and warning structure
- [ ] Verify `bash -n scripts/smoke.sh` passes (syntax check)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added authenticated smoke checks for shared-filesystem status and connection clobber endpoints, validating HTTP responses, required fields and array shapes, and conditionally verifying overlap-related warnings to catch configuration or data issues earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->