### PR TITLE
fix: DDG VQD extraction and Lidarr config unmarshal

### DIFF
--- a/internal/connection/lidarr/client.go
+++ b/internal/connection/lidarr/client.go
@@ -162,10 +162,14 @@ func (c *Client) getMetadataProviderConfigs(ctx context.Context) ([]MetadataProv
 	defer resp.Body.Close() //nolint:errcheck
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+		// Read a small prefix for diagnostics and drain the rest so the
+		// transport can reuse the connection.
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, bytes.TrimSpace(snippet))
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // cap at 1 MB
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}
@@ -175,20 +179,23 @@ func (c *Client) getMetadataProviderConfigs(ctx context.Context) ([]MetadataProv
 		return nil, nil
 	}
 
-	// Determine shape by checking the first byte: '[' means array, '{' means object
-	if body[0] == '[' {
+	// Determine shape by checking the first byte: '[' means array, '{' means object.
+	switch body[0] {
+	case '[':
 		var configs []MetadataProviderConfig
 		if err := json.Unmarshal(body, &configs); err != nil {
 			return nil, fmt.Errorf("decoding array response: %w", err)
 		}
 		return configs, nil
+	case '{':
+		var single MetadataProviderConfig
+		if err := json.Unmarshal(body, &single); err != nil {
+			return nil, fmt.Errorf("decoding object response: %w", err)
+		}
+		return []MetadataProviderConfig{single}, nil
+	default:
+		return nil, fmt.Errorf("unexpected JSON root type %q in response", string(body[:1]))
 	}
-
-	var single MetadataProviderConfig
-	if err := json.Unmarshal(body, &single); err != nil {
-		return nil, fmt.Errorf("decoding object response: %w", err)
-	}
-	return []MetadataProviderConfig{single}, nil
 }
 
 func (c *Client) setAuth(req *http.Request) {

--- a/internal/connection/lidarr/client.go
+++ b/internal/connection/lidarr/client.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/connection"
 	"github.com/sydlexius/stillwater/internal/connection/httpclient"
 )
 
@@ -64,8 +66,8 @@ func (c *Client) GetMetadataProfiles(ctx context.Context) ([]MetadataProfile, er
 // Returns true if any metadata consumer with NFO/Kodi type is enabled.
 // The library name is always empty for Lidarr (the setting is global, not per-library).
 func (c *Client) CheckNFOWriterEnabled(ctx context.Context) (bool, string, error) {
-	var configs []MetadataProviderConfig
-	if err := c.Get(ctx, "/api/v1/config/metadataprovider", &configs); err != nil {
+	configs, err := c.getMetadataProviderConfigs(ctx)
+	if err != nil {
 		// Some Lidarr versions may not expose this endpoint; treat as unknown
 		c.Logger.Warn("could not check metadata provider config", "error", err)
 		return false, "", nil
@@ -109,8 +111,8 @@ type MetadataConsumerStatus struct {
 // GetMetadataConsumers returns the metadata consumer configuration from Lidarr.
 // This is a global setting, not per-library.
 func (c *Client) GetMetadataConsumers(ctx context.Context) ([]MetadataConsumerStatus, error) {
-	var configs []MetadataProviderConfig
-	if err := c.Get(ctx, "/api/v1/config/metadataprovider", &configs); err != nil {
+	configs, err := c.getMetadataProviderConfigs(ctx)
+	if err != nil {
 		return nil, fmt.Errorf("getting metadata provider config: %w", err)
 	}
 
@@ -139,6 +141,54 @@ func (c *Client) DisableMetadataConsumer(ctx context.Context, configID int) erro
 
 	path := fmt.Sprintf("/api/v1/config/metadataprovider/%d", configID)
 	return c.PutJSON(ctx, path, bytes.NewReader(body), nil)
+}
+
+// getMetadataProviderConfigs fetches the metadata provider config from Lidarr,
+// handling both response formats: newer Lidarr versions return a single JSON
+// object, while older versions return a JSON array.
+func (c *Client) getMetadataProviderConfigs(ctx context.Context) ([]MetadataProviderConfig, error) {
+	const path = "/api/v1/config/metadataprovider"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connection.BuildRequestURL(c.BaseURL, path), nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	c.AuthFunc(req)
+
+	resp, err := c.HTTPClient.Do(req) //nolint:gosec // URL constructed from trusted base + API path
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	body = bytes.TrimSpace(body)
+	if len(body) == 0 {
+		return nil, nil
+	}
+
+	// Determine shape by checking the first byte: '[' means array, '{' means object
+	if body[0] == '[' {
+		var configs []MetadataProviderConfig
+		if err := json.Unmarshal(body, &configs); err != nil {
+			return nil, fmt.Errorf("decoding array response: %w", err)
+		}
+		return configs, nil
+	}
+
+	var single MetadataProviderConfig
+	if err := json.Unmarshal(body, &single); err != nil {
+		return nil, fmt.Errorf("decoding object response: %w", err)
+	}
+	return []MetadataProviderConfig{single}, nil
 }
 
 func (c *Client) setAuth(req *http.Request) {

--- a/internal/connection/lidarr/client_test.go
+++ b/internal/connection/lidarr/client_test.go
@@ -109,6 +109,24 @@ func TestCheckNFOWriterEnabled_True(t *testing.T) {
 	}
 }
 
+func TestCheckNFOWriterEnabled_SingleObject(t *testing.T) {
+	// Newer Lidarr versions return a single object instead of an array
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"metadataType":"Kodi (XBMC) / Emby","consumerId":1,"consumerName":"Kodi (XBMC) / Emby","enable":true}`))
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "key", srv.Client(), testLogger())
+	enabled, _, err := c.CheckNFOWriterEnabled(context.Background())
+	if err != nil {
+		t.Fatalf("CheckNFOWriterEnabled (single object) failed: %v", err)
+	}
+	if !enabled {
+		t.Error("expected NFO writer to be enabled from single object response")
+	}
+}
+
 func TestCheckNFOWriterEnabled_False(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -192,6 +210,33 @@ func TestGetMetadataConsumers(t *testing.T) {
 	}
 	if consumers[1].Enabled {
 		t.Error("expected second consumer to be disabled")
+	}
+}
+
+func TestGetMetadataConsumers_SingleObject(t *testing.T) {
+	// Newer Lidarr versions return a single object instead of an array
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/config/metadataprovider" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"metadataType":"Kodi (XBMC) / Emby","consumerId":1,"consumerName":"Kodi (XBMC) / Emby","enable":true}`))
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "key", srv.Client(), testLogger())
+	consumers, err := c.GetMetadataConsumers(context.Background())
+	if err != nil {
+		t.Fatalf("GetMetadataConsumers (single object): %v", err)
+	}
+	if len(consumers) != 1 {
+		t.Fatalf("got %d consumers, want 1", len(consumers))
+	}
+	if consumers[0].ConsumerName != "Kodi (XBMC) / Emby" {
+		t.Errorf("consumer = %q, want Kodi (XBMC) / Emby", consumers[0].ConsumerName)
+	}
+	if !consumers[0].Enabled {
+		t.Error("expected consumer to be enabled")
 	}
 }
 

--- a/internal/connection/lidarr/client_test.go
+++ b/internal/connection/lidarr/client_test.go
@@ -112,6 +112,15 @@ func TestCheckNFOWriterEnabled_True(t *testing.T) {
 func TestCheckNFOWriterEnabled_SingleObject(t *testing.T) {
 	// Newer Lidarr versions return a single object instead of an array
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/v1/config/metadataprovider" {
+			t.Errorf("path = %s, want /api/v1/config/metadataprovider", r.URL.Path)
+		}
+		if r.Header.Get("X-Api-Key") != "key" {
+			t.Errorf("X-Api-Key = %q, want key", r.Header.Get("X-Api-Key"))
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":1,"metadataType":"Kodi (XBMC) / Emby","consumerId":1,"consumerName":"Kodi (XBMC) / Emby","enable":true}`))
 	}))
@@ -216,8 +225,14 @@ func TestGetMetadataConsumers(t *testing.T) {
 func TestGetMetadataConsumers_SingleObject(t *testing.T) {
 	// Newer Lidarr versions return a single object instead of an array
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
 		if r.URL.Path != "/api/v1/config/metadataprovider" {
-			t.Errorf("unexpected path: %s", r.URL.Path)
+			t.Errorf("path = %s, want /api/v1/config/metadataprovider", r.URL.Path)
+		}
+		if r.Header.Get("X-Api-Key") != "key" {
+			t.Errorf("X-Api-Key = %q, want key", r.Header.Get("X-Api-Key"))
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":1,"metadataType":"Kodi (XBMC) / Emby","consumerId":1,"consumerName":"Kodi (XBMC) / Emby","enable":true}`))

--- a/internal/provider/duckduckgo/duckduckgo.go
+++ b/internal/provider/duckduckgo/duckduckgo.go
@@ -32,7 +32,11 @@ var searchTerms = map[provider.ImageType]string{
 	provider.ImageBanner: "band banner header wide",
 }
 
-var vqdRegex = regexp.MustCompile(`vqd=([0-9-]+)`)
+// vqdRegex matches VQD tokens in various DDG response formats:
+//   - vqd=4-123456789 (query parameter style)
+//   - vqd='4-123456789' (single-quoted in script tags)
+//   - vqd="4-123456789" (double-quoted in script tags)
+var vqdRegex = regexp.MustCompile(`vqd=["']?([0-9a-zA-Z_-]+)["']?`)
 
 // Adapter implements provider.WebImageProvider for DuckDuckGo image search.
 type Adapter struct {
@@ -121,7 +125,54 @@ func (a *Adapter) SearchImages(ctx context.Context, artistName string, imageType
 }
 
 // getVQDToken obtains the validation query digest token from DuckDuckGo.
+// It first tries the main search page (GET /?q=QUERY), which embeds the VQD
+// token in a script tag or inline JS. Falls back to the HTML endpoint
+// (POST /html/) for compatibility with older DDG response formats.
 func (a *Adapter) getVQDToken(ctx context.Context, query string) (string, error) {
+	// Try the main search page first (current DDG format)
+	token, err := a.getVQDFromMainPage(ctx, query)
+	if err == nil && token != "" {
+		return token, nil
+	}
+
+	a.logger.Debug("main page VQD extraction failed, trying HTML endpoint",
+		slog.String("query", query),
+		slog.Any("error", err))
+
+	// Fall back to HTML endpoint (older DDG format)
+	return a.getVQDFromHTMLPage(ctx, query)
+}
+
+// getVQDFromMainPage extracts the VQD token from the main DuckDuckGo search page.
+func (a *Adapter) getVQDFromMainPage(ctx context.Context, query string) (string, error) {
+	params := url.Values{"q": {query}}
+	reqURL := a.baseURL + "/?" + params.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "text/html")
+
+	resp, err := a.client.Do(req) //nolint:gosec // URL constructed from adapter config, not user input
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return "", &provider.ErrProviderUnavailable{
+			Provider: provider.NameDuckDuckGo,
+			Cause:    fmt.Errorf("VQD request returned status %d", resp.StatusCode),
+		}
+	}
+
+	return a.extractVQD(resp.Body)
+}
+
+// getVQDFromHTMLPage extracts the VQD token from the legacy HTML search endpoint.
+func (a *Adapter) getVQDFromHTMLPage(ctx context.Context, query string) (string, error) {
 	form := url.Values{"q": {query}}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.htmlURL+"/html/", strings.NewReader(form.Encode()))
 	if err != nil {
@@ -144,12 +195,17 @@ func (a *Adapter) getVQDToken(ctx context.Context, query string) (string, error)
 		}
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 512*1024))
+	return a.extractVQD(resp.Body)
+}
+
+// extractVQD reads the response body and extracts the VQD token using regex.
+func (a *Adapter) extractVQD(body io.Reader) (string, error) {
+	data, err := io.ReadAll(io.LimitReader(body, 512*1024))
 	if err != nil {
 		return "", err
 	}
 
-	matches := vqdRegex.FindSubmatch(body)
+	matches := vqdRegex.FindSubmatch(data)
 	if len(matches) < 2 {
 		return "", &provider.ErrProviderUnavailable{
 			Provider: provider.NameDuckDuckGo,

--- a/internal/provider/duckduckgo/duckduckgo.go
+++ b/internal/provider/duckduckgo/duckduckgo.go
@@ -154,7 +154,7 @@ func (a *Adapter) getVQDFromMainPage(ctx context.Context, query string) (string,
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Accept", "text/html")
 
-	resp, err := a.client.Do(req) //nolint:gosec // URL constructed from adapter config, not user input
+	resp, err := a.client.Do(req) //nolint:gosec // trusted base URL + URL-encoded query parameters
 	if err != nil {
 		return "", err
 	}
@@ -181,7 +181,7 @@ func (a *Adapter) getVQDFromHTMLPage(ctx context.Context, query string) (string,
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := a.client.Do(req) //nolint:gosec // URL constructed from adapter config, not user input
+	resp, err := a.client.Do(req) //nolint:gosec // trusted base URL + URL-encoded query parameters
 	if err != nil {
 		return "", err
 	}
@@ -236,7 +236,7 @@ func (a *Adapter) fetchImages(ctx context.Context, query, vqd string) ([]imageHi
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Referer", a.baseURL+"/")
 
-	resp, err := a.client.Do(req) //nolint:gosec // URL constructed from adapter config, not user input
+	resp, err := a.client.Do(req) //nolint:gosec // trusted base URL + URL-encoded query parameters
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/duckduckgo/duckduckgo_test.go
+++ b/internal/provider/duckduckgo/duckduckgo_test.go
@@ -23,13 +23,15 @@ func loadFixture(t *testing.T, name string) []byte {
 func TestSearchImages(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 
-	// Mock server that serves VQD token page and image results
+	// Mock server that serves VQD token page and image results.
+	// The main page (GET /) returns the VQD in a script tag, matching
+	// the current DDG response format.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.URL.Path == "/html/" && r.Method == http.MethodPost:
-			// Return HTML containing VQD token
+		case r.URL.Path == "/" && r.Method == http.MethodGet && r.URL.Query().Get("q") != "":
+			// Main search page with VQD token in script tag
 			w.Header().Set("Content-Type", "text/html")
-			w.Write([]byte(`<html><script>vqd=12345-67890&</script></html>`))
+			w.Write([]byte(`<html><script>vqd='4-12345_abc-DEF'</script></html>`))
 		case r.URL.Path == "/i.js":
 			w.Header().Set("Content-Type", "application/json")
 			w.Write(loadFixture(t, "search_radiohead_thumb.json"))
@@ -75,10 +77,10 @@ func TestSearchImagesEmpty(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/html/":
-			w.Write([]byte(`<html><script>vqd=12345&</script></html>`))
-		case "/i.js":
+		switch {
+		case r.URL.Path == "/" && r.URL.Query().Get("q") != "":
+			w.Write([]byte(`<html><script>vqd='12345'</script></html>`))
+		case r.URL.Path == "/i.js":
 			w.Header().Set("Content-Type", "application/json")
 			w.Write([]byte(`{"results":[]}`))
 		default:
@@ -103,10 +105,10 @@ func TestSearchImagesServerError(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/html/":
-			w.Write([]byte(`<html><script>vqd=12345&</script></html>`))
-		case "/i.js":
+		switch {
+		case r.URL.Path == "/" && r.URL.Query().Get("q") != "":
+			w.Write([]byte(`<html><script>vqd='12345'</script></html>`))
+		case r.URL.Path == "/i.js":
 			w.WriteHeader(http.StatusServiceUnavailable)
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -168,11 +170,71 @@ func TestName(t *testing.T) {
 	}
 }
 
+func TestVQDFallbackToHTML(t *testing.T) {
+	limiter := provider.NewRateLimiterMap()
+
+	// Main page returns no VQD, but HTML endpoint does (fallback path)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/" && r.URL.Query().Get("q") != "":
+			// Main page without VQD token
+			w.Write([]byte(`<html><body>no token here</body></html>`))
+		case r.URL.Path == "/html/" && r.Method == http.MethodPost:
+			// Legacy HTML endpoint with VQD
+			w.Write([]byte(`<html><script>vqd=98765&</script></html>`))
+		case r.URL.Path == "/i.js":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(loadFixture(t, "search_radiohead_thumb.json"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
+
+	images, err := a.SearchImages(context.Background(), "Radiohead", provider.ImageThumb)
+	if err != nil {
+		t.Fatalf("SearchImages with HTML fallback: %v", err)
+	}
+	if len(images) != 3 {
+		t.Fatalf("expected 3 images, got %d", len(images))
+	}
+}
+
+func TestVQDTokenFormats(t *testing.T) {
+	// Test that the regex matches various DDG VQD token formats
+	tests := []struct {
+		name  string
+		html  string
+		token string
+	}{
+		{"numeric with dash", `vqd=4-123456789`, "4-123456789"},
+		{"single quoted", `vqd='4-abc_DEF-123'`, "4-abc_DEF-123"},
+		{"double quoted", `vqd="4-abc_DEF-123"`, "4-abc_DEF-123"},
+		{"alphanumeric", `vqd=abc123_DEF`, "abc123_DEF"},
+		{"in script tag", `<script>vqd='token-42';</script>`, "token-42"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := vqdRegex.FindStringSubmatch(tt.html)
+			if len(matches) < 2 {
+				t.Fatalf("regex did not match: %s", tt.html)
+			}
+			if matches[1] != tt.token {
+				t.Errorf("got token %q, want %q", matches[1], tt.token)
+			}
+		})
+	}
+}
+
 func TestSearchImagesContextCanceled(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`<html><script>vqd=12345&</script></html>`))
+		w.Write([]byte(`<html><script>vqd='12345'</script></html>`))
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary
- Update DuckDuckGo VQD token extraction to try the main search page (GET /?q=QUERY) first with a broader regex that handles alphanumeric and quoted token formats, falling back to the legacy HTML endpoint for compatibility
- Fix Lidarr MetadataProviderConfig unmarshal error by reading raw JSON bytes and detecting whether the response is a single object or array, supporting both newer and older Lidarr API versions
- Add tests for VQD fallback path, token format variations, and single-object Lidarr responses

## Test plan
- [x] DDG VQD regex matches numeric, alphanumeric, single-quoted, and double-quoted token formats
- [x] DDG main page extraction works with current response format
- [x] DDG falls back to HTML endpoint when main page has no VQD token
- [x] Lidarr CheckNFOWriterEnabled handles single-object response
- [x] Lidarr GetMetadataConsumers handles single-object response
- [x] Existing array-format Lidarr tests still pass (backward compatibility)
- [x] `go test -race` passes for both packages
- [x] `scripts/pre-push-gate.sh` passes (all tests, OpenAPI, generated files, error leak check)

Closes #965
Closes #780

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of metadata provider responses to accept both single-object and array formats, reducing integration errors with external music APIs.
  * Expanded search token detection to match more token formats and added automatic fallback routes for token retrieval, increasing reliability of search-based features.

* **Tests**
  * Added tests covering varied response formats and fallback behaviors to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->