### PR TITLE
fix: dismiss stale violations when library removed without deleting artists

### DIFF
--- a/internal/api/handlers_connection.go
+++ b/internal/api/handlers_connection.go
@@ -414,6 +414,12 @@ func (r *Router) handleDeleteConnection(w http.ResponseWriter, req *http.Request
 					return
 				}
 			} else {
+				// Dismiss active violations before the delete NULLs library_id.
+				if _, dismissErr := r.ruleService.DismissViolationsForLibrary(req.Context(), lib.ID); dismissErr != nil {
+					r.logger.Error("dismissing violations for library removal", "library_id", lib.ID, "error", dismissErr)
+					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+					return
+				}
 				if err := r.libraryService.Delete(req.Context(), lib.ID); err != nil {
 					r.logger.Error("deleting library", "library_id", lib.ID, "error", err)
 					writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
@@ -421,6 +427,9 @@ func (r *Router) handleDeleteConnection(w http.ResponseWriter, req *http.Request
 				}
 			}
 		}
+		// When the last local library is removed, auto-disable filesystem-dependent
+		// rules so they do not evaluate against artists without filesystem paths.
+		r.maybeDisableFilesystemRules(req.Context())
 	} else {
 		// Default: clear library FK references. Imported libraries keep their
 		// source/external_id for provenance.

--- a/internal/api/handlers_library.go
+++ b/internal/api/handlers_library.go
@@ -197,6 +197,15 @@ func (r *Router) handleDeleteLibrary(w http.ResponseWriter, req *http.Request) {
 	if req.URL.Query().Get("deleteArtists") == "true" {
 		err = r.libraryService.DeleteWithArtists(req.Context(), id)
 	} else {
+		// Dismiss active violations before the delete NULLs library_id
+		// (after which the association is lost and cleanup is impossible).
+		if _, dismissErr := r.ruleService.DismissViolationsForLibrary(req.Context(), id); dismissErr != nil {
+			r.logger.Error("dismissing violations for library removal", "library_id", id, "error", dismissErr)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{
+				"error": "failed to clean up library violations; deletion was not performed",
+			})
+			return
+		}
 		err = r.libraryService.Delete(req.Context(), id)
 	}
 	if err != nil {

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -1001,6 +1001,25 @@ func (s *Service) CountActiveViolationsBySeverity(ctx context.Context) (map[stri
 	return counts, rows.Err()
 }
 
+// DismissViolationsForLibrary dismisses all active violations for artists that
+// belong to the given library. This should be called before deleting a library
+// with deleteArtists=false, because the delete NULLs artists.library_id and the
+// association is lost. Returns the number of violations dismissed.
+func (s *Service) DismissViolationsForLibrary(ctx context.Context, libraryID string) (int, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE rule_violations
+		SET status = ?, dismissed_at = ?, updated_at = ?
+		WHERE status IN (?, ?)
+		AND artist_id IN (SELECT id FROM artists WHERE library_id = ?)
+	`, ViolationStatusDismissed, now, now, ViolationStatusOpen, ViolationStatusPendingChoice, libraryID)
+	if err != nil {
+		return 0, fmt.Errorf("dismissing violations for library %s: %w", libraryID, err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
 // DismissOrphanedViolations dismisses all active violations whose artist_id
 // no longer exists in the artists table. Returns the number dismissed.
 func (s *Service) DismissOrphanedViolations(ctx context.Context) (int, error) {

--- a/internal/rule/service_test.go
+++ b/internal/rule/service_test.go
@@ -1073,6 +1073,96 @@ func TestDismissOrphanedViolations(t *testing.T) {
 	}
 }
 
+func TestDismissViolationsForLibrary(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	// Insert two libraries.
+	for _, lib := range []struct{ id, name string }{
+		{"lib-a", "Library A"},
+		{"lib-b", "Library B"},
+	} {
+		_, err := db.ExecContext(ctx, `INSERT INTO libraries (id, name, type, created_at, updated_at)
+			VALUES (?, ?, 'regular', datetime('now'), datetime('now'))`, lib.id, lib.name)
+		if err != nil {
+			t.Fatalf("inserting library %s: %v", lib.id, err)
+		}
+	}
+
+	// Insert artists belonging to each library.
+	for _, a := range []struct{ id, name, libID string }{
+		{"artist-a1", "Artist A1", "lib-a"},
+		{"artist-a2", "Artist A2", "lib-a"},
+		{"artist-b1", "Artist B1", "lib-b"},
+	} {
+		_, err := db.ExecContext(ctx, `INSERT INTO artists (id, name, sort_name, type, path, library_id)
+			VALUES (?, ?, ?, 'person', '/music/'||?, ?)`, a.id, a.name, a.name, a.id, a.libID)
+		if err != nil {
+			t.Fatalf("inserting artist %s: %v", a.id, err)
+		}
+	}
+
+	// Create violations for both libraries' artists.
+	violations := []*RuleViolation{
+		{RuleID: RuleNFOExists, ArtistID: "artist-a1", ArtistName: "Artist A1",
+			Severity: "error", Message: "missing nfo", Fixable: true, Status: ViolationStatusOpen},
+		{RuleID: RuleThumbExists, ArtistID: "artist-a2", ArtistName: "Artist A2",
+			Severity: "warning", Message: "missing thumb", Fixable: true, Status: ViolationStatusPendingChoice,
+			Candidates: []ImageCandidate{{URL: "http://example.com/img.jpg", Width: 500, Height: 500, Source: "test", ImageType: "thumb"}}},
+		{RuleID: RuleNFOExists, ArtistID: "artist-b1", ArtistName: "Artist B1",
+			Severity: "error", Message: "missing nfo", Fixable: true, Status: ViolationStatusOpen},
+	}
+	for _, v := range violations {
+		if err := svc.UpsertViolation(ctx, v); err != nil {
+			t.Fatalf("upserting violation: %v", err)
+		}
+	}
+
+	// Dismiss violations for library A only.
+	n, err := svc.DismissViolationsForLibrary(ctx, "lib-a")
+	if err != nil {
+		t.Fatalf("DismissViolationsForLibrary: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("dismissed = %d, want 2", n)
+	}
+
+	// Library A's violations should be dismissed.
+	for _, v := range violations[:2] {
+		got, err := svc.GetViolationByID(ctx, v.ID)
+		if err != nil {
+			t.Fatalf("GetViolationByID(%s): %v", v.ID, err)
+		}
+		if got.Status != ViolationStatusDismissed {
+			t.Errorf("lib-a violation %s status = %q, want %q", v.ID, got.Status, ViolationStatusDismissed)
+		}
+	}
+
+	// Library B's violation should still be open.
+	got, err := svc.GetViolationByID(ctx, violations[2].ID)
+	if err != nil {
+		t.Fatalf("GetViolationByID(%s): %v", violations[2].ID, err)
+	}
+	if got.Status != ViolationStatusOpen {
+		t.Errorf("lib-b violation status = %q, want %q", got.Status, ViolationStatusOpen)
+	}
+}
+
+func TestDismissViolationsForLibrary_NoViolations(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	n, err := svc.DismissViolationsForLibrary(ctx, "nonexistent-lib")
+	if err != nil {
+		t.Fatalf("DismissViolationsForLibrary: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("dismissed = %d, want 0", n)
+	}
+}
+
 func TestGetComplianceForArtists(t *testing.T) {
 	db := setupTestDB(t)
 	svc := NewService(db)


### PR DESCRIPTION
## Summary

- Add `DismissViolationsForLibrary` to rule service that dismisses open/pending violations for artists belonging to a library (must run before delete NULLs `library_id`)
- Wire into `handleDeleteLibrary` and `handleDeleteConnection` for the `deleteArtists=false` path
- Add missing `maybeDisableFilesystemRules` call to `handleDeleteConnection`
- Two service-level tests covering multi-library isolation and no-op case

Closes #877

## Test plan
- [x] `go test -count=1 ./...` passes
- [x] `go test -race` passes for `./internal/rule/...` and `./internal/api/...`
- [x] OpenAPI consistency verified
- [x] `golangci-lint run ./...` clean
- [x] Local review toolkit passed (code-reviewer, silent-failure-hunter, test-analyzer)

Generated with [Claude Code](https://claude.com/claude-code)