### PR TITLE
chore: bump version to 0.9.3

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // These variables are set at build time via -ldflags.
 var (
-	Version = "0.9.1"
+	Version = "0.9.3"
 	Commit  = "unknown"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

- Bumps `internal/version/version.go` to `0.9.3` to match the v0.9.3 tag.

The tag `v0.9.3` has already been pushed and the release workflow is running. This PR lands the version file change on main so `go run` without ldflags reports the correct version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 0.9.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->