### PR TITLE
feat: add Codecov and OpenSSF Scorecard quality badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,13 +98,13 @@ jobs:
         run: templ generate
 
       - name: Run tests
-        run: go test -v -race -count=1 -coverprofile=coverage.out ./...
+        run: go test -v -race -count=1 -coverpkg=./... -coverprofile=coverage.out ./...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: coverage.out
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,13 @@ jobs:
         run: templ generate
 
       - name: Run tests
-        run: go test -v -race -count=1 ./...
+        run: go test -v -race -count=1 -coverprofile=coverage.out ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        with:
+          files: coverage.out
+          fail_ci_if_error: false
 
   build:
     name: Build

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: Scorecard
+
+on:
+  schedule:
+    - cron: '30 1 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: SARIF file
+          path: scorecard-results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        with:
+          sarif_file: scorecard-results.sarif

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![CI](https://github.com/sydlexius/stillwater/actions/workflows/ci.yml/badge.svg)](https://github.com/sydlexius/stillwater/actions/workflows/ci.yml)
 [![Release](https://github.com/sydlexius/stillwater/actions/workflows/release.yml/badge.svg)](https://github.com/sydlexius/stillwater/actions/workflows/release.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/sydlexius/stillwater)](https://goreportcard.com/report/github.com/sydlexius/stillwater)
+[![codecov](https://codecov.io/gh/sydlexius/stillwater/branch/main/graph/badge.svg)](https://codecov.io/gh/sydlexius/stillwater)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sydlexius/stillwater/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sydlexius/stillwater)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/github/go-mod-go-version/sydlexius/stillwater)](go.mod)
-[![CodeRabbit](https://img.shields.io/badge/CodeRabbit-AI%20Reviews-FF570A?logo=coderabbit&logoColor=white)](https://coderabbit.ai)
 
 Stillwater is a self-hosted web application for managing artist and composer metadata and images for Emby, Jellyfin, and Kodi media servers. It reads and writes NFO files and handles artist artwork, letting you keep your music library metadata clean and consistent from a single interface.
 


### PR DESCRIPTION
## Summary

- Removes the broken Go Report Card badge (404 on private/new repos) and the generic CodeRabbit badge
- Adds **Codecov** badge: coverage percentage from the existing test suite, uploaded on each CI run via `codecov-action@v5`
- Adds **OpenSSF Scorecard** badge: supply chain security score, evaluated weekly and on every push to main

## Changes

- `.github/workflows/ci.yml` -- adds `-coverprofile=coverage.out` to the test command and a Codecov upload step
- `.github/workflows/scorecard.yml` -- new workflow running Scorecard analysis with SARIF upload to GitHub code-scanning
- `README.md` -- swaps the two removed badges for Codecov and Scorecard

## Notes

The Codecov badge will show "unknown" until the repo is connected at codecov.io (authorize via GitHub OAuth, add the repo). The Scorecard badge populates after the first workflow run on main.

## Test plan

- [ ] Merge and verify CI passes with coverage upload step
- [ ] Confirm Codecov receives the report at codecov.io after connecting the repo
- [ ] Verify Scorecard workflow runs and badge resolves at securityscorecards.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated code coverage reporting with Codecov to track test coverage across the codebase
  * Added a weekly and on-push security analysis using OpenSSF Scorecard to monitor repository security posture and publish results

* **Documentation**
  * Updated README badges to show current code coverage and security assessment status
<!-- end of auto-generated comment: release notes by coderabbit.ai -->