### PR TITLE
fix: scope workflow token permissions to job level, pin fetch-metadata, fix Go badge

### DIFF
--- a/.claude/release.toml
+++ b/.claude/release.toml
@@ -29,6 +29,7 @@ default_group = "Other Changes"
 [release_notes.group_labels]
 enhancement = "New Features"
 bug         = "Bug Fixes"
+security    = "Security"
 ux          = "UX Improvements"
 database    = "Database"
 documentation = "Documentation"
@@ -43,6 +44,7 @@ webhooks    = "Webhooks"
 emby        = "Emby"
 jellyfin    = "Jellyfin"
 reports     = "Reports"
+chore       = "Maintenance"
 
 [release]
 tag_prefix = "v"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,13 +10,15 @@ on:
   workflow_dispatch:
 
 permissions:
-  security-events: write
   contents: read
 
 jobs:
   analyze:
     name: Analyze Go
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/copilot-re-review.yml
+++ b/.github/workflows/copilot-re-review.yml
@@ -11,12 +11,13 @@ on:
     types:
       - synchronize
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   re-request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Check for prior Copilot review

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -14,12 +14,13 @@ on:
     branches:
       - main
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     concurrency:
       group: dependabot-auto-approve-${{ github.event.pull_request.number }}
@@ -27,7 +28,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -15,13 +15,14 @@ on:
     types:
       - completed
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   merge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       startsWith(github.event.workflow_run.head_branch, 'dependabot/')

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,9 +5,7 @@ on:
     - cron: '0 0 * * *' # midnight UTC
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +16,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     name: Nightly Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -27,15 +27,16 @@ on:
     types: [opened, reopened, edited, synchronize, labeled, unlabeled]
     branches: [main]
 
-permissions:
-  contents: read
-  issues: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   require-label:
     name: Require release label
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: write
     if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     steps:

--- a/.github/workflows/pr-milestone.yml
+++ b/.github/workflows/pr-milestone.yml
@@ -10,13 +10,14 @@ on:
     types: [opened, edited]
     branches: [main]
 
-permissions:
-  issues: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   assign-milestone:
     runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: write
     # Skip bot PRs (Dependabot, etc.) -- they never reference milestone issues
     if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,15 +5,16 @@ on:
     tags:
       - 'v*.*.*'
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
+permissions: {}
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,6 @@ concurrency:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   govulncheck:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/sydlexius/stillwater/branch/main/graph/badge.svg)](https://codecov.io/gh/sydlexius/stillwater)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sydlexius/stillwater/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sydlexius/stillwater)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
-[![Go Version](https://img.shields.io/github/go-mod-go-version/sydlexius/stillwater)](go.mod)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/sydlexius/stillwater)](go.mod)
 
 Stillwater is a self-hosted web application for managing artist and composer metadata and images for Emby, Jellyfin, and Kodi media servers. It reads and writes NFO files and handles artist artwork, letting you keep your music library metadata clean and consistent from a single interface.
 


### PR DESCRIPTION
## Summary

- Moves all `GITHUB_TOKEN` write grants from the workflow level to the job level in 8 workflows (`release`, `nightly`, `dependabot-merge`, `dependabot-auto-approve`, `copilot-re-review`, `pr-labels`, `pr-milestone`, `codeql`). Top-level permissions are now `{}` or read-only everywhere.
- Removes the stray top-level `security-events: write` from `security.yml` -- `trivy` and `sbom` jobs already declare it at the job level.
- Upgrades `dependabot/fetch-metadata` from unpinned `@v2` to SHA-pinned `@ffa630c # v3.0.0`, closing the last gap in the Pinned-Dependencies check.
- Fixes the shields.io Go version badge (path was `go-mod-go-version`, correct path is `go-mod/go-version`).

Addresses the two actionable items from the OpenSSF Scorecard triage: Token-Permissions (0/10) and Pinned-Dependencies (8/10).

## Test plan

- [ ] CI passes (no workflow YAML parse errors)
- [ ] Release workflow still succeeds on next tag push (job-level permissions are equivalent)
- [ ] Nightly build pushes to GHCR successfully
- [ ] Dependabot auto-approve and merge workflows function on next Dependabot PR
- [ ] Go version badge renders correctly in README (should show `v1.26.2`)
- [ ] OpenSSF Scorecard re-run reflects improved Token-Permissions score

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined CI/CD workflow security permissions configuration for improved scoping
  * Updated internal workflow action dependencies

* **Documentation**
  * Fixed Go Version badge reference in README

<!-- end of auto-generated comment: release notes by coderabbit.ai -->