### PR TITLE
feat(wikipedia): walk full language preference list (#967)

### DIFF
--- a/internal/provider/wikipedia/types.go
+++ b/internal/provider/wikipedia/types.go
@@ -1,9 +1,15 @@
 package wikipedia
 
 // sparqlResponse is the SPARQL query result for resolving MBID to Wikipedia title.
+// The Item binding carries the Wikidata entity URI (e.g.
+// https://www.wikidata.org/entity/Q44190) which is used to derive the Q-ID for
+// localized sitelink lookups.
 type sparqlResponse struct {
 	Results struct {
 		Bindings []struct {
+			Item struct {
+				Value string `json:"value"`
+			} `json:"item"`
 			Article struct {
 				Value string `json:"value"`
 			} `json:"article"`

--- a/internal/provider/wikipedia/wikipedia.go
+++ b/internal/provider/wikipedia/wikipedia.go
@@ -430,10 +430,17 @@ func (a *Adapter) resolveToTitleAndQID(ctx context.Context, id string) (string, 
 
 // orderedLanguages builds the language list to attempt. It normalizes each
 // preference to a 2- or 3-letter lowercase code, removes duplicates while
-// preserving order, and guarantees "en" appears as a final fallback.
+// preserving order, and appends "en" at the end if not already present.
 func orderedLanguages(prefs []string) []string {
-	seen := make(map[string]struct{}, len(prefs)+1)
-	out := make([]string, 0, len(prefs)+1)
+	// Cap the preallocation hint to a sane upper bound. Language preference
+	// lists are tiny in practice; the explicit cap also silences CodeQL's
+	// "size computation may overflow" warning on len(prefs)+1.
+	n := len(prefs)
+	if n > 256 {
+		n = 256
+	}
+	seen := make(map[string]struct{}, n+1)
+	out := make([]string, 0, n+1)
 	for _, p := range prefs {
 		base := strings.SplitN(strings.ToLower(strings.TrimSpace(p)), "-", 2)[0]
 		if len(base) != 2 && len(base) != 3 {

--- a/internal/provider/wikipedia/wikipedia.go
+++ b/internal/provider/wikipedia/wikipedia.go
@@ -88,64 +88,121 @@ func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSe
 // Returns biography text from the article intro section and structured
 // metadata (members, genres, years active, origin) from infobox parsing.
 // When the user has metadata language preferences set in the context,
-// the adapter tries the preferred language's Wikipedia first, falling back
-// to English if the preferred language article does not exist.
+// the adapter walks the full preference list in order: for each language it
+// looks up the localized Wikipedia article title via Wikidata sitelinks and
+// fetches the extract from that language's Wikipedia. The first language
+// that returns a real article wins; missing articles, not-found responses,
+// and empty extracts cause a graceful fall-through to the next language.
+// English is always tried last as a final fallback.
 func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
-	// Determine the preferred Wikipedia language from context.
-	wikiLang := "en"
-	if langPrefs := provider.MetadataLanguages(ctx); len(langPrefs) > 0 {
-		base := strings.SplitN(strings.ToLower(langPrefs[0]), "-", 2)[0]
-		if len(base) == 2 || len(base) == 3 {
-			wikiLang = base
-		}
-	}
-
-	title, err := a.resolveToTitle(ctx, id)
+	// Resolve the input ID to an English-wiki title and, when possible, a
+	// Wikidata Q-ID that we can use to look up localized sitelinks.
+	enTitle, qid, err := a.resolveToTitleAndQID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	// Build a language-specific action endpoint for the preferred language.
-	actionEP := a.actionEndpointForLang(wikiLang)
+	// Build the ordered language list to try. User preferences first (in order),
+	// then "en" as a guaranteed final fallback. Duplicates are removed while
+	// preserving order.
+	langs := orderedLanguages(provider.MetadataLanguages(ctx))
 
-	// Fetch the article intro extract for biography text.
-	if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-	name, extract, err := a.fetchExtractFrom(ctx, actionEP, title)
-	if err != nil {
-		// If the preferred language wiki returned not-found, fall back to English
-		// rather than failing outright. The title from resolveToTitle is an enwiki
-		// title and may not exist on the localized wiki.
-		var notFound *provider.ErrNotFound
-		var unavailable *provider.ErrProviderUnavailable
-		if wikiLang == "en" || (!errors.As(err, &notFound) && !errors.As(err, &unavailable)) {
-			return nil, err
-		}
-		extract = "" // trigger the fallback below
-	}
+	var (
+		name     string
+		extract  string
+		wikiLang string
+		title    string
+		lastErr  error
+	)
 
-	// If the preferred language returned an empty extract and it is not English,
-	// fall back to English.
-	if strings.TrimSpace(extract) == "" && wikiLang != "en" {
+	for _, lang := range langs {
+		// Determine the article title for this language.
+		var candidateTitle string
+		switch {
+		case lang == "en":
+			// The enTitle we resolved is already the enwiki title.
+			candidateTitle = enTitle
+		case qid != "":
+			// Look up the localized sitelink via Wikidata.
+			if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
+				return nil, &provider.ErrProviderUnavailable{
+					Provider: provider.NameWikipedia,
+					Cause:    fmt.Errorf("rate limiter: %w", err),
+				}
+			}
+			localized, err := a.resolveToLocalizedTitle(ctx, qid, lang)
+			if err != nil {
+				var notFound *provider.ErrNotFound
+				if errors.As(err, &notFound) {
+					a.logger.Debug("no localized Wikipedia sitelink for language; trying next",
+						slog.String("qid", qid),
+						slog.String("lang", lang))
+					lastErr = err
+					continue
+				}
+				// Provider unavailable or other transport error: record and try next lang.
+				a.logger.Debug("localized title lookup failed; trying next language",
+					slog.String("qid", qid),
+					slog.String("lang", lang),
+					slog.Any("error", err))
+				lastErr = err
+				continue
+			}
+			candidateTitle = localized
+		default:
+			// No Q-ID available (input was a plain article title). Only the
+			// enwiki title is meaningful here, so skip non-English attempts.
+			a.logger.Debug("skipping non-English attempt without Q-ID",
+				slog.String("title", enTitle),
+				slog.String("lang", lang))
+			continue
+		}
+
+		// Fetch the article intro extract for biography text.
 		if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
 			return nil, &provider.ErrProviderUnavailable{
 				Provider: provider.NameWikipedia,
 				Cause:    fmt.Errorf("rate limiter: %w", err),
 			}
 		}
-		wikiLang = "en"
-		actionEP = a.actionEndpointForLang("en")
-		name, extract, err = a.fetchExtractFrom(ctx, actionEP, title)
+		actionEP := a.actionEndpointForLang(lang)
+		gotName, gotExtract, err := a.fetchExtractFrom(ctx, actionEP, candidateTitle)
 		if err != nil {
+			var notFound *provider.ErrNotFound
+			var unavailable *provider.ErrProviderUnavailable
+			if errors.As(err, &notFound) || errors.As(err, &unavailable) {
+				a.logger.Debug("extract fetch missed; trying next language",
+					slog.String("title", candidateTitle),
+					slog.String("lang", lang),
+					slog.Any("error", err))
+				lastErr = err
+				continue
+			}
+			// Unexpected error type: propagate immediately.
 			return nil, err
 		}
+		if strings.TrimSpace(gotExtract) == "" {
+			a.logger.Debug("empty extract; trying next language",
+				slog.String("title", candidateTitle),
+				slog.String("lang", lang))
+			lastErr = &provider.ErrNotFound{Provider: provider.NameWikipedia, ID: candidateTitle}
+			continue
+		}
+
+		a.logger.Debug("Wikipedia extract hit",
+			slog.String("title", candidateTitle),
+			slog.String("lang", lang))
+		name = gotName
+		extract = gotExtract
+		wikiLang = lang
+		title = candidateTitle
+		break
 	}
 
 	if strings.TrimSpace(extract) == "" {
+		if lastErr != nil {
+			return nil, lastErr
+		}
 		return nil, &provider.ErrNotFound{Provider: provider.NameWikipedia, ID: id}
 	}
 	if name == "" {
@@ -338,12 +395,14 @@ func (a *Adapter) TestConnection(ctx context.Context) error {
 	return nil
 }
 
-// resolveToTitle determines the ID type and resolves it to a Wikipedia article title.
-func (a *Adapter) resolveToTitle(ctx context.Context, id string) (string, error) {
+// resolveToTitleAndQID determines the ID type and resolves it to (enwiki title, Q-ID).
+// The Q-ID is returned when available so that callers can later look up localized
+// sitelinks for other languages. For plain article-title inputs the Q-ID is "".
+func (a *Adapter) resolveToTitleAndQID(ctx context.Context, id string) (string, string, error) {
 	switch {
 	case provider.IsUUID(id):
 		if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
-			return "", &provider.ErrProviderUnavailable{
+			return "", "", &provider.ErrProviderUnavailable{
 				Provider: provider.NameWikipedia,
 				Cause:    fmt.Errorf("rate limiter: %w", err),
 			}
@@ -352,17 +411,44 @@ func (a *Adapter) resolveToTitle(ctx context.Context, id string) (string, error)
 
 	case isQID(id):
 		if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
-			return "", &provider.ErrProviderUnavailable{
+			return "", "", &provider.ErrProviderUnavailable{
 				Provider: provider.NameWikipedia,
 				Cause:    fmt.Errorf("rate limiter: %w", err),
 			}
 		}
-		return a.resolveFromQID(ctx, id)
+		title, err := a.resolveFromQID(ctx, id)
+		if err != nil {
+			return "", "", err
+		}
+		return title, strings.ToUpper(id), nil
 
 	default:
-		// Treat as a Wikipedia article title directly.
-		return id, nil
+		// Treat as a Wikipedia article title directly. No Q-ID available.
+		return id, "", nil
 	}
+}
+
+// orderedLanguages builds the language list to attempt. It normalizes each
+// preference to a 2- or 3-letter lowercase code, removes duplicates while
+// preserving order, and guarantees "en" appears as a final fallback.
+func orderedLanguages(prefs []string) []string {
+	seen := make(map[string]struct{}, len(prefs)+1)
+	out := make([]string, 0, len(prefs)+1)
+	for _, p := range prefs {
+		base := strings.SplitN(strings.ToLower(strings.TrimSpace(p)), "-", 2)[0]
+		if len(base) != 2 && len(base) != 3 {
+			continue
+		}
+		if _, ok := seen[base]; ok {
+			continue
+		}
+		seen[base] = struct{}{}
+		out = append(out, base)
+	}
+	if _, ok := seen["en"]; !ok {
+		out = append(out, "en")
+	}
+	return out
 }
 
 // isQID returns true if id looks like a Wikidata Q-ID (e.g. "Q44190").
@@ -379,9 +465,11 @@ func isQID(id string) bool {
 }
 
 // resolveFromMBID uses a Wikidata SPARQL query to find the English Wikipedia
-// article title for an artist identified by MusicBrainz ID.
-func (a *Adapter) resolveFromMBID(ctx context.Context, mbid string) (string, error) {
-	query := fmt.Sprintf(`SELECT ?article WHERE {
+// article title and Wikidata Q-ID for an artist identified by MusicBrainz ID.
+// The Q-ID is extracted from the bound ?item URI so that callers can look up
+// localized sitelinks for other languages.
+func (a *Adapter) resolveFromMBID(ctx context.Context, mbid string) (string, string, error) {
+	query := fmt.Sprintf(`SELECT ?item ?article WHERE {
   ?item wdt:P434 "%s" .
   ?article schema:about ?item ;
            schema:isPartOf <https://en.wikipedia.org/> .
@@ -395,7 +483,7 @@ func (a *Adapter) resolveFromMBID(ctx context.Context, mbid string) (string, err
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
-		return "", &provider.ErrProviderUnavailable{
+		return "", "", &provider.ErrProviderUnavailable{
 			Provider: provider.NameWikipedia,
 			Cause:    fmt.Errorf("creating SPARQL request: %w", err),
 		}
@@ -406,6 +494,97 @@ func (a *Adapter) resolveFromMBID(ctx context.Context, mbid string) (string, err
 	a.logger.Debug("resolving MBID to Wikipedia title via Wikidata", slog.String("mbid", mbid))
 
 	resp, err := a.client.Do(req) //nolint:gosec // URL constructed from trusted SPARQL endpoint
+	if err != nil {
+		return "", "", &provider.ErrProviderUnavailable{
+			Provider: provider.NameWikipedia,
+			Cause:    err,
+		}
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return "", "", &provider.ErrProviderUnavailable{
+			Provider: provider.NameWikipedia,
+			Cause:    fmt.Errorf("wikidata SPARQL HTTP %d", resp.StatusCode),
+		}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if err != nil {
+		return "", "", &provider.ErrProviderUnavailable{
+			Provider: provider.NameWikipedia,
+			Cause:    fmt.Errorf("reading SPARQL response: %w", err),
+		}
+	}
+
+	var sparql sparqlResponse
+	if err := json.Unmarshal(body, &sparql); err != nil {
+		return "", "", &provider.ErrProviderUnavailable{
+			Provider: provider.NameWikipedia,
+			Cause:    fmt.Errorf("parsing SPARQL response: %w", err),
+		}
+	}
+
+	if len(sparql.Results.Bindings) == 0 {
+		return "", "", &provider.ErrNotFound{Provider: provider.NameWikipedia, ID: mbid}
+	}
+
+	title, err := extractArticleTitle(sparql.Results.Bindings[0].Article.Value, mbid, a.logger)
+	if err != nil {
+		return "", "", err
+	}
+	qid := extractQID(sparql.Results.Bindings[0].Item.Value)
+	return title, qid, nil
+}
+
+// extractQID pulls the Q-ID out of a Wikidata entity URI such as
+// "http://www.wikidata.org/entity/Q44190". Returns "" if the URI does not
+// contain a recognizable Q-ID suffix. An empty result is not fatal; callers
+// simply skip localized sitelink lookups when the Q-ID is unknown.
+func extractQID(entityURI string) string {
+	if entityURI == "" {
+		return ""
+	}
+	// Take the segment after the last '/'.
+	idx := strings.LastIndex(entityURI, "/")
+	if idx < 0 || idx == len(entityURI)-1 {
+		return ""
+	}
+	tail := entityURI[idx+1:]
+	if !isQID(tail) {
+		return ""
+	}
+	return strings.ToUpper(tail)
+}
+
+// resolveToLocalizedTitle looks up the Wikipedia article title for the given
+// Q-ID on a specific language wiki via Wikidata sitelinks. Returns
+// provider.ErrNotFound when no sitelink exists for that language.
+func (a *Adapter) resolveToLocalizedTitle(ctx context.Context, qid, lang string) (string, error) {
+	site := lang + "wiki"
+	params := url.Values{
+		"action":     {"wbgetentities"},
+		"ids":        {strings.ToUpper(qid)},
+		"props":      {"sitelinks"},
+		"sitefilter": {site},
+		"format":     {"json"},
+	}
+	reqURL := a.wikidataAPIEndpoint + "?" + params.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return "", &provider.ErrProviderUnavailable{
+			Provider: provider.NameWikipedia,
+			Cause:    fmt.Errorf("creating Wikidata API request: %w", err),
+		}
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	a.logger.Debug("resolving localized Wikipedia title via Wikidata sitelinks",
+		slog.String("qid", qid), slog.String("lang", lang))
+
+	resp, err := a.client.Do(req) //nolint:gosec // URL constructed from trusted Wikidata endpoint
 	if err != nil {
 		return "", &provider.ErrProviderUnavailable{
 			Provider: provider.NameWikipedia,
@@ -418,7 +597,7 @@ func (a *Adapter) resolveFromMBID(ctx context.Context, mbid string) (string, err
 		_, _ = io.Copy(io.Discard, resp.Body)
 		return "", &provider.ErrProviderUnavailable{
 			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("wikidata SPARQL HTTP %d", resp.StatusCode),
+			Cause:    fmt.Errorf("wikidata API HTTP %d", resp.StatusCode),
 		}
 	}
 
@@ -426,23 +605,29 @@ func (a *Adapter) resolveFromMBID(ctx context.Context, mbid string) (string, err
 	if err != nil {
 		return "", &provider.ErrProviderUnavailable{
 			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("reading SPARQL response: %w", err),
+			Cause:    fmt.Errorf("reading Wikidata API response: %w", err),
 		}
 	}
 
-	var sparql sparqlResponse
-	if err := json.Unmarshal(body, &sparql); err != nil {
+	var wbResp wbEntityResponse
+	if err := json.Unmarshal(body, &wbResp); err != nil {
 		return "", &provider.ErrProviderUnavailable{
 			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("parsing SPARQL response: %w", err),
+			Cause:    fmt.Errorf("parsing Wikidata API response: %w", err),
 		}
 	}
 
-	if len(sparql.Results.Bindings) == 0 {
-		return "", &provider.ErrNotFound{Provider: provider.NameWikipedia, ID: mbid}
+	upperQID := strings.ToUpper(qid)
+	entity, ok := wbResp.Entities[upperQID]
+	if !ok {
+		return "", &provider.ErrNotFound{Provider: provider.NameWikipedia, ID: qid}
 	}
 
-	return extractArticleTitle(sparql.Results.Bindings[0].Article.Value, mbid, a.logger)
+	link, ok := entity.Sitelinks[site]
+	if !ok || link.Title == "" {
+		return "", &provider.ErrNotFound{Provider: provider.NameWikipedia, ID: qid}
+	}
+	return link.Title, nil
 }
 
 // resolveFromQID uses the Wikidata entity API to resolve a Q-ID to a

--- a/internal/provider/wikipedia/wikipedia.go
+++ b/internal/provider/wikipedia/wikipedia.go
@@ -97,6 +97,11 @@ func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSe
 // preference list; if the user has explicitly placed "en" earlier, it
 // is tried in that position rather than last.
 func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, &provider.ErrNotFound{Provider: provider.NameWikipedia, ID: id}
+	}
+
 	// Resolve the input ID to an English-wiki title and, when possible, a
 	// Wikidata Q-ID that we can use to look up localized sitelinks.
 	enTitle, qid, err := a.resolveToTitleAndQID(ctx, id)

--- a/internal/provider/wikipedia/wikipedia.go
+++ b/internal/provider/wikipedia/wikipedia.go
@@ -93,7 +93,9 @@ func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSe
 // fetches the extract from that language's Wikipedia. The first language
 // that returns a real article wins; missing articles, not-found responses,
 // and empty extracts cause a graceful fall-through to the next language.
-// English is always tried last as a final fallback.
+// English is appended as a fallback when not already present in the
+// preference list; if the user has explicitly placed "en" earlier, it
+// is tried in that position rather than last.
 func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
 	// Resolve the input ID to an English-wiki title and, when possible, a
 	// Wikidata Q-ID that we can use to look up localized sitelinks.
@@ -432,15 +434,13 @@ func (a *Adapter) resolveToTitleAndQID(ctx context.Context, id string) (string, 
 // preference to a 2- or 3-letter lowercase code, removes duplicates while
 // preserving order, and appends "en" at the end if not already present.
 func orderedLanguages(prefs []string) []string {
-	// Cap the preallocation hint to a sane upper bound. Language preference
-	// lists are tiny in practice; the explicit cap also silences CodeQL's
-	// "size computation may overflow" warning on len(prefs)+1.
-	n := len(prefs)
-	if n > 256 {
-		n = 256
-	}
-	seen := make(map[string]struct{}, n+1)
-	out := make([]string, 0, n+1)
+	// Use a small literal preallocation hint. Language preference lists are
+	// tiny in practice (typically 1-5 entries), so the slice will rarely need
+	// to grow. Avoiding any arithmetic on len(prefs) also keeps CodeQL's
+	// "size computation may overflow" rule satisfied.
+	const initialHint = 8
+	seen := make(map[string]struct{}, initialHint)
+	out := make([]string, 0, initialHint)
 	for _, p := range prefs {
 		base := strings.SplitN(strings.ToLower(strings.TrimSpace(p)), "-", 2)[0]
 		if len(base) != 2 && len(base) != 3 {

--- a/internal/provider/wikipedia/wikipedia_test.go
+++ b/internal/provider/wikipedia/wikipedia_test.go
@@ -39,21 +39,33 @@ func newTestAdapter(t *testing.T, actionURL, sparqlURL, wikidataAPIURL string) *
 
 func sparqlServerReturning(t *testing.T, articleURL string) *httptest.Server {
 	t.Helper()
+	return sparqlServerReturningWithItem(t, articleURL, "")
+}
+
+// sparqlServerReturningWithItem returns a SPARQL stub that includes both the
+// article URL and the Wikidata item URI (used to derive the Q-ID).
+func sparqlServerReturningWithItem(t *testing.T, articleURL, itemURI string) *httptest.Server {
+	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := sparqlResponse{}
+		// Build the response using a raw JSON literal so the test does not
+		// depend on the exact anonymous struct shape of sparqlResponse.
+		type binding struct {
+			Item    map[string]string `json:"item,omitempty"`
+			Article map[string]string `json:"article,omitempty"`
+		}
+		var bindings []binding
 		if articleURL != "" {
-			resp.Results.Bindings = append(resp.Results.Bindings, struct {
-				Article struct {
-					Value string `json:"value"`
-				} `json:"article"`
-			}{
-				Article: struct {
-					Value string `json:"value"`
-				}{Value: articleURL},
-			})
+			b := binding{Article: map[string]string{"value": articleURL}}
+			if itemURI != "" {
+				b.Item = map[string]string{"value": itemURI}
+			}
+			bindings = append(bindings, b)
+		}
+		payload := map[string]any{
+			"results": map[string]any{"bindings": bindings},
 		}
 		w.Header().Set("Content-Type", "application/sparql-results+json")
-		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+		json.NewEncoder(w).Encode(payload) //nolint:errcheck
 	}))
 }
 
@@ -747,6 +759,274 @@ func TestGetImages_ReturnsNil(t *testing.T) {
 	}
 	if results != nil {
 		t.Errorf("GetImages: expected nil, got %v", results)
+	}
+}
+
+// --- Language walk tests (issue #967) ---
+
+// langWalkFixture wires up a mock Wikidata entity API + one mock action API
+// per language so the GetArtist language-walk logic can be tested end-to-end.
+type langWalkFixture struct {
+	sparql  *httptest.Server
+	entity  *httptest.Server
+	actions map[string]*httptest.Server // keyed by lang code
+}
+
+func (f *langWalkFixture) close() {
+	if f.sparql != nil {
+		f.sparql.Close()
+	}
+	if f.entity != nil {
+		f.entity.Close()
+	}
+	for _, s := range f.actions {
+		s.Close()
+	}
+}
+
+// newLangWalkAdapter builds an adapter whose actionEndpointForLang rewrites to
+// per-language mock action servers. Because the real actionEndpointForLang only
+// rewrites when the adapter was constructed with the default production
+// endpoint, we install a custom helper via a small subclass approach: we make
+// the default action server route requests based on the Host header the test
+// sets. Simpler: point the adapter's actionEndpoint at a dispatcher that
+// chooses the backend using a `lang` query parameter we inject.
+//
+// We take the simpler route of invoking the adapter with the language-prefix
+// URL directly by teaching actionEndpointForLang via a per-test override: we
+// install the dispatcher as actionEndpoint and give each mock server a path
+// prefix that identifies the lang. The dispatcher reads the request Host or
+// path and proxies accordingly.
+//
+// In practice, the easiest approach is to construct per-language action
+// endpoints with distinct URLs and rely on the custom-endpoint branch of
+// actionEndpointForLang returning a single URL. To allow multiple backends
+// while using the default branch, we instead start one httptest server whose
+// handler dispatches based on a "titles" query containing a lang marker.
+//
+// To keep tests readable we simply run one dispatcher server whose handler
+// looks at an X-Test-Lang header. Since adapter code does not set such a
+// header, we encode the lang into the title by prefixing it ("ja:Title")
+// only in the sitelink response, so the dispatcher can route by title prefix.
+// That works because Wikidata sitelinks are whatever Wikidata says they are,
+// and the adapter passes them verbatim to the action API.
+func buildLangWalkAdapter(t *testing.T, perLangExtracts map[string]string, enTitle, qid string) (*Adapter, *langWalkFixture) {
+	t.Helper()
+	// One dispatcher action server that returns extract based on title prefix.
+	actionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		action := r.URL.Query().Get("action")
+		title := r.URL.Query().Get("titles")
+		if action == "parse" {
+			title = r.URL.Query().Get("page")
+		}
+		// Determine lang by title prefix "lang::" or default to en for bare enTitle.
+		lang := "en"
+		articleTitle := title
+		if idx := strings.Index(title, "::"); idx > 0 {
+			lang = title[:idx]
+			articleTitle = title[idx+2:]
+		}
+		switch action {
+		case "query":
+			extract := perLangExtracts[lang]
+			resp := extractResponse{}
+			if extract == "__notfound__" {
+				resp.Query.Pages = map[string]extractPage{"-1": {}}
+			} else {
+				resp.Query.Pages = map[string]extractPage{
+					"42": {PageID: 42, Title: articleTitle, Extract: extract},
+				}
+			}
+			json.NewEncoder(w).Encode(resp) //nolint:errcheck
+		case "parse":
+			// Return empty wikitext.
+			resp := parseResponse{}
+			json.NewEncoder(w).Encode(resp) //nolint:errcheck
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+
+	// Wikidata entity server: return sitelinks keyed by "{lang}wiki".
+	entitySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		site := r.URL.Query().Get("sitefilter")
+		resp := wbEntityResponse{Entities: map[string]wbEntity{
+			qid: {Sitelinks: map[string]wbSitelink{}},
+		}}
+		// Only include the sitelink if a lang-specific extract is configured.
+		if strings.HasSuffix(site, "wiki") && site != "" {
+			lang := strings.TrimSuffix(site, "wiki")
+			if _, ok := perLangExtracts[lang]; ok {
+				resp.Entities[qid].Sitelinks[site] = wbSitelink{Title: lang + "::LocalTitle"}
+			}
+		}
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}))
+
+	sparqlSrv := sparqlServerReturningWithItem(t,
+		"https://en.wikipedia.org/wiki/"+enTitle,
+		"https://www.wikidata.org/entity/"+qid)
+
+	adapter := newTestAdapter(t, actionSrv.URL, sparqlSrv.URL, entitySrv.URL)
+	return adapter, &langWalkFixture{
+		sparql: sparqlSrv,
+		entity: entitySrv,
+		actions: map[string]*httptest.Server{
+			"dispatcher": actionSrv,
+		},
+	}
+}
+
+func TestGetArtist_LangWalk(t *testing.T) {
+	mbid := "a74b1b7f-71a5-4011-9441-d0b5e4122711"
+
+	tests := []struct {
+		name          string
+		prefs         []string
+		extracts      map[string]string // lang -> extract (or "__notfound__" for -1 page)
+		wantBioPrefix string
+		wantErr       bool
+	}{
+		{
+			name:          "hit on first preference",
+			prefs:         []string{"ja", "de", "en"},
+			extracts:      map[string]string{"ja": "Japanese biography.", "en": "English biography."},
+			wantBioPrefix: "Japanese biography",
+		},
+		{
+			name:          "fall through to second preference",
+			prefs:         []string{"ja", "de", "en"},
+			extracts:      map[string]string{"de": "German biography.", "en": "English biography."},
+			wantBioPrefix: "German biography",
+		},
+		{
+			name:          "fall through to English fallback",
+			prefs:         []string{"ja", "de"},
+			extracts:      map[string]string{"en": "English biography."},
+			wantBioPrefix: "English biography",
+		},
+		{
+			name:     "all languages miss",
+			prefs:    []string{"ja", "de"},
+			extracts: map[string]string{"en": "__notfound__"},
+			wantErr:  true,
+		},
+		{
+			name:          "no prefs uses English only",
+			prefs:         nil,
+			extracts:      map[string]string{"en": "English biography."},
+			wantBioPrefix: "English biography",
+		},
+		{
+			name:          "duplicate and empty prefs are normalized",
+			prefs:         []string{"ja-JP", "ja", "", "en-US"},
+			extracts:      map[string]string{"ja": "Japanese biography.", "en": "English biography."},
+			wantBioPrefix: "Japanese biography",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter, fx := buildLangWalkAdapter(t, tt.extracts, "Test_Artist", "Q12345")
+			defer fx.close()
+
+			ctx := context.Background()
+			if tt.prefs != nil {
+				ctx = provider.WithMetadataLanguages(ctx, tt.prefs)
+			}
+			meta, err := adapter.GetArtist(ctx, mbid)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got meta=%+v", meta)
+				}
+				var notFound *provider.ErrNotFound
+				if !errors.As(err, &notFound) {
+					t.Errorf("expected ErrNotFound after walking all languages, got %T: %v", err, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetArtist: %v", err)
+			}
+			if !strings.HasPrefix(meta.Biography, tt.wantBioPrefix) {
+				t.Errorf("Biography = %q, want prefix %q", meta.Biography, tt.wantBioPrefix)
+			}
+		})
+	}
+}
+
+// TestGetArtist_LangWalk_RateLimitedContext verifies that a canceled context
+// mid-walk surfaces as an ErrProviderUnavailable wrapping the cancellation
+// error (the rate limiter returns ctx.Err()).
+func TestGetArtist_LangWalk_RateLimitedContext(t *testing.T) {
+	mbid := "a74b1b7f-71a5-4011-9441-d0b5e4122711"
+	adapter, fx := buildLangWalkAdapter(t,
+		map[string]string{"en": "English biography."},
+		"Test_Artist", "Q12345")
+	defer fx.close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = provider.WithMetadataLanguages(ctx, []string{"ja", "de", "en"})
+	cancel() // pre-cancel; the first limiter.Wait will return immediately.
+
+	_, err := adapter.GetArtist(ctx, mbid)
+	if err == nil {
+		t.Fatal("expected error from canceled context")
+	}
+	// Either provider.ErrProviderUnavailable (wrapping ctx.Err) or ctx.Err itself is acceptable.
+	if !errors.Is(err, context.Canceled) {
+		var unavail *provider.ErrProviderUnavailable
+		if !errors.As(err, &unavail) {
+			t.Errorf("expected context.Canceled or ErrProviderUnavailable, got %T: %v", err, err)
+		}
+	}
+}
+
+func TestOrderedLanguages(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil prefs yields en only", nil, []string{"en"}},
+		{"single non-en adds en fallback", []string{"ja"}, []string{"ja", "en"}},
+		{"explicit en stays sole", []string{"en"}, []string{"en"}},
+		{"prefs preserved in order", []string{"ja", "de", "fr"}, []string{"ja", "de", "fr", "en"}},
+		{"duplicates removed", []string{"ja", "ja", "de"}, []string{"ja", "de", "en"}},
+		{"locale tags trimmed", []string{"ja-JP", "de-DE"}, []string{"ja", "de", "en"}},
+		{"invalid entries skipped", []string{"zzzz", "x", "ja"}, []string{"ja", "en"}},
+		{"whitespace trimmed", []string{"  ja ", "de"}, []string{"ja", "de", "en"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := orderedLanguages(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("orderedLanguages(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("orderedLanguages(%v) = %v, want %v", tt.in, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractQID(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"http://www.wikidata.org/entity/Q44190", "Q44190"},
+		{"https://www.wikidata.org/entity/Q1", "Q1"},
+		{"https://www.wikidata.org/entity/q7", "Q7"},
+		{"", ""},
+		{"https://www.wikidata.org/entity/", ""},
+		{"https://www.wikidata.org/entity/NotAQID", ""},
+	}
+	for _, tt := range tests {
+		if got := extractQID(tt.in); got != tt.want {
+			t.Errorf("extractQID(%q) = %q, want %q", tt.in, got, tt.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Wikipedia provider now iterates the full ordered metadata language preference list via Wikidata sitelinks; first hit wins, `en` is guaranteed as final fallback
- Each language attempt respects the existing rate limiter; misses (no sitelink, 404, empty extract) log at debug and fall through

Closes #967

## Test plan
- [x] `go test -race ./internal/provider/wikipedia/...`
- [x] `bash scripts/pre-push-gate.sh`
- [x] Manual UAT: with prefs `[ja, de, en]` on a Japanese-only band, biography returns Japanese; with `[de, ja, en]` same band falls through `de` to `ja` instead of jumping to `en`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Artist lookup now captures linked Wikidata entity IDs and uses them to fetch localized Wikipedia titles, walking a preferred-language list with guaranteed English fallback to improve biography selection across locales.

* **Tests**
  * Expanded end-to-end and unit tests covering multi-language resolution, language-order normalization, entity-ID extraction, and error handling (including cancellation/rate-limit scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->