### PR TITLE
fix(security): pin Docker images and templ CLI by hash

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install templ
-        run: go install github.com/a-h/templ/cmd/templ@latest
+        run: go install github.com/a-h/templ/cmd/templ@v0.3.1001
 
       - name: Generate templ
         run: templ generate

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26-alpine@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 AS builder
 
 RUN apk add --no-cache curl libstdc++ libgcc
 
@@ -32,7 +32,7 @@ RUN tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minif
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /bin/stillwater ./cmd/stillwater
 
 # Runtime stage
-FROM alpine:3.23
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 LABEL org.opencontainers.image.source="https://github.com/sydlexius/stillwater" \
       org.opencontainers.image.description="Artist metadata and image manager for Emby, Jellyfin, and Kodi" \

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -18,6 +18,9 @@ RUN chmod +x /entrypoint.sh
 
 EXPOSE 1973
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD sh -c 'curl -f "http://localhost:1973${SW_BASE_PATH:-}/api/v1/health" || exit 1'
+
 VOLUME ["/config", "/music"]
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM alpine:3.23
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 
 RUN apk add --no-cache ca-certificates tzdata su-exec curl && \
     apk upgrade --no-cache


### PR DESCRIPTION
## Summary
- Pin `alpine:3.23` and `golang:1.26-alpine` by SHA256 digest in both Dockerfiles
- Pin `templ` install in CodeQL workflow to `v0.3.1001` (matches go.mod)
- Resolves OpenSSF Scorecard `PinnedDependenciesID` alerts #61, #62, #63, #64

## Test plan
- [ ] Docker image builds (both Dockerfile and Dockerfile.goreleaser)
- [ ] CodeQL workflow passes on this PR
- [ ] Scorecard re-run after merge shows pinned-deps alerts resolved

Non-actionable Scorecard alerts being dismissed separately:
- #52 BranchProtection (by design — solo maintainer policy)
- #65 Maintained (<90 days old — time-based, auto-resolves)
- #66 CIIBestPractices (requires external badge application)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pin build tools and container base images to fixed versions/digests to improve reproducibility and deployment stability.
  * Lock workflow install of a build tool to a specific release instead of using the latest.
  * Add a container health check that regularly verifies the service is responding, causing the container to fail if unhealthy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->