### PR TITLE
fix: use jellyfin.svg instead of nonexistent jellyfin-128.png

### DIFF
--- a/web/templates/login.templ
+++ b/web/templates/login.templ
@@ -102,7 +102,7 @@ templ loginFederatedButtons(assets AssetPaths, providers []auth.Authenticator) {
 				onclick="document.getElementById('federated-form-provider').value='jellyfin'; document.getElementById('federated-form').classList.remove('hidden'); document.getElementById('federated-form-title').textContent='Sign in with Jellyfin'; document.getElementById('federated-submit').textContent='Sign In with Jellyfin';"
 				class="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300/60 dark:border-gray-600/60 bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm px-4 py-2.5 text-sm font-semibold text-gray-700 dark:text-gray-200 shadow-sm hover:bg-gray-50/80 dark:hover:bg-gray-700/60 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-colors"
 			>
-				<img src={ assets.BasePath + "/static/img/logos/jellyfin-128.png" } alt="" class="h-5 w-5" aria-hidden="true"/>
+				<img src={ assets.BasePath + "/static/img/logos/jellyfin.svg" } alt="" class="h-5 w-5" aria-hidden="true"/>
 				Sign in with Jellyfin
 			</button>
 		}

--- a/web/templates/login_templ.go
+++ b/web/templates/login_templ.go
@@ -249,9 +249,9 @@ func loginFederatedButtons(assets AssetPaths, providers []auth.Authenticator) te
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var14 string
-				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(assets.BasePath + "/static/img/logos/jellyfin-128.png")
+				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(assets.BasePath + "/static/img/logos/jellyfin.svg")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/login.templ`, Line: 105, Col: 69}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/login.templ`, Line: 105, Col: 65}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {

--- a/web/templates/register.templ
+++ b/web/templates/register.templ
@@ -207,7 +207,7 @@ templ registerProviderGrid(assets AssetPaths, data RegisterPageData) {
 					id="reg-card-jellyfin"
 					class="reg-provider-card flex flex-col items-center rounded-xl border-2 border-gray-200 dark:border-gray-700 bg-white/40 dark:bg-gray-800/40 p-4 text-center transition-all hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500/50"
 				>
-					<img src={ assets.BasePath + "/static/img/logos/jellyfin-128.png" } alt="" class="h-8 w-8 mb-2" aria-hidden="true"/>
+					<img src={ assets.BasePath + "/static/img/logos/jellyfin.svg" } alt="" class="h-8 w-8 mb-2" aria-hidden="true"/>
 					<span class="text-sm font-semibold text-gray-900 dark:text-gray-100">Jellyfin</span>
 					<span class="mt-1 text-xs text-gray-500 dark:text-gray-400">Use Jellyfin account</span>
 				</button>

--- a/web/templates/register_templ.go
+++ b/web/templates/register_templ.go
@@ -462,9 +462,9 @@ func registerProviderGrid(assets AssetPaths, data RegisterPageData) templ.Compon
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var23 string
-				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(assets.BasePath + "/static/img/logos/jellyfin-128.png")
+				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(assets.BasePath + "/static/img/logos/jellyfin.svg")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/register.templ`, Line: 210, Col: 70}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/register.templ`, Line: 210, Col: 66}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 				if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

- Login and register pages referenced `jellyfin-128.png` which does not exist -- only `jellyfin.svg` is in the logos directory
- Found during UAT of #768 (invite register page)

## Test plan

- [ ] Login page Jellyfin button shows the SVG logo (no broken image)
- [ ] Register page Jellyfin provider card shows the SVG logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Jellyfin logo assets on login and registration pages from PNG to SVG format for improved image clarity and scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->