### PR TITLE
build: add coverage-on-changed-files check to pre-push gate

### DIFF
--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -7,7 +7,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BASE=$(git merge-base main HEAD 2>/dev/null || echo "HEAD~1")
 
 COVER_OUT=$(mktemp /tmp/stillwater-cover.XXXXXX.out)
-trap 'rm -f "${COVER_OUT:-}"' EXIT
+tmp_openapi=""
+cleanup() {
+  rm -f "${COVER_OUT:-}" "${tmp_openapi:-}"
+}
+trap cleanup EXIT
 
 echo "=== Tests ==="
 go test -race -count=1 -covermode=atomic -coverprofile="$COVER_OUT" ./...
@@ -39,10 +43,8 @@ echo ""
 echo "=== OpenAPI breaking changes ==="
 if command -v oasdiff &>/dev/null; then
   tmp_openapi=$(mktemp /tmp/openapi-base.XXXXXX.yaml)
-  trap 'rm -f "${tmp_openapi:-}"' EXIT
   if git show main:internal/api/openapi.yaml > "$tmp_openapi" 2>/dev/null; then
     breaking=$(oasdiff breaking "$tmp_openapi" internal/api/openapi.yaml 2>&1 || true)
-    rm -f "$tmp_openapi"
     if [ -n "$breaking" ]; then
       echo "WARNING: Breaking OpenAPI changes detected (may be intentional):"
       echo "$breaking"
@@ -50,7 +52,6 @@ if command -v oasdiff &>/dev/null; then
       echo "No breaking changes."
     fi
   else
-    rm -f "$tmp_openapi"
     echo "Skipped (openapi.yaml not yet on main)."
   fi
 else
@@ -63,9 +64,10 @@ changed_go=$(git diff "$BASE"..HEAD --name-only -- '*.go' | grep -v '_test.go' |
 if [ -z "$changed_go" ]; then
   echo "Skipped (no Go source changes)."
 else
+  cover_funcs=$(go tool cover -func="$COVER_OUT" 2>/dev/null || true)
   uncovered=""
   while IFS= read -r f; do
-    hits=$(go tool cover -func="$COVER_OUT" 2>/dev/null | grep "/${f}:" | awk '$NF == "0.0%"' || true)
+    hits=$(printf '%s\n' "$cover_funcs" | grep "/${f}:" | awk '$NF == "0.0%"' || true)
     if [ -n "$hits" ]; then
       uncovered="${uncovered}${hits}"$'\n'
     fi

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -6,8 +6,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BASE=$(git merge-base main HEAD 2>/dev/null || echo "HEAD~1")
 
+COVER_OUT=$(mktemp /tmp/stillwater-cover.XXXXXX.out)
+trap 'rm -f "${COVER_OUT:-}"' EXIT
+
 echo "=== Tests ==="
-go test -race -count=1 ./...
+go test -race -count=1 -covermode=atomic -coverprofile="$COVER_OUT" ./...
 
 echo ""
 echo "=== OpenAPI consistency ==="
@@ -52,6 +55,30 @@ if command -v oasdiff &>/dev/null; then
   fi
 else
   echo "Skipped (oasdiff not installed -- install: go install github.com/oasdiff/oasdiff@latest)"
+fi
+
+echo ""
+echo "=== Coverage on changed files ==="
+changed_go=$(git diff "$BASE"..HEAD --name-only -- '*.go' | grep -v '_test.go' || true)
+if [ -z "$changed_go" ]; then
+  echo "Skipped (no Go source changes)."
+else
+  uncovered=""
+  while IFS= read -r f; do
+    hits=$(go tool cover -func="$COVER_OUT" 2>/dev/null | grep "/${f}:" | awk '$NF == "0.0%"' || true)
+    if [ -n "$hits" ]; then
+      uncovered="${uncovered}${hits}"$'\n'
+    fi
+  done <<< "$changed_go"
+
+  if [ -n "$uncovered" ]; then
+    echo "WARNING: Functions with 0% coverage in changed files:"
+    echo "$uncovered"
+    echo "These may be intentionally tested via integration or missing unit tests."
+    echo "Codecov will flag patch coverage -- consider adding tests before opening a PR."
+  else
+    echo "OK"
+  fi
 fi
 
 echo ""

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -64,16 +64,22 @@ changed_go=$(git diff "$BASE"..HEAD --name-only -- '*.go' | grep -v '_test.go' |
 if [ -z "$changed_go" ]; then
   echo "Skipped (no Go source changes)."
 else
-  cover_funcs=$(go tool cover -func="$COVER_OUT" 2>/dev/null || true)
+  if ! cover_funcs=$(go tool cover -func="$COVER_OUT" 2>/dev/null); then
+    echo "WARNING: Unable to parse coverage profile; skipping changed-file coverage check."
+    echo "Codecov will still validate patch coverage in CI."
+    cover_funcs=""
+  fi
   uncovered=""
   while IFS= read -r f; do
-    hits=$(printf '%s\n' "$cover_funcs" | grep "/${f}:" | awk '$NF == "0.0%"' || true)
+    hits=$(printf '%s\n' "$cover_funcs" | grep -F "/${f}:" | awk '$NF == "0.0%"' || true)
     if [ -n "$hits" ]; then
       uncovered="${uncovered}${hits}"$'\n'
     fi
   done <<< "$changed_go"
 
-  if [ -n "$uncovered" ]; then
+  if [ -z "$cover_funcs" ]; then
+    :
+  elif [ -n "$uncovered" ]; then
     echo "WARNING: Functions with 0% coverage in changed files:"
     echo "$uncovered"
     echo "These may be intentionally tested via integration or missing unit tests."


### PR DESCRIPTION
## Summary

- Generates a cover profile during the existing `go test -race` run (zero extra test execution cost -- same run, added flags)
- After tests pass, checks whether any function in a changed source file shows 0% coverage
- Prints a `WARNING` with the uncovered function list and a Codecov note
- Non-blocking (exits 0) -- functions intentionally tested via integration don't become hard blockers

## Motivation

PR #1035 had a `codecov/patch` failure caught only after CI. This check would have surfaced the gap at pre-push time, prompting the test addition before the PR was opened.

## Test plan
- [ ] Run `bash scripts/pre-push-gate.sh` on a branch with an uncovered changed function -- verify WARNING appears
- [ ] Run on a branch with no Go source changes -- verify "Skipped" message
- [ ] Run on a branch with covered changed functions -- verify "OK"

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced pre-push validation to generate coverage data and warn when any modified Go function has 0% coverage, skipping when no relevant changes or coverage cannot be parsed.
* **Chores**
  * Consolidated temporary artifact cleanup into a single shared teardown to ensure reliable removal of coverage and API temp files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->