### PR TITLE
fix: accept both gh CLI author formats for Dependabot merge workflow

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -54,8 +54,10 @@ jobs:
         run: |
           AUTHOR=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
             --json author --jq '.author.login')
-          if [ "$AUTHOR" != "dependabot[bot]" ]; then
-            echo "::warning::PR #$PR_NUMBER author is '$AUTHOR', not dependabot[bot]. Skipping."
+          # gh CLI may return "dependabot[bot]" or "app/dependabot" depending
+          # on the CLI version. Accept both formats.
+          if [ "$AUTHOR" != "dependabot[bot]" ] && [ "$AUTHOR" != "app/dependabot" ]; then
+            echo "::warning::PR #$PR_NUMBER author is '$AUTHOR', not dependabot. Skipping."
             exit 0
           fi
           echo "verified=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- The `gh` CLI now returns `app/dependabot` instead of `dependabot[bot]` for bot account logins
- This broke the author verification in `dependabot-merge.yml`, causing it to skip every Dependabot PR
- Updated the check to accept both formats

## Test plan
- [ ] Merge this PR and verify the next Dependabot PR CI completion triggers a successful merge workflow run
- [ ] Check workflow logs show the author check passing instead of skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to improve Dependabot integration handling and verification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->