### PR TITLE
fix(ci): use previous stable tag for release changelog range

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,22 @@ jobs:
         with:
           cosign-release: 'v2.4.1'
 
+      # For stable tags (no -rc/-beta/-alpha suffix), force goreleaser to
+      # compute the changelog from the previous *stable* tag, not the most
+      # recent pre-release. Without this override, promoting vX.Y.Z after
+      # vX.Y.Z-rc.N produces a nearly-empty changelog because only the
+      # commits between rc.N and the stable tag are included.
+      - name: Compute previous stable tag
+        id: prev
+        if: "!contains(github.ref_name, '-rc') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-alpha')"
+        run: |
+          prev=$(git tag --list 'v*' --sort=-v:refname \
+            | grep -vE '\-(rc|beta|alpha)' \
+            | grep -v "^${GITHUB_REF_NAME}$" \
+            | head -n1)
+          echo "prev=$prev" >> "$GITHUB_OUTPUT"
+          echo "Previous stable tag: $prev"
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
@@ -53,6 +69,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_PREVIOUS_TAG: ${{ steps.prev.outputs.prev }}
 
       - name: Mark stable release as latest
         if: "!contains(github.ref_name, '-rc') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-alpha')"


### PR DESCRIPTION
## Summary
Promoting a stable tag (\`vX.Y.Z\`) after its release candidate (\`vX.Y.Z-rc.N\`) produced an almost-empty GitHub Release body because goreleaser diffed against the most recent tag (the rc), not the prior stable. v0.9.5 hit this today -- the release body only listed commits between rc.1 and the stable tag.

This change computes the previous *stable* tag (excluding \`-rc\`/\`-beta\`/\`-alpha\` suffixes and the current tag) in a workflow step and passes it to goreleaser via \`GORELEASER_PREVIOUS_TAG\`, so stable release notes span the full release cycle.

Pre-release builds continue to use goreleaser's default behavior (diff against immediately previous tag).

## Test plan
- [ ] Next stable release (\`v0.9.6\` or similar) produces a full changelog covering all intervening PRs, not just post-rc commits.
- [ ] Pre-release (\`v0.9.6-rc.1\`) still diffs against the most recent prior tag (no regression).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to more accurately identify and track stable releases, ensuring proper versioning between stable and pre-release versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->