### PR TITLE
feat: sign release artifacts with cosign (Sigstore keyless)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
   release:
@@ -37,6 +38,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+        with:
+          cosign-release: 'v2.4.1'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,6 +89,26 @@ docker_manifests:
       - "ghcr.io/sydlexius/stillwater:{{ .Version }}-amd64"
       - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
 
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - --output-certificate=${certificate}
+      - --output-signature=${signature}
+      - ${artifact}
+      - --yes
+    artifacts: checksum
+    output: true
+
+docker_signs:
+  - cmd: cosign
+    args:
+      - sign
+      - --yes
+      - ${artifact}
+    artifacts: all
+
 changelog:
   sort: asc
   use: github


### PR DESCRIPTION
## Summary

- Adds keyless release signing via Sigstore/cosign, satisfying the OpenSSF Scorecard Signed-Releases check
- No key management or external accounts required -- signatures are anchored to the GitHub Actions OIDC identity and recorded in the public Sigstore transparency log

## Note on SAST

CodeQL was already wired up in \`.github/workflows/codeql.yml\` (runs on every PR and push to main), so no changes needed there -- that check is already passing.

## Changes

- \`.github/workflows/release.yml\` -- adds \`id-token: write\` permission, \`sigstore/cosign-installer\` step (pinned to v2.4.1) before GoReleaser
- \`.goreleaser.yml\` -- adds \`signs\` block (signs the checksums file, uploads \`.sig\` + \`.pem\` to the GitHub Release) and \`docker_signs\` block (signs all Docker manifests in GHCR)

## Verification

After the next release, verify the checksums file signature:
\`\`\`
cosign verify-blob \
  --certificate stillwater_<version>_checksums.txt.pem \
  --signature stillwater_<version>_checksums.txt.sig \
  --certificate-identity-regexp="https://github.com/sydlexius/stillwater" \
  --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
  stillwater_<version>_checksums.txt
\`\`\`

The checksums file contains SHA256 hashes of all release archives, so this single signature transitively covers every artifact. To then verify an archive:
\`\`\`
sha256sum -c --ignore-missing stillwater_<version>_checksums.txt
\`\`\`

Verify Docker image signatures:
\`\`\`
cosign verify ghcr.io/sydlexius/stillwater:<version> \
  --certificate-identity-regexp="https://github.com/sydlexius/stillwater" \
  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
\`\`\`

## Test plan

- [ ] Merge and tag a release
- [ ] Verify \`.sig\` and \`.pem\` files appear in the GitHub Release assets
- [ ] Verify Docker manifests are signed: \`cosign verify ghcr.io/sydlexius/stillwater:<version>\`
- [ ] Confirm Scorecard Signed-Releases check passes on next weekly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented cryptographic signing for release artifacts and container images to enable verification and enhance release security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->