### PR TITLE
chore(release): v0.9.5

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // These variables are set at build time via -ldflags.
 var (
-	Version = "0.9.3"
+	Version = "0.9.5"
 	Commit  = "unknown"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary
- Bump `internal/version/version.go` to 0.9.5 ahead of tagging v0.9.5.
- Release notes and signed annotated tag will follow once this lands.

## Test plan
- [x] `bash scripts/pre-push-gate.sh` passes on release branch tip
- [x] All main-tip CI runs green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.9.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->