### PR TITLE
fix: auto-regenerate templ files in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: templ-generate
         name: templ-generate
         language: system
-        entry: bash -c 'templ generate && changed=$(git diff --name-only -- "*_templ.go"); [ -z "$changed" ] || echo "$changed" | xargs git add' --
+        entry: bash -c 'go run github.com/a-h/templ/cmd/templ@v0.3.1001 generate && git diff -z --name-only -- "*_templ.go" | xargs -0 git add --' --
         files: '\.templ$'
         pass_filenames: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: templ-generate
+        name: templ-generate
+        language: system
+        entry: bash -c 'templ generate && changed=$(git diff --name-only -- "*_templ.go"); [ -z "$changed" ] || echo "$changed" | xargs git add' --
+        files: '\.templ$'
+        pass_filenames: false
+
       - id: gofmt
         name: gofmt
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: templ-generate
         name: templ-generate
         language: system
-        entry: bash -c 'go run github.com/a-h/templ/cmd/templ@v0.3.1001 generate && git diff -z --name-only -- "*_templ.go" | xargs -0 git add --' --
+        entry: bash -c 'go run github.com/a-h/templ/cmd/templ@v0.3.1001 generate && { git diff -z --name-only -- "*_templ.go"; git ls-files -z --others --exclude-standard -- "*_templ.go"; } | xargs -0 git add --' --
         files: '\.templ$'
         pass_filenames: false
 


### PR DESCRIPTION
## Summary
- Adds a `templ-generate` pre-commit hook that automatically runs `templ generate` and stages changed `*_templ.go` files whenever `.templ` files are committed
- Prevents the recurring CI lint failure where generated Go files fall out of sync with their `.templ` sources

## Test plan
- [x] `pre-commit validate-config` passes
- [x] `pre-commit run templ-generate --files web/templates/settings.templ` passes
- [ ] Verify hook fires on a real commit that modifies a `.templ` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a local pre-commit hook that automatically runs code generation when template files change and stages the resulting generated files. This streamlines developer workflows, keeps generated artifacts up to date, and reduces manual commit steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->