### PR TITLE
fix(ci): prevent goreleaser make_latest 422 on pre-release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,3 +53,9 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mark stable release as latest
+        if: "!contains(github.ref_name, '-rc') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-alpha')"
+        run: gh release edit "${{ github.ref_name }}" --latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -145,7 +145,7 @@ release:
     owner: sydlexius
     name: stillwater
   prerelease: auto
-  make_latest: auto
+  make_latest: false
   header: |
     ## Stillwater {{ .Tag }}
 


### PR DESCRIPTION
## Summary

- goreleaser 2.15.x sends `make_latest` to the GitHub Releases API even for pre-release tags when configured as `auto`, triggering a `422 Validation Failed: Latest release cannot be draft or prerelease` on the final PATCH-to-publish step
- Change `.goreleaser.yml` to `make_latest: false` to stop goreleaser from sending the field at all
- Add a post-goreleaser CI step that runs `gh release edit --latest` only for stable tags (no `-rc`, `-beta`, or `-alpha` suffix), preserving the correct "latest" behavior for production releases

## Test plan

- [x] Merge this PR, delete the remote `v0.9.5-rc.1` tag, re-push it, verify the Release workflow completes without the 422
- [x] Verify `v0.9.4` remains marked as "latest" on the releases page (pre-release should not replace it)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced release tagging logic to more precisely control which versions are marked as "latest" in GitHub Releases, excluding prerelease versions from automatic latest designation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->