### PR TITLE
fix: persist directory rename path and handle stale image flags

### DIFF
--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -1042,6 +1042,25 @@ func (r *Router) handleServeImage(w http.ResponseWriter, req *http.Request) {
 	patterns := r.getActiveNamingConfig(req.Context(), imageType)
 	filePath, found := img.FindExistingImage(dir, patterns)
 	if !found {
+		// If the DB flag says the image exists but the file is gone, clear
+		// the stale flag so subsequent UI renders show a placeholder instead
+		// of a broken image tag. This is best-effort and non-blocking.
+		if imageExistsFlag(a, imageType) {
+			go func() { //nolint:gosec // Background context is intentional: this goroutine outlives the request.
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) //nolint:gosec
+				defer cancel()
+				if err := r.artistService.ClearImageFlag(ctx, a.ID, imageType, 0); err != nil {
+					r.logger.Warn("failed to clear stale image flag",
+						slog.String("artist_id", a.ID),
+						slog.String("image_type", imageType),
+						slog.String("error", err.Error()))
+				} else {
+					r.logger.Info("cleared stale image flag",
+						slog.String("artist_id", a.ID),
+						slog.String("image_type", imageType))
+				}
+			}()
+		}
 		http.NotFound(w, req)
 		return
 	}
@@ -1052,6 +1071,23 @@ func (r *Router) handleServeImage(w http.ResponseWriter, req *http.Request) {
 	// served fresh on the very next request (including a normal F5 reload).
 	w.Header().Set("Cache-Control", "no-cache")
 	http.ServeFile(w, req, filePath)
+}
+
+// imageExistsFlag returns the value of the exists flag for the given image
+// type on the artist model. Returns false for unknown image types.
+func imageExistsFlag(a *artist.Artist, imageType string) bool {
+	switch imageType {
+	case "thumb":
+		return a.ThumbExists
+	case "fanart":
+		return a.FanartExists
+	case "logo":
+		return a.LogoExists
+	case "banner":
+		return a.BannerExists
+	default:
+		return false
+	}
 }
 
 // handleImageInfo returns metadata about a local artist image (dimensions, file size).

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -1791,7 +1791,8 @@ func TestHandleServeImage_ClearsStaleFlag(t *testing.T) {
 	}
 
 	// The flag clearing happens asynchronously; poll until it takes effect.
-	deadline := time.Now().Add(2 * time.Second)
+	// The background goroutine uses a 5s context timeout, so allow 6s here.
+	deadline := time.Now().Add(6 * time.Second)
 	for time.Now().Before(deadline) {
 		images, err := artistSvc.GetImagesForArtist(ctx, a.ID)
 		if err != nil {

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -1764,27 +1764,32 @@ func TestHandleServeImage_ClearsStaleFlag(t *testing.T) {
 		t.Errorf("expected 404, got %d", w.Code)
 	}
 
-	// The flag clearing happens asynchronously; give it a moment.
-	time.Sleep(200 * time.Millisecond)
-
-	// Reload the artist and verify the flag was cleared.
-	updated, err := artistSvc.GetByID(ctx, a.ID)
-	if err != nil {
-		t.Fatalf("reloading artist: %v", err)
-	}
-
-	// Check the image row directly since the flag is stored in artist_images.
-	images, err := artistSvc.GetImagesForArtist(ctx, a.ID)
-	if err != nil {
-		t.Fatalf("GetImagesForArtist: %v", err)
-	}
-	for _, im := range images {
-		if im.ImageType == "thumb" && im.SlotIndex == 0 && im.Exists {
-			t.Error("thumb exists_flag should have been cleared after serving a missing file")
+	// The flag clearing happens asynchronously; poll until it takes effect.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		images, err := artistSvc.GetImagesForArtist(ctx, a.ID)
+		if err != nil {
+			t.Fatalf("GetImagesForArtist: %v", err)
 		}
+		cleared := true
+		for _, im := range images {
+			if im.ImageType == "thumb" && im.SlotIndex == 0 && im.Exists {
+				cleared = false
+				break
+			}
+		}
+		if cleared {
+			// Also verify the model-level flag reflects the cleared state.
+			updated, err := artistSvc.GetByID(ctx, a.ID)
+			if err != nil {
+				t.Fatalf("reloading artist: %v", err)
+			}
+			if updated.ThumbExists {
+				t.Error("artist.ThumbExists should be false after flag clear")
+			}
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
-
-	// The Artist model fields are populated from the image rows on read;
-	// verify the model-level flag reflects the cleared state.
-	_ = updated // updated is loaded fresh and should show the cleared state via image metadata
+	t.Error("thumb exists_flag should have been cleared after serving a missing file (timed out)")
 }

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -1726,3 +1726,65 @@ func TestSetArtistImageFlag_ClearsProvenance_OnDelete(t *testing.T) {
 		}
 	}
 }
+
+// TestHandleServeImage_ClearsStaleFlag verifies that when the DB says an image
+// exists but the file is missing on disk, the serve endpoint returns 404 and
+// asynchronously clears the stale exists flag so subsequent UI renders show a
+// placeholder instead of a broken image.
+func TestHandleServeImage_ClearsStaleFlag(t *testing.T) {
+	r, artistSvc := testRouterWithPlatform(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	a := &artist.Artist{Name: "Stale Flag", SortName: "Stale Flag", Path: dir}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// Write a thumb so the flag is set, then delete the file.
+	writeJPEG(t, filepath.Join(dir, "folder.jpg"), 500, 500)
+	r.setArtistImageFlag(ctx, a, "thumb", true)
+	if !a.ThumbExists {
+		t.Fatal("ThumbExists should be true after setting flag")
+	}
+	if err := os.Remove(filepath.Join(dir, "folder.jpg")); err != nil {
+		t.Fatalf("removing image: %v", err)
+	}
+
+	// Request the image file via the serve endpoint.
+	url := fmt.Sprintf("/api/v1/artists/%s/images/thumb/file", a.ID)
+	req := httptest.NewRequest("GET", url, nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "thumb")
+	w := httptest.NewRecorder()
+
+	r.handleServeImage(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+
+	// The flag clearing happens asynchronously; give it a moment.
+	time.Sleep(200 * time.Millisecond)
+
+	// Reload the artist and verify the flag was cleared.
+	updated, err := artistSvc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("reloading artist: %v", err)
+	}
+
+	// Check the image row directly since the flag is stored in artist_images.
+	images, err := artistSvc.GetImagesForArtist(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetImagesForArtist: %v", err)
+	}
+	for _, im := range images {
+		if im.ImageType == "thumb" && im.SlotIndex == 0 && im.Exists {
+			t.Error("thumb exists_flag should have been cleared after serving a missing file")
+		}
+	}
+
+	// The Artist model fields are populated from the image rows on read;
+	// verify the model-level flag reflects the cleared state.
+	_ = updated // updated is loaded fresh and should show the cleared state via image metadata
+}

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -1747,6 +1747,32 @@ func TestHandleServeImage_ClearsStaleFlag(t *testing.T) {
 	if !a.ThumbExists {
 		t.Fatal("ThumbExists should be true after setting flag")
 	}
+
+	// Verify the flag was persisted to the DB before testing its cleanup.
+	// Checking only the in-memory field would let this test pass even if the
+	// DB write regressed, since the poll loop below checks DB state.
+	preImages, err := artistSvc.GetImagesForArtist(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetImagesForArtist (precondition): %v", err)
+	}
+	thumbPersisted := false
+	for _, im := range preImages {
+		if im.ImageType == "thumb" && im.SlotIndex == 0 && im.Exists {
+			thumbPersisted = true
+			break
+		}
+	}
+	if !thumbPersisted {
+		t.Fatal("precondition: thumb image row Exists not persisted to DB before file removal")
+	}
+	preReloaded, err := artistSvc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID (precondition): %v", err)
+	}
+	if !preReloaded.ThumbExists {
+		t.Fatal("precondition: artist.ThumbExists not persisted to DB before file removal")
+	}
+
 	if err := os.Remove(filepath.Join(dir, "folder.jpg")); err != nil {
 		t.Fatalf("removing image: %v", err)
 	}

--- a/internal/artist/repository.go
+++ b/internal/artist/repository.go
@@ -72,6 +72,10 @@ type ImageRepository interface {
 	Upsert(ctx context.Context, img *ArtistImage) error
 	UpsertAll(ctx context.Context, artistID string, images []ArtistImage) error
 	UpdateProvenance(ctx context.Context, artistID, imageType string, slotIndex int, phash, source, fileFormat, lastWrittenAt string) error
+	// ClearExistsFlag sets exists_flag=0 for the given artist/image_type/slot.
+	// Used to mark stale image entries when the file is confirmed missing on disk.
+	ClearExistsFlag(ctx context.Context, artistID, imageType string, slotIndex int) error
+
 	DeleteByArtistID(ctx context.Context, artistID string) error
 
 	// NewestWriteTimesByArtist returns a map of artist_id to their most recent

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -350,6 +350,14 @@ func (s *Service) UpdateImageProvenance(ctx context.Context, artistID, imageType
 	return s.images.UpdateProvenance(ctx, artistID, imageType, slotIndex, phash, source, fileFormat, lastWrittenAt)
 }
 
+// ClearImageFlag sets the exists flag to false for a single image slot.
+// This is called when a request to serve an image discovers the file is
+// missing on disk, clearing the stale flag so subsequent UI renders show a
+// placeholder instead of a broken image tag.
+func (s *Service) ClearImageFlag(ctx context.Context, artistID, imageType string, slotIndex int) error {
+	return s.images.ClearExistsFlag(ctx, artistID, imageType, slotIndex)
+}
+
 // IsEditableField reports whether the given field name can be updated via
 // the field-level API. This includes both direct-column fields (in
 // fieldColumnMap) and provider-ID fields (in providerFieldMap).

--- a/internal/artist/sqlite_image.go
+++ b/internal/artist/sqlite_image.go
@@ -219,6 +219,22 @@ func (r *sqliteImageRepo) UpdateProvenance(ctx context.Context, artistID, imageT
 	return nil
 }
 
+// ClearExistsFlag sets exists_flag=0 for the given artist/image_type/slot.
+// This is a best-effort update used when a previously existing image file is
+// confirmed missing on disk, so that subsequent UI renders show a placeholder
+// instead of a broken image.
+func (r *sqliteImageRepo) ClearExistsFlag(ctx context.Context, artistID, imageType string, slotIndex int) error {
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE artist_images SET exists_flag = 0
+		WHERE artist_id = ? AND image_type = ? AND slot_index = ?`,
+		artistID, imageType, slotIndex,
+	)
+	if err != nil {
+		return fmt.Errorf("clearing exists flag for %s/%s/%d: %w", artistID, imageType, slotIndex, err)
+	}
+	return nil
+}
+
 func (r *sqliteImageRepo) DeleteByArtistID(ctx context.Context, artistID string) error {
 	_, err := r.db.ExecContext(ctx, `DELETE FROM artist_images WHERE artist_id = ?`, artistID)
 	if err != nil {

--- a/internal/artist/sqlite_image_test.go
+++ b/internal/artist/sqlite_image_test.go
@@ -371,12 +371,26 @@ func TestClearExistsFlag(t *testing.T) {
 		t.Fatalf("GetImagesForArtist: %v", err)
 	}
 
+	foundThumb := false
+	foundFanart := false
 	for _, im := range images {
-		if im.ImageType == "thumb" && im.SlotIndex == 0 && im.Exists {
-			t.Error("thumb exists_flag should be false after ClearImageFlag")
+		if im.ImageType == "thumb" && im.SlotIndex == 0 {
+			foundThumb = true
+			if im.Exists {
+				t.Error("thumb exists_flag should be false after ClearImageFlag")
+			}
 		}
-		if im.ImageType == "fanart" && im.SlotIndex == 0 && !im.Exists {
-			t.Error("fanart exists_flag should still be true")
+		if im.ImageType == "fanart" && im.SlotIndex == 0 {
+			foundFanart = true
+			if !im.Exists {
+				t.Error("fanart exists_flag should still be true")
+			}
 		}
+	}
+	if !foundThumb {
+		t.Error("expected thumb image slot 0 to be present")
+	}
+	if !foundFanart {
+		t.Error("expected fanart image slot 0 to be present")
 	}
 }

--- a/internal/artist/sqlite_image_test.go
+++ b/internal/artist/sqlite_image_test.go
@@ -340,3 +340,43 @@ func TestUpsertAll_PreservesProvenance(t *testing.T) {
 		t.Error("LowRes should be true after second UpsertAll")
 	}
 }
+
+// TestClearExistsFlag verifies that ClearExistsFlag sets the exists_flag to 0
+// for the targeted image slot without affecting other slots.
+func TestClearExistsFlag(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	a := testArtist("Flag Test", "/music/FlagTest")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Set the thumb flag.
+	a.ThumbExists = true
+	a.FanartExists = true
+	if err := svc.Update(ctx, a); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	// Clear only the thumb flag.
+	if err := svc.ClearImageFlag(ctx, a.ID, "thumb", 0); err != nil {
+		t.Fatalf("ClearImageFlag: %v", err)
+	}
+
+	// Verify thumb is cleared but fanart is still set.
+	images, err := svc.GetImagesForArtist(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetImagesForArtist: %v", err)
+	}
+
+	for _, im := range images {
+		if im.ImageType == "thumb" && im.SlotIndex == 0 && im.Exists {
+			t.Error("thumb exists_flag should be false after ClearImageFlag")
+		}
+		if im.ImageType == "fanart" && im.SlotIndex == 0 && !im.Exists {
+			t.Error("fanart exists_flag should still be true")
+		}
+	}
+}

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -240,16 +240,9 @@ func (p *Pipeline) RunRule(ctx context.Context, ruleID string) (*RunResult, erro
 				}
 			}
 
-			// Persist any in-memory changes that fixers made to the artist
-			// model (e.g. updated Path after a directory rename).
-			if perRuleDirty {
-				if err := p.artistService.Update(ctx, a); err != nil {
-					p.logger.Warn("persisting artist after fixes", "artist", a.Name, "error", err)
-				}
-			}
-
-			// Re-evaluate and persist health score, then publish changes.
-			p.updateHealthScore(ctx, a)
+			// Re-evaluate and persist health score (and any in-memory
+			// changes fixers made) in a single write, then publish.
+			p.updateHealthScore(ctx, a, perRuleDirty)
 			p.publishAccumulated(ctx, a, perRuleMetadata, perRuleImages)
 		}
 
@@ -398,15 +391,9 @@ func (p *Pipeline) RunForArtist(ctx context.Context, a *artist.Artist) (*RunResu
 		}
 	}
 
-	// Persist any in-memory changes that fixers made to the artist model
-	// (e.g. updated Path after a directory rename, NFOExists after NFO creation).
-	if artistDirty {
-		if err := p.artistService.Update(ctx, a); err != nil {
-			p.logger.Warn("persisting artist after fixes", "artist", a.Name, "error", err)
-		}
-	}
-
-	p.updateHealthScore(ctx, a)
+	// Re-evaluate and persist health score (and any in-memory
+	// changes fixers made) in a single write, then publish.
+	p.updateHealthScore(ctx, a, artistDirty)
 	p.publishAccumulated(ctx, a, metadataFixed, fixedImageTypes)
 	return result, nil
 }
@@ -567,16 +554,9 @@ func (p *Pipeline) RunAll(ctx context.Context) (*RunResult, error) {
 				}
 			}
 
-			// Persist any in-memory changes that fixers made to the artist
-			// model (e.g. updated Path after a directory rename).
-			if perArtistDirty {
-				if err := p.artistService.Update(ctx, a); err != nil {
-					p.logger.Warn("persisting artist after fixes", "artist", a.Name, "error", err)
-				}
-			}
-
-			// Re-evaluate and persist health score, then publish changes.
-			p.updateHealthScore(ctx, a)
+			// Re-evaluate and persist health score (and any in-memory
+			// changes fixers made) in a single write, then publish.
+			p.updateHealthScore(ctx, a, perArtistDirty)
 			p.publishAccumulated(ctx, a, perArtistMetadata, perArtistImages)
 		}
 
@@ -656,7 +636,7 @@ func (p *Pipeline) FixViolation(ctx context.Context, violationID string) (*FixRe
 		if err := p.ruleService.ResolveViolation(ctx, rv.ID); err != nil {
 			return nil, fmt.Errorf("resolving violation after fix: %w", err)
 		}
-		p.updateHealthScore(ctx, a)
+		p.updateHealthScore(ctx, a, false)
 		p.publishAfterFix(ctx, a, fr)
 	}
 
@@ -773,16 +753,21 @@ func (p *Pipeline) publishAccumulated(ctx context.Context, a *artist.Artist, met
 }
 
 // updateHealthScore re-evaluates the artist and persists the score.
-func (p *Pipeline) updateHealthScore(ctx context.Context, a *artist.Artist) {
+// When mustPersist is true, the artist is persisted even if health
+// evaluation fails, to flush in-memory changes made by fixers.
+func (p *Pipeline) updateHealthScore(ctx context.Context, a *artist.Artist, mustPersist bool) {
 	eval, err := p.engine.Evaluate(ctx, a)
 	if err != nil {
 		p.logger.Warn("re-evaluating health score", "artist", a.Name, "error", err)
-		return
+		if !mustPersist {
+			return
+		}
+	} else {
+		a.HealthScore = eval.HealthScore
+		now := time.Now().UTC()
+		a.HealthEvaluatedAt = &now
 	}
-	a.HealthScore = eval.HealthScore
-	now := time.Now().UTC()
-	a.HealthEvaluatedAt = &now
 	if err := p.artistService.Update(ctx, a); err != nil {
-		p.logger.Warn("persisting health score", "artist", a.Name, "error", err)
+		p.logger.Error("persisting artist after fixes", "artist", a.Name, "error", err)
 	}
 }

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -121,6 +121,7 @@ func (p *Pipeline) RunRule(ctx context.Context, ruleID string) (*RunResult, erro
 			result.ArtistsProcessed++
 			var perRuleMetadata bool
 			var perRuleImages []string
+			var perRuleDirty bool
 
 			eval, err := p.engine.Evaluate(ctx, a)
 			if err != nil {
@@ -210,6 +211,7 @@ func (p *Pipeline) RunRule(ctx context.Context, ruleID string) (*RunResult, erro
 				if fr.Fixed {
 					result.FixesSucceeded++
 					status = ViolationStatusResolved
+					perRuleDirty = true
 					if fr.ImageType != "" {
 						perRuleImages = append(perRuleImages, fr.ImageType)
 					} else {
@@ -235,6 +237,14 @@ func (p *Pipeline) RunRule(ctx context.Context, ruleID string) (*RunResult, erro
 				}
 				if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
 					p.logger.Warn("persisting fix result violation", "rule_id", ruleID, "artist", a.Name, "error", err)
+				}
+			}
+
+			// Persist any in-memory changes that fixers made to the artist
+			// model (e.g. updated Path after a directory rename).
+			if perRuleDirty {
+				if err := p.artistService.Update(ctx, a); err != nil {
+					p.logger.Warn("persisting artist after fixes", "artist", a.Name, "error", err)
 				}
 			}
 
@@ -265,6 +275,7 @@ func (p *Pipeline) RunForArtist(ctx context.Context, a *artist.Artist) (*RunResu
 
 	var metadataFixed bool
 	var fixedImageTypes []string
+	var artistDirty bool // tracks whether the artist model was modified by a fixer
 
 	eval, err := p.engine.Evaluate(ctx, a)
 	if err != nil {
@@ -358,6 +369,7 @@ func (p *Pipeline) RunForArtist(ctx context.Context, a *artist.Artist) (*RunResu
 		if fr.Fixed {
 			result.FixesSucceeded++
 			status = ViolationStatusResolved
+			artistDirty = true
 			if fr.ImageType != "" {
 				fixedImageTypes = append(fixedImageTypes, fr.ImageType)
 			} else {
@@ -383,6 +395,14 @@ func (p *Pipeline) RunForArtist(ctx context.Context, a *artist.Artist) (*RunResu
 		}
 		if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
 			p.logger.Warn("persisting fix result violation", "rule_id", v.RuleID, "artist", a.Name, "error", err)
+		}
+	}
+
+	// Persist any in-memory changes that fixers made to the artist model
+	// (e.g. updated Path after a directory rename, NFOExists after NFO creation).
+	if artistDirty {
+		if err := p.artistService.Update(ctx, a); err != nil {
+			p.logger.Warn("persisting artist after fixes", "artist", a.Name, "error", err)
 		}
 	}
 
@@ -423,6 +443,7 @@ func (p *Pipeline) RunAll(ctx context.Context) (*RunResult, error) {
 			result.ArtistsProcessed++
 			var perArtistMetadata bool
 			var perArtistImages []string
+			var perArtistDirty bool
 
 			eval, err := p.engine.Evaluate(ctx, a)
 			if err != nil {
@@ -517,6 +538,7 @@ func (p *Pipeline) RunAll(ctx context.Context) (*RunResult, error) {
 				if fr.Fixed {
 					result.FixesSucceeded++
 					status = ViolationStatusResolved
+					perArtistDirty = true
 					if fr.ImageType != "" {
 						perArtistImages = append(perArtistImages, fr.ImageType)
 					} else {
@@ -542,6 +564,14 @@ func (p *Pipeline) RunAll(ctx context.Context) (*RunResult, error) {
 				}
 				if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
 					p.logger.Warn("persisting fix result violation", "rule_id", v.RuleID, "artist", a.Name, "error", err)
+				}
+			}
+
+			// Persist any in-memory changes that fixers made to the artist
+			// model (e.g. updated Path after a directory rename).
+			if perArtistDirty {
+				if err := p.artistService.Update(ctx, a); err != nil {
+					p.logger.Warn("persisting artist after fixes", "artist", a.Name, "error", err)
 				}
 			}
 

--- a/internal/rule/fixer_test.go
+++ b/internal/rule/fixer_test.go
@@ -2051,3 +2051,63 @@ func (m *mockArtistMutatingFixer) Fix(_ context.Context, a *artist.Artist, v *Vi
 	}
 	return &FixResult{RuleID: v.RuleID, Fixed: true, Message: "mock mutated artist"}, nil
 }
+
+// TestPipeline_RunRule_PersistsArtistChanges verifies that RunRule persists
+// in-memory artist mutations made by fixers, covering the same dirty-tracking
+// path tested for RunForArtist above.
+func TestPipeline_RunRule_PersistsArtistChanges(t *testing.T) {
+	db := setupTestDB(t)
+	artistSvc := artist.NewService(db)
+	ruleSvc := NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+
+	nfoRule, err := ruleSvc.GetByID(ctx, RuleNFOExists)
+	if err != nil {
+		t.Fatalf("getting nfo_exists rule: %v", err)
+	}
+	nfoRule.AutomationMode = AutomationModeAuto
+	if err := ruleSvc.Update(ctx, nfoRule); err != nil {
+		t.Fatalf("updating rule: %v", err)
+	}
+
+	dir := t.TempDir()
+	a := &artist.Artist{
+		Name:     "RunRule Persist Artist",
+		SortName: "RunRule Persist Artist",
+		Path:     dir,
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	pathFixer := &mockArtistMutatingFixer{
+		canFixRuleID: RuleNFOExists,
+		mutate: func(a *artist.Artist) {
+			a.Biography = "set-by-runrule"
+		},
+	}
+
+	logger := testLogger()
+	engine := NewEngine(ruleSvc, db, nil, nil, logger)
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{pathFixer}, nil, logger)
+
+	result, err := pipeline.RunRule(ctx, RuleNFOExists)
+	if err != nil {
+		t.Fatalf("RunRule: %v", err)
+	}
+	if result.FixesSucceeded == 0 {
+		t.Fatal("expected at least one successful fix")
+	}
+
+	reloaded, err := artistSvc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID after RunRule: %v", err)
+	}
+	if reloaded.Biography != "set-by-runrule" {
+		t.Errorf("Biography = %q, want %q (fixer mutation not persisted via RunRule)", reloaded.Biography, "set-by-runrule")
+	}
+}

--- a/internal/rule/fixer_test.go
+++ b/internal/rule/fixer_test.go
@@ -1873,3 +1873,181 @@ func TestLogoPaddingFixer_FixViaAPI_EmptyData(t *testing.T) {
 		t.Errorf("Message = %q", fr.Message)
 	}
 }
+
+// TestPipeline_FixViolation_DirectoryRename_PersistsPath verifies that when a
+// directory rename fix succeeds through the pipeline, the new path is persisted
+// to the database (not just updated in-memory on the artist struct).
+func TestPipeline_FixViolation_DirectoryRename_PersistsPath(t *testing.T) {
+	db := setupTestDB(t)
+	artistSvc := artist.NewService(db)
+	ruleSvc := NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+
+	// Create a library with non-shared FS so the rename is not blocked.
+	libSvc := library.NewService(db)
+	tmp := t.TempDir()
+	lib := &library.Library{
+		Name:   "Test Library",
+		Path:   tmp,
+		Type:   library.TypeRegular,
+		Source: library.SourceManual,
+	}
+	if err := libSvc.Create(ctx, lib); err != nil {
+		t.Fatalf("creating library: %v", err)
+	}
+
+	// Create a directory whose name differs from the artist name.
+	oldPath := filepath.Join(tmp, "Wrong Name")
+	if err := os.MkdirAll(oldPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write a file to verify it moves.
+	if err := os.WriteFile(filepath.Join(oldPath, "artist.nfo"), []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &artist.Artist{
+		Name:      "Correct Name",
+		SortName:  "Correct Name",
+		Path:      oldPath,
+		LibraryID: lib.ID,
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// Create a violation for the directory name mismatch.
+	rv := &RuleViolation{
+		RuleID:     RuleDirectoryNameMismatch,
+		ArtistID:   a.ID,
+		ArtistName: a.Name,
+		Severity:   "warning",
+		Message:    "directory 'Wrong Name' does not match expected 'Correct Name'",
+		Fixable:    true,
+		Status:     ViolationStatusOpen,
+	}
+	if err := ruleSvc.UpsertViolation(ctx, rv); err != nil {
+		t.Fatalf("upserting violation: %v", err)
+	}
+
+	logger := testLogger()
+	fsCheck := NewSharedFSCheck(libSvc, logger)
+	fixer := NewDirectoryRenameFixer(fsCheck, logger)
+	engine := NewEngine(ruleSvc, db, nil, nil, logger)
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{fixer}, nil, logger)
+
+	fr, err := pipeline.FixViolation(ctx, rv.ID)
+	if err != nil {
+		t.Fatalf("FixViolation: %v", err)
+	}
+	if !fr.Fixed {
+		t.Fatalf("Fixed = false, want true; message: %s", fr.Message)
+	}
+
+	// The key assertion: reload the artist from the database and verify the
+	// path was persisted, not just updated in the in-memory struct.
+	reloaded, err := artistSvc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID after fix: %v", err)
+	}
+
+	expectedPath := filepath.Join(tmp, "Correct Name")
+	if reloaded.Path != expectedPath {
+		t.Errorf("reloaded.Path = %q, want %q", reloaded.Path, expectedPath)
+	}
+
+	// Verify the file was actually moved.
+	data, err := os.ReadFile(filepath.Join(expectedPath, "artist.nfo"))
+	if err != nil {
+		t.Fatalf("reading moved file: %v", err)
+	}
+	if string(data) != "test" {
+		t.Errorf("file content = %q, want %q", data, "test")
+	}
+}
+
+// TestPipeline_RunForArtist_PersistsArtistChanges verifies that RunForArtist
+// calls Update on the artist after a fixer modifies it in-memory (e.g. setting
+// a path or flag). This was a bug where fixers modified the artist struct but
+// the changes were never written to the database.
+func TestPipeline_RunForArtist_PersistsArtistChanges(t *testing.T) {
+	db := setupTestDB(t)
+	artistSvc := artist.NewService(db)
+	ruleSvc := NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+
+	// Set the nfo_exists rule to auto mode so RunForArtist will fix it.
+	nfoRule, err := ruleSvc.GetByID(ctx, RuleNFOExists)
+	if err != nil {
+		t.Fatalf("getting nfo_exists rule: %v", err)
+	}
+	nfoRule.AutomationMode = AutomationModeAuto
+	if err := ruleSvc.Update(ctx, nfoRule); err != nil {
+		t.Fatalf("updating rule: %v", err)
+	}
+
+	dir := t.TempDir()
+	a := &artist.Artist{
+		Name:     "Auto Fix Artist",
+		SortName: "Auto Fix Artist",
+		Path:     dir,
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// A mock fixer that sets a field on the artist model when it fixes.
+	pathFixer := &mockArtistMutatingFixer{
+		canFixRuleID: RuleNFOExists,
+		mutate: func(a *artist.Artist) {
+			a.Biography = "set-by-fixer"
+		},
+	}
+
+	logger := testLogger()
+	engine := NewEngine(ruleSvc, db, nil, nil, logger)
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{pathFixer}, nil, logger)
+
+	result, err := pipeline.RunForArtist(ctx, a)
+	if err != nil {
+		t.Fatalf("RunForArtist: %v", err)
+	}
+	if result.FixesSucceeded == 0 {
+		t.Fatal("expected at least one successful fix")
+	}
+
+	// Reload from DB and verify the mutation was persisted.
+	reloaded, err := artistSvc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID after RunForArtist: %v", err)
+	}
+	if reloaded.Biography != "set-by-fixer" {
+		t.Errorf("Biography = %q, want %q (fixer mutation not persisted)", reloaded.Biography, "set-by-fixer")
+	}
+}
+
+// mockArtistMutatingFixer is a test fixer that modifies the artist in-memory
+// when Fix is called, used to verify that pipeline methods persist the changes.
+type mockArtistMutatingFixer struct {
+	canFixRuleID string
+	mutate       func(a *artist.Artist)
+}
+
+func (m *mockArtistMutatingFixer) CanFix(v *Violation) bool {
+	return v.RuleID == m.canFixRuleID
+}
+
+func (m *mockArtistMutatingFixer) Fix(_ context.Context, a *artist.Artist, v *Violation) (*FixResult, error) {
+	if m.mutate != nil {
+		m.mutate(a)
+	}
+	return &FixResult{RuleID: v.RuleID, Fixed: true, Message: "mock mutated artist"}, nil
+}


### PR DESCRIPTION
## Summary
- Fix directory rename appearing to do nothing (#963): the rule engine fixer updated `a.Path` in memory but never called `artistService.Update()` to persist it. Added dirty tracking to `RunRule`, `RunForArtist`, and `RunAll` so the artist model is saved after any successful fix.
- Handle stale image DB flags (#922): when serving an image file, if the DB `exists_flag` says the image exists but the file is missing on disk, return 404 and clear the stale flag in a background goroutine so the UI shows a placeholder on next load.

## Test plan
- [ ] Verify directory rename works: trigger a directory-name rule violation, fix it, confirm the directory is renamed on disk and the DB path is updated
- [ ] Verify stale image flag handling: delete an image file from disk, request the image URL, confirm 404 is returned and the `exists_flag` is cleared
- [ ] `go test -race ./internal/rule/... ./internal/artist/... ./internal/api/...` passes
- [ ] `bash scripts/pre-push-gate.sh` passes

Closes #963
Closes #922

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Best-effort, asynchronous cleanup of stale image metadata when image files are missing.

* **Improvements**
  * Fixers now more reliably persist artist metadata changes (e.g., directory, biography) during rule processing.
  * Service-level support added to explicitly clear stale image-exists flags.

* **Tests**
  * Added unit and pipeline tests validating stale-image cleanup and that fixer-driven artist changes are persisted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->