### PR TITLE
refactor: extract Publisher from Router for unified platform publishing

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/sydlexius/stillwater/internal/provider/spotify"
 	"github.com/sydlexius/stillwater/internal/provider/wikidata"
 	"github.com/sydlexius/stillwater/internal/provider/wikipedia"
+	"github.com/sydlexius/stillwater/internal/publish"
 	"github.com/sydlexius/stillwater/internal/rule"
 	"github.com/sydlexius/stillwater/internal/scanner"
 	"github.com/sydlexius/stillwater/internal/scraper"
@@ -304,6 +305,16 @@ func run() error {
 	}
 
 	// Set up HTTP router
+	publisher := publish.New(publish.Deps{
+		ArtistService:      artistService,
+		ConnectionService:  connectionService,
+		NFOSnapshotService: nfoSnapshotService,
+		PlatformService:    platformService,
+		ExpectedWrites:     expectedWrites,
+		ImageCacheDir:      filepath.Join(filepath.Dir(cfg.Database.Path), "cache", "images"),
+		Logger:             logger,
+	})
+
 	router := api.NewRouter(api.RouterDeps{
 		AuthService:        authService,
 		ArtistService:      artistService,
@@ -338,6 +349,7 @@ func run() error {
 		BasePath:           cfg.Server.BasePath,
 		StaticDir:          "web/static",
 		ImageCacheDir:      filepath.Join(filepath.Dir(cfg.Database.Path), "cache", "images"),
+		Publisher:          publisher,
 	})
 
 	// Graceful shutdown

--- a/internal/api/handlers_backdrop.go
+++ b/internal/api/handlers_backdrop.go
@@ -369,7 +369,7 @@ func (r *Router) handleFanartSlotAssign(w http.ResponseWriter, req *http.Request
 	// Sync all fanart to connected platforms.
 	syncCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
 	defer cancel()
-	syncWarnings := r.syncAllFanartToPlatforms(syncCtx, a)
+	syncWarnings := r.publisher.SyncAllFanartToPlatforms(syncCtx, a)
 
 	r.logger.Info("assigned platform backdrop to fanart slot",
 		slog.String("artist_id", artistID),
@@ -477,7 +477,7 @@ func (r *Router) handleFanartSlotDelete(w http.ResponseWriter, req *http.Request
 	if renumberWarning == "" {
 		syncCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
 		defer cancel()
-		syncWarnings = r.syncAllFanartToPlatforms(syncCtx, a)
+		syncWarnings = r.publisher.SyncAllFanartToPlatforms(syncCtx, a)
 	} else {
 		renumberWarning += ", platform sync skipped"
 		syncWarnings = append(syncWarnings, renumberWarning)
@@ -658,7 +658,7 @@ func (r *Router) handleFanartReorder(w http.ResponseWriter, req *http.Request) {
 	// Sync reordered fanart to connected platforms.
 	syncCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
 	defer cancel()
-	syncWarnings := r.syncAllFanartToPlatforms(syncCtx, a)
+	syncWarnings := r.publisher.SyncAllFanartToPlatforms(syncCtx, a)
 
 	r.logger.Info("reordered fanart",
 		slog.String("artist_id", artistID),

--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -922,7 +922,7 @@ func (r *Router) downloadPlatformImages(ctx context.Context, dl imageDownloader,
 		}
 
 		patterns := r.getActiveNamingConfig(ctx, stillwaterType)
-		if _, found := findExistingImage(dir, patterns); found {
+		if _, found := img.FindExistingImage(dir, patterns); found {
 			r.logger.Debug("skipping existing image", "artist", a.Name, "type", stillwaterType)
 			continue
 		}

--- a/internal/api/handlers_field.go
+++ b/internal/api/handlers_field.go
@@ -1,19 +1,13 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"os"
-	"path/filepath"
-	"runtime/debug"
 	"strings"
-	"time"
 
 	"github.com/sydlexius/stillwater/internal/artist"
-	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/web/templates"
 )
@@ -122,8 +116,7 @@ func (r *Router) handleFieldUpdate(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	r.writeBackNFO(req.Context(), a)
-	r.asyncPushMetadataToConnections(req.Context(), a)
+	r.publisher.PublishMetadata(req.Context(), a)
 
 	if isHTMXRequest(req) {
 		providers := r.fieldProviderNames(req, field)
@@ -170,8 +163,7 @@ func (r *Router) handleFieldClear(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	r.writeBackNFO(req.Context(), a)
-	r.asyncPushMetadataToConnections(req.Context(), a)
+	r.publisher.PublishMetadata(req.Context(), a)
 
 	if isHTMXRequest(req) {
 		providers := r.fieldProviderNames(req, field)
@@ -399,113 +391,4 @@ func buildFieldProvidersMap(priorities []provider.FieldPriority) map[string][]st
 		m[pri.Field] = names
 	}
 	return m
-}
-
-// asyncPushMetadataToConnections fires a background PushMetadata call for every
-// enabled Emby or Jellyfin connection that has a platform ID mapping for the
-// artist. Each connection runs in its own goroutine so they are independent.
-// Errors are logged server-side only and never affect the HTTP response.
-//
-// ctx is the request context and is used only for the synchronous GetPlatformIDs
-// call. Each goroutine creates its own context.Background()-based timeout so the
-// push outlives the HTTP response without blocking it.
-func (r *Router) asyncPushMetadataToConnections(ctx context.Context, a *artist.Artist) {
-	platformIDs, err := r.artistService.GetPlatformIDs(ctx, a.ID)
-	if err != nil {
-		r.logger.Error("auto-push: listing platform IDs",
-			slog.String("artist_id", a.ID),
-			slog.String("error", err.Error()))
-		return
-	}
-	if len(platformIDs) == 0 {
-		return
-	}
-
-	// a is a freshly-allocated struct from GetByID with no shared mutable
-	// references; reading its fields from goroutines is safe.
-	data := buildArtistPushData(a)
-
-	for _, pid := range platformIDs {
-		go func() { //nolint:gosec // G118: goroutine must outlive the HTTP request context; context.Background() with explicit timeout is correct here
-			gCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			defer func() {
-				if v := recover(); v != nil {
-					r.logger.Error("auto-push: panic in goroutine",
-						slog.String("artist_id", a.ID),
-						slog.String("connection_id", pid.ConnectionID),
-						slog.Any("panic", v),
-						slog.String("stack", string(debug.Stack())))
-				}
-			}()
-
-			conn, err := r.connectionService.GetByID(gCtx, pid.ConnectionID)
-			if err != nil {
-				r.logger.Error("auto-push: fetching connection",
-					slog.String("artist_id", a.ID),
-					slog.String("connection_id", pid.ConnectionID),
-					slog.String("error", err.Error()))
-				return
-			}
-			if !conn.Enabled {
-				return
-			}
-
-			pusher, ok := newMetadataPusher(conn, r.logger)
-			if !ok {
-				return // connection type does not support PushMetadata (e.g. Lidarr)
-			}
-
-			if err := pusher.PushMetadata(gCtx, pid.PlatformArtistID, data); err != nil {
-				r.logger.Error("auto-push: metadata push failed",
-					slog.String("artist_id", a.ID),
-					slog.String("artist_name", a.Name),
-					slog.String("connection", conn.Name),
-					slog.String("error", err.Error()))
-			} else {
-				r.logger.Info("auto-push: metadata pushed",
-					slog.String("artist_id", a.ID),
-					slog.String("artist_name", a.Name),
-					slog.String("connection", conn.Name))
-			}
-		}()
-	}
-}
-
-// writeBackNFO writes the artist's current metadata to its artist.nfo file
-// (best effort). Skips silently when the artist has no filesystem path or no
-// existing NFO file on disk -- creating new NFOs from scratch is the rule
-// engine's job. The on-disk check (os.Stat) guards against stale NFOExists
-// flags when the file has been deleted or moved since the last scan.
-func (r *Router) writeBackNFO(ctx context.Context, a *artist.Artist) {
-	if a.Path == "" {
-		return
-	}
-	nfoPath := filepath.Join(a.Path, "artist.nfo")
-	if _, err := os.Stat(nfoPath); err != nil { //nolint:gosec // G703: path constructed from DB artist record, not user input
-		if os.IsNotExist(err) {
-			return
-		}
-		r.logger.Warn("NFO write-back stat error",
-			slog.String("artist_id", a.ID),
-			slog.String("nfo_path", nfoPath),
-			slog.String("error", err.Error()),
-		)
-		return
-	}
-
-	// Register expected write so the filesystem watcher does not treat
-	// this write-back as an external modification.
-	if r.expectedWrites != nil {
-		r.expectedWrites.Add(nfoPath)
-		defer r.expectedWrites.Remove(nfoPath)
-	}
-
-	if err := nfo.WriteBackArtistNFO(ctx, a, r.nfoSnapshotService, r.logger); err != nil {
-		r.logger.Error("NFO write-back failed",
-			slog.String("artist_id", a.ID),
-			slog.String("artist_name", a.Name),
-			slog.String("error", err.Error()),
-		)
-	}
 }

--- a/internal/api/handlers_field_test.go
+++ b/internal/api/handlers_field_test.go
@@ -181,7 +181,7 @@ func TestWriteBackNFO_CreatesSnapshot(t *testing.T) {
 		t.Fatalf("re-fetching artist: %v", err)
 	}
 
-	r.writeBackNFO(context.Background(), a)
+	r.publisher.WriteBackNFO(context.Background(), a)
 
 	// Verify a snapshot was saved
 	snapshots, err := r.nfoSnapshotService.List(context.Background(), a.ID)
@@ -323,7 +323,7 @@ func TestWriteBackNFO_StatNotExist(t *testing.T) {
 	}
 
 	// Do NOT seed an artist.nfo on disk -- file is missing
-	r.writeBackNFO(context.Background(), a)
+	r.publisher.WriteBackNFO(context.Background(), a)
 
 	// Verify no NFO was created (the NotExist branch should return early)
 	if _, err := os.Stat(filepath.Join(dir, "artist.nfo")); err == nil {

--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -182,7 +182,7 @@ func (r *Router) handleImageUpload(w http.ResponseWriter, req *http.Request) {
 
 	syncCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
 	defer cancel()
-	warnings := r.syncImageToPlatforms(syncCtx, a, imageType)
+	warnings := r.publisher.SyncImageToPlatforms(syncCtx, a, imageType)
 
 	resp := map[string]any{
 		"status":        "ok",
@@ -261,7 +261,7 @@ func (r *Router) handleImageFetch(w http.ResponseWriter, req *http.Request) {
 
 		syncCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
 		defer cancel()
-		syncWarnings := r.syncAllFanartToPlatforms(syncCtx, a)
+		syncWarnings := r.publisher.SyncAllFanartToPlatforms(syncCtx, a)
 
 		if isHTMXRequest(req) {
 			setSyncWarningTrigger(w, syncWarnings)
@@ -294,7 +294,7 @@ func (r *Router) handleImageFetch(w http.ResponseWriter, req *http.Request) {
 
 	syncCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
 	defer cancel()
-	warnings := r.syncImageToPlatforms(syncCtx, a, imageType)
+	warnings := r.publisher.SyncImageToPlatforms(syncCtx, a, imageType)
 
 	if isHTMXRequest(req) {
 		setSyncWarningTrigger(w, warnings)
@@ -499,7 +499,7 @@ func (r *Router) handleImageCrop(w http.ResponseWriter, req *http.Request) {
 	// Preserve existing provenance metadata if present, updating the timestamp.
 	var cropMeta *img.ExifMeta
 	patterns := r.getActiveNamingConfig(req.Context(), body.Type)
-	if filePath, found := findExistingImage(r.imageDir(a), patterns); found {
+	if filePath, found := img.FindExistingImage(r.imageDir(a), patterns); found {
 		if existing, readErr := img.ReadProvenance(filePath); readErr == nil && existing != nil {
 			cropMeta = existing
 		} else if readErr != nil {
@@ -525,7 +525,7 @@ func (r *Router) handleImageCrop(w http.ResponseWriter, req *http.Request) {
 
 	syncCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
 	defer cancel()
-	warnings := r.syncImageToPlatforms(syncCtx, a, body.Type)
+	warnings := r.publisher.SyncImageToPlatforms(syncCtx, a, body.Type)
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"status":        "ok",
@@ -757,7 +757,7 @@ func (r *Router) setArtistImageFlag(ctx context.Context, a *artist.Artist, image
 	var resolvedPath string // path to the image file on disk, used for provenance readback
 	if exists {
 		patterns := r.getActiveNamingConfig(ctx, imageType)
-		if filePath, found := findExistingImage(r.imageDir(a), patterns); found {
+		if filePath, found := img.FindExistingImage(r.imageDir(a), patterns); found {
 			if f, openErr := os.Open(filePath); openErr == nil { //nolint:gosec // path from trusted naming patterns
 				resolvedPath = filePath
 				defer f.Close() //nolint:errcheck
@@ -892,7 +892,7 @@ func (r *Router) handleServeImage(w http.ResponseWriter, req *http.Request) {
 	}
 
 	patterns := r.getActiveNamingConfig(req.Context(), imageType)
-	filePath, found := findExistingImage(dir, patterns)
+	filePath, found := img.FindExistingImage(dir, patterns)
 	if !found {
 		http.NotFound(w, req)
 		return
@@ -933,7 +933,7 @@ func (r *Router) handleImageInfo(w http.ResponseWriter, req *http.Request) {
 	}
 
 	patterns := r.getActiveNamingConfig(req.Context(), imageType)
-	filePath, found := findExistingImage(dir, patterns)
+	filePath, found := img.FindExistingImage(dir, patterns)
 	if !found {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "image not found"})
 		return
@@ -1061,7 +1061,7 @@ func (r *Router) handleDeleteImage(w http.ResponseWriter, req *http.Request) {
 	patterns := r.getActiveNamingConfig(req.Context(), imageType)
 	deleted, deleteFailed := deleteImageFiles(r.fileRemover, r.imageDir(a), patterns, r.logger)
 
-	if _, found := findExistingImage(r.imageDir(a), patterns); !found {
+	if _, found := img.FindExistingImage(r.imageDir(a), patterns); !found {
 		r.clearArtistImageFlag(req.Context(), a, imageType)
 	}
 	warnings := make([]string, 0)
@@ -1090,177 +1090,6 @@ func (r *Router) handleDeleteImage(w http.ResponseWriter, req *http.Request) {
 // clearArtistImageFlag sets the image existence flag to false and persists it.
 func (r *Router) clearArtistImageFlag(ctx context.Context, a *artist.Artist, imageType string) {
 	r.setArtistImageFlag(ctx, a, imageType, false)
-}
-
-// syncImageToPlatforms uploads the just-saved image to every platform connection
-// that has a stored artist ID mapping. Errors are logged and returned as warning
-// strings so the caller can surface them to the client. The local operation
-// already succeeded, so failures here are non-fatal.
-func (r *Router) syncImageToPlatforms(ctx context.Context, a *artist.Artist, imageType string) []string {
-	warnings := make([]string, 0)
-
-	platformIDs, err := r.artistService.GetPlatformIDs(ctx, a.ID)
-	if err != nil {
-		r.logger.Error("getting platform IDs for image sync", "artist_id", a.ID, "type", imageType, "error", err)
-		warnings = append(warnings, "platform sync skipped: failed to load platform mappings")
-		return warnings
-	}
-	if len(platformIDs) == 0 {
-		return warnings
-	}
-
-	dir := r.imageDir(a)
-	if dir == "" {
-		r.logger.Warn("skipping platform image sync: artist has no image directory", "artist", a.Name, "type", imageType)
-		warnings = append(warnings, "platform sync skipped: artist has no image directory configured")
-		return warnings
-	}
-	patterns := r.getActiveNamingConfig(ctx, imageType)
-	filePath, found := findExistingImage(dir, patterns)
-	if !found {
-		warnings = append(warnings, "platform sync skipped: no local image found to upload")
-		return warnings
-	}
-
-	data, err := os.ReadFile(filePath) //nolint:gosec // path from trusted naming patterns
-	if err != nil {
-		r.logger.Error("reading image for platform sync", "artist", a.Name, "type", imageType, "path", filePath, "error", err)
-		warnings = append(warnings, "platform sync skipped: failed to read image for upload")
-		return warnings
-	}
-
-	ct := "image/jpeg"
-	if strings.EqualFold(filepath.Ext(filePath), ".png") {
-		ct = "image/png"
-	}
-
-	for _, pid := range platformIDs {
-		conn, connErr := r.connectionService.GetByID(ctx, pid.ConnectionID)
-		if connErr != nil {
-			r.logger.Error("getting connection for image sync", "connection_id", pid.ConnectionID, "error", connErr)
-			warnings = append(warnings, truncateWarning(fmt.Sprintf("connection %s: failed to load", pid.ConnectionID)))
-			continue
-		}
-		if !conn.Enabled {
-			r.logger.Debug("skipping disabled connection for image sync", "connection", conn.Name, "type", imageType)
-			continue
-		}
-
-		var uploader connection.ImageUploader
-		switch conn.Type {
-		case connection.TypeEmby:
-			uploader = emby.New(conn.URL, conn.APIKey, conn.PlatformUserID, r.logger)
-		case connection.TypeJellyfin:
-			uploader = jellyfin.New(conn.URL, conn.APIKey, conn.PlatformUserID, r.logger)
-		default:
-			r.logger.Warn("unsupported connection type for image sync", "type", conn.Type)
-			warnings = append(warnings, truncateWarning(fmt.Sprintf("%s: unsupported connection type %q", conn.Name, conn.Type)))
-			continue
-		}
-
-		if uploadErr := uploader.UploadImage(ctx, pid.PlatformArtistID, imageType, data, ct); uploadErr != nil {
-			r.logger.Error("syncing image to platform", "artist", a.Name, "connection", conn.Name, "type", imageType, "error", uploadErr)
-			warnings = append(warnings, truncateWarning(fmt.Sprintf("%s (%s): image upload failed", conn.Name, conn.Type)))
-		}
-	}
-	return warnings
-}
-
-// syncAllFanartToPlatforms uploads all local fanart files to every connected
-// platform at their respective indices. Unlike syncImageToPlatforms which only
-// syncs the primary image, this discovers all fanart files and uploads each one
-// at the correct backdrop index. Errors are logged and returned as warnings.
-func (r *Router) syncAllFanartToPlatforms(ctx context.Context, a *artist.Artist) []string {
-	warnings := make([]string, 0)
-
-	platformIDs, err := r.artistService.GetPlatformIDs(ctx, a.ID)
-	if err != nil {
-		r.logger.Error("getting platform IDs for fanart sync",
-			slog.String("artist_id", a.ID),
-			slog.String("error", err.Error()))
-		warnings = append(warnings, "platform sync skipped: failed to load platform mappings")
-		return warnings
-	}
-	if len(platformIDs) == 0 {
-		return warnings
-	}
-
-	dir := r.imageDir(a)
-	if dir == "" {
-		r.logger.Warn("skipping platform fanart sync: artist has no image directory",
-			slog.String("artist", a.Name))
-		warnings = append(warnings, "platform sync skipped: artist has no image directory configured")
-		return warnings
-	}
-
-	primary := r.getActiveFanartPrimary(ctx)
-	fanartPaths, discoverErr := img.DiscoverFanart(dir, primary)
-	if discoverErr != nil {
-		r.logger.Error("discovering fanart for platform sync",
-			slog.String("artist_id", a.ID),
-			slog.String("error", discoverErr.Error()))
-		warnings = append(warnings, "platform sync skipped: failed to read fanart directory")
-		return warnings
-	}
-	if len(fanartPaths) == 0 {
-		return warnings
-	}
-
-	for _, pid := range platformIDs {
-		conn, connErr := r.connectionService.GetByID(ctx, pid.ConnectionID)
-		if connErr != nil {
-			r.logger.Error("getting connection for fanart sync",
-				slog.String("connection_id", pid.ConnectionID),
-				slog.String("error", connErr.Error()))
-			warnings = append(warnings, truncateWarning(fmt.Sprintf("connection %s: failed to load", pid.ConnectionID)))
-			continue
-		}
-		if !conn.Enabled || conn.Status != "ok" {
-			r.logger.Debug("skipping connection for fanart sync",
-				slog.String("connection", conn.Name),
-				slog.String("status", conn.Status))
-			continue
-		}
-
-		var uploader connection.IndexedImageUploader
-		switch conn.Type {
-		case connection.TypeEmby:
-			uploader = emby.New(conn.URL, conn.APIKey, conn.PlatformUserID, r.logger)
-		case connection.TypeJellyfin:
-			uploader = jellyfin.New(conn.URL, conn.APIKey, conn.PlatformUserID, r.logger)
-		default:
-			r.logger.Warn("unsupported connection type for fanart sync",
-				slog.String("type", conn.Type))
-			warnings = append(warnings, truncateWarning(fmt.Sprintf("%s: unsupported connection type %q", conn.Name, conn.Type)))
-			continue
-		}
-
-		for i, fp := range fanartPaths {
-			data, readErr := os.ReadFile(fp) //nolint:gosec // path from trusted fanart discovery
-			if readErr != nil {
-				r.logger.Error("reading fanart for platform sync",
-					slog.String("path", fp),
-					slog.String("error", readErr.Error()))
-				warnings = append(warnings, truncateWarning(fmt.Sprintf("%s: failed to read fanart %d", conn.Name, i)))
-				continue
-			}
-
-			ct := "image/jpeg"
-			if strings.EqualFold(filepath.Ext(fp), ".png") {
-				ct = "image/png"
-			}
-
-			if uploadErr := uploader.UploadImageAtIndex(ctx, pid.PlatformArtistID, "fanart", i, data, ct); uploadErr != nil {
-				r.logger.Error("syncing fanart to platform",
-					slog.String("artist", a.Name),
-					slog.String("connection", conn.Name),
-					slog.Int("index", i),
-					slog.String("error", uploadErr.Error()))
-				warnings = append(warnings, truncateWarning(fmt.Sprintf("%s (%s): fanart %d upload failed", conn.Name, conn.Type, i)))
-			}
-		}
-	}
-	return warnings
 }
 
 // deleteImageFromPlatforms removes the image from every platform connection that
@@ -1358,31 +1187,6 @@ func truncateWarning(msg string) string {
 	return msg
 }
 
-// findExistingImage searches for the first matching image file in a directory.
-// For each configured pattern it first checks the exact filename, then probes
-// alternate supported extensions (.jpg, .png) to handle cases where the saved
-// format differs from the configured name (e.g. a PNG crop saved over folder.jpg).
-func findExistingImage(dir string, patterns []string) (string, bool) {
-	for _, pattern := range patterns {
-		p := filepath.Join(dir, pattern)
-		if _, err := os.Stat(p); err == nil { //nolint:gosec // path from trusted naming patterns
-			return p, true
-		}
-		// Check alternate extensions in case the format changed after save.
-		base := strings.TrimSuffix(pattern, filepath.Ext(pattern))
-		for _, ext := range []string{".jpg", ".jpeg", ".png"} {
-			if ext == filepath.Ext(pattern) {
-				continue
-			}
-			alt := filepath.Join(dir, base+ext)
-			if _, err := os.Stat(alt); err == nil { //nolint:gosec // path from trusted naming patterns
-				return alt, true
-			}
-		}
-	}
-	return "", false
-}
-
 // deleteImageFiles removes all matching image files from a directory and returns deleted filenames
 // and whether any removal failed. For each pattern, it also probes alternate extensions
 // (.jpg, .jpeg, .png) to catch cases where the saved format differs from the configured name.
@@ -1475,7 +1279,7 @@ func (r *Router) handleLogoTrim(w http.ResponseWriter, req *http.Request) {
 	}
 
 	patterns := r.getActiveNamingConfig(req.Context(), "logo")
-	filePath, found := findExistingImage(r.imageDir(a), patterns)
+	filePath, found := img.FindExistingImage(r.imageDir(a), patterns)
 	if !found {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "logo not found"})
 		return
@@ -1523,7 +1327,7 @@ func (r *Router) handleLogoTrim(w http.ResponseWriter, req *http.Request) {
 
 	syncCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
 	defer cancel()
-	warnings := r.syncImageToPlatforms(syncCtx, a, "logo")
+	warnings := r.publisher.SyncImageToPlatforms(syncCtx, a, "logo")
 
 	if isHTMXRequest(req) {
 		setSyncWarningTrigger(w, warnings)
@@ -1859,7 +1663,7 @@ func (r *Router) handleFanartBatchDelete(w http.ResponseWriter, req *http.Reques
 	if !renumberWarning {
 		syncCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
 		defer cancel()
-		syncWarnings = r.syncAllFanartToPlatforms(syncCtx, a)
+		syncWarnings = r.publisher.SyncAllFanartToPlatforms(syncCtx, a)
 	}
 
 	warnings := make([]string, 0)
@@ -1966,7 +1770,7 @@ func (r *Router) handleFanartBatchFetch(w http.ResponseWriter, req *http.Request
 	if len(allSaved) > 0 {
 		syncCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
 		defer cancel()
-		syncWarnings = r.syncAllFanartToPlatforms(syncCtx, a)
+		syncWarnings = r.publisher.SyncAllFanartToPlatforms(syncCtx, a)
 	}
 
 	if isHTMXRequest(req) {

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sydlexius/stillwater/internal/artist"
 	img "github.com/sydlexius/stillwater/internal/image"
 	"github.com/sydlexius/stillwater/internal/platform"
+	"github.com/sydlexius/stillwater/internal/publish"
 )
 
 // testRouterWithPlatform returns a Router that includes a platform service,
@@ -29,8 +30,27 @@ import (
 func testRouterWithPlatform(t *testing.T) (*Router, *artist.Service) {
 	t.Helper()
 	r, artistSvc := testRouter(t)
-	r.platformService = platform.NewService(r.db)
+	platSvc := platform.NewService(r.db)
+	r.platformService = platSvc
+	// Rebuild publisher with the platform service so image sync tests work.
+	r.publisher = publish.New(publish.Deps{
+		ArtistService:      r.artistService,
+		ConnectionService:  r.connectionService,
+		NFOSnapshotService: r.nfoSnapshotService,
+		PlatformService:    platSvc,
+		ExpectedWrites:     r.expectedWrites,
+		ImageCacheDir:      r.imageCacheDir,
+		Logger:             r.logger,
+	})
 	return r, artistSvc
+}
+
+// setImageCacheDir sets both the Router's and Publisher's image cache dir.
+func setImageCacheDir(r *Router, dir string) {
+	r.imageCacheDir = dir
+	if r.publisher != nil {
+		r.publisher.SetImageCacheDir(dir)
+	}
 }
 
 // failingRemover is a FileRemover stub that always returns an error.
@@ -191,7 +211,7 @@ func TestRequireArtistPath_Pathless(t *testing.T) {
 func TestRequireImageDir_WithCacheDir(t *testing.T) {
 	r, _ := testRouterWithPlatform(t)
 	cacheDir := t.TempDir()
-	r.imageCacheDir = cacheDir
+	setImageCacheDir(r, cacheDir)
 
 	// Pathless artist with cache configured should pass.
 	a := &artist.Artist{ID: "abc123", Name: "Cached Artist", SortName: "Cached Artist", Path: ""}
@@ -220,7 +240,7 @@ func TestRequireImageDir_WithCacheDir(t *testing.T) {
 func TestRequireImageDir_RejectsNoCacheNoPath(t *testing.T) {
 	r, _ := testRouterWithPlatform(t)
 	// No cache dir, no artist path.
-	r.imageCacheDir = ""
+	setImageCacheDir(r, "")
 
 	a := &artist.Artist{ID: "abc123", Name: "No Path Artist", SortName: "No Path Artist", Path: ""}
 
@@ -383,7 +403,7 @@ func TestHandleImageUpload_SyncsToPlatform(t *testing.T) {
 	defer srv.Close()
 
 	r, artistSvc := testRouterWithPlatform(t)
-	r.imageCacheDir = t.TempDir()
+	setImageCacheDir(r, t.TempDir())
 	addTestConnectionWithURL(t, r, "conn-emby", "Emby", "emby", srv.URL)
 
 	// Platform artist: no local path, images stored in cache dir.
@@ -462,7 +482,7 @@ func TestHandleDeleteImage_SyncsToPlatform(t *testing.T) {
 
 	r, artistSvc := testRouterWithPlatform(t)
 	cacheDir := t.TempDir()
-	r.imageCacheDir = cacheDir
+	setImageCacheDir(r, cacheDir)
 	addTestConnectionWithURL(t, r, "conn-emby", "Emby", "emby", srv.URL)
 
 	// Platform artist: no local path, images stored in cache dir.
@@ -576,7 +596,7 @@ func TestHandleImageUpload_SyncWarnings_PlatformFailure(t *testing.T) {
 	defer srv.Close()
 
 	r, artistSvc := testRouterWithPlatform(t)
-	r.imageCacheDir = t.TempDir()
+	setImageCacheDir(r, t.TempDir())
 	addTestConnectionWithURL(t, r, "conn-emby", "Emby", "emby", srv.URL)
 
 	a := &artist.Artist{Name: "Platform Artist", SortName: "Platform Artist", Path: ""}
@@ -639,7 +659,7 @@ func TestHandleDeleteImage_SyncWarnings_PlatformFailure(t *testing.T) {
 
 	r, artistSvc := testRouterWithPlatform(t)
 	cacheDir := t.TempDir()
-	r.imageCacheDir = cacheDir
+	setImageCacheDir(r, cacheDir)
 	addTestConnectionWithURL(t, r, "conn-emby", "Emby", "emby", srv.URL)
 
 	a := &artist.Artist{
@@ -721,7 +741,7 @@ func TestSyncImageToPlatforms_GetByIDError(t *testing.T) {
 		t.Fatalf("re-enabling FK: %v", err)
 	}
 
-	warnings := r.syncImageToPlatforms(context.Background(), a, "thumb")
+	warnings := r.publisher.SyncImageToPlatforms(context.Background(), a, "thumb")
 
 	if len(warnings) == 0 {
 		t.Fatal("expected warning for orphaned connection, got none")
@@ -733,7 +753,7 @@ func TestSyncImageToPlatforms_GetByIDError(t *testing.T) {
 
 func TestHandleImageUpload_SyncWarnings_UnsupportedConnType(t *testing.T) {
 	r, artistSvc := testRouterWithPlatform(t)
-	r.imageCacheDir = t.TempDir()
+	setImageCacheDir(r, t.TempDir())
 
 	// A connection whose type is not handled by the image sync switch.
 	addTestConnection(t, r, "conn-lidarr", "Lidarr", "lidarr")
@@ -812,7 +832,7 @@ func TestDeleteImageFromPlatforms_GetByIDError(t *testing.T) {
 func TestHandleDeleteImage_SyncWarnings_UnsupportedConnType(t *testing.T) {
 	r, artistSvc := testRouterWithPlatform(t)
 	cacheDir := t.TempDir()
-	r.imageCacheDir = cacheDir
+	setImageCacheDir(r, cacheDir)
 
 	addTestConnection(t, r, "conn-lidarr", "Lidarr", "lidarr")
 
@@ -1056,7 +1076,7 @@ func TestHandleImageCrop_SyncWarnings_PlatformFailure(t *testing.T) {
 	defer srv.Close()
 
 	r, artistSvc := testRouterWithPlatform(t)
-	r.imageCacheDir = t.TempDir()
+	setImageCacheDir(r, t.TempDir())
 	addTestConnectionWithURL(t, r, "conn-emby", "Emby", "emby", srv.URL)
 
 	a := &artist.Artist{Name: "Platform Crop Artist", SortName: "Platform Crop Artist", Path: ""}

--- a/internal/api/handlers_nfo.go
+++ b/internal/api/handlers_nfo.go
@@ -160,7 +160,7 @@ func (r *Router) handleNFOSnapshotRestore(w http.ResponseWriter, req *http.Reque
 			writeError(w, req, http.StatusInternalServerError, "failed to restore NFO")
 			return
 		}
-		r.asyncPushMetadataToConnections(req.Context(), a)
+		r.publisher.PushMetadataAsync(req.Context(), a)
 		writeJSON(w, http.StatusOK, map[string]string{"status": "restored"})
 		return
 	}

--- a/internal/api/handlers_push.go
+++ b/internal/api/handlers_push.go
@@ -8,11 +8,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/connection"
 	"github.com/sydlexius/stillwater/internal/connection/emby"
 	"github.com/sydlexius/stillwater/internal/connection/jellyfin"
 	img "github.com/sydlexius/stillwater/internal/image"
+	"github.com/sydlexius/stillwater/internal/publish"
 )
 
 // handlePushMetadata pushes artist metadata to a specified platform connection.
@@ -66,9 +66,9 @@ func (r *Router) handlePushMetadata(w http.ResponseWriter, req *http.Request) {
 		body.PlatformArtistID = stored
 	}
 
-	data := buildArtistPushData(a)
+	data := publish.BuildArtistPushData(a)
 
-	pusher, ok := newMetadataPusher(conn, r.logger)
+	pusher, ok := publish.NewMetadataPusher(conn, r.logger)
 	if !ok {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "connection type does not support metadata push"})
 		return
@@ -202,7 +202,7 @@ func (r *Router) handlePushImages(w http.ResponseWriter, req *http.Request) {
 		}
 
 		patterns := r.getActiveNamingConfig(req.Context(), imgType)
-		filePath, found := findExistingImage(r.imageDir(a), patterns)
+		filePath, found := img.FindExistingImage(r.imageDir(a), patterns)
 		if !found {
 			continue
 		}
@@ -317,54 +317,4 @@ func (r *Router) handleDeletePushImage(w http.ResponseWriter, req *http.Request)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
-}
-
-// buildArtistPushData constructs an ArtistPushData from an artist record.
-// Shared by handlePushMetadata (synchronous) and asyncPushMetadataToConnections
-// (fire-and-forget). Update this function when adding new push fields.
-//
-// Date fields are filtered by artist type to prevent cross-contamination from
-// providers that do not distinguish persons from groups. Groups get Formed and
-// Disbanded; persons get Born and Died. Unknown types get all four fields so the
-// push code's Born > Formed fallback chain still works.
-func buildArtistPushData(a *artist.Artist) connection.ArtistPushData {
-	data := connection.ArtistPushData{
-		Name:           a.Name,
-		SortName:       a.SortName,
-		Biography:      a.Biography,
-		Genres:         a.Genres,
-		Styles:         a.Styles,
-		Moods:          a.Moods,
-		Disambiguation: a.Disambiguation,
-		YearsActive:    a.YearsActive,
-		MusicBrainzID:  a.MusicBrainzID,
-	}
-	switch a.Type {
-	case "group", "orchestra", "choir":
-		data.Formed = a.Formed
-		data.Disbanded = a.Disbanded
-	case "solo":
-		data.Born = a.Born
-		data.Died = a.Died
-	default:
-		data.Born = a.Born
-		data.Formed = a.Formed
-		data.Died = a.Died
-		data.Disbanded = a.Disbanded
-	}
-	return data
-}
-
-// newMetadataPusher constructs a MetadataPusher for the given connection type.
-// Returns (nil, false) for connection types that do not support metadata push
-// (e.g. Lidarr). Shared by handlePushMetadata and asyncPushMetadataToConnections.
-func newMetadataPusher(conn *connection.Connection, logger *slog.Logger) (connection.MetadataPusher, bool) {
-	switch conn.Type {
-	case connection.TypeEmby:
-		return emby.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger), true
-	case connection.TypeJellyfin:
-		return jellyfin.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger), true
-	default:
-		return nil, false
-	}
 }

--- a/internal/api/handlers_push_test.go
+++ b/internal/api/handlers_push_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/connection"
 	"github.com/sydlexius/stillwater/internal/platform"
+	"github.com/sydlexius/stillwater/internal/publish"
 )
 
 // addTestConnectionWithURL creates a connection with a custom URL for handler tests
@@ -595,7 +596,7 @@ func TestBuildArtistPushData_TypeAwareDates(t *testing.T) {
 				Died:      "2016",
 				Disbanded: "2010",
 			}
-			data := buildArtistPushData(a)
+			data := publish.BuildArtistPushData(a)
 			if data.Born != tt.wantBorn {
 				t.Errorf("Born = %q, want %q", data.Born, tt.wantBorn)
 			}

--- a/internal/api/handlers_refresh.go
+++ b/internal/api/handlers_refresh.go
@@ -185,7 +185,7 @@ func (r *Router) handleRefreshLink(w http.ResponseWriter, req *http.Request) {
 				// The NFO written by executeRefresh still has the old
 				// name because the name update happens after the
 				// refresh completes.
-				r.writeBackNFO(req.Context(), a)
+				r.publisher.WriteBackNFO(req.Context(), a)
 			}
 		}
 	}
@@ -231,7 +231,7 @@ func (r *Router) executeRefresh(req *http.Request, a *artist.Artist) (*provider.
 		return nil, err
 	}
 
-	r.writeBackNFO(req.Context(), a)
+	r.publisher.WriteBackNFO(req.Context(), a)
 
 	rule.UpdateProviderFetchTimestamps(req.Context(), r.artistService, a.ID, result.AttemptedProviders, r.logger)
 

--- a/internal/api/handlers_report_test.go
+++ b/internal/api/handlers_report_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/provider"
+	"github.com/sydlexius/stillwater/internal/publish"
 	"github.com/sydlexius/stillwater/internal/rule"
 )
 
@@ -51,6 +52,13 @@ func testRouter(t *testing.T) (*Router, *artist.Service) {
 	nfoSnapSvc := nfo.NewSnapshotService(db)
 	providerSettings := provider.NewSettingsService(db, nil)
 
+	pub := publish.New(publish.Deps{
+		ArtistService:      artistSvc,
+		ConnectionService:  connSvc,
+		NFOSnapshotService: nfoSnapSvc,
+		Logger:             logger,
+	})
+
 	r := NewRouter(RouterDeps{
 		AuthService:        authSvc,
 		ArtistService:      artistSvc,
@@ -62,6 +70,7 @@ func testRouter(t *testing.T) (*Router, *artist.Service) {
 		DB:                 db,
 		Logger:             logger,
 		StaticDir:          "../../web/static",
+		Publisher:          pub,
 	})
 
 	return r, artistSvc

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/platform"
 	"github.com/sydlexius/stillwater/internal/provider"
+	"github.com/sydlexius/stillwater/internal/publish"
 	"github.com/sydlexius/stillwater/internal/rule"
 	"github.com/sydlexius/stillwater/internal/scanner"
 	"github.com/sydlexius/stillwater/internal/scraper"
@@ -64,6 +65,7 @@ type RouterDeps struct {
 	BasePath           string
 	StaticDir          string
 	ImageCacheDir      string
+	Publisher          *publish.Publisher
 }
 
 // Router sets up all HTTP routes for the application.
@@ -96,6 +98,7 @@ type Router struct {
 	probeCache         *watcher.ProbeCache
 	expectedWrites     *watcher.ExpectedWrites
 	eventBus           *event.Bus
+	publisher          *publish.Publisher
 	logger             *slog.Logger
 	basePath           string
 	imageCacheDir      string
@@ -147,6 +150,7 @@ func NewRouter(deps RouterDeps) *Router {
 		logger:             deps.Logger,
 		basePath:           deps.BasePath,
 		imageCacheDir:      deps.ImageCacheDir,
+		publisher:          deps.Publisher,
 		staticAssets:       NewStaticAssets(deps.StaticDir, deps.Logger),
 		ssrfClient: &http.Client{
 			Timeout:   fetchTimeout,

--- a/internal/image/naming.go
+++ b/internal/image/naming.go
@@ -1,5 +1,11 @@
 package image
 
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
 // DefaultFileNames returns the default naming patterns for each image type.
 // These are the known filename patterns used by media servers.
 var DefaultFileNames = map[string][]string{
@@ -26,4 +32,29 @@ func PrimaryFileName(naming map[string][]string, imageType string) string {
 		return names[0]
 	}
 	return ""
+}
+
+// FindExistingImage searches for the first matching image file in a directory.
+// For each configured pattern it first checks the exact filename, then probes
+// alternate supported extensions (.jpg, .png) to handle cases where the saved
+// format differs from the configured name (e.g. a PNG crop saved over folder.jpg).
+func FindExistingImage(dir string, patterns []string) (string, bool) {
+	for _, pattern := range patterns {
+		p := filepath.Join(dir, pattern)
+		if _, err := os.Stat(p); err == nil { //nolint:gosec // path from trusted naming patterns
+			return p, true
+		}
+		// Check alternate extensions in case the format changed after save.
+		base := strings.TrimSuffix(pattern, filepath.Ext(pattern))
+		for _, ext := range []string{".jpg", ".jpeg", ".png"} {
+			if ext == filepath.Ext(pattern) {
+				continue
+			}
+			alt := filepath.Join(dir, base+ext)
+			if _, err := os.Stat(alt); err == nil { //nolint:gosec // path from trusted naming patterns
+				return alt, true
+			}
+		}
+	}
+	return "", false
 }

--- a/internal/publish/publisher.go
+++ b/internal/publish/publisher.go
@@ -1,0 +1,466 @@
+// Package publish provides a unified abstraction for publishing artist metadata
+// and images to external platforms (Emby, Jellyfin) and local NFO files.
+// It replaces the previously scattered pattern of ad-hoc writeBackNFO,
+// asyncPushMetadataToConnections, and syncImageToPlatforms calls.
+package publish
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/connection"
+	"github.com/sydlexius/stillwater/internal/connection/emby"
+	"github.com/sydlexius/stillwater/internal/connection/jellyfin"
+	img "github.com/sydlexius/stillwater/internal/image"
+	"github.com/sydlexius/stillwater/internal/nfo"
+	"github.com/sydlexius/stillwater/internal/platform"
+)
+
+const (
+	// pushTimeout is the per-connection timeout for async metadata pushes.
+	pushTimeout = 30 * time.Second
+	// maxWarningRunes caps warning strings to prevent oversized JSON responses.
+	maxWarningRunes = 200
+)
+
+// Deps holds all dependencies for a Publisher.
+type Deps struct {
+	ArtistService      artistPlatformLister
+	ConnectionService  connectionGetter
+	NFOSnapshotService *nfo.SnapshotService
+	PlatformService    namingConfigProvider
+	ExpectedWrites     expectedWritesTracker
+	ImageCacheDir      string
+	Logger             *slog.Logger
+}
+
+// Publisher coordinates writing artist metadata and images to local files
+// (NFO) and external platform connections (Emby/Jellyfin). All operations
+// are best-effort: errors are logged but never propagated to the caller,
+// since the primary operation (DB update) has already succeeded.
+type Publisher struct {
+	artistService      artistPlatformLister
+	connectionService  connectionGetter
+	nfoSnapshotService *nfo.SnapshotService
+	platformService    namingConfigProvider
+	expectedWrites     expectedWritesTracker
+	imageCacheDir      string
+	logger             *slog.Logger
+}
+
+// Narrow interfaces keep the publish package decoupled from concrete types.
+
+type artistPlatformLister interface {
+	GetPlatformIDs(ctx context.Context, artistID string) ([]artist.PlatformID, error)
+}
+
+type connectionGetter interface {
+	GetByID(ctx context.Context, id string) (*connection.Connection, error)
+}
+
+type namingConfigProvider interface {
+	GetActive(ctx context.Context) (*platform.Profile, error)
+}
+
+type expectedWritesTracker interface {
+	Add(path string)
+	Remove(path string)
+}
+
+// New creates a Publisher from the given dependencies.
+func New(d Deps) *Publisher {
+	return &Publisher{
+		artistService:      d.ArtistService,
+		connectionService:  d.ConnectionService,
+		nfoSnapshotService: d.NFOSnapshotService,
+		platformService:    d.PlatformService,
+		expectedWrites:     d.ExpectedWrites,
+		imageCacheDir:      d.ImageCacheDir,
+		logger:             d.Logger,
+	}
+}
+
+// PublishMetadata writes the artist's NFO file and pushes metadata to all
+// connected platforms. This is the primary convenience method that closes
+// the gap between NFO-only writes and full platform synchronization.
+func (p *Publisher) PublishMetadata(ctx context.Context, a *artist.Artist) {
+	if p == nil {
+		return
+	}
+	p.WriteBackNFO(ctx, a)
+	p.PushMetadataAsync(ctx, a)
+}
+
+// WriteBackNFO writes the artist's current metadata to its artist.nfo file
+// (best effort). Skips silently when the artist has no filesystem path or no
+// existing NFO file on disk -- creating new NFOs from scratch is the rule
+// engine's job. The on-disk check (os.Stat) guards against stale NFOExists
+// flags when the file has been deleted or moved since the last scan.
+func (p *Publisher) WriteBackNFO(ctx context.Context, a *artist.Artist) {
+	if p == nil {
+		return
+	}
+	if a.Path == "" {
+		return
+	}
+	nfoPath := filepath.Join(a.Path, "artist.nfo")
+	if _, err := os.Stat(nfoPath); err != nil { //nolint:gosec // G703: path constructed from DB artist record, not user input
+		if os.IsNotExist(err) {
+			return
+		}
+		p.logger.Warn("NFO write-back stat error",
+			slog.String("artist_id", a.ID),
+			slog.String("nfo_path", nfoPath),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	// Register expected write so the filesystem watcher does not treat
+	// this write-back as an external modification.
+	if p.expectedWrites != nil {
+		p.expectedWrites.Add(nfoPath)
+		defer p.expectedWrites.Remove(nfoPath)
+	}
+
+	if err := nfo.WriteBackArtistNFO(ctx, a, p.nfoSnapshotService, p.logger); err != nil {
+		p.logger.Error("NFO write-back failed",
+			slog.String("artist_id", a.ID),
+			slog.String("artist_name", a.Name),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// PushMetadataAsync pushes the artist's current metadata to all connected
+// platforms (Emby/Jellyfin) in background goroutines. Each goroutine creates
+// its own context with an explicit timeout so the push outlives the HTTP
+// response without blocking it.
+func (p *Publisher) PushMetadataAsync(ctx context.Context, a *artist.Artist) {
+	if p == nil {
+		return
+	}
+	platformIDs, err := p.artistService.GetPlatformIDs(ctx, a.ID)
+	if err != nil {
+		p.logger.Error("auto-push: listing platform IDs",
+			slog.String("artist_id", a.ID),
+			slog.String("error", err.Error()))
+		return
+	}
+	if len(platformIDs) == 0 {
+		return
+	}
+
+	// a is a freshly-allocated struct from GetByID with no shared mutable
+	// references; reading its fields from goroutines is safe.
+	data := BuildArtistPushData(a)
+
+	for _, pid := range platformIDs {
+		go func() {
+			gCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), pushTimeout)
+			defer cancel()
+			defer func() {
+				if v := recover(); v != nil {
+					p.logger.Error("auto-push: panic in goroutine",
+						slog.String("artist_id", a.ID),
+						slog.String("connection_id", pid.ConnectionID),
+						slog.Any("panic", v),
+						slog.String("stack", string(debug.Stack())))
+				}
+			}()
+
+			conn, connErr := p.connectionService.GetByID(gCtx, pid.ConnectionID)
+			if connErr != nil {
+				p.logger.Error("auto-push: fetching connection",
+					slog.String("artist_id", a.ID),
+					slog.String("connection_id", pid.ConnectionID),
+					slog.String("error", connErr.Error()))
+				return
+			}
+			if !conn.Enabled {
+				return
+			}
+
+			pusher, ok := NewMetadataPusher(conn, p.logger)
+			if !ok {
+				return // connection type does not support PushMetadata (e.g. Lidarr)
+			}
+
+			if pushErr := pusher.PushMetadata(gCtx, pid.PlatformArtistID, data); pushErr != nil {
+				p.logger.Error("auto-push: metadata push failed",
+					slog.String("artist_id", a.ID),
+					slog.String("artist_name", a.Name),
+					slog.String("connection", conn.Name),
+					slog.String("error", pushErr.Error()))
+			} else {
+				p.logger.Info("auto-push: metadata pushed",
+					slog.String("artist_id", a.ID),
+					slog.String("artist_name", a.Name),
+					slog.String("connection", conn.Name))
+			}
+		}()
+	}
+}
+
+// SyncImageToPlatforms uploads the specified image type to every platform
+// connection that has a stored artist ID mapping. Errors are logged and
+// returned as warning strings so the caller can surface them to the client.
+// The local operation already succeeded, so failures here are non-fatal.
+func (p *Publisher) SyncImageToPlatforms(ctx context.Context, a *artist.Artist, imageType string) []string {
+	if p == nil {
+		return nil
+	}
+	warnings := make([]string, 0)
+
+	platformIDs, err := p.artistService.GetPlatformIDs(ctx, a.ID)
+	if err != nil {
+		p.logger.Error("getting platform IDs for image sync", "artist_id", a.ID, "type", imageType, "error", err)
+		warnings = append(warnings, "platform sync skipped: failed to load platform mappings")
+		return warnings
+	}
+	if len(platformIDs) == 0 {
+		return warnings
+	}
+
+	dir := p.ImageDir(a)
+	if dir == "" {
+		p.logger.Warn("skipping platform image sync: artist has no image directory", "artist", a.Name, "type", imageType)
+		warnings = append(warnings, "platform sync skipped: artist has no image directory configured")
+		return warnings
+	}
+	patterns := p.getActiveNamingConfig(ctx, imageType)
+	filePath, found := img.FindExistingImage(dir, patterns)
+	if !found {
+		warnings = append(warnings, "platform sync skipped: no local image found to upload")
+		return warnings
+	}
+
+	data, readErr := os.ReadFile(filePath) //nolint:gosec // path from trusted naming patterns
+	if readErr != nil {
+		p.logger.Error("reading image for platform sync", "artist", a.Name, "type", imageType, "path", filePath, "error", readErr)
+		warnings = append(warnings, "platform sync skipped: failed to read image for upload")
+		return warnings
+	}
+
+	ct := "image/jpeg"
+	if strings.EqualFold(filepath.Ext(filePath), ".png") {
+		ct = "image/png"
+	}
+
+	for _, pid := range platformIDs {
+		conn, connErr := p.connectionService.GetByID(ctx, pid.ConnectionID)
+		if connErr != nil {
+			p.logger.Error("getting connection for image sync", "connection_id", pid.ConnectionID, "error", connErr)
+			warnings = append(warnings, truncateWarning(fmt.Sprintf("connection %s: failed to load", pid.ConnectionID)))
+			continue
+		}
+		if !conn.Enabled || conn.Status != "ok" {
+			p.logger.Debug("skipping connection for image sync", "connection", conn.Name, "type", imageType, "status", conn.Status)
+			continue
+		}
+
+		uploader := newImageUploader(conn, p.logger)
+		if uploader == nil {
+			p.logger.Warn("unsupported connection type for image sync", "type", conn.Type)
+			warnings = append(warnings, truncateWarning(fmt.Sprintf("%s: unsupported connection type %q", conn.Name, conn.Type)))
+			continue
+		}
+
+		if uploadErr := uploader.UploadImage(ctx, pid.PlatformArtistID, imageType, data, ct); uploadErr != nil {
+			p.logger.Error("syncing image to platform", "artist", a.Name, "connection", conn.Name, "type", imageType, "error", uploadErr)
+			warnings = append(warnings, truncateWarning(fmt.Sprintf("%s (%s): image upload failed", conn.Name, conn.Type)))
+		}
+	}
+	return warnings
+}
+
+// SyncAllFanartToPlatforms uploads all local fanart files to every connected
+// platform at their respective indices. Unlike SyncImageToPlatforms which only
+// syncs the primary image, this discovers all fanart files and uploads each one
+// at the correct backdrop index. Errors are logged and returned as warnings.
+func (p *Publisher) SyncAllFanartToPlatforms(ctx context.Context, a *artist.Artist) []string {
+	if p == nil {
+		return nil
+	}
+	warnings := make([]string, 0)
+
+	platformIDs, err := p.artistService.GetPlatformIDs(ctx, a.ID)
+	if err != nil {
+		p.logger.Error("getting platform IDs for fanart sync",
+			slog.String("artist_id", a.ID),
+			slog.String("error", err.Error()))
+		warnings = append(warnings, "platform sync skipped: failed to load platform mappings")
+		return warnings
+	}
+	if len(platformIDs) == 0 {
+		return warnings
+	}
+
+	dir := p.ImageDir(a)
+	if dir == "" {
+		p.logger.Warn("skipping platform fanart sync: artist has no image directory",
+			slog.String("artist", a.Name))
+		warnings = append(warnings, "platform sync skipped: artist has no image directory configured")
+		return warnings
+	}
+
+	primary := p.getActiveFanartPrimary(ctx)
+	fanartPaths, discoverErr := img.DiscoverFanart(dir, primary)
+	if discoverErr != nil {
+		p.logger.Error("discovering fanart for platform sync",
+			slog.String("artist_id", a.ID),
+			slog.String("error", discoverErr.Error()))
+		warnings = append(warnings, "platform sync skipped: failed to read fanart directory")
+		return warnings
+	}
+	if len(fanartPaths) == 0 {
+		return warnings
+	}
+
+	for _, pid := range platformIDs {
+		conn, connErr := p.connectionService.GetByID(ctx, pid.ConnectionID)
+		if connErr != nil {
+			p.logger.Error("getting connection for fanart sync",
+				slog.String("connection_id", pid.ConnectionID),
+				slog.String("error", connErr.Error()))
+			warnings = append(warnings, truncateWarning(fmt.Sprintf("connection %s: failed to load", pid.ConnectionID)))
+			continue
+		}
+		if !conn.Enabled || conn.Status != "ok" {
+			p.logger.Debug("skipping connection for fanart sync",
+				slog.String("connection", conn.Name),
+				slog.String("status", conn.Status))
+			continue
+		}
+
+		indexedUploader := newIndexedImageUploader(conn, p.logger)
+		if indexedUploader == nil {
+			p.logger.Warn("unsupported connection type for fanart sync",
+				slog.String("type", conn.Type))
+			warnings = append(warnings, truncateWarning(fmt.Sprintf("%s: unsupported connection type %q", conn.Name, conn.Type)))
+			continue
+		}
+
+		for i, fp := range fanartPaths {
+			data, readErr := os.ReadFile(fp) //nolint:gosec // path from trusted fanart discovery
+			if readErr != nil {
+				p.logger.Error("reading fanart for platform sync",
+					slog.String("path", fp),
+					slog.String("error", readErr.Error()))
+				warnings = append(warnings, truncateWarning(fmt.Sprintf("%s: failed to read fanart %d", conn.Name, i)))
+				continue
+			}
+
+			ct := "image/jpeg"
+			if strings.EqualFold(filepath.Ext(fp), ".png") {
+				ct = "image/png"
+			}
+
+			if uploadErr := indexedUploader.UploadImageAtIndex(ctx, pid.PlatformArtistID, "fanart", i, data, ct); uploadErr != nil {
+				p.logger.Error("syncing fanart to platform",
+					slog.String("artist", a.Name),
+					slog.String("connection", conn.Name),
+					slog.Int("index", i),
+					slog.String("error", uploadErr.Error()))
+				warnings = append(warnings, truncateWarning(fmt.Sprintf("%s (%s): fanart %d upload failed", conn.Name, conn.Type, i)))
+			}
+		}
+	}
+	return warnings
+}
+
+// SetImageCacheDir updates the fallback image cache directory. This is used
+// by tests that configure the cache dir after Publisher construction.
+func (p *Publisher) SetImageCacheDir(dir string) {
+	if p != nil {
+		p.imageCacheDir = dir
+	}
+}
+
+// ImageDir returns the directory where images for this artist should be
+// stored and served from. Uses the artist's filesystem path if available,
+// otherwise falls back to the managed cache directory.
+func (p *Publisher) ImageDir(a *artist.Artist) string {
+	if a.Path != "" {
+		return a.Path
+	}
+	if p.imageCacheDir != "" && a.ID != "" {
+		return filepath.Join(p.imageCacheDir, a.ID)
+	}
+	return ""
+}
+
+// getActiveNamingConfig returns the filenames configured for the given image
+// type in the active platform profile, falling back to defaults.
+func (p *Publisher) getActiveNamingConfig(ctx context.Context, imageType string) []string {
+	if p.platformService == nil {
+		return img.FileNamesForType(img.DefaultFileNames, imageType)
+	}
+	profile, err := p.platformService.GetActive(ctx)
+	if err != nil || profile == nil {
+		return img.FileNamesForType(img.DefaultFileNames, imageType)
+	}
+	names := profile.ImageNaming.NamesForType(imageType)
+	if len(names) == 0 {
+		return img.FileNamesForType(img.DefaultFileNames, imageType)
+	}
+	return names
+}
+
+// getActiveFanartPrimary returns the primary fanart filename from the active
+// platform profile, falling back to the default.
+func (p *Publisher) getActiveFanartPrimary(ctx context.Context) string {
+	if p.platformService == nil {
+		return img.PrimaryFileName(img.DefaultFileNames, "fanart")
+	}
+	profile, err := p.platformService.GetActive(ctx)
+	if err != nil || profile == nil {
+		return img.PrimaryFileName(img.DefaultFileNames, "fanart")
+	}
+	name := profile.ImageNaming.PrimaryName("fanart")
+	if name == "" {
+		return img.PrimaryFileName(img.DefaultFileNames, "fanart")
+	}
+	return name
+}
+
+// newImageUploader constructs an ImageUploader for the given connection type.
+// Returns nil for connection types that do not support image upload.
+func newImageUploader(conn *connection.Connection, logger *slog.Logger) connection.ImageUploader {
+	switch conn.Type {
+	case connection.TypeEmby:
+		return emby.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger)
+	case connection.TypeJellyfin:
+		return jellyfin.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger)
+	default:
+		return nil
+	}
+}
+
+// newIndexedImageUploader constructs an IndexedImageUploader for the given
+// connection type. Returns nil for unsupported types.
+func newIndexedImageUploader(conn *connection.Connection, logger *slog.Logger) connection.IndexedImageUploader {
+	switch conn.Type {
+	case connection.TypeEmby:
+		return emby.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger)
+	case connection.TypeJellyfin:
+		return jellyfin.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger)
+	default:
+		return nil
+	}
+}
+
+// truncateWarning caps a warning string at maxWarningRunes runes.
+func truncateWarning(msg string) string {
+	if runes := []rune(msg); len(runes) > maxWarningRunes {
+		return string(runes[:maxWarningRunes]) + " (truncated)"
+	}
+	return msg
+}

--- a/internal/publish/push_data.go
+++ b/internal/publish/push_data.go
@@ -1,0 +1,56 @@
+package publish
+
+import (
+	"log/slog"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/connection"
+	"github.com/sydlexius/stillwater/internal/connection/emby"
+	"github.com/sydlexius/stillwater/internal/connection/jellyfin"
+)
+
+// BuildArtistPushData maps an Artist into the platform-agnostic push payload.
+// Groups and orchestras get Formed and Disbanded; solo artists get Born and
+// Died; unknown types get all four fields so the push code's Born > Formed
+// fallback chain still works.
+func BuildArtistPushData(a *artist.Artist) connection.ArtistPushData {
+	data := connection.ArtistPushData{
+		Name:           a.Name,
+		SortName:       a.SortName,
+		Biography:      a.Biography,
+		Genres:         a.Genres,
+		Styles:         a.Styles,
+		Moods:          a.Moods,
+		Disambiguation: a.Disambiguation,
+		YearsActive:    a.YearsActive,
+		MusicBrainzID:  a.MusicBrainzID,
+	}
+	switch a.Type {
+	case "group", "orchestra", "choir":
+		data.Formed = a.Formed
+		data.Disbanded = a.Disbanded
+	case "solo":
+		data.Born = a.Born
+		data.Died = a.Died
+	default:
+		data.Born = a.Born
+		data.Formed = a.Formed
+		data.Died = a.Died
+		data.Disbanded = a.Disbanded
+	}
+	return data
+}
+
+// NewMetadataPusher constructs a MetadataPusher for the given connection type.
+// Returns (nil, false) for connection types that do not support metadata push
+// (e.g. Lidarr).
+func NewMetadataPusher(conn *connection.Connection, logger *slog.Logger) (connection.MetadataPusher, bool) {
+	switch conn.Type {
+	case connection.TypeEmby:
+		return emby.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger), true
+	case connection.TypeJellyfin:
+		return jellyfin.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger), true
+	default:
+		return nil, false
+	}
+}


### PR DESCRIPTION
## Summary
- Create `internal/publish` package with `Publisher` struct that centralizes NFO write-back, async metadata push, and platform image sync operations
- Move `writeBackNFO`, `asyncPushMetadataToConnections`, `syncImageToPlatforms`, `syncAllFanartToPlatforms` from Router to Publisher
- Move `buildArtistPushData`, `newMetadataPusher` to `publish` package as exported functions
- Move `findExistingImage` to `internal/image/naming.go` as shared utility (`FindExistingImage`)
- Wire Publisher into Router, RouterDeps, and main.go
- Fix: use `context.WithoutCancel(ctx)` instead of `context.Background()` in async metadata push (per concurrency guidelines)
- Fix: unify `conn.Status` check in `SyncImageToPlatforms` to skip non-ok connections (matches `SyncAllFanartToPlatforms`)

Phase 1 of #542: pure refactor with zero behavior change (except the two fixes above). All existing call sites delegate to Publisher instead of calling Router methods directly.

16 files changed, 639 insertions, 403 deletions. Net new logic is minimal -- most additions are moved code.

## Test plan
- [x] `go test ./...` passes (42 packages)
- [x] OpenAPI consistency verified (no API changes)
- [x] Rename completeness: zero stale references to old method names
- [x] No raw error leaks to clients
- [x] Local review toolkit: code-reviewer, silent-failure-hunter, type-design-analyzer, pr-test-analyzer -- no critical findings
- [x] Generated files: no .templ changes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal metadata and image publishing workflows into a centralized service for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->