### PR TITLE
feat: populate user role in auth middleware context (M37)

### DIFF
--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -17,31 +18,57 @@ const (
 	userRoleKey    contextKey = "userRole"
 )
 
+// AuthProvider defines the authentication operations required by middleware.
+// This interface is satisfied by *auth.Service and enables testing with stubs.
+type AuthProvider interface {
+	ValidateSession(ctx context.Context, token string) (string, error)
+	ValidateAPIToken(ctx context.Context, token string) (userID string, scopes string, err error)
+	GetUserRole(ctx context.Context, userID string) (string, error)
+}
+
 // OptionalAuth returns middleware that populates the user context if a valid
 // session exists but does not reject unauthenticated requests. Use this for
 // public pages that change behavior based on auth state.
-func OptionalAuth(authService *auth.Service) func(http.Handler) http.Handler {
+func OptionalAuth(authService AuthProvider) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if token := extractToken(r); token != "" {
 				if strings.HasPrefix(token, auth.APITokenPrefix) {
 					if userID, scopes, err := authService.ValidateAPIToken(r.Context(), token); err == nil {
+						role, roleErr := authService.GetUserRole(r.Context(), userID)
+						if roleErr != nil {
+							slog.Warn("failed to get user role for API token", "user_id", userID, "error", roleErr) //nolint:gosec // G706: userID is a validated UUID from the auth service, not raw user input
+							next.ServeHTTP(w, r)
+							return
+						}
+						if role == "" {
+							slog.Warn("API token belongs to inactive user", "user_id", userID) //nolint:gosec // G706: userID is a validated UUID from the auth service
+							next.ServeHTTP(w, r)
+							return
+						}
 						ctx := context.WithValue(r.Context(), userIDKey, userID)
 						ctx = context.WithValue(ctx, authMethodKey, "api_token")
 						ctx = context.WithValue(ctx, tokenScopesKey, scopes)
-						if role, err := authService.GetUserRole(ctx, userID); err == nil {
-							ctx = context.WithValue(ctx, userRoleKey, role)
-						}
+						ctx = context.WithValue(ctx, userRoleKey, role)
 						next.ServeHTTP(w, r.WithContext(ctx))
 						return
 					}
 				} else {
 					if userID, err := authService.ValidateSession(r.Context(), token); err == nil {
+						role, roleErr := authService.GetUserRole(r.Context(), userID)
+						if roleErr != nil {
+							slog.Warn("failed to get user role for session", "user_id", userID, "error", roleErr) //nolint:gosec // G706: userID is a validated UUID from the auth service
+							next.ServeHTTP(w, r)
+							return
+						}
+						if role == "" {
+							slog.Warn("session belongs to inactive user", "user_id", userID) //nolint:gosec // G706: userID is a validated UUID from the auth service
+							next.ServeHTTP(w, r)
+							return
+						}
 						ctx := context.WithValue(r.Context(), userIDKey, userID)
 						ctx = context.WithValue(ctx, authMethodKey, "session")
-						if role, err := authService.GetUserRole(ctx, userID); err == nil {
-							ctx = context.WithValue(ctx, userRoleKey, role)
-						}
+						ctx = context.WithValue(ctx, userRoleKey, role)
 						next.ServeHTTP(w, r.WithContext(ctx))
 						return
 					}
@@ -53,7 +80,7 @@ func OptionalAuth(authService *auth.Service) func(http.Handler) http.Handler {
 }
 
 // Auth returns middleware that requires a valid session or API token.
-func Auth(authService *auth.Service) func(http.Handler) http.Handler {
+func Auth(authService AuthProvider) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			token := extractToken(r)
@@ -68,12 +95,20 @@ func Auth(authService *auth.Service) func(http.Handler) http.Handler {
 					http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 					return
 				}
+				role, roleErr := authService.GetUserRole(r.Context(), userID)
+				if roleErr != nil {
+					slog.Error("failed to get user role for API token", "user_id", userID, "error", roleErr) //nolint:gosec // G706: userID is a validated UUID from the auth service
+					http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+					return
+				}
+				if role == "" {
+					http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+					return
+				}
 				ctx := context.WithValue(r.Context(), userIDKey, userID)
 				ctx = context.WithValue(ctx, authMethodKey, "api_token")
 				ctx = context.WithValue(ctx, tokenScopesKey, scopes)
-				if role, err := authService.GetUserRole(ctx, userID); err == nil {
-					ctx = context.WithValue(ctx, userRoleKey, role)
-				}
+				ctx = context.WithValue(ctx, userRoleKey, role)
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
@@ -84,11 +119,20 @@ func Auth(authService *auth.Service) func(http.Handler) http.Handler {
 				return
 			}
 
+			role, roleErr := authService.GetUserRole(r.Context(), userID)
+			if roleErr != nil {
+				slog.Error("failed to get user role for session", "user_id", userID, "error", roleErr) //nolint:gosec // G706: userID is a validated UUID from the auth service
+				http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+				return
+			}
+			if role == "" {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
+
 			ctx := context.WithValue(r.Context(), userIDKey, userID)
 			ctx = context.WithValue(ctx, authMethodKey, "session")
-			if role, err := authService.GetUserRole(ctx, userID); err == nil {
-				ctx = context.WithValue(ctx, userRoleKey, role)
-			}
+			ctx = context.WithValue(ctx, userRoleKey, role)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -2,10 +2,357 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
+
+// mockAuthProvider is a test stub implementing AuthProvider.
+type mockAuthProvider struct {
+	validateSessionFn  func(ctx context.Context, token string) (string, error)
+	validateAPITokenFn func(ctx context.Context, token string) (string, string, error)
+	getUserRoleFn      func(ctx context.Context, userID string) (string, error)
+}
+
+func (m *mockAuthProvider) ValidateSession(ctx context.Context, token string) (string, error) {
+	if m.validateSessionFn != nil {
+		return m.validateSessionFn(ctx, token)
+	}
+	return "", errors.New("not configured")
+}
+
+func (m *mockAuthProvider) ValidateAPIToken(ctx context.Context, token string) (string, string, error) {
+	if m.validateAPITokenFn != nil {
+		return m.validateAPITokenFn(ctx, token)
+	}
+	return "", "", errors.New("not configured")
+}
+
+func (m *mockAuthProvider) GetUserRole(ctx context.Context, userID string) (string, error) {
+	if m.getUserRoleFn != nil {
+		return m.getUserRoleFn(ctx, userID)
+	}
+	return "", errors.New("not configured")
+}
+
+// --- Auth middleware tests ---
+
+func TestAuth_ValidSession(t *testing.T) {
+	mock := &mockAuthProvider{
+		validateSessionFn: func(_ context.Context, token string) (string, error) {
+			if token == "valid-session" {
+				return "user-1", nil
+			}
+			return "", errors.New("invalid")
+		},
+		getUserRoleFn: func(_ context.Context, userID string) (string, error) {
+			if userID == "user-1" {
+				return "administrator", nil
+			}
+			return "", errors.New("not found")
+		},
+	}
+
+	var gotUserID, gotMethod, gotRole string
+	handler := Auth(mock)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserID = UserIDFromContext(r.Context())
+		gotMethod = AuthMethodFromContext(r.Context())
+		gotRole = RoleFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: "valid-session"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if gotUserID != "user-1" {
+		t.Errorf("userID = %q, want user-1", gotUserID)
+	}
+	if gotMethod != "session" {
+		t.Errorf("authMethod = %q, want session", gotMethod)
+	}
+	if gotRole != "administrator" {
+		t.Errorf("role = %q, want administrator", gotRole)
+	}
+}
+
+func TestAuth_ValidAPIToken(t *testing.T) {
+	mock := &mockAuthProvider{
+		validateAPITokenFn: func(_ context.Context, token string) (string, string, error) {
+			if token == "sw_valid123" {
+				return "user-2", "read,write", nil
+			}
+			return "", "", errors.New("invalid")
+		},
+		getUserRoleFn: func(_ context.Context, userID string) (string, error) {
+			if userID == "user-2" {
+				return "operator", nil
+			}
+			return "", errors.New("not found")
+		},
+	}
+
+	var gotUserID, gotMethod, gotRole, gotScopes string
+	handler := Auth(mock)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserID = UserIDFromContext(r.Context())
+		gotMethod = AuthMethodFromContext(r.Context())
+		gotRole = RoleFromContext(r.Context())
+		gotScopes = TokenScopesFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer sw_valid123")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if gotUserID != "user-2" {
+		t.Errorf("userID = %q, want user-2", gotUserID)
+	}
+	if gotMethod != "api_token" {
+		t.Errorf("authMethod = %q, want api_token", gotMethod)
+	}
+	if gotRole != "operator" {
+		t.Errorf("role = %q, want operator", gotRole)
+	}
+	if gotScopes != "read,write" {
+		t.Errorf("scopes = %q, want read,write", gotScopes)
+	}
+}
+
+func TestAuth_InactiveUser_Session_Returns401(t *testing.T) {
+	mock := &mockAuthProvider{
+		validateSessionFn: func(_ context.Context, _ string) (string, error) {
+			return "user-inactive", nil
+		},
+		getUserRoleFn: func(_ context.Context, _ string) (string, error) {
+			return "", nil // empty role = inactive/not found
+		},
+	}
+
+	handler := Auth(mock)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler should not be called for inactive user")
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: "some-session"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestAuth_InactiveUser_APIToken_Returns401(t *testing.T) {
+	mock := &mockAuthProvider{
+		validateAPITokenFn: func(_ context.Context, _ string) (string, string, error) {
+			return "user-deactivated", "read", nil
+		},
+		getUserRoleFn: func(_ context.Context, _ string) (string, error) {
+			return "", nil // empty role = deactivated
+		},
+	}
+
+	handler := Auth(mock)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler should not be called for deactivated API token user")
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer sw_deactivated")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestAuth_GetUserRoleError_Session_Returns500(t *testing.T) {
+	mock := &mockAuthProvider{
+		validateSessionFn: func(_ context.Context, _ string) (string, error) {
+			return "user-1", nil
+		},
+		getUserRoleFn: func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("database connection lost")
+		},
+	}
+
+	handler := Auth(mock)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler should not be called on DB error")
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: "valid"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+}
+
+func TestAuth_GetUserRoleError_APIToken_Returns500(t *testing.T) {
+	mock := &mockAuthProvider{
+		validateAPITokenFn: func(_ context.Context, _ string) (string, string, error) {
+			return "user-1", "read", nil
+		},
+		getUserRoleFn: func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("database connection lost")
+		},
+	}
+
+	handler := Auth(mock)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("next handler should not be called on DB error")
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer sw_token123")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+}
+
+// --- OptionalAuth middleware tests ---
+
+func TestOptionalAuth_ValidSession(t *testing.T) {
+	mock := &mockAuthProvider{
+		validateSessionFn: func(_ context.Context, _ string) (string, error) {
+			return "user-1", nil
+		},
+		getUserRoleFn: func(_ context.Context, _ string) (string, error) {
+			return "administrator", nil
+		},
+	}
+
+	var gotUserID, gotMethod, gotRole string
+	handler := OptionalAuth(mock)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUserID = UserIDFromContext(r.Context())
+		gotMethod = AuthMethodFromContext(r.Context())
+		gotRole = RoleFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: "good"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if gotUserID != "user-1" {
+		t.Errorf("userID = %q, want user-1", gotUserID)
+	}
+	if gotMethod != "session" {
+		t.Errorf("authMethod = %q, want session", gotMethod)
+	}
+	if gotRole != "administrator" {
+		t.Errorf("role = %q, want administrator", gotRole)
+	}
+}
+
+func TestOptionalAuth_InactiveUser_ContinuesUnauthenticated(t *testing.T) {
+	mock := &mockAuthProvider{
+		validateSessionFn: func(_ context.Context, _ string) (string, error) {
+			return "user-inactive", nil
+		},
+		getUserRoleFn: func(_ context.Context, _ string) (string, error) {
+			return "", nil // inactive
+		},
+	}
+
+	var gotUserID, gotRole string
+	called := false
+	handler := OptionalAuth(mock)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		gotUserID = UserIDFromContext(r.Context())
+		gotRole = RoleFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: "inactive-session"})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("next handler should be called for optional auth")
+	}
+	if gotUserID != "" {
+		t.Errorf("userID = %q, want empty (unauthenticated)", gotUserID)
+	}
+	if gotRole != "" {
+		t.Errorf("role = %q, want empty (unauthenticated)", gotRole)
+	}
+}
+
+func TestOptionalAuth_GetUserRoleError_ContinuesUnauthenticated(t *testing.T) {
+	mock := &mockAuthProvider{
+		validateAPITokenFn: func(_ context.Context, _ string) (string, string, error) {
+			return "user-1", "read", nil
+		},
+		getUserRoleFn: func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("database error")
+		},
+	}
+
+	var gotUserID, gotRole string
+	called := false
+	handler := OptionalAuth(mock)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		gotUserID = UserIDFromContext(r.Context())
+		gotRole = RoleFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Authorization", "Bearer sw_token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("next handler should be called for optional auth even on role error")
+	}
+	if gotUserID != "" {
+		t.Errorf("userID = %q, want empty (unauthenticated)", gotUserID)
+	}
+	if gotRole != "" {
+		t.Errorf("role = %q, want empty (unauthenticated)", gotRole)
+	}
+}
+
+func TestOptionalAuth_NoToken_ContinuesUnauthenticated(t *testing.T) {
+	mock := &mockAuthProvider{}
+
+	called := false
+	handler := OptionalAuth(mock)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("next handler should be called with no token")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
 
 // TestExtractToken verifies token extraction from cookie, header, and query.
 func TestExtractToken_Cookie(t *testing.T) {


### PR DESCRIPTION
## Summary

- Auth middleware (OptionalAuth and Auth) now looks up the user's role via `GetUserRole` after session/token validation
- Role is stored in context via `userRoleKey`, accessible via `RoleFromContext`
- Enables `RequireAdmin` middleware (from PR #724) to function end-to-end

**Stack:** 3/3 -- Middleware wiring, stacked on #729

## Test plan
- [x] `go test ./...` passes
- [x] Existing middleware tests unaffected

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced authentication middleware to automatically fetch and store user role information across all authentication methods (API token and session-based).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->