### PR TITLE
fix: image dimension rules use DB dimensions for API-imported artists (#726)

### DIFF
--- a/internal/artist/model.go
+++ b/internal/artist/model.go
@@ -50,6 +50,14 @@ type Artist struct {
 	FanartPlaceholder   string            `json:"fanart_placeholder,omitempty"`
 	LogoPlaceholder     string            `json:"logo_placeholder,omitempty"`
 	BannerPlaceholder   string            `json:"banner_placeholder,omitempty"`
+	ThumbWidth          int               `json:"thumb_width,omitempty"`
+	ThumbHeight         int               `json:"thumb_height,omitempty"`
+	FanartWidth         int               `json:"fanart_width,omitempty"`
+	FanartHeight        int               `json:"fanart_height,omitempty"`
+	LogoWidth           int               `json:"logo_width,omitempty"`
+	LogoHeight          int               `json:"logo_height,omitempty"`
+	BannerWidth         int               `json:"banner_width,omitempty"`
+	BannerHeight        int               `json:"banner_height,omitempty"`
 	HealthScore         float64           `json:"health_score"`
 	HealthEvaluatedAt   *time.Time        `json:"health_evaluated_at,omitempty"`
 	IsExcluded          bool              `json:"is_excluded"`

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -982,11 +982,15 @@ func applyImageMetadata(a *Artist, imgs []ArtistImage) {
 			a.ThumbExists = img.Exists
 			a.ThumbLowRes = img.LowRes
 			a.ThumbPlaceholder = img.Placeholder
+			a.ThumbWidth = img.Width
+			a.ThumbHeight = img.Height
 		case "fanart":
 			if img.SlotIndex == 0 {
 				a.FanartExists = img.Exists
 				a.FanartLowRes = img.LowRes
 				a.FanartPlaceholder = img.Placeholder
+				a.FanartWidth = img.Width
+				a.FanartHeight = img.Height
 			}
 			if img.Exists {
 				fanartCount++
@@ -995,10 +999,14 @@ func applyImageMetadata(a *Artist, imgs []ArtistImage) {
 			a.LogoExists = img.Exists
 			a.LogoLowRes = img.LowRes
 			a.LogoPlaceholder = img.Placeholder
+			a.LogoWidth = img.Width
+			a.LogoHeight = img.Height
 		case "banner":
 			a.BannerExists = img.Exists
 			a.BannerLowRes = img.LowRes
 			a.BannerPlaceholder = img.Placeholder
+			a.BannerWidth = img.Width
+			a.BannerHeight = img.Height
 		}
 	}
 	a.FanartCount = fanartCount
@@ -1019,6 +1027,8 @@ func extractImageMetadata(a *Artist) []ArtistImage {
 			Exists:      a.ThumbExists,
 			LowRes:      a.ThumbLowRes,
 			Placeholder: a.ThumbPlaceholder,
+			Width:       a.ThumbWidth,
+			Height:      a.ThumbHeight,
 		})
 	}
 	if a.FanartExists || a.FanartLowRes || a.FanartPlaceholder != "" {
@@ -1029,6 +1039,8 @@ func extractImageMetadata(a *Artist) []ArtistImage {
 			Exists:      a.FanartExists,
 			LowRes:      a.FanartLowRes,
 			Placeholder: a.FanartPlaceholder,
+			Width:       a.FanartWidth,
+			Height:      a.FanartHeight,
 		})
 		// Persist additional fanart slots so FanartCount round-trips through the DB.
 		// Slots 1..FanartCount-1 only track existence; per-slot metadata (dimensions,
@@ -1052,6 +1064,8 @@ func extractImageMetadata(a *Artist) []ArtistImage {
 			Exists:      a.LogoExists,
 			LowRes:      a.LogoLowRes,
 			Placeholder: a.LogoPlaceholder,
+			Width:       a.LogoWidth,
+			Height:      a.LogoHeight,
 		})
 	}
 	if a.BannerExists || a.BannerLowRes || a.BannerPlaceholder != "" {
@@ -1062,6 +1076,8 @@ func extractImageMetadata(a *Artist) []ArtistImage {
 			Exists:      a.BannerExists,
 			LowRes:      a.BannerLowRes,
 			Placeholder: a.BannerPlaceholder,
+			Width:       a.BannerWidth,
+			Height:      a.BannerHeight,
 		})
 	}
 

--- a/internal/artist/sqlite_image.go
+++ b/internal/artist/sqlite_image.go
@@ -130,8 +130,8 @@ func (r *sqliteImageRepo) UpsertAll(ctx context.Context, artistID string, images
 			exists_flag = excluded.exists_flag,
 			low_res     = excluded.low_res,
 			placeholder = excluded.placeholder,
-			width       = excluded.width,
-			height      = excluded.height`)
+			width  = CASE WHEN excluded.width  > 0 THEN excluded.width  ELSE artist_images.width  END,
+			height = CASE WHEN excluded.height > 0 THEN excluded.height ELSE artist_images.height END`)
 	if err != nil {
 		return fmt.Errorf("preparing upsert: %w", err)
 	}

--- a/internal/rule/checkers.go
+++ b/internal/rule/checkers.go
@@ -75,14 +75,14 @@ func checkThumbExists(a *artist.Artist, _ RuleConfig) *Violation {
 }
 
 // makeThumbSquareChecker returns a Checker closure that uses the Engine's
-// cached directory listing to find and measure the thumbnail image.
+// DB-stored dimensions (with filesystem fallback) to measure the thumbnail.
 func (e *Engine) makeThumbSquareChecker() Checker {
 	return func(a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.ThumbExists {
 			return nil // thumb_exists rule handles this case
 		}
 
-		w, h, err := e.getImageDimensionsCached(a.Path, thumbPatterns)
+		w, h, err := e.getImageDimensionsResolved(a.ID, a.Path, "thumb", thumbPatterns)
 		if err != nil {
 			return nil // cannot read image; skip check
 		}
@@ -113,14 +113,14 @@ func (e *Engine) makeThumbSquareChecker() Checker {
 }
 
 // makeThumbMinResChecker returns a Checker closure that uses the Engine's
-// cached directory listing to find and measure the thumbnail image.
+// DB-stored dimensions (with filesystem fallback) to measure the thumbnail.
 func (e *Engine) makeThumbMinResChecker() Checker {
 	return func(a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.ThumbExists {
 			return nil // thumb_exists rule handles this case
 		}
 
-		w, h, err := e.getImageDimensionsCached(a.Path, thumbPatterns)
+		w, h, err := e.getImageDimensionsResolved(a.ID, a.Path, "thumb", thumbPatterns)
 		if err != nil {
 			return nil // cannot read image; skip check
 		}
@@ -203,13 +203,13 @@ func checkBioExists(a *artist.Artist, cfg RuleConfig) *Violation {
 }
 
 // makeFanartMinResChecker returns a Checker closure that uses the Engine's
-// cached directory listing to find and measure the fanart image.
+// DB-stored dimensions (with filesystem fallback) to measure the fanart.
 func (e *Engine) makeFanartMinResChecker() Checker {
 	return func(a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.FanartExists {
 			return nil // fanart_exists handles missing fanart
 		}
-		w, h, err := e.getImageDimensionsCached(a.Path, fanartPatterns)
+		w, h, err := e.getImageDimensionsResolved(a.ID, a.Path, "fanart", fanartPatterns)
 		if err != nil {
 			return nil
 		}
@@ -235,13 +235,13 @@ func (e *Engine) makeFanartMinResChecker() Checker {
 }
 
 // makeFanartAspectChecker returns a Checker closure that uses the Engine's
-// cached directory listing to find and measure the fanart image.
+// DB-stored dimensions (with filesystem fallback) to measure the fanart.
 func (e *Engine) makeFanartAspectChecker() Checker {
 	return func(a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.FanartExists {
 			return nil
 		}
-		w, h, err := e.getImageDimensionsCached(a.Path, fanartPatterns)
+		w, h, err := e.getImageDimensionsResolved(a.ID, a.Path, "fanart", fanartPatterns)
 		if err != nil {
 			return nil
 		}
@@ -269,13 +269,13 @@ func (e *Engine) makeFanartAspectChecker() Checker {
 }
 
 // makeLogoMinResChecker returns a Checker closure that uses the Engine's
-// cached directory listing to find and measure the logo image.
+// DB-stored dimensions (with filesystem fallback) to measure the logo.
 func (e *Engine) makeLogoMinResChecker() Checker {
 	return func(a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.LogoExists {
 			return nil
 		}
-		w, _, err := e.getImageDimensionsCached(a.Path, logoPatterns)
+		w, _, err := e.getImageDimensionsResolved(a.ID, a.Path, "logo", logoPatterns)
 		if err != nil {
 			return nil
 		}
@@ -312,13 +312,13 @@ func checkBannerExists(a *artist.Artist, _ RuleConfig) *Violation {
 }
 
 // makeBannerMinResChecker returns a Checker closure that uses the Engine's
-// cached directory listing to find and measure the banner image.
+// DB-stored dimensions (with filesystem fallback) to measure the banner.
 func (e *Engine) makeBannerMinResChecker() Checker {
 	return func(a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.BannerExists {
 			return nil
 		}
-		w, h, err := e.getImageDimensionsCached(a.Path, bannerPatterns)
+		w, h, err := e.getImageDimensionsResolved(a.ID, a.Path, "banner", bannerPatterns)
 		if err != nil {
 			return nil
 		}

--- a/internal/rule/checkers_test.go
+++ b/internal/rule/checkers_test.go
@@ -1,6 +1,7 @@
 package rule
 
 import (
+	"database/sql"
 	"image"
 	"image/color"
 	"image/jpeg"
@@ -1192,5 +1193,309 @@ func TestLogoBoundsCache_ConcurrentAccess(t *testing.T) {
 
 	if size > maxLogoBoundsCacheSize {
 		t.Errorf("cache size %d exceeds maximum %d after concurrent access", size, maxLogoBoundsCacheSize)
+	}
+}
+
+// --- DB-backed dimension resolution tests ---
+
+// seedImageDimensions inserts an artist_images row with the given dimensions
+// for use in tests that exercise getImageDimensionsFromDB.
+func seedImageDimensions(t *testing.T, db *sql.DB, artistID, imageType string, w, h int) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO artist_images (id, artist_id, image_type, slot_index, exists_flag, low_res, placeholder, width, height, phash, file_format, source, last_written_at)
+		VALUES (?, ?, ?, 0, 1, 0, '', ?, ?, '', '', '', '')
+		ON CONFLICT(artist_id, image_type, slot_index) DO UPDATE SET exists_flag = 1, width = excluded.width, height = excluded.height`,
+		artistID+"-"+imageType, artistID, imageType, w, h,
+	)
+	if err != nil {
+		t.Fatalf("seeding image dimensions: %v", err)
+	}
+}
+
+func TestGetImageDimensionsFromDB(t *testing.T) {
+	db := setupTestDB(t)
+
+	e := &Engine{db: db, logger: slog.Default()}
+
+	// No row: returns (0, 0, nil).
+	w, h, err := e.getImageDimensionsFromDB("nonexistent", "thumb")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w != 0 || h != 0 {
+		t.Errorf("expected (0,0), got (%d,%d)", w, h)
+	}
+
+	// Insert a row with real dimensions.
+	seedImageDimensions(t, db, "artist-1", "thumb", 600, 600)
+
+	w, h, err = e.getImageDimensionsFromDB("artist-1", "thumb")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w != 600 || h != 600 {
+		t.Errorf("expected (600,600), got (%d,%d)", w, h)
+	}
+
+	// Different image type returns (0, 0) when not seeded.
+	w, h, err = e.getImageDimensionsFromDB("artist-1", "fanart")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w != 0 || h != 0 {
+		t.Errorf("expected (0,0) for unseeded type, got (%d,%d)", w, h)
+	}
+}
+
+func TestGetImageDimensionsFromDB_NilDB(t *testing.T) {
+	e := &Engine{db: nil, logger: slog.Default()}
+
+	w, h, err := e.getImageDimensionsFromDB("artist-1", "thumb")
+	if err != nil {
+		t.Fatalf("unexpected error with nil db: %v", err)
+	}
+	if w != 0 || h != 0 {
+		t.Errorf("expected (0,0) with nil db, got (%d,%d)", w, h)
+	}
+}
+
+func TestGetImageDimensionsResolved_DBFirst(t *testing.T) {
+	db := setupTestDB(t)
+	e := &Engine{db: db, logger: slog.Default()}
+
+	seedImageDimensions(t, db, "artist-2", "fanart", 1920, 1080)
+
+	// DB has dimensions: should return them even with empty Path.
+	w, h, err := e.getImageDimensionsResolved("artist-2", "", "fanart", fanartPatterns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w != 1920 || h != 1080 {
+		t.Errorf("expected (1920,1080), got (%d,%d)", w, h)
+	}
+}
+
+func TestGetImageDimensionsResolved_FallbackToFS(t *testing.T) {
+	db := setupTestDB(t)
+	e := &Engine{db: db, logger: slog.Default()}
+
+	// DB has (0,0) dimensions for this artist (no row at all).
+	dir := t.TempDir()
+	createTestJPEG(t, filepath.Join(dir, "fanart.jpg"), 1920, 1080)
+
+	w, h, err := e.getImageDimensionsResolved("artist-3", dir, "fanart", fanartPatterns)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w != 1920 || h != 1080 {
+		t.Errorf("expected (1920,1080), got (%d,%d)", w, h)
+	}
+}
+
+func TestGetImageDimensionsResolved_NoDBNoFS(t *testing.T) {
+	db := setupTestDB(t)
+	e := &Engine{db: db, logger: slog.Default()}
+
+	// No DB dimensions and empty path: should return an error.
+	_, _, err := e.getImageDimensionsResolved("artist-4", "", "thumb", thumbPatterns)
+	if err == nil {
+		t.Error("expected error when neither DB nor filesystem can provide dimensions")
+	}
+}
+
+// TestCheckers_EmptyPath_DBDimensions verifies that all 6 dimension-based
+// checkers produce violations for API-imported artists (Path == "") when the
+// artist_images table contains dimensions that fail the rule. This is the core
+// bug scenario from issue #726.
+func TestCheckers_EmptyPath_DBDimensions(t *testing.T) {
+	db := setupTestDB(t)
+
+	tests := []struct {
+		name      string
+		imageType string
+		w, h      int
+		checker   func(*Engine) Checker
+		cfg       RuleConfig
+		artistFn  func(id string) *artist.Artist
+		ruleID    string
+	}{
+		{
+			name:      "thumb_square with non-square DB dimensions",
+			imageType: "thumb",
+			w:         800, h: 400,
+			checker: func(e *Engine) Checker { return e.makeThumbSquareChecker() },
+			cfg:     RuleConfig{AspectRatio: 1.0, Tolerance: 0.1},
+			artistFn: func(id string) *artist.Artist {
+				return &artist.Artist{ID: id, Name: "Test", ThumbExists: true, Path: ""}
+			},
+			ruleID: RuleThumbSquare,
+		},
+		{
+			name:      "thumb_min_res with low-res DB dimensions",
+			imageType: "thumb",
+			w:         200, h: 200,
+			checker: func(e *Engine) Checker { return e.makeThumbMinResChecker() },
+			cfg:     RuleConfig{MinWidth: 500, MinHeight: 500},
+			artistFn: func(id string) *artist.Artist {
+				return &artist.Artist{ID: id, Name: "Test", ThumbExists: true, Path: ""}
+			},
+			ruleID: RuleThumbMinRes,
+		},
+		{
+			name:      "fanart_min_res with low-res DB dimensions",
+			imageType: "fanart",
+			w:         800, h: 450,
+			checker: func(e *Engine) Checker { return e.makeFanartMinResChecker() },
+			cfg:     RuleConfig{MinWidth: 1920, MinHeight: 1080},
+			artistFn: func(id string) *artist.Artist {
+				return &artist.Artist{ID: id, Name: "Test", FanartExists: true, Path: ""}
+			},
+			ruleID: RuleFanartMinRes,
+		},
+		{
+			name:      "fanart_aspect with square DB dimensions",
+			imageType: "fanart",
+			w:         1000, h: 1000,
+			checker: func(e *Engine) Checker { return e.makeFanartAspectChecker() },
+			cfg:     RuleConfig{AspectRatio: 16.0 / 9.0, Tolerance: 0.1},
+			artistFn: func(id string) *artist.Artist {
+				return &artist.Artist{ID: id, Name: "Test", FanartExists: true, Path: ""}
+			},
+			ruleID: RuleFanartAspect,
+		},
+		{
+			name:      "logo_min_res with narrow DB dimensions",
+			imageType: "logo",
+			w:         200, h: 100,
+			checker: func(e *Engine) Checker { return e.makeLogoMinResChecker() },
+			cfg:     RuleConfig{MinWidth: 400},
+			artistFn: func(id string) *artist.Artist {
+				return &artist.Artist{ID: id, Name: "Test", LogoExists: true, Path: ""}
+			},
+			ruleID: RuleLogoMinRes,
+		},
+		{
+			name:      "banner_min_res with small DB dimensions",
+			imageType: "banner",
+			w:         500, h: 100,
+			checker: func(e *Engine) Checker { return e.makeBannerMinResChecker() },
+			cfg:     RuleConfig{MinWidth: 1000, MinHeight: 185},
+			artistFn: func(id string) *artist.Artist {
+				return &artist.Artist{ID: id, Name: "Test", BannerExists: true, Path: ""}
+			},
+			ruleID: RuleBannerMinRes,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			artistID := "api-artist-" + tt.name
+			seedImageDimensions(t, db, artistID, tt.imageType, tt.w, tt.h)
+
+			e := &Engine{db: db, logger: slog.Default()}
+			checker := tt.checker(e)
+			a := tt.artistFn(artistID)
+
+			v := checker(a, tt.cfg)
+			if v == nil {
+				t.Fatalf("expected violation for %s with DB dimensions %dx%d and empty Path", tt.ruleID, tt.w, tt.h)
+			}
+			if v.RuleID != tt.ruleID {
+				t.Errorf("RuleID = %q, want %q", v.RuleID, tt.ruleID)
+			}
+		})
+	}
+}
+
+// TestCheckers_EmptyPath_DBDimensions_Pass verifies that checkers pass (return
+// nil) when DB dimensions satisfy the rule, even with empty Path.
+func TestCheckers_EmptyPath_DBDimensions_Pass(t *testing.T) {
+	db := setupTestDB(t)
+
+	tests := []struct {
+		name      string
+		imageType string
+		w, h      int
+		checker   func(*Engine) Checker
+		cfg       RuleConfig
+		artistFn  func(id string) *artist.Artist
+	}{
+		{
+			name:      "thumb_square passes with square DB dimensions",
+			imageType: "thumb",
+			w:         500, h: 500,
+			checker: func(e *Engine) Checker { return e.makeThumbSquareChecker() },
+			cfg:     RuleConfig{AspectRatio: 1.0, Tolerance: 0.1},
+			artistFn: func(id string) *artist.Artist {
+				return &artist.Artist{ID: id, Name: "Test", ThumbExists: true, Path: ""}
+			},
+		},
+		{
+			name:      "thumb_min_res passes with high-res DB dimensions",
+			imageType: "thumb",
+			w:         1000, h: 1000,
+			checker: func(e *Engine) Checker { return e.makeThumbMinResChecker() },
+			cfg:     RuleConfig{MinWidth: 500, MinHeight: 500},
+			artistFn: func(id string) *artist.Artist {
+				return &artist.Artist{ID: id, Name: "Test", ThumbExists: true, Path: ""}
+			},
+		},
+		{
+			name:      "fanart_min_res passes with full-res DB dimensions",
+			imageType: "fanart",
+			w:         1920, h: 1080,
+			checker: func(e *Engine) Checker { return e.makeFanartMinResChecker() },
+			cfg:     RuleConfig{MinWidth: 1920, MinHeight: 1080},
+			artistFn: func(id string) *artist.Artist {
+				return &artist.Artist{ID: id, Name: "Test", FanartExists: true, Path: ""}
+			},
+		},
+		{
+			name:      "fanart_aspect passes with correct aspect ratio DB dimensions",
+			imageType: "fanart",
+			w:         1920, h: 1080,
+			checker: func(e *Engine) Checker { return e.makeFanartAspectChecker() },
+			cfg:     RuleConfig{AspectRatio: 16.0 / 9.0, Tolerance: 0.1},
+			artistFn: func(id string) *artist.Artist {
+				return &artist.Artist{ID: id, Name: "Test", FanartExists: true, Path: ""}
+			},
+		},
+		{
+			name:      "logo_min_res passes with high-res DB dimensions",
+			imageType: "logo",
+			w:         800, h: 400,
+			checker: func(e *Engine) Checker { return e.makeLogoMinResChecker() },
+			cfg:     RuleConfig{MinWidth: 400},
+			artistFn: func(id string) *artist.Artist {
+				return &artist.Artist{ID: id, Name: "Test", LogoExists: true, Path: ""}
+			},
+		},
+		{
+			name:      "banner_min_res passes with high-res DB dimensions",
+			imageType: "banner",
+			w:         1200, h: 300,
+			checker: func(e *Engine) Checker { return e.makeBannerMinResChecker() },
+			cfg:     RuleConfig{MinWidth: 1000, MinHeight: 185},
+			artistFn: func(id string) *artist.Artist {
+				return &artist.Artist{ID: id, Name: "Test", BannerExists: true, Path: ""}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			artistID := "api-pass-" + tt.name
+			seedImageDimensions(t, db, artistID, tt.imageType, tt.w, tt.h)
+
+			e := &Engine{db: db, logger: slog.Default()}
+			checker := tt.checker(e)
+			a := tt.artistFn(artistID)
+
+			v := checker(a, tt.cfg)
+			if v != nil {
+				t.Errorf("expected nil (passing rule), got violation: %s", v.Message)
+			}
+		})
 	}
 }

--- a/internal/rule/fscache.go
+++ b/internal/rule/fscache.go
@@ -1,6 +1,9 @@
 package rule
 
 import (
+	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -372,4 +375,55 @@ func (e *Engine) getImageDimensionsCached(dirPath string, patterns []string) (in
 	}
 
 	return 0, 0, fmt.Errorf("no matching image in %s", dirPath)
+}
+
+// getImageDimensionsFromDB queries the artist_images table for the dimensions
+// of a specific image type (slot 0, exists_flag = 1). Returns (0, 0, nil) when
+// the row exists but dimensions are not populated, or when no matching row
+// exists. An error is only returned on actual database failures.
+func (e *Engine) getImageDimensionsFromDB(artistID, imageType string) (int, int, error) {
+	if e.db == nil {
+		return 0, 0, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var w, h int
+	err := e.db.QueryRowContext(
+		ctx,
+		`SELECT width, height FROM artist_images
+		 WHERE artist_id = ? AND image_type = ? AND slot_index = 0 AND exists_flag = 1`,
+		artistID, imageType,
+	).Scan(&w, &h)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, 0, nil
+	}
+	if err != nil {
+		return 0, 0, fmt.Errorf("querying artist_images dimensions: %w", err)
+	}
+	return w, h, nil
+}
+
+// getImageDimensionsResolved tries to resolve image dimensions using DB-stored
+// values first, then falls back to the filesystem cache when the DB has no
+// dimensions (0, 0) and a directory path is available. This allows dimension
+// checks to work for API-imported artists (no filesystem path) as long as some
+// pipeline (e.g., scanner or provider image downloads) has populated the
+// artist_images width/height columns.
+func (e *Engine) getImageDimensionsResolved(artistID, dirPath, imageType string, patterns []string) (int, int, error) {
+	// Try DB first -- works for both filesystem and API-imported artists.
+	w, h, err := e.getImageDimensionsFromDB(artistID, imageType)
+	if err != nil {
+		return 0, 0, fmt.Errorf("querying dimensions from DB: %w", err)
+	}
+	if w > 0 && h > 0 {
+		return w, h, nil
+	}
+
+	// Fall back to filesystem when DB dimensions are missing and path is available.
+	if dirPath != "" {
+		return e.getImageDimensionsCached(dirPath, patterns)
+	}
+
+	return 0, 0, fmt.Errorf("no dimensions available for %s/%s", artistID, imageType)
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -286,6 +286,14 @@ func (s *Service) processDirectory(ctx context.Context, dirPath, name, libraryID
 			FanartPlaceholder: detected.FanartPlaceholder,
 			LogoPlaceholder:   detected.LogoPlaceholder,
 			BannerPlaceholder: detected.BannerPlaceholder,
+			ThumbWidth:        detected.ThumbWidth,
+			ThumbHeight:       detected.ThumbHeight,
+			FanartWidth:       detected.FanartWidth,
+			FanartHeight:      detected.FanartHeight,
+			LogoWidth:         detected.LogoWidth,
+			LogoHeight:        detected.LogoHeight,
+			BannerWidth:       detected.BannerWidth,
+			BannerHeight:      detected.BannerHeight,
 		}
 		if excluded {
 			a.IsExcluded = true
@@ -342,6 +350,24 @@ func (s *Service) processDirectory(ctx context.Context, dirPath, name, libraryID
 			bannerPH = existing.BannerPlaceholder
 		}
 
+		// Preserve existing dimensions when probe fails (returns 0,0).
+		if detected.ThumbWidth == 0 && existing.ThumbWidth > 0 {
+			detected.ThumbWidth = existing.ThumbWidth
+			detected.ThumbHeight = existing.ThumbHeight
+		}
+		if detected.FanartWidth == 0 && existing.FanartWidth > 0 {
+			detected.FanartWidth = existing.FanartWidth
+			detected.FanartHeight = existing.FanartHeight
+		}
+		if detected.LogoWidth == 0 && existing.LogoWidth > 0 {
+			detected.LogoWidth = existing.LogoWidth
+			detected.LogoHeight = existing.LogoHeight
+		}
+		if detected.BannerWidth == 0 && existing.BannerWidth > 0 {
+			detected.BannerWidth = existing.BannerWidth
+			detected.BannerHeight = existing.BannerHeight
+		}
+
 		// Update file existence, low-resolution, and placeholder flags
 		changed := existing.NFOExists != detected.NFOExists ||
 			existing.ThumbExists != detected.ThumbExists ||
@@ -357,6 +383,14 @@ func (s *Service) processDirectory(ctx context.Context, dirPath, name, libraryID
 			existing.FanartPlaceholder != fanartPH ||
 			existing.LogoPlaceholder != logoPH ||
 			existing.BannerPlaceholder != bannerPH ||
+			existing.ThumbWidth != detected.ThumbWidth ||
+			existing.ThumbHeight != detected.ThumbHeight ||
+			existing.FanartWidth != detected.FanartWidth ||
+			existing.FanartHeight != detected.FanartHeight ||
+			existing.LogoWidth != detected.LogoWidth ||
+			existing.LogoHeight != detected.LogoHeight ||
+			existing.BannerWidth != detected.BannerWidth ||
+			existing.BannerHeight != detected.BannerHeight ||
 			existing.IsExcluded != excluded
 
 		if changed || detected.NFOExists {
@@ -374,6 +408,14 @@ func (s *Service) processDirectory(ctx context.Context, dirPath, name, libraryID
 			existing.FanartPlaceholder = fanartPH
 			existing.LogoPlaceholder = logoPH
 			existing.BannerPlaceholder = bannerPH
+			existing.ThumbWidth = detected.ThumbWidth
+			existing.ThumbHeight = detected.ThumbHeight
+			existing.FanartWidth = detected.FanartWidth
+			existing.FanartHeight = detected.FanartHeight
+			existing.LogoWidth = detected.LogoWidth
+			existing.LogoHeight = detected.LogoHeight
+			existing.BannerWidth = detected.BannerWidth
+			existing.BannerHeight = detected.BannerHeight
 
 			// Update exclusion status
 			if excluded {
@@ -556,7 +598,8 @@ func (s *Service) detectRemoved(ctx context.Context, discoveredPaths map[string]
 	}
 }
 
-// detectedFiles holds file existence, low-resolution, and placeholder flags for an artist directory.
+// detectedFiles holds file existence, low-resolution, placeholder, and dimension
+// (width/height) flags for an artist directory.
 type detectedFiles struct {
 	NFOExists         bool
 	ThumbExists       bool
@@ -572,6 +615,14 @@ type detectedFiles struct {
 	FanartPlaceholder string
 	LogoPlaceholder   string
 	BannerPlaceholder string
+	ThumbWidth        int
+	ThumbHeight       int
+	FanartWidth       int
+	FanartHeight      int
+	LogoWidth         int
+	LogoHeight        int
+	BannerWidth       int
+	BannerHeight      int
 }
 
 // detectFiles checks for the presence of known image and NFO files in an artist
@@ -611,7 +662,7 @@ func detectFiles(dirPath string, existing *artist.Artist) (detectedFiles, error)
 		if actual, ok := files[strings.ToLower(p)]; ok {
 			fp := filepath.Join(dirPath, actual)
 			d.ThumbExists = true
-			d.ThumbLowRes, d.ThumbPlaceholder = probeImageFile(fp, "thumb", existThumbPH)
+			d.ThumbWidth, d.ThumbHeight, d.ThumbLowRes, d.ThumbPlaceholder = probeImageFile(fp, "thumb", existThumbPH)
 			break
 		}
 	}
@@ -619,7 +670,7 @@ func detectFiles(dirPath string, existing *artist.Artist) (detectedFiles, error)
 		if actual, ok := files[strings.ToLower(p)]; ok {
 			fp := filepath.Join(dirPath, actual)
 			d.FanartExists = true
-			d.FanartLowRes, d.FanartPlaceholder = probeImageFile(fp, "fanart", existFanartPH)
+			d.FanartWidth, d.FanartHeight, d.FanartLowRes, d.FanartPlaceholder = probeImageFile(fp, "fanart", existFanartPH)
 			// Count all fanart files (primary + numbered variants).
 			fanartPaths, fanartErr := img.DiscoverFanart(dirPath, actual)
 			if fanartErr != nil {
@@ -639,7 +690,7 @@ func detectFiles(dirPath string, existing *artist.Artist) (detectedFiles, error)
 		if actual, ok := files[strings.ToLower(p)]; ok {
 			fp := filepath.Join(dirPath, actual)
 			d.LogoExists = true
-			d.LogoLowRes, d.LogoPlaceholder = probeImageFile(fp, "logo", existLogoPH)
+			d.LogoWidth, d.LogoHeight, d.LogoLowRes, d.LogoPlaceholder = probeImageFile(fp, "logo", existLogoPH)
 			break
 		}
 	}
@@ -647,7 +698,7 @@ func detectFiles(dirPath string, existing *artist.Artist) (detectedFiles, error)
 		if actual, ok := files[strings.ToLower(p)]; ok {
 			fp := filepath.Join(dirPath, actual)
 			d.BannerExists = true
-			d.BannerLowRes, d.BannerPlaceholder = probeImageFile(fp, "banner", existBannerPH)
+			d.BannerWidth, d.BannerHeight, d.BannerLowRes, d.BannerPlaceholder = probeImageFile(fp, "banner", existBannerPH)
 			break
 		}
 	}
@@ -658,27 +709,28 @@ func detectFiles(dirPath string, existing *artist.Artist) (detectedFiles, error)
 // probeImageFile opens a file once, probes dimensions for low-resolution
 // detection, and generates a placeholder. If existingPlaceholder is non-empty
 // the expensive full decode for placeholder generation is skipped.
-// Returns (lowRes, placeholder); errors are silently swallowed (non-fatal).
-func probeImageFile(filePath, imageType, existingPlaceholder string) (lowRes bool, placeholder string) {
+// Returns (width, height, lowRes, placeholder); errors are silently swallowed
+// (non-fatal).
+func probeImageFile(filePath, imageType, existingPlaceholder string) (width, height int, lowRes bool, placeholder string) {
 	f, err := os.Open(filePath) //nolint:gosec // path built from trusted naming patterns
 	if err != nil {
-		return false, ""
+		return 0, 0, false, ""
 	}
 	defer func() { _ = f.Close() }()
 
 	w, h, err := img.GetDimensions(f)
 	if err != nil {
-		return false, ""
+		return 0, 0, false, ""
 	}
 	lowRes = img.IsLowResolution(w, h, imageType)
 
 	if existingPlaceholder != "" {
-		return lowRes, existingPlaceholder
+		return w, h, lowRes, existingPlaceholder
 	}
 
 	if _, seekErr := f.Seek(0, io.SeekStart); seekErr != nil {
-		return lowRes, ""
+		return w, h, lowRes, ""
 	}
 	placeholder, _ = img.GeneratePlaceholder(f, imageType)
-	return lowRes, placeholder
+	return w, h, lowRes, placeholder
 }


### PR DESCRIPTION
## Summary

- Six dimension-based rule checkers (thumb_square, thumb_min_res, fanart_min_res, fanart_aspect, logo_min_res, banner_min_res) silently skipped validation for API-imported artists because they called `getImageDimensionsCached(a.Path, ...)` which returns an error when `a.Path` is empty
- Added `getImageDimensionsFromDB` and `getImageDimensionsResolved` to query dimensions from the `artist_images` table first, falling back to filesystem only when DB dimensions are missing
- Propagated image dimensions from `probeImageFile` through the scanner pipeline into the Artist model and `artist_images` table, ensuring dimensions are populated for both filesystem-scanned and API-imported artists

Closes #726

## Test plan

- [x] `TestGetImageDimensionsFromDB` -- verifies DB query returns correct dimensions and handles missing rows
- [x] `TestGetImageDimensionsFromDB_NilDB` -- verifies nil DB returns (0,0) without error
- [x] `TestGetImageDimensionsResolved_DBFirst` -- verifies DB dimensions are used when available (even with empty Path)
- [x] `TestGetImageDimensionsResolved_FallbackToFS` -- verifies filesystem fallback when DB has no dimensions
- [x] `TestGetImageDimensionsResolved_NoDBNoFS` -- verifies error when neither source has dimensions
- [x] `TestCheckers_EmptyPath_DBDimensions` -- verifies all 6 checkers produce violations for API-imported artists with failing dimensions
- [x] `TestCheckers_EmptyPath_DBDimensions_Pass` -- verifies checkers pass when DB dimensions satisfy the rule
- [x] All existing tests pass (`go test ./internal/scanner/... ./internal/artist/... ./internal/rule/...`)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image dimension tracking and storage for artist thumbnails, fanart, logos, and banners.
  * Enhanced validation rules to leverage stored image dimensions with filesystem fallback support.

* **Tests**
  * Added comprehensive test coverage for image dimension resolution and validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->