### PR TITLE
chore: fix typos and agent hook empty-input guard

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,7 +62,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$TOOL_INPUT\" | jq -e '.run_in_background == true' >/dev/null 2>&1; then echo 'BLOCKED: Never use run_in_background for agents. They stall on permission prompts. Use superpowers:dispatching-parallel-agents instead.' >&2; exit 2; fi"
+            "command": "if [ -n \"$TOOL_INPUT\" ] && echo \"$TOOL_INPUT\" | jq -e '.run_in_background == true' >/dev/null 2>&1; then echo 'BLOCKED: Never use run_in_background for agents. They stall on permission prompts. Use superpowers:dispatching-parallel-agents instead.' >&2; exit 2; fi"
           }
         ]
       }

--- a/internal/connection/date.go
+++ b/internal/connection/date.go
@@ -30,7 +30,7 @@ var namedMonthLayouts = []string{
 // returns the original string for values already in ISO 8601 format, pads
 // partial dates (yyyy or yyyy-MM), parses named-month formats, and falls
 // back to extracting the first 4-digit year. Returns "" for completely
-// unparseable input.
+// unparsable input.
 func NormalizeDateForPlatform(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {

--- a/internal/connection/date_test.go
+++ b/internal/connection/date_test.go
@@ -18,7 +18,7 @@ func TestNormalizeDateForPlatform(t *testing.T) {
 		{"named month with location", "October 14, 1946 in Abingdon, England", "1946-10-14"},
 		{"year with location", "2006 in Cardiff, CA", "2006-01-01"},
 		{"month year", "January 2006", "2006-01-01"},
-		{"unparseable", "not a date", ""},
+		{"unparsable", "not a date", ""},
 		{"year in text", "some text 1987 more text", "1987-01-01"},
 		{"whitespace padded", "   1991   ", "1991-01-01"},
 		{"short month name", "Oct 14, 1946", "1946-10-14"},


### PR DESCRIPTION
## Summary

- Fix spellcheck typo: `unparseable` -> `unparsable` in date normalization code comment and test case name (`internal/connection/date.go`, `internal/connection/date_test.go`)
- Fix PreToolUse Agent hook in `.claude/settings.json` that was blocking all agent dispatches. The `jq -e` command returns exit code 0 when `$TOOL_INPUT` is empty (null input produces `false`, and `-e` exits 0 for `false`), which caused the `if` block to trigger the BLOCKED message on every agent invocation regardless of `run_in_background`. Adding `[ -n "$TOOL_INPUT" ]` as a guard skips the check entirely when the input is empty.

## Test plan

- [x] `go test ./internal/connection/ -run TestNormalize -v` passes
- [x] `.claude/settings.json` validates as valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced command input validation to properly handle cases when tool input is absent before processing.

* **Documentation**
  * Corrected spelling in function documentation for consistency.

* **Tests**
  * Updated test case labels to align with documentation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->