### PR TITLE
perf: add Count() query path for sidebar artist badge (#852)

### DIFF
--- a/internal/api/handlers_artist.go
+++ b/internal/api/handlers_artist.go
@@ -46,19 +46,13 @@ func (r *Router) handleListArtists(w http.ResponseWriter, req *http.Request) {
 }
 
 // handleArtistsBadge returns an HTML fragment with the total artist count for the
-// sidebar badge. The response is intentionally lightweight: it fetches only the
-// total count (page_size=1) rather than the full artist list.
+// sidebar badge. Uses the dedicated Count() path to avoid fetching and hydrating
+// full artist rows.
 // GET /api/v1/artists/badge
 func (r *Router) handleArtistsBadge(w http.ResponseWriter, req *http.Request) {
-	params := artist.ListParams{
-		Page:     1,
-		PageSize: 1,
-	}
-	params.Validate()
-
 	w.Header().Set("Cache-Control", "no-store")
 
-	_, total, err := r.artistService.List(req.Context(), params)
+	total, err := r.artistService.Count(req.Context(), artist.CountParams{})
 	if err != nil {
 		r.logger.Error("fetching artist count for badge", "error", err)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/artist/count_test.go
+++ b/internal/artist/count_test.go
@@ -124,37 +124,88 @@ func TestCount_WithExcludedFilter(t *testing.T) {
 }
 
 func TestCount_ConsistentWithList(t *testing.T) {
-	// Verify that Count returns the same total as List for the same filters.
+	// Verify that Count returns the same total as List for several filter
+	// shapes. This catches drift between buildWhereClause and toListParams.
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
 
 	a1 := testArtist("Alpha", "/music/Alpha")
 	a1.LibraryID = "lib-1"
+
 	a2 := testArtist("Bravo", "/music/Bravo")
 	a2.LibraryID = "lib-2"
+	a2.IsExcluded = true
 
-	for _, a := range []*Artist{a1, a2} {
+	a3 := testArtist("Charlie", "/music/Charlie")
+	a3.LibraryID = "lib-1"
+	a3.IsExcluded = true
+
+	for _, a := range []*Artist{a1, a2, a3} {
 		if err := svc.Create(ctx, a); err != nil {
 			t.Fatalf("Create %s: %v", a.Name, err)
 		}
 	}
 
-	countTotal, err := svc.Count(ctx, CountParams{LibraryID: "lib-1"})
-	if err != nil {
-		t.Fatalf("Count: %v", err)
+	tests := []struct {
+		name  string
+		count CountParams
+		list  ListParams
+	}{
+		{
+			name:  "library_id",
+			count: CountParams{LibraryID: "lib-1"},
+			list: ListParams{
+				Page:      1,
+				PageSize:  50,
+				LibraryID: "lib-1",
+			},
+		},
+		{
+			name:  "excluded",
+			count: CountParams{Filter: "excluded"},
+			list: ListParams{
+				Page:     1,
+				PageSize: 50,
+				Filter:   "excluded",
+			},
+		},
+		{
+			name:  "not_excluded",
+			count: CountParams{Filter: "not_excluded"},
+			list: ListParams{
+				Page:     1,
+				PageSize: 50,
+				Filter:   "not_excluded",
+			},
+		},
+		{
+			name:  "library_id_and_excluded",
+			count: CountParams{LibraryID: "lib-1", Filter: "excluded"},
+			list: ListParams{
+				Page:      1,
+				PageSize:  50,
+				LibraryID: "lib-1",
+				Filter:    "excluded",
+			},
+		},
 	}
 
-	_, listTotal, err := svc.List(ctx, ListParams{
-		Page:      1,
-		PageSize:  50,
-		LibraryID: "lib-1",
-	})
-	if err != nil {
-		t.Fatalf("List: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			countTotal, err := svc.Count(ctx, tt.count)
+			if err != nil {
+				t.Fatalf("Count: %v", err)
+			}
 
-	if countTotal != listTotal {
-		t.Errorf("Count = %d, List total = %d; they should match", countTotal, listTotal)
+			_, listTotal, err := svc.List(ctx, tt.list)
+			if err != nil {
+				t.Fatalf("List: %v", err)
+			}
+
+			if countTotal != listTotal {
+				t.Errorf("Count = %d, List total = %d; they should match", countTotal, listTotal)
+			}
+		})
 	}
 }

--- a/internal/artist/count_test.go
+++ b/internal/artist/count_test.go
@@ -1,0 +1,160 @@
+package artist
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCount_NoArtists(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	total, err := svc.Count(ctx, CountParams{})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("Count = %d, want 0", total)
+	}
+}
+
+func TestCount_AllArtists(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	for _, name := range []string{"Alpha", "Bravo", "Charlie"} {
+		a := testArtist(name, "/music/"+name)
+		if err := svc.Create(ctx, a); err != nil {
+			t.Fatalf("Create %s: %v", name, err)
+		}
+	}
+
+	total, err := svc.Count(ctx, CountParams{})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if total != 3 {
+		t.Errorf("Count = %d, want 3", total)
+	}
+}
+
+func TestCount_WithLibraryFilter(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	a1 := testArtist("Alpha", "/music/Alpha")
+	a1.LibraryID = "lib-1"
+	a2 := testArtist("Bravo", "/music/Bravo")
+	a2.LibraryID = "lib-2"
+	a3 := testArtist("Charlie", "/music/Charlie")
+	a3.LibraryID = "lib-1"
+
+	for _, a := range []*Artist{a1, a2, a3} {
+		if err := svc.Create(ctx, a); err != nil {
+			t.Fatalf("Create %s: %v", a.Name, err)
+		}
+	}
+
+	total, err := svc.Count(ctx, CountParams{LibraryID: "lib-1"})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("Count with library filter = %d, want 2", total)
+	}
+}
+
+func TestCount_WithSearchQuery(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	for _, name := range []string{"Radiohead", "Rage Against the Machine", "Pink Floyd"} {
+		a := testArtist(name, "/music/"+name)
+		if err := svc.Create(ctx, a); err != nil {
+			t.Fatalf("Create %s: %v", name, err)
+		}
+	}
+
+	total, err := svc.Count(ctx, CountParams{Search: "Ra"})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("Count with search = %d, want 2", total)
+	}
+}
+
+func TestCount_WithExcludedFilter(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	a1 := testArtist("Active", "/music/Active")
+	if err := svc.Create(ctx, a1); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	a2 := testArtist("Excluded", "/music/Excluded")
+	a2.IsExcluded = true
+	if err := svc.Create(ctx, a2); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Count only excluded artists.
+	total, err := svc.Count(ctx, CountParams{Filter: "excluded"})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("Count with excluded filter = %d, want 1", total)
+	}
+
+	// Count only non-excluded artists.
+	total, err = svc.Count(ctx, CountParams{Filter: "not_excluded"})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("Count with not_excluded filter = %d, want 1", total)
+	}
+}
+
+func TestCount_ConsistentWithList(t *testing.T) {
+	// Verify that Count returns the same total as List for the same filters.
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	a1 := testArtist("Alpha", "/music/Alpha")
+	a1.LibraryID = "lib-1"
+	a2 := testArtist("Bravo", "/music/Bravo")
+	a2.LibraryID = "lib-2"
+
+	for _, a := range []*Artist{a1, a2} {
+		if err := svc.Create(ctx, a); err != nil {
+			t.Fatalf("Create %s: %v", a.Name, err)
+		}
+	}
+
+	countTotal, err := svc.Count(ctx, CountParams{LibraryID: "lib-1"})
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+
+	_, listTotal, err := svc.List(ctx, ListParams{
+		Page:      1,
+		PageSize:  50,
+		LibraryID: "lib-1",
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if countTotal != listTotal {
+		t.Errorf("Count = %d, List total = %d; they should match", countTotal, listTotal)
+	}
+}

--- a/internal/artist/params.go
+++ b/internal/artist/params.go
@@ -18,6 +18,33 @@ type ListParams struct {
 	Filters map[string]string
 }
 
+// CountParams configures filtered artist count queries. It mirrors the
+// filtering subset of ListParams but omits pagination, sorting, and ordering
+// since COUNT(*) does not need them.
+type CountParams struct {
+	Search         string
+	Filter         string
+	LibraryID      string
+	HealthScoreMin int
+	HealthScoreMax int
+	Filters        map[string]string
+}
+
+// toListParams converts CountParams to ListParams so the shared
+// buildWhereClause helper can be reused.
+func (p CountParams) toListParams() ListParams {
+	return ListParams{
+		Page:           1,
+		PageSize:       10, // unused but satisfies Validate
+		Search:         p.Search,
+		Filter:         p.Filter,
+		LibraryID:      p.LibraryID,
+		HealthScoreMin: p.HealthScoreMin,
+		HealthScoreMax: p.HealthScoreMax,
+		Filters:        p.Filters,
+	}
+}
+
 // Validate normalizes and validates list parameters.
 func (p *ListParams) Validate() {
 	if p.Page < 1 {

--- a/internal/artist/repository.go
+++ b/internal/artist/repository.go
@@ -12,6 +12,10 @@ type Repository interface {
 	FindByMBIDOrName(ctx context.Context, mbid, name, libraryID string) (*Artist, error)
 	GetByPath(ctx context.Context, path string) (*Artist, error)
 	List(ctx context.Context, params ListParams) ([]Artist, int, error)
+	// Count returns the total number of artists matching the given filters
+	// without fetching any row data. Use this instead of List when only the
+	// count is needed (e.g., sidebar badge).
+	Count(ctx context.Context, params CountParams) (int, error)
 	Update(ctx context.Context, a *Artist) error
 	UpdateField(ctx context.Context, id, field, value string) error
 	ClearField(ctx context.Context, id, field string) error

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -286,6 +286,13 @@ func (s *Service) List(ctx context.Context, params ListParams) ([]Artist, int, e
 	return artists, total, nil
 }
 
+// Count returns the total number of artists matching the given filters without
+// fetching or hydrating any row data. Prefer this over List when only the count
+// is needed (e.g., sidebar badge).
+func (s *Service) Count(ctx context.Context, params CountParams) (int, error) {
+	return s.artists.Count(ctx, params)
+}
+
 // Update modifies an existing artist and persists its provider IDs and image metadata.
 // Note: if provider or image persistence fails after the artist row is updated,
 // we cannot rollback the artist update (the old data is already overwritten).

--- a/internal/artist/sqlite_artist.go
+++ b/internal/artist/sqlite_artist.go
@@ -239,6 +239,21 @@ func (r *sqliteArtistRepo) List(ctx context.Context, params ListParams) ([]Artis
 	return artists, total, nil
 }
 
+// Count returns the number of artists matching the given filter parameters
+// using a lightweight SELECT COUNT(*) query. It reuses buildWhereClause for
+// consistent filtering with List.
+func (r *sqliteArtistRepo) Count(ctx context.Context, params CountParams) (int, error) {
+	lp := params.toListParams()
+	lp.Validate()
+
+	where, args := buildWhereClause(lp)
+	var total int
+	if err := r.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM artists"+where, args...).Scan(&total); err != nil {
+		return 0, fmt.Errorf("counting artists: %w", err)
+	}
+	return total, nil
+}
+
 func (r *sqliteArtistRepo) Update(ctx context.Context, a *Artist) error {
 	a.UpdatedAt = time.Now().UTC()
 


### PR DESCRIPTION
## Summary
- Add `Count(ctx, CountParams)` to the artist `Repository` interface and SQLite implementation using `SELECT COUNT(*)`
- Add `CountParams` type that mirrors filtering from `ListParams` but omits pagination/sorting
- Switch `handleArtistsBadge` from `List()` to `Count()`, eliminating row scanning and provider/image hydration
- Add 6 tests covering: empty DB, total count, library filter, search query, excluded filter, and consistency with List

## Test plan
- [x] Unit tests for Count with no artists
- [x] Unit tests for Count with various filters (library, search, excluded)
- [x] Verify Count returns same total as List for identical filters
- [ ] Verify sidebar badge shows correct count in browser
- [ ] Verify List() behavior unchanged

Closes #852

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved artist total retrieval to use a dedicated counting implementation for more efficient and accurate sidebar totals.

* **New Features**
  * Added a dedicated artist counting endpoint in the backend to support filtered total queries (no row data returned).

* **Tests**
  * Added comprehensive unit tests covering artist count behavior across filters, search, and library scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->