### PR TITLE
Update Claude hook matcher and Serena defaults

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -69,7 +69,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit",
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -133,3 +133,17 @@ read_only_memory_patterns: []
 # Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
 # This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
 line_ending:
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}


### PR DESCRIPTION
## Summary
- Add `Write` to the PostToolUse hook matcher in `.claude/settings.json`
- Append default config stubs to `.serena/project.yml` from Serena MCP activation

## Test plan
- [x] No Go code changes -- pre-commit checks skipped correctly
- [x] Config-only changes, no functional impact

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code formatting for Go and template files now automatically runs after write operations, in addition to edit operations.
  * Added project configuration options to exclude memories by pattern and customize language-server settings per language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->