### PR TITLE
feat(musicbrainz): localize band member names from preferred-language aliases (#964)

### DIFF
--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -127,7 +127,115 @@ func (a *Adapter) GetArtist(ctx context.Context, mbid string) (*provider.ArtistM
 		return nil, fmt.Errorf("parsing artist response: %w", err)
 	}
 
-	return a.mapArtist(ctx, &artist), nil
+	meta := a.mapArtist(ctx, &artist)
+
+	// Localize member names from each member's primary aliases when the user
+	// has set metadata language preferences. MusicBrainz omits aliases from
+	// embedded relation artists, so a per-member lookup is required. Failures
+	// are logged and the canonical (non-localized) name is retained so a single
+	// member fetch error cannot block the artist refresh.
+	if langPrefs := provider.MetadataLanguages(ctx); len(langPrefs) > 0 && len(meta.Members) > 0 {
+		a.localizeMembers(ctx, meta.Members, langPrefs, newMemberAliasCache())
+	}
+
+	return meta, nil
+}
+
+// memberAliasCache is an in-memory, per-request cache of member MBID to
+// fetched aliases. It avoids refetching the same member when the same MBID
+// appears across multiple code paths during a single artist refresh.
+type memberAliasCache struct {
+	entries map[string][]MBAlias
+}
+
+func newMemberAliasCache() *memberAliasCache {
+	return &memberAliasCache{entries: make(map[string][]MBAlias)}
+}
+
+// localizeMembers promotes each member's name to its best-matching primary
+// alias for the configured language preferences. Members without an MBID, or
+// whose alias fetch fails, retain their canonical name. The shared rate
+// limiter ensures MusicBrainz's 1 req/sec policy is honored even when many
+// members are resolved in sequence.
+func (a *Adapter) localizeMembers(ctx context.Context, members []provider.MemberInfo, langPrefs []string, cache *memberAliasCache) {
+	for i := range members {
+		m := &members[i]
+		mbid := m.MBID
+		if mbid == "" {
+			continue
+		}
+
+		aliases, cached := cache.entries[mbid]
+		if !cached {
+			fetched, err := a.fetchMemberAliases(ctx, mbid)
+			if err != nil {
+				a.logger.Warn("member alias fetch failed; retaining canonical name",
+					slog.String("member_mbid", mbid),
+					slog.String("member_name", m.Name),
+					slog.Any("err", err))
+				// Cache the failure as an empty slice so repeated members with
+				// the same MBID do not trigger redundant fetches.
+				cache.entries[mbid] = nil
+				continue
+			}
+			cache.entries[mbid] = fetched
+			aliases = fetched
+		}
+
+		if len(aliases) == 0 {
+			continue
+		}
+
+		bestScore := -1
+		var bestAlias MBAlias
+		for _, al := range aliases {
+			if al.Name == "" || !al.Primary {
+				continue
+			}
+			score := provider.MatchLanguagePreference(al.Locale, langPrefs)
+			if score >= 0 && (bestScore < 0 || score < bestScore) {
+				bestScore = score
+				bestAlias = al
+			}
+		}
+		if bestScore < 0 {
+			continue
+		}
+		promoted := normalizeHyphens(bestAlias.Name)
+		if promoted == "" || promoted == m.Name {
+			continue
+		}
+		a.logger.Debug("promoting localized member name",
+			slog.String("from", m.Name),
+			slog.String("to", promoted),
+			slog.String("locale", bestAlias.Locale))
+		m.Name = promoted
+	}
+}
+
+// fetchMemberAliases retrieves only the alias list for a given member MBID.
+// Uses the shared rate-limited doRequest path so the MusicBrainz 1 req/sec
+// policy is enforced across all provider traffic.
+func (a *Adapter) fetchMemberAliases(ctx context.Context, mbid string) ([]MBAlias, error) {
+	params := url.Values{
+		"inc": {"aliases"},
+		"fmt": {"json"},
+	}
+	a.mu.RLock()
+	base := a.baseURL
+	a.mu.RUnlock()
+	reqURL := base + "/artist/" + url.PathEscape(mbid) + "?" + params.Encode()
+
+	body, err := a.doRequest(ctx, reqURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp MBArtist
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parsing member alias response: %w", err)
+	}
+	return resp.Aliases, nil
 }
 
 // GetImages returns nil since MusicBrainz does not host artist images.

--- a/internal/provider/musicbrainz/musicbrainz_test.go
+++ b/internal/provider/musicbrainz/musicbrainz_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/provider"
 )
@@ -45,6 +46,22 @@ func newTestServer(t *testing.T) *httptest.Server {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
+			// Member alias lookups return per-member fixtures so tests can
+			// verify localization behavior without mocking a second server.
+			switch mbid {
+			case "8bfac288-ccc5-448d-9573-c33ea2aa5c30":
+				w.Write(loadFixture(t, "member_thom_yorke.json"))
+				return
+			case "member-002":
+				w.Write(loadFixture(t, "member_jonny_greenwood.json"))
+				return
+			case "member-003":
+				w.Write(loadFixture(t, "member_no_aliases.json"))
+				return
+			case "member-error":
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
 			w.Write(loadFixture(t, "artist_radiohead.json"))
 
 		case r.URL.Path == "/release-group" && r.URL.Query().Get("artist") != "":
@@ -64,6 +81,9 @@ func newTestServer(t *testing.T) *httptest.Server {
 func newTestAdapter(t *testing.T, baseURL string) *Adapter {
 	t.Helper()
 	limiter := provider.NewRateLimiterMap()
+	// Tests use a high rate to avoid the real 1 req/sec MusicBrainz pacing.
+	// Production uses the default limiter; see internal/provider/ratelimit.go.
+	limiter.SetLimit(provider.NameMusicBrainz, 1000)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	return NewWithBaseURL(limiter, logger, baseURL)
 }
@@ -1072,5 +1092,225 @@ func TestMergeDateRanges_NilAndEmpty(t *testing.T) {
 	e2, l2 := mergeDateRanges([][2]string{})
 	if e2 != "" || l2 != "" {
 		t.Errorf("empty input: expected both empty, got %q %q", e2, l2)
+	}
+}
+
+// --- #964: member name localization via MusicBrainz aliases ---
+
+// TestGetArtist_MemberNamePromotion drives member alias localization through
+// GetArtist, verifying each table case from the issue: language match,
+// no-match fallback, cache-hit behavior, and fetch failure tolerance.
+func TestGetArtist_MemberNamePromotion(t *testing.T) {
+	tests := []struct {
+		name      string
+		langs     []string
+		wantThom  string
+		wantJonny string
+		wantColin string
+	}{
+		{
+			name:      "JapanesePreferenceLocalizesMembers",
+			langs:     []string{"ja"},
+			wantThom:  "トム・ヨーク",
+			wantJonny: "ジョニー・グリーンウッド",
+			// Colin has no aliases, so his canonical name is retained.
+			wantColin: "Colin Greenwood",
+		},
+		{
+			name:      "UnmatchedPreferenceKeepsCanonicalName",
+			langs:     []string{"de"},
+			wantThom:  "Thom Yorke",
+			wantJonny: "Jonny Greenwood",
+			wantColin: "Colin Greenwood",
+		},
+		{
+			name:      "NoPreferencesSkipsMemberFetch",
+			langs:     nil,
+			wantThom:  "Thom Yorke",
+			wantJonny: "Jonny Greenwood",
+			wantColin: "Colin Greenwood",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newTestServer(t)
+			defer srv.Close()
+			a := newTestAdapter(t, srv.URL)
+
+			ctx := context.Background()
+			if len(tc.langs) > 0 {
+				ctx = provider.WithMetadataLanguages(ctx, tc.langs)
+			}
+
+			meta, err := a.GetArtist(ctx, "a74b1b7f-71a5-4011-9441-d0b5e4122711")
+			if err != nil {
+				t.Fatalf("GetArtist: %v", err)
+			}
+
+			byMBID := make(map[string]string, len(meta.Members))
+			for _, m := range meta.Members {
+				byMBID[m.MBID] = m.Name
+			}
+
+			if got := byMBID["8bfac288-ccc5-448d-9573-c33ea2aa5c30"]; got != tc.wantThom {
+				t.Errorf("Thom Yorke: got %q, want %q", got, tc.wantThom)
+			}
+			if got := byMBID["member-002"]; got != tc.wantJonny {
+				t.Errorf("Jonny Greenwood: got %q, want %q", got, tc.wantJonny)
+			}
+			if got := byMBID["member-003"]; got != tc.wantColin {
+				t.Errorf("Colin Greenwood: got %q, want %q", got, tc.wantColin)
+			}
+		})
+	}
+}
+
+// TestGetArtist_MemberAliasFetchFailureFallsBack verifies that a per-member
+// upstream failure does not block the overall artist refresh and that the
+// member retains the canonical (non-localized) name returned in the primary
+// artist payload.
+func TestGetArtist_MemberAliasFetchFailureFallsBack(t *testing.T) {
+	// Serve a custom artist payload that includes a member whose MBID always
+	// returns 503. The rest of the artist should still localize where it can.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		mbid := strings.TrimPrefix(r.URL.Path, "/artist/")
+		switch mbid {
+		case "main-artist":
+			w.Write([]byte(`{
+				"id": "main-artist",
+				"type": "Group",
+				"name": "Test Band",
+				"sort-name": "Test Band",
+				"relations": [
+					{"type": "member of band", "target-type": "artist", "direction": "backward",
+					 "artist": {"id": "member-error", "name": "Broken Member", "sort-name": "Member, Broken", "type": "Person"}},
+					{"type": "member of band", "target-type": "artist", "direction": "backward",
+					 "artist": {"id": "8bfac288-ccc5-448d-9573-c33ea2aa5c30", "name": "Thom Yorke", "sort-name": "Yorke, Thom", "type": "Person"}}
+				]
+			}`))
+		case "member-error":
+			w.WriteHeader(http.StatusServiceUnavailable)
+		case "8bfac288-ccc5-448d-9573-c33ea2aa5c30":
+			w.Write(loadFixture(t, "member_thom_yorke.json"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	ctx := provider.WithMetadataLanguages(context.Background(), []string{"ja"})
+
+	meta, err := a.GetArtist(ctx, "main-artist")
+	if err != nil {
+		t.Fatalf("GetArtist should not fail because one member alias fetch failed: %v", err)
+	}
+	if len(meta.Members) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(meta.Members))
+	}
+
+	var broken, thom string
+	for _, m := range meta.Members {
+		switch m.MBID {
+		case "member-error":
+			broken = m.Name
+		case "8bfac288-ccc5-448d-9573-c33ea2aa5c30":
+			thom = m.Name
+		}
+	}
+	if broken != "Broken Member" {
+		t.Errorf("broken member: expected canonical name retained, got %q", broken)
+	}
+	if thom != "トム・ヨーク" {
+		t.Errorf("good member: expected Japanese promotion, got %q", thom)
+	}
+}
+
+// TestLocalizeMembers_CacheAvoidsRefetch verifies the per-request cache
+// prevents redundant upstream calls when the same member MBID appears more
+// than once in a single refresh.
+func TestLocalizeMembers_CacheAvoidsRefetch(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(loadFixture(t, "member_thom_yorke.json"))
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	ctx := provider.WithMetadataLanguages(context.Background(), []string{"ja"})
+
+	members := []provider.MemberInfo{
+		{MBID: "8bfac288-ccc5-448d-9573-c33ea2aa5c30", Name: "Thom Yorke"},
+		{MBID: "8bfac288-ccc5-448d-9573-c33ea2aa5c30", Name: "Thom Yorke"},
+		{MBID: "8bfac288-ccc5-448d-9573-c33ea2aa5c30", Name: "Thom Yorke"},
+	}
+	a.localizeMembers(ctx, members, []string{"ja"}, newMemberAliasCache())
+
+	if hits != 1 {
+		t.Errorf("expected exactly 1 upstream fetch due to cache, got %d", hits)
+	}
+	for _, m := range members {
+		if m.Name != "トム・ヨーク" {
+			t.Errorf("expected all members localized, got %q", m.Name)
+		}
+	}
+}
+
+// TestLocalizeMembers_RateLimiterIsInvoked ensures the member-alias path
+// routes through the shared rate limiter. We install a 1 req/sec limiter
+// and verify two sequential lookups take at least ~1 second in aggregate.
+func TestLocalizeMembers_RateLimiterIsInvoked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(loadFixture(t, "member_thom_yorke.json"))
+	}))
+	defer srv.Close()
+
+	limiter := provider.NewRateLimiterMap()
+	// Real MB production rate; burst 1 means the second call waits ~1 second.
+	limiter.SetLimit(provider.NameMusicBrainz, 1)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	a := NewWithBaseURL(limiter, logger, srv.URL)
+
+	ctx := provider.WithMetadataLanguages(context.Background(), []string{"ja"})
+	members := []provider.MemberInfo{
+		{MBID: "mbid-a", Name: "A"},
+		{MBID: "mbid-b", Name: "B"},
+	}
+
+	start := time.Now()
+	a.localizeMembers(ctx, members, []string{"ja"}, newMemberAliasCache())
+	elapsed := time.Since(start)
+
+	// Two distinct MBIDs; burst=1 means the second Wait blocks ~1s. Allow
+	// some slack for CI. If the limiter were bypassed this would be ms-scale.
+	if elapsed < 800*time.Millisecond {
+		t.Errorf("expected rate-limited sequential fetch (>=800ms), got %v", elapsed)
+	}
+}
+
+// TestLocalizeMembers_PreservesNonMBIDMembers asserts that members without
+// an MBID (user-added entries that have not been matched to MusicBrainz)
+// keep whatever name they arrived with. Localization only runs for members
+// whose MBID can be resolved upstream.
+func TestLocalizeMembers_PreservesNonMBIDMembers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("no upstream fetch expected for member without MBID, but got request %q", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	members := []provider.MemberInfo{
+		{MBID: "", Name: "Custom Manual Entry"},
+	}
+	a.localizeMembers(context.Background(), members, []string{"ja"}, newMemberAliasCache())
+
+	if members[0].Name != "Custom Manual Entry" {
+		t.Errorf("expected user-added member name preserved, got %q", members[0].Name)
 	}
 }

--- a/internal/provider/musicbrainz/testdata/member_jonny_greenwood.json
+++ b/internal/provider/musicbrainz/testdata/member_jonny_greenwood.json
@@ -1,0 +1,15 @@
+{
+  "id": "member-002",
+  "type": "Person",
+  "name": "Jonny Greenwood",
+  "sort-name": "Greenwood, Jonny",
+  "aliases": [
+    {
+      "name": "ジョニー・グリーンウッド",
+      "sort-name": "ジョニー・グリーンウッド",
+      "type": "Artist name",
+      "locale": "ja",
+      "primary": true
+    }
+  ]
+}

--- a/internal/provider/musicbrainz/testdata/member_no_aliases.json
+++ b/internal/provider/musicbrainz/testdata/member_no_aliases.json
@@ -1,0 +1,7 @@
+{
+  "id": "member-003",
+  "type": "Person",
+  "name": "Colin Greenwood",
+  "sort-name": "Greenwood, Colin",
+  "aliases": []
+}

--- a/internal/provider/musicbrainz/testdata/member_thom_yorke.json
+++ b/internal/provider/musicbrainz/testdata/member_thom_yorke.json
@@ -1,0 +1,22 @@
+{
+  "id": "8bfac288-ccc5-448d-9573-c33ea2aa5c30",
+  "type": "Person",
+  "name": "Thom Yorke",
+  "sort-name": "Yorke, Thom",
+  "aliases": [
+    {
+      "name": "トム・ヨーク",
+      "sort-name": "トム・ヨーク",
+      "type": "Artist name",
+      "locale": "ja",
+      "primary": true
+    },
+    {
+      "name": "Thomas Edward Yorke",
+      "sort-name": "Yorke, Thomas Edward",
+      "type": "Legal name",
+      "locale": "en",
+      "primary": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Band member names now promoted from MusicBrainz primary aliases matching the user's metadata language preferences, mirroring the #959 primary-name logic
- Per-request in-memory cache keyed by MBID; 1 req/sec via the provider's existing rate limiter; fetch failures logged and fall back to canonical names
- Members without an MBID (e.g. manually added) are never touched

Closes #964

## Test plan
- [x] `go test -race ./internal/provider/musicbrainz/...`
- [x] `bash scripts/pre-push-gate.sh`
- [x] Manual UAT confirmed on a real international artist: with `ja` above `en`, band members render in Japanese script; reverting prefs restores Latin-script names

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Artist band member names now localize to your preferred language when alternative name options are available in the metadata source.

* **Tests**
  * Added comprehensive test coverage for member name localization, language preference matching, alias resolution with caching, rate-limit verification, and error handling for unavailable aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->