### PR TITLE
chore(release): v0.9.6-rc.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // These variables are set at build time via -ldflags.
 var (
-	Version = "0.9.5"
+	Version = "0.9.6-rc.2"
 	Commit  = "unknown"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

Bumps the dev fallback version in `internal/version/version.go` from `0.9.5` to `0.9.6-rc.2` ahead of the `v0.9.6-rc.2` tag. Release artifacts inject the version via `-ldflags` at build time; this file only affects `go run` / dev builds.

## Test plan

- [x] `bash scripts/pre-push-gate.sh` passes
- [x] `grype dir:.` clean
- [ ] After merge, tag `v0.9.6-rc.2` will be cut against the merge commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.9.6-rc.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->