### PR TITLE
feat: define shared Artist schema in OpenAPI spec

### DIFF
--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -470,7 +470,7 @@ components:
           type: string
         type:
           type: string
-          description: Artist type, e.g. "Person" or "Group".
+          description: Artist type, e.g. "person" or "group".
         gender:
           type: string
         disambiguation:
@@ -488,15 +488,21 @@ components:
         spotify_id:
           type: string
         genres:
-          type: array
+          type:
+            - array
+            - "null"
           items:
             type: string
         styles:
-          type: array
+          type:
+            - array
+            - "null"
           items:
             type: string
         moods:
-          type: array
+          type:
+            - array
+            - "null"
           items:
             type: string
         years_active:
@@ -567,27 +573,22 @@ components:
         locked_at:
           type: string
           format: date-time
-          nullable: true
           description: Timestamp when the lock was applied. Omitted when not locked.
         audiodb_id_fetched_at:
           type: string
           format: date-time
-          nullable: true
           description: When the AudioDB ID was last fetched. Omitted when never fetched.
         discogs_id_fetched_at:
           type: string
           format: date-time
-          nullable: true
           description: When the Discogs ID was last fetched. Omitted when never fetched.
         wikidata_id_fetched_at:
           type: string
           format: date-time
-          nullable: true
           description: When the Wikidata ID was last fetched. Omitted when never fetched.
         lastfm_fetched_at:
           type: string
           format: date-time
-          nullable: true
           description: When Last.fm metadata was last fetched. Omitted when never fetched.
         metadata_sources:
           type: object
@@ -597,7 +598,6 @@ components:
         last_scanned_at:
           type: string
           format: date-time
-          nullable: true
           description: When the artist directory was last scanned. Omitted when never scanned.
         created_at:
           type: string
@@ -659,7 +659,9 @@ components:
           type: string
           description: MusicBrainz ID for this member. Omitted when not set.
         instruments:
-          type: array
+          type:
+            - array
+            - "null"
           items:
             type: string
         vocal_type:
@@ -996,7 +998,10 @@ paths:
                         $ref: "#/components/schemas/Artist"
                     reason:
                       type: string
-                      description: Why these artists are considered duplicates (e.g. "same_mbid", "alias_match").
+                      description: >-
+                        Human-readable explanation of why these artists are considered
+                        duplicates (e.g. "shared MusicBrainz ID: abc123",
+                        "shared alias: The Beatles").
 
   /artists/locked:
     get:


### PR DESCRIPTION
## Summary

- Define reusable `Artist` and `BandMember` component schemas in `openapi.yaml`
- Replace bare `type: object` with `$ref` references across all artist-returning endpoints
- All 38 Artist fields and 12 BandMember fields mapped with correct types, nullable annotations, and required lists

Closes #610

## Changes

- `internal/api/openapi.yaml`: Added `#/components/schemas/Artist` and `#/components/schemas/BandMember`
- Updated 6 endpoints (listArtists, getDuplicates, listLockedArtists, lockArtist, unlockArtist, getArtist) to use shared schema refs
- `health_score` uses `format: double` (matches Go `float64`)
- Pointer-typed `*time.Time` fields (`locked_at`, `*_fetched_at`, `last_scanned_at`) marked `nullable: true`

## Test plan

- [x] `go test ./internal/api/...` passes (OpenAPI consistency test validates spec against handlers)
- [x] No handler code changes -- spec-only PR
- [ ] Verify generated SDK types match expected shape (manual)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added typed Artist and BandMember schemas to the API documentation for clearer artist and member data.
  * Standardized artist-related endpoint responses (list, detail, duplicates) to return consistent, structured artist and member objects; duplicates now include a reason field.
  * Lock/unlock responses now return a standardized artist object on success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->