### PR TITLE
fix: decode HTML entities in Wikipedia years_active (#969)

### DIFF
--- a/internal/provider/wikipedia/infobox.go
+++ b/internal/provider/wikipedia/infobox.go
@@ -1,6 +1,7 @@
 package wikipedia
 
 import (
+	"html"
 	"strings"
 	"unicode"
 )
@@ -613,6 +614,10 @@ func splitOnBR(s string) []string {
 // cleanYearsActive normalizes a years_active value.
 // Strips markup and normalizes common patterns like "1985-present", "{{start date|1985}}".
 func cleanYearsActive(s string) string {
+	// Decode HTML entities first so that &ndash; &#8211; etc. become actual
+	// Unicode characters before any further processing removes or normalizes them.
+	s = html.UnescapeString(s)
+
 	s = stripRefs(s)
 	s = stripHTMLTags(s)
 

--- a/internal/provider/wikipedia/infobox_test.go
+++ b/internal/provider/wikipedia/infobox_test.go
@@ -419,7 +419,7 @@ func TestCleanYearsActive(t *testing.T) {
 		{"named entity ndash", "1987&ndash;present", "1987-present"},
 		{"numeric entity ndash", "1987&#8211;present", "1987-present"},
 		{"amp entity", "rock &amp; roll", "rock & roll"},
-		{"realistic wikipedia value", "1987&ndash;present", "1987-present"},
+		{"realistic wikipedia value", "{{start date|1987}}&ndash;present<ref>source</ref>", "1987-present"},
 		{"multiple ranges with entities", "1972&#8211;1982, 2018&#8211;2022", "1972-1982, 2018-2022"},
 	}
 

--- a/internal/provider/wikipedia/infobox_test.go
+++ b/internal/provider/wikipedia/infobox_test.go
@@ -416,6 +416,11 @@ func TestCleanYearsActive(t *testing.T) {
 		{"en-dash", "1985\u2013present", "1985-present"},
 		{"with start date template", "{{start date|1985}}-present", "1985-present"},
 		{"with ref", "1985-present<ref>source</ref>", "1985-present"},
+		{"named entity ndash", "1987&ndash;present", "1987-present"},
+		{"numeric entity ndash", "1987&#8211;present", "1987-present"},
+		{"amp entity", "rock &amp; roll", "rock & roll"},
+		{"realistic wikipedia value", "1987&ndash;present", "1987-present"},
+		{"multiple ranges with entities", "1972&#8211;1982, 2018&#8211;2022", "1972-1982, 2018-2022"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Add `html.UnescapeString()` as the first step in `cleanYearsActive()` so HTML entities (`&ndash;`, `&#8211;`, `&amp;`) are decoded to Unicode before further processing
- The existing en-dash/em-dash normalization then converts decoded characters to hyphens as intended
- Other providers (audiodb, lastfm, deezer) do not handle years_active, so no changes needed there

## Test plan
- [x] New test cases for named entity (`&ndash;`), numeric entity (`&#8211;`), and `&amp;`
- [x] Test for realistic Wikipedia value `1987&ndash;present` -> `1987-present`
- [x] Test for multiple ranges with numeric entities
- [x] All existing tests continue to pass
- [x] `go test -race ./internal/provider/wikipedia/...` passes
- [x] `scripts/pre-push-gate.sh` passes

Closes #969

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of HTML entity-encoded characters (dashes, ampersands) in year-range data extracted from Wikipedia infoboxes, normalizing them for consistent display.
* **Tests**
  * Added test coverage for year-range inputs containing entity-encoded dashes, ampersands, refs and combined ranges to ensure correct normalization and preservation of existing cleaning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->