### PR TITLE
fix: broaden .gitignore to cover all dotenv variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,8 @@ web/static/css/styles.css
 docker-compose.local.yml
 docker-compose.wsl.yml
 setupdocker.sh
-.env.integration
+.env
+.env.*
 
 # Node (Tailwind v4, MCP servers)
 node_modules/


### PR DESCRIPTION
## Summary

- Broadens `.gitignore` from a single `.env.integration` entry to `.env` and `.env.*` so no dotenv variants are accidentally committed
- Dismisses stale Dependabot alert #1 (GHSA-78h2-9frx-2jm8): `go-jose/v4` was already bumped to the patched v4.1.4 in #850, but the alert was not auto-closed because it was a manual bump rather than a Dependabot PR

## Test plan

- [x] Verify `.env`, `.env.local`, `.env.production` etc. are now ignored
- [x] Confirmed `go-jose/v4@v4.1.4` already in `go.mod` via #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)