### PR TITLE
feat(rule): add name_language_pref rule with Unicode script detection (#961)

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -200,6 +200,9 @@ func run() error {
 	// images for API-only artists that have no local filesystem path.
 	imageBridge := imagebridge.New(connectionService, artistService, logger)
 	ruleEngine.SetImageFetcher(imageBridge)
+	// Wired below after orchestrator is constructed; this keeps the rule
+	// engine usable during scanner init even though the language-preference
+	// rule will no-op until SetMetadataProvider is called.
 
 	// Initialize scanner (depends on rule engine for health scoring)
 	scannerService := scanner.NewService(artistService, ruleEngine, ruleService, logger, cfg.Music.LibraryPath, cfg.Scanner.Exclusions)
@@ -246,6 +249,10 @@ func run() error {
 
 	orchestrator := provider.NewOrchestrator(providerRegistry, providerSettings, logger)
 
+	// Wire the orchestrator into the rule engine so the name_language_pref
+	// rule can fetch localized aliases for comparison and promotion.
+	ruleEngine.SetMetadataProvider(orchestrator)
+
 	// Initialize scraper configuration and executor
 	scraperService := scraper.NewService(db, logger)
 	if err := scraperService.SeedDefaults(context.Background()); err != nil {
@@ -286,6 +293,7 @@ func run() error {
 	fixers := []rule.Fixer{
 		rule.NewNFOFixer(nfoSnapshotService, nfoSettingsService, fsCheck, expectedWrites),
 		rule.NewMetadataFixer(orchestrator, logger),
+		rule.NewNameLanguageFixer(orchestrator, logger),
 		rule.NewImageFixer(orchestrator, platformService, fsCheck, logger),
 		rule.NewExtraneousImagesFixer(platformService, fsCheck, logger),
 		logoPaddingFixer,

--- a/internal/api/handlers_bulk_actions.go
+++ b/internal/api/handlers_bulk_actions.go
@@ -247,7 +247,8 @@ func (r *Router) handleBulkAction(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	r.runBulkAction(req.Context(), body.Action, ids, progress)
+	bulkCtx := r.injectMetadataLanguages(req.Context())
+	r.runBulkAction(bulkCtx, body.Action, ids, progress)
 
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"status": "running",

--- a/internal/api/handlers_fix.go
+++ b/internal/api/handlers_fix.go
@@ -52,7 +52,10 @@ func (r *Router) handleFixViolation(w http.ResponseWriter, req *http.Request) {
 		pfs = r.capturePreFixState(req.Context(), id)
 	}
 
-	fr, err := r.pipeline.FixViolation(req.Context(), id)
+	// Inject metadata language preferences so language-aware fixers
+	// (e.g. name_language_pref) can promote localized aliases.
+	fixCtx := r.injectMetadataLanguages(req.Context())
+	fr, err := r.pipeline.FixViolation(fixCtx, id)
 	if err != nil {
 		r.logger.Error("fix violation failed", "id", id, "error", err)
 		writeError(w, req, http.StatusInternalServerError, "failed to apply fix")

--- a/internal/api/handlers_fix.go
+++ b/internal/api/handlers_fix.go
@@ -424,7 +424,8 @@ func (r *Router) handleFixAll(w http.ResponseWriter, req *http.Request) {
 	progress.Total = len(fixable)
 	progress.mu.Unlock()
 
-	r.runFixAll(req.Context(), fixable, scoped, progress)
+	fixAllCtx := r.injectMetadataLanguages(req.Context())
+	r.runFixAll(fixAllCtx, fixable, scoped, progress)
 
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"status": "running",

--- a/internal/api/handlers_rule.go
+++ b/internal/api/handlers_rule.go
@@ -155,7 +155,8 @@ func (r *Router) handleEvaluateArtist(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	result, err := r.ruleEngine.Evaluate(req.Context(), a)
+	evalCtx := r.injectMetadataLanguages(req.Context())
+	result, err := r.ruleEngine.Evaluate(evalCtx, a)
 	if err != nil {
 		r.logger.Error("evaluating artist health", "artist_id", artistID, "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to evaluate artist"})

--- a/internal/api/handlers_rule.go
+++ b/internal/api/handlers_rule.go
@@ -218,8 +218,10 @@ func (r *Router) handleRunRule(w http.ResponseWriter, req *http.Request) {
 
 	// Run in a background goroutine so the request can return immediately.
 	// WithoutCancel preserves request-scoped values but prevents navigation
-	// cancellation from aborting the pipeline.
-	ctx := context.WithoutCancel(req.Context())
+	// cancellation from aborting the pipeline. Inject metadata language
+	// preferences so language-aware rules (e.g. name_language_pref) see
+	// the user's preferred locales.
+	ctx := r.injectMetadataLanguages(context.WithoutCancel(req.Context()))
 	go func() {
 		defer func() {
 			if rv := recover(); rv != nil {
@@ -336,7 +338,8 @@ func (r *Router) handleRunArtistRules(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	result, err := r.pipeline.RunForArtist(req.Context(), a)
+	ctx := r.injectMetadataLanguages(req.Context())
+	result, err := r.pipeline.RunForArtist(ctx, a)
 	if err != nil {
 		r.logger.Error("running rules for artist", "artist_id", artistID, "error", err)
 		if req.Header.Get("HX-Request") == "true" {
@@ -398,7 +401,9 @@ func (r *Router) handleRunAllRules(w http.ResponseWriter, req *http.Request) {
 	}
 	r.ruleRunMu.Unlock()
 
-	ctx := context.WithoutCancel(req.Context())
+	// Inject metadata language preferences so language-aware rules see the
+	// user's preferred locales during background evaluation.
+	ctx := r.injectMetadataLanguages(context.WithoutCancel(req.Context()))
 	go func() {
 		defer func() {
 			if rv := recover(); rv != nil {

--- a/internal/rule/checkers.go
+++ b/internal/rule/checkers.go
@@ -23,7 +23,7 @@ import (
 
 // Checker evaluates a single rule against an artist.
 // Returns a Violation if the rule is not satisfied, or nil if it passes.
-type Checker func(a *artist.Artist, cfg RuleConfig) *Violation
+type Checker func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation
 
 // thumbPatterns matches the scanner's detection patterns for thumbnails.
 var thumbPatterns = []string{
@@ -36,7 +36,7 @@ var fanartPatterns = []string{"fanart.jpg", "fanart.png", "backdrop.jpg", "backd
 var logoPatterns = []string{"logo.png", "logo-white.png"}
 var bannerPatterns = []string{"banner.jpg", "banner.png"}
 
-func checkNFOExists(a *artist.Artist, _ RuleConfig) *Violation {
+func checkNFOExists(_ context.Context, a *artist.Artist, _ RuleConfig) *Violation {
 	if a.NFOExists {
 		return nil
 	}
@@ -50,7 +50,7 @@ func checkNFOExists(a *artist.Artist, _ RuleConfig) *Violation {
 	}
 }
 
-func checkNFOHasMBID(a *artist.Artist, _ RuleConfig) *Violation {
+func checkNFOHasMBID(_ context.Context, a *artist.Artist, _ RuleConfig) *Violation {
 	if a.MusicBrainzID != "" {
 		return nil
 	}
@@ -64,7 +64,7 @@ func checkNFOHasMBID(a *artist.Artist, _ RuleConfig) *Violation {
 	}
 }
 
-func checkThumbExists(a *artist.Artist, _ RuleConfig) *Violation {
+func checkThumbExists(_ context.Context, a *artist.Artist, _ RuleConfig) *Violation {
 	if a.ThumbExists {
 		return nil
 	}
@@ -81,7 +81,7 @@ func checkThumbExists(a *artist.Artist, _ RuleConfig) *Violation {
 // makeThumbSquareChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the thumbnail.
 func (e *Engine) makeThumbSquareChecker() Checker {
-	return func(a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.ThumbExists {
 			return nil // thumb_exists rule handles this case
 		}
@@ -119,7 +119,7 @@ func (e *Engine) makeThumbSquareChecker() Checker {
 // makeThumbMinResChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the thumbnail.
 func (e *Engine) makeThumbMinResChecker() Checker {
-	return func(a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.ThumbExists {
 			return nil // thumb_exists rule handles this case
 		}
@@ -153,7 +153,7 @@ func (e *Engine) makeThumbMinResChecker() Checker {
 	}
 }
 
-func checkFanartExists(a *artist.Artist, _ RuleConfig) *Violation {
+func checkFanartExists(_ context.Context, a *artist.Artist, _ RuleConfig) *Violation {
 	if a.FanartExists {
 		return nil
 	}
@@ -167,7 +167,7 @@ func checkFanartExists(a *artist.Artist, _ RuleConfig) *Violation {
 	}
 }
 
-func checkLogoExists(a *artist.Artist, _ RuleConfig) *Violation {
+func checkLogoExists(_ context.Context, a *artist.Artist, _ RuleConfig) *Violation {
 	if a.LogoExists {
 		return nil
 	}
@@ -181,7 +181,7 @@ func checkLogoExists(a *artist.Artist, _ RuleConfig) *Violation {
 	}
 }
 
-func checkBioExists(a *artist.Artist, cfg RuleConfig) *Violation {
+func checkBioExists(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 	minLen := cfg.MinLength
 	if minLen == 0 {
 		minLen = 10
@@ -209,7 +209,7 @@ func checkBioExists(a *artist.Artist, cfg RuleConfig) *Violation {
 // makeFanartMinResChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the fanart.
 func (e *Engine) makeFanartMinResChecker() Checker {
-	return func(a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.FanartExists {
 			return nil // fanart_exists handles missing fanart
 		}
@@ -241,7 +241,7 @@ func (e *Engine) makeFanartMinResChecker() Checker {
 // makeFanartAspectChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the fanart.
 func (e *Engine) makeFanartAspectChecker() Checker {
-	return func(a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.FanartExists {
 			return nil
 		}
@@ -275,7 +275,7 @@ func (e *Engine) makeFanartAspectChecker() Checker {
 // makeLogoMinResChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the logo.
 func (e *Engine) makeLogoMinResChecker() Checker {
-	return func(a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.LogoExists {
 			return nil
 		}
@@ -301,7 +301,7 @@ func (e *Engine) makeLogoMinResChecker() Checker {
 	}
 }
 
-func checkBannerExists(a *artist.Artist, _ RuleConfig) *Violation {
+func checkBannerExists(_ context.Context, a *artist.Artist, _ RuleConfig) *Violation {
 	if a.BannerExists {
 		return nil
 	}
@@ -318,7 +318,7 @@ func checkBannerExists(a *artist.Artist, _ RuleConfig) *Violation {
 // makeBannerMinResChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the banner.
 func (e *Engine) makeBannerMinResChecker() Checker {
-	return func(a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.BannerExists {
 			return nil
 		}
@@ -482,7 +482,7 @@ func (e *Engine) getLogoBoundsFromBytes(data []byte) (content, original goimage.
 // the logo through the platform image fetcher and caches the raw bytes only
 // when a violation is found, so the fixer can consume them.
 func (e *Engine) makeLogoPaddingChecker() Checker {
-	return func(a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.LogoExists {
 			return nil
 		}
@@ -588,7 +588,7 @@ func (e *Engine) makeLogoPaddingChecker() Checker {
 	}
 }
 
-func checkArtistIDMismatch(a *artist.Artist, cfg RuleConfig) *Violation {
+func checkArtistIDMismatch(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 	if a.Path == "" {
 		return nil
 	}
@@ -730,7 +730,7 @@ func expectedImageFiles(profile *platform.Profile, artistPath string) map[string
 // backdrop3.jpg with no backdrop2.jpg). Gap detection is handled by the
 // backdrop_sequencing rule (#519).
 func (e *Engine) makeExtraneousImagesChecker() Checker {
-	return func(a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if a.Path == "" {
 			return e.checkExtraneousImagesFromDB(a, cfg)
 		}
@@ -995,7 +995,7 @@ func canonicalDirName(name, articleMode string) string {
 	return name
 }
 
-func checkDirectoryNameMismatch(a *artist.Artist, cfg RuleConfig) *Violation {
+func checkDirectoryNameMismatch(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 	if a.Path == "" {
 		return nil
 	}
@@ -1036,7 +1036,7 @@ func checkDirectoryNameMismatch(a *artist.Artist, cfg RuleConfig) *Violation {
 // pre-computed dHash values from the artist_images table and compares all
 // pairs using Hamming distance.
 func (e *Engine) makeImageDuplicateChecker() Checker {
-	return func(a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if a.Path == "" || e.db == nil {
 			return nil
 		}
@@ -1113,7 +1113,7 @@ func truncateStr(s string, max int) string {
 	return string(runes[:max]) + "..."
 }
 
-func checkMetadataQuality(a *artist.Artist, cfg RuleConfig) *Violation {
+func checkMetadataQuality(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 	// Check biography for known placeholder/junk patterns.
 	// This complements bio_exists (which checks length): a biography that is
 	// "?" passes the length check at minLength=1 but is clearly junk.
@@ -1135,7 +1135,7 @@ func checkMetadataQuality(a *artist.Artist, cfg RuleConfig) *Violation {
 // backdrop3.jpg exist (gap at 1,2), or backdrop1.jpg exists without
 // backdrop.jpg (wrong starting point), a violation is returned.
 func (e *Engine) makeBackdropSequencingChecker() Checker {
-	return func(a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if a.Path == "" {
 			return e.checkBackdropSequencingFromDB(a, cfg)
 		}
@@ -1320,7 +1320,7 @@ func (e *Engine) countBackdropsFromDB(artistID string) int {
 // scanning the directory. For API-imported artists (no path), the artist_images
 // table is queried instead.
 func (e *Engine) makeBackdropMinCountChecker() Checker {
-	return func(a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		minCount := cfg.MinCount
 		if minCount <= 0 {
 			minCount = 1 // safety default

--- a/internal/rule/checkers_directory_test.go
+++ b/internal/rule/checkers_directory_test.go
@@ -1,6 +1,7 @@
 package rule
 
 import (
+	"context"
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/artist"
@@ -92,28 +93,28 @@ func TestCheckDirectoryNameMismatch(t *testing.T) {
 
 	t.Run("empty path", func(t *testing.T) {
 		a := &artist.Artist{Name: "Test", Path: ""}
-		if v := checkDirectoryNameMismatch(a, cfg); v != nil {
+		if v := checkDirectoryNameMismatch(context.Background(), a, cfg); v != nil {
 			t.Errorf("expected nil for empty path, got %+v", v)
 		}
 	})
 
 	t.Run("matching", func(t *testing.T) {
 		a := &artist.Artist{Name: "The Beatles", Path: "/music/The Beatles"}
-		if v := checkDirectoryNameMismatch(a, cfg); v != nil {
+		if v := checkDirectoryNameMismatch(context.Background(), a, cfg); v != nil {
 			t.Errorf("expected nil for matching dir, got %+v", v)
 		}
 	})
 
 	t.Run("case insensitive match", func(t *testing.T) {
 		a := &artist.Artist{Name: "The Beatles", Path: "/music/the beatles"}
-		if v := checkDirectoryNameMismatch(a, cfg); v != nil {
+		if v := checkDirectoryNameMismatch(context.Background(), a, cfg); v != nil {
 			t.Errorf("expected nil for case-insensitive match, got %+v", v)
 		}
 	})
 
 	t.Run("mismatch", func(t *testing.T) {
 		a := &artist.Artist{Name: "The Beatles", Path: "/music/Beatles"}
-		v := checkDirectoryNameMismatch(a, cfg)
+		v := checkDirectoryNameMismatch(context.Background(), a, cfg)
 		if v == nil {
 			t.Fatal("expected violation for mismatch, got nil")
 		}
@@ -128,7 +129,7 @@ func TestCheckDirectoryNameMismatch(t *testing.T) {
 	t.Run("suffix mode match", func(t *testing.T) {
 		cfgSuffix := RuleConfig{Severity: "warning", ArticleMode: "suffix"}
 		a := &artist.Artist{Name: "The Beatles", Path: "/music/Beatles, The"}
-		if v := checkDirectoryNameMismatch(a, cfgSuffix); v != nil {
+		if v := checkDirectoryNameMismatch(context.Background(), a, cfgSuffix); v != nil {
 			t.Errorf("expected nil for suffix mode match, got %+v", v)
 		}
 	})
@@ -141,7 +142,7 @@ func TestCheckDirectoryNameMismatch(t *testing.T) {
 		nfd := "Maria Joa\u0303o Pires" // o + combining tilde
 		nfc := "Maria Jo\u00e3o Pires"  // precomposed o-tilde
 		a := &artist.Artist{Name: nfc, Path: "/music/" + nfd}
-		if v := checkDirectoryNameMismatch(a, cfg); v != nil {
+		if v := checkDirectoryNameMismatch(context.Background(), a, cfg); v != nil {
 			t.Errorf("expected nil for NFC/NFD equivalent names, got %+v", v)
 		}
 	})
@@ -154,7 +155,7 @@ func TestCheckDirectoryNameMismatch(t *testing.T) {
 		nfdLower := "maria joa\u0303o pires" // lowercase, decomposed
 		nfcUpper := "Maria Jo\u00e3o Pires"  // mixed case, precomposed
 		a := &artist.Artist{Name: nfcUpper, Path: "/music/" + nfdLower}
-		if v := checkDirectoryNameMismatch(a, cfg); v != nil {
+		if v := checkDirectoryNameMismatch(context.Background(), a, cfg); v != nil {
 			t.Errorf("expected nil for NFC/NFD + case equivalent names, got %+v", v)
 		}
 	})

--- a/internal/rule/checkers_language.go
+++ b/internal/rule/checkers_language.go
@@ -37,7 +37,7 @@ func (e *Engine) makeNameLanguagePrefChecker() Checker {
 		}
 
 		nameScript := dominantScript(a.Name)
-		nameOK := scriptMatchesAnyLocale(nameScript, langPrefs)
+		nameOK := nameScript == scriptUnknown || scriptMatchesAnyLocale(nameScript, langPrefs)
 
 		sortScript := dominantScript(a.SortName)
 		sortOK := sortScript == scriptUnknown || scriptMatchesAnyLocale(sortScript, langPrefs)

--- a/internal/rule/checkers_language.go
+++ b/internal/rule/checkers_language.go
@@ -55,7 +55,16 @@ func (e *Engine) makeNameLanguagePrefChecker() Checker {
 
 		prefList := strings.Join(langPrefs, ", ")
 
-		fixable, aliasName, aliasSort := e.lookupPreferredAlias(ctx, a)
+		aliasName, aliasSort := e.lookupPreferredAlias(ctx, a)
+
+		// The violation is fixable only when the alias can repair every
+		// out-of-policy field. If Name is in the wrong script, the alias
+		// must supply a different Name; same for SortName. Otherwise the
+		// Fix button would leave part of the mismatch behind, causing the
+		// violation to reopen on the next evaluation.
+		nameFixable := nameOK || (aliasName != "" && aliasName != a.Name)
+		sortFixable := sortOK || (aliasSort != "" && aliasSort != a.SortName)
+		fixable := nameFixable && sortFixable
 
 		var msg string
 		if fixable {
@@ -95,19 +104,20 @@ func (e *Engine) makeNameLanguagePrefChecker() Checker {
 	}
 }
 
-// lookupPreferredAlias attempts to find a localized alias from MusicBrainz
-// that matches a preferred language. Returns fixable=true with the alias
-// name/sort when one is found. Falls back to fixable=false when MBID is
-// missing, the provider is not wired, or no suitable alias exists.
-func (e *Engine) lookupPreferredAlias(ctx context.Context, a *artist.Artist) (fixable bool, aliasName, aliasSort string) {
+// lookupPreferredAlias returns the localized Name and SortName (if any)
+// from MusicBrainz that match the user's language preferences. The caller
+// decides whether each field is fixable by comparing against the stored
+// values. Returns empty strings when the provider is unwired, the MBID is
+// missing, or the lookup fails or times out.
+func (e *Engine) lookupPreferredAlias(ctx context.Context, a *artist.Artist) (aliasName, aliasSort string) {
 	if a.MusicBrainzID == "" || e.metadataProvider == nil {
-		return false, "", ""
+		return "", ""
 	}
 
 	// The orchestrator may query multiple providers (MB, Wikipedia, etc.),
 	// which is far heavier than the alias check we need here. Cap the lookup
 	// so evaluation does not block the request for 30+ seconds; degrade to
-	// "unfixable" on timeout rather than hanging.
+	// empty result on timeout rather than hanging.
 	fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -117,21 +127,11 @@ func (e *Engine) lookupPreferredAlias(ctx context.Context, a *artist.Artist) (fi
 			slog.String("artist", a.Name),
 			slog.String("mbid", a.MusicBrainzID),
 			slog.String("error", err.Error()))
-		return false, "", ""
+		return "", ""
 	}
 	if fr == nil || fr.Metadata == nil {
-		return false, "", ""
+		return "", ""
 	}
 
-	bestName := strings.TrimSpace(fr.Metadata.Name)
-	bestSort := strings.TrimSpace(fr.Metadata.SortName)
-
-	nameDiff := bestName != "" && bestName != a.Name
-	sortDiff := bestSort != "" && bestSort != a.SortName
-
-	if !nameDiff && !sortDiff {
-		return false, "", ""
-	}
-
-	return true, bestName, bestSort
+	return strings.TrimSpace(fr.Metadata.Name), strings.TrimSpace(fr.Metadata.SortName)
 }

--- a/internal/rule/checkers_language.go
+++ b/internal/rule/checkers_language.go
@@ -1,0 +1,116 @@
+package rule
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// makeNameLanguagePrefChecker returns a Checker that flags artists whose
+// stored Name is in a script that does not match any of the user's preferred
+// metadata languages.
+//
+// Detection uses Unicode script analysis (v1): non-Latin vs Latin mismatches
+// are caught reliably. Latin-vs-Latin (e.g. German vs English) is out of
+// scope -- the rule cannot distinguish those without a language detector.
+//
+// When a MusicBrainz alias in a preferred language is available, the violation
+// is marked fixable. When no alias exists (or no MBID, or MB lookup fails),
+// the violation is still raised but marked unfixable so the user can edit
+// manually or dismiss.
+func (e *Engine) makeNameLanguagePrefChecker() Checker {
+	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+		if a.Locked || strings.TrimSpace(a.Name) == "" {
+			return nil
+		}
+
+		langPrefs := provider.MetadataLanguages(ctx)
+		if len(langPrefs) == 0 {
+			e.logger.Debug("name_language_pref: no language preferences in context, skipping",
+				slog.String("artist", a.Name))
+			return nil
+		}
+
+		script := dominantScript(a.Name)
+		if scriptMatchesAnyLocale(script, langPrefs) {
+			return nil
+		}
+
+		prefList := strings.Join(langPrefs, ", ")
+
+		fixable, aliasName, aliasSort := e.lookupPreferredAlias(ctx, a)
+
+		var msg string
+		if fixable {
+			switch {
+			case aliasName != a.Name && aliasSort != "" && aliasSort != a.SortName:
+				msg = fmt.Sprintf("artist name '%s' (sort '%s') does not match preferred languages [%s]; localized alias '%s' (sort '%s') available",
+					a.Name, a.SortName, prefList, aliasName, aliasSort)
+			case aliasName != a.Name:
+				msg = fmt.Sprintf("artist name '%s' does not match preferred languages [%s]; localized alias '%s' available",
+					a.Name, prefList, aliasName)
+			default:
+				msg = fmt.Sprintf("artist sort name '%s' does not match preferred languages [%s]; localized sort '%s' available",
+					a.SortName, prefList, aliasSort)
+			}
+		} else {
+			msg = fmt.Sprintf("artist name '%s' is in %s script but preferred languages are [%s]; no localized alias available -- edit manually or dismiss",
+				a.Name, script, prefList)
+		}
+
+		return &Violation{
+			RuleID:   RuleNameLanguagePref,
+			RuleName: "Artist name matches preferred language",
+			Category: "metadata",
+			Severity: effectiveSeverity(cfg),
+			Message:  msg,
+			Fixable:  fixable,
+		}
+	}
+}
+
+// lookupPreferredAlias attempts to find a localized alias from MusicBrainz
+// that matches a preferred language. Returns fixable=true with the alias
+// name/sort when one is found. Falls back to fixable=false when MBID is
+// missing, the provider is not wired, or no suitable alias exists.
+func (e *Engine) lookupPreferredAlias(ctx context.Context, a *artist.Artist) (fixable bool, aliasName, aliasSort string) {
+	if a.MusicBrainzID == "" || e.metadataProvider == nil {
+		return false, "", ""
+	}
+
+	// The orchestrator may query multiple providers (MB, Wikipedia, etc.),
+	// which is far heavier than the alias check we need here. Cap the lookup
+	// so evaluation does not block the request for 30+ seconds; degrade to
+	// "unfixable" on timeout rather than hanging.
+	fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	fr, err := e.metadataProvider.FetchMetadata(fetchCtx, a.MusicBrainzID, a.Name, a.ProviderIDMap())
+	if err != nil {
+		e.logger.Warn("name_language_pref: metadata fetch failed",
+			slog.String("artist", a.Name),
+			slog.String("mbid", a.MusicBrainzID),
+			slog.String("error", err.Error()))
+		return false, "", ""
+	}
+	if fr == nil || fr.Metadata == nil {
+		return false, "", ""
+	}
+
+	bestName := strings.TrimSpace(fr.Metadata.Name)
+	bestSort := strings.TrimSpace(fr.Metadata.SortName)
+
+	nameDiff := bestName != "" && bestName != a.Name
+	sortDiff := bestSort != "" && bestSort != a.SortName
+
+	if !nameDiff && !sortDiff {
+		return false, "", ""
+	}
+
+	return true, bestName, bestSort
+}

--- a/internal/rule/checkers_language.go
+++ b/internal/rule/checkers_language.go
@@ -69,10 +69,10 @@ func (e *Engine) makeNameLanguagePrefChecker() Checker {
 		var msg string
 		if fixable {
 			switch {
-			case aliasName != a.Name && aliasSort != "" && aliasSort != a.SortName:
+			case !nameOK && !sortOK && strings.TrimSpace(a.SortName) != "":
 				msg = fmt.Sprintf("artist name '%s' (sort '%s') does not match preferred languages [%s]; localized alias '%s' (sort '%s') available",
 					a.Name, a.SortName, prefList, aliasName, aliasSort)
-			case aliasName != a.Name:
+			case !nameOK:
 				msg = fmt.Sprintf("artist name '%s' does not match preferred languages [%s]; localized alias '%s' available",
 					a.Name, prefList, aliasName)
 			default:

--- a/internal/rule/checkers_language.go
+++ b/internal/rule/checkers_language.go
@@ -71,8 +71,17 @@ func (e *Engine) makeNameLanguagePrefChecker() Checker {
 					a.SortName, prefList, aliasSort)
 			}
 		} else {
-			msg = fmt.Sprintf("artist name '%s' is in %s script but preferred languages are [%s]; no localized alias available -- edit manually or dismiss",
-				a.Name, script, prefList)
+			switch {
+			case !nameOK && !sortOK && strings.TrimSpace(a.SortName) != "":
+				msg = fmt.Sprintf("artist name '%s' (sort '%s') does not match preferred languages [%s]; no localized alias available -- edit manually or dismiss",
+					a.Name, a.SortName, prefList)
+			case !nameOK:
+				msg = fmt.Sprintf("artist name '%s' is in %s script but preferred languages are [%s]; no localized alias available -- edit manually or dismiss",
+					a.Name, script, prefList)
+			default:
+				msg = fmt.Sprintf("artist sort name '%s' is in %s script but preferred languages are [%s]; no localized alias available -- edit manually or dismiss",
+					a.SortName, script, prefList)
+			}
 		}
 
 		return &Violation{

--- a/internal/rule/checkers_language.go
+++ b/internal/rule/checkers_language.go
@@ -12,8 +12,9 @@ import (
 )
 
 // makeNameLanguagePrefChecker returns a Checker that flags artists whose
-// stored Name is in a script that does not match any of the user's preferred
-// metadata languages.
+// stored Name or SortName is in a script that does not match any of the
+// user's preferred metadata languages. Both fields are validated
+// independently so a mismatch on either raises a violation.
 //
 // Detection uses Unicode script analysis (v1): non-Latin vs Latin mismatches
 // are caught reliably. Latin-vs-Latin (e.g. German vs English) is out of

--- a/internal/rule/checkers_language.go
+++ b/internal/rule/checkers_language.go
@@ -36,9 +36,21 @@ func (e *Engine) makeNameLanguagePrefChecker() Checker {
 			return nil
 		}
 
-		script := dominantScript(a.Name)
-		if scriptMatchesAnyLocale(script, langPrefs) {
+		nameScript := dominantScript(a.Name)
+		nameOK := scriptMatchesAnyLocale(nameScript, langPrefs)
+
+		sortScript := dominantScript(a.SortName)
+		sortOK := sortScript == scriptUnknown || scriptMatchesAnyLocale(sortScript, langPrefs)
+
+		if nameOK && sortOK {
 			return nil
+		}
+
+		// Use the mismatched script for the message; prefer Name's script
+		// since it is the primary display field.
+		script := nameScript
+		if nameOK {
+			script = sortScript
 		}
 
 		prefList := strings.Join(langPrefs, ", ")

--- a/internal/rule/checkers_language_test.go
+++ b/internal/rule/checkers_language_test.go
@@ -1,0 +1,221 @@
+package rule
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// stubMetadataProvider is a fake MetadataProvider used by checker and fixer
+// tests. It returns the configured metadata regardless of input, and records
+// the number of FetchMetadata calls so tests can assert no-op behavior.
+type stubMetadataProvider struct {
+	metadata *provider.ArtistMetadata
+	err      error
+	calls    int
+}
+
+func (s *stubMetadataProvider) FetchMetadata(_ context.Context, _, _ string, _ map[provider.ProviderName]string) (*provider.FetchResult, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &provider.FetchResult{Metadata: s.metadata}, nil
+}
+
+// engineWithMetadataStub builds a minimal Engine wired with the given
+// metadata-provider stub. Used by name_language_pref checker and fixer tests.
+func engineWithMetadataStub(stub MetadataProvider) *Engine {
+	e := newTestEngine()
+	e.metadataProvider = stub
+	return e
+}
+
+func TestNameLanguagePrefChecker(t *testing.T) {
+	tests := []struct {
+		name        string
+		artist      artist.Artist
+		stub        *stubMetadataProvider
+		ctx         context.Context
+		wantViol    bool
+		wantFixable bool
+		wantSubstr  string
+		wantNoCalls bool
+	}{
+		{
+			name:   "skips when artist is locked",
+			artist: artist.Artist{Name: "BTS", MusicBrainzID: "mbid-1", Locked: true},
+			stub: &stubMetadataProvider{
+				metadata: &provider.ArtistMetadata{Name: "Bangtan Sonyeondan"},
+			},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"ko", "en"}),
+			wantViol:    false,
+			wantNoCalls: true,
+		},
+		{
+			name:   "skips when no language preferences in context",
+			artist: artist.Artist{Name: "Rammstein", MusicBrainzID: "mbid-1"},
+			stub: &stubMetadataProvider{
+				metadata: &provider.ArtistMetadata{Name: "Rammstein"},
+			},
+			ctx:         context.Background(),
+			wantViol:    false,
+			wantNoCalls: true,
+		},
+		{
+			name:   "passes when script matches preferred locale",
+			artist: artist.Artist{Name: "Rammstein", SortName: "Rammstein", MusicBrainzID: "mbid-1"},
+			stub: &stubMetadataProvider{
+				metadata: &provider.ArtistMetadata{Name: "Rammstein", SortName: "Rammstein"},
+			},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"de", "en"}),
+			wantViol:    false,
+			wantNoCalls: true,
+		},
+		{
+			name:   "flags kanji name with english prefs and MB alias available",
+			artist: artist.Artist{Name: "\u5c3e\u5d0e\u8c4a", SortName: "\u5c3e\u5d0e\u8c4a", MusicBrainzID: "mbid-2"},
+			stub: &stubMetadataProvider{
+				metadata: &provider.ArtistMetadata{Name: "Ozaki Yutaka", SortName: "Ozaki, Yutaka"},
+			},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"en"}),
+			wantViol:    true,
+			wantFixable: true,
+			wantSubstr:  "Ozaki Yutaka",
+		},
+		{
+			name:   "flags kanji name with english prefs and no MB alias",
+			artist: artist.Artist{Name: "\u5c3e\u5d0e\u8c4a", MusicBrainzID: "mbid-3"},
+			stub: &stubMetadataProvider{
+				metadata: &provider.ArtistMetadata{Name: "\u5c3e\u5d0e\u8c4a"},
+			},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"en"}),
+			wantViol:    true,
+			wantFixable: false,
+			wantSubstr:  "no localized alias available",
+		},
+		{
+			name:        "flags kanji name with no MBID at all",
+			artist:      artist.Artist{Name: "\u5c3e\u5d0e\u8c4a", MusicBrainzID: ""},
+			stub:        &stubMetadataProvider{},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"en"}),
+			wantViol:    true,
+			wantFixable: false,
+			wantSubstr:  "no localized alias available",
+			wantNoCalls: true,
+		},
+		{
+			name:   "flags kanji name when MB fetch fails",
+			artist: artist.Artist{Name: "\u5c3e\u5d0e\u8c4a", MusicBrainzID: "mbid-err"},
+			stub: &stubMetadataProvider{
+				err: errors.New("upstream 503"),
+			},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"en"}),
+			wantViol:    true,
+			wantFixable: false,
+			wantSubstr:  "no localized alias available",
+		},
+		{
+			name:   "flags cyrillic name with english-only prefs",
+			artist: artist.Artist{Name: "\u0420\u0430\u043c\u043c\u0448\u0442\u0430\u0439\u043d", MusicBrainzID: "mbid-4"},
+			stub: &stubMetadataProvider{
+				metadata: &provider.ArtistMetadata{Name: "Rammstein"},
+			},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"en"}),
+			wantViol:    true,
+			wantFixable: true,
+			wantSubstr:  "Rammstein",
+		},
+		{
+			name:        "cyrillic name passes with russian in prefs",
+			artist:      artist.Artist{Name: "\u0420\u0430\u043c\u043c\u0448\u0442\u0430\u0439\u043d", MusicBrainzID: "mbid-5"},
+			stub:        &stubMetadataProvider{},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"ru", "en"}),
+			wantViol:    false,
+			wantNoCalls: true,
+		},
+		{
+			name:        "hangul name passes with korean in prefs",
+			artist:      artist.Artist{Name: "\ubc29\ud0c4\uc18c\ub144\ub2e8", MusicBrainzID: "mbid-6"},
+			stub:        &stubMetadataProvider{},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"ko"}),
+			wantViol:    false,
+			wantNoCalls: true,
+		},
+		{
+			name:        "latin name with japanese prefs flags unfixable",
+			artist:      artist.Artist{Name: "Rammstein", MusicBrainzID: "mbid-7"},
+			stub:        &stubMetadataProvider{},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"ja"}),
+			wantViol:    true,
+			wantFixable: false,
+			wantSubstr:  "latin script",
+		},
+		{
+			name:   "flags only sort name when alias sort differs",
+			artist: artist.Artist{Name: "\u5c3e\u5d0e\u8c4a", SortName: "\u5c3e\u5d0e\u8c4a", MusicBrainzID: "mbid-8"},
+			stub: &stubMetadataProvider{
+				metadata: &provider.ArtistMetadata{Name: "\u5c3e\u5d0e\u8c4a", SortName: "Ozaki, Yutaka"},
+			},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"en"}),
+			wantViol:    true,
+			wantFixable: true,
+			wantSubstr:  "sort",
+		},
+		{
+			name:        "skips empty name",
+			artist:      artist.Artist{Name: "", MusicBrainzID: "mbid-9"},
+			stub:        &stubMetadataProvider{},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"en"}),
+			wantViol:    false,
+			wantNoCalls: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := engineWithMetadataStub(tt.stub)
+			checker := e.makeNameLanguagePrefChecker()
+			v := checker(tt.ctx, &tt.artist, RuleConfig{})
+
+			if tt.wantViol && v == nil {
+				t.Fatalf("expected violation, got nil")
+			}
+			if !tt.wantViol && v != nil {
+				t.Fatalf("expected no violation, got: %s", v.Message)
+			}
+			if v != nil {
+				if v.RuleID != RuleNameLanguagePref {
+					t.Errorf("RuleID = %q, want %q", v.RuleID, RuleNameLanguagePref)
+				}
+				if v.Fixable != tt.wantFixable {
+					t.Errorf("Fixable = %v, want %v (msg: %s)", v.Fixable, tt.wantFixable, v.Message)
+				}
+				if tt.wantSubstr != "" && !strings.Contains(v.Message, tt.wantSubstr) {
+					t.Errorf("message %q does not contain %q", v.Message, tt.wantSubstr)
+				}
+			}
+			if tt.wantNoCalls && tt.stub.calls != 0 {
+				t.Errorf("expected no FetchMetadata calls, got %d", tt.stub.calls)
+			}
+		})
+	}
+}
+
+func TestNameLanguagePrefChecker_NilProvider(t *testing.T) {
+	e := newTestEngine()
+	ctx := provider.WithMetadataLanguages(context.Background(), []string{"en"})
+
+	checker := e.makeNameLanguagePrefChecker()
+	v := checker(ctx, &artist.Artist{Name: "\u5c3e\u5d0e\u8c4a", MusicBrainzID: "mbid"}, RuleConfig{})
+	if v == nil {
+		t.Fatal("expected violation for script mismatch even without provider")
+	}
+	if v.Fixable {
+		t.Error("expected Fixable=false when metadataProvider is nil")
+	}
+}

--- a/internal/rule/checkers_language_test.go
+++ b/internal/rule/checkers_language_test.go
@@ -156,10 +156,21 @@ func TestNameLanguagePrefChecker(t *testing.T) {
 			wantSubstr:  "latin script",
 		},
 		{
-			name:   "flags only sort name when alias sort differs",
+			name:   "name and sort both wrong-script; alias repairs only sort -> unfixable",
 			artist: artist.Artist{Name: "\u5c3e\u5d0e\u8c4a", SortName: "\u5c3e\u5d0e\u8c4a", MusicBrainzID: "mbid-8"},
 			stub: &stubMetadataProvider{
 				metadata: &provider.ArtistMetadata{Name: "\u5c3e\u5d0e\u8c4a", SortName: "Ozaki, Yutaka"},
+			},
+			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"en"}),
+			wantViol:    true,
+			wantFixable: false,
+			wantSubstr:  "no localized alias available",
+		},
+		{
+			name:   "name-ok, sort-wrong, alias supplies different sort -> fixable",
+			artist: artist.Artist{Name: "Ozaki Yutaka", SortName: "\u5c3e\u5d0e\u8c4a", MusicBrainzID: "mbid-8b"},
+			stub: &stubMetadataProvider{
+				metadata: &provider.ArtistMetadata{Name: "Ozaki Yutaka", SortName: "Ozaki, Yutaka"},
 			},
 			ctx:         provider.WithMetadataLanguages(context.Background(), []string{"en"}),
 			wantViol:    true,

--- a/internal/rule/checkers_test.go
+++ b/internal/rule/checkers_test.go
@@ -42,7 +42,7 @@ func TestCheckNFOExists(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v := checkNFOExists(&tt.artist, RuleConfig{})
+			v := checkNFOExists(context.Background(), &tt.artist, RuleConfig{})
 			if (v == nil) != tt.wantNil {
 				t.Errorf("checkNFOExists = %v, wantNil = %v", v, tt.wantNil)
 			}
@@ -78,7 +78,7 @@ func TestCheckNFOHasMBID(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v := checkNFOHasMBID(&tt.artist, RuleConfig{})
+			v := checkNFOHasMBID(context.Background(), &tt.artist, RuleConfig{})
 			if (v == nil) != tt.wantNil {
 				t.Errorf("checkNFOHasMBID = %v, wantNil = %v", v, tt.wantNil)
 			}
@@ -88,24 +88,24 @@ func TestCheckNFOHasMBID(t *testing.T) {
 
 func TestCheckThumbExists(t *testing.T) {
 	a := artist.Artist{Name: "Test", ThumbExists: true}
-	if v := checkThumbExists(&a, RuleConfig{}); v != nil {
+	if v := checkThumbExists(context.Background(), &a, RuleConfig{}); v != nil {
 		t.Errorf("expected nil for artist with thumb, got %v", v)
 	}
 
 	a.ThumbExists = false
-	if v := checkThumbExists(&a, RuleConfig{}); v == nil {
+	if v := checkThumbExists(context.Background(), &a, RuleConfig{}); v == nil {
 		t.Error("expected violation for artist without thumb")
 	}
 }
 
 func TestCheckFanartExists(t *testing.T) {
 	a := artist.Artist{Name: "Test", FanartExists: true}
-	if v := checkFanartExists(&a, RuleConfig{}); v != nil {
+	if v := checkFanartExists(context.Background(), &a, RuleConfig{}); v != nil {
 		t.Errorf("expected nil for artist with fanart, got %v", v)
 	}
 
 	a.FanartExists = false
-	v := checkFanartExists(&a, RuleConfig{})
+	v := checkFanartExists(context.Background(), &a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation for artist without fanart")
 	}
@@ -116,12 +116,12 @@ func TestCheckFanartExists(t *testing.T) {
 
 func TestCheckLogoExists(t *testing.T) {
 	a := artist.Artist{Name: "Test", LogoExists: true}
-	if v := checkLogoExists(&a, RuleConfig{}); v != nil {
+	if v := checkLogoExists(context.Background(), &a, RuleConfig{}); v != nil {
 		t.Errorf("expected nil for artist with logo, got %v", v)
 	}
 
 	a.LogoExists = false
-	v := checkLogoExists(&a, RuleConfig{})
+	v := checkLogoExists(context.Background(), &a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation for artist without logo")
 	}
@@ -167,7 +167,7 @@ func TestCheckBioExists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			a := artist.Artist{Name: "Test", Biography: tt.bio}
 			cfg := RuleConfig{MinLength: tt.minLen}
-			v := checkBioExists(&a, cfg)
+			v := checkBioExists(context.Background(), &a, cfg)
 			if (v == nil) != tt.wantNil {
 				t.Errorf("checkBioExists = %v, wantNil = %v", v, tt.wantNil)
 			}
@@ -184,7 +184,7 @@ func TestCheckThumbSquare(t *testing.T) {
 	createTestJPEG(t, filepath.Join(dir, "folder.jpg"), 500, 500)
 
 	a := artist.Artist{Name: "Test", ThumbExists: true, Path: dir}
-	v := checker(&a, RuleConfig{AspectRatio: 1.0, Tolerance: 0.1})
+	v := checker(context.Background(), &a, RuleConfig{AspectRatio: 1.0, Tolerance: 0.1})
 	if v != nil {
 		t.Errorf("expected nil for square thumbnail, got %v", v)
 	}
@@ -194,7 +194,7 @@ func TestCheckThumbSquare(t *testing.T) {
 	createTestJPEG(t, filepath.Join(dir2, "folder.jpg"), 800, 400)
 
 	a2 := artist.Artist{Name: "Test2", ThumbExists: true, Path: dir2}
-	v2 := checker(&a2, RuleConfig{AspectRatio: 1.0, Tolerance: 0.1})
+	v2 := checker(context.Background(), &a2, RuleConfig{AspectRatio: 1.0, Tolerance: 0.1})
 	if v2 == nil {
 		t.Error("expected violation for non-square thumbnail")
 	}
@@ -206,7 +206,7 @@ func TestCheckThumbSquare_NoThumb(t *testing.T) {
 
 	// When thumb does not exist, checker should return nil (thumb_exists handles it)
 	a := artist.Artist{Name: "Test", ThumbExists: false}
-	v := checker(&a, RuleConfig{AspectRatio: 1.0, Tolerance: 0.1})
+	v := checker(context.Background(), &a, RuleConfig{AspectRatio: 1.0, Tolerance: 0.1})
 	if v != nil {
 		t.Errorf("expected nil when ThumbExists is false, got %v", v)
 	}
@@ -221,7 +221,7 @@ func TestCheckThumbMinRes(t *testing.T) {
 	createTestJPEG(t, filepath.Join(dir, "folder.jpg"), 1000, 1000)
 
 	a := artist.Artist{Name: "Test", ThumbExists: true, Path: dir}
-	v := checker(&a, RuleConfig{MinWidth: 500, MinHeight: 500})
+	v := checker(context.Background(), &a, RuleConfig{MinWidth: 500, MinHeight: 500})
 	if v != nil {
 		t.Errorf("expected nil for high-res thumbnail, got %v", v)
 	}
@@ -231,7 +231,7 @@ func TestCheckThumbMinRes(t *testing.T) {
 	createTestJPEG(t, filepath.Join(dir2, "folder.jpg"), 200, 200)
 
 	a2 := artist.Artist{Name: "Test2", ThumbExists: true, Path: dir2}
-	v2 := checker(&a2, RuleConfig{MinWidth: 500, MinHeight: 500})
+	v2 := checker(context.Background(), &a2, RuleConfig{MinWidth: 500, MinHeight: 500})
 	if v2 == nil {
 		t.Error("expected violation for low-res thumbnail")
 	}
@@ -246,7 +246,7 @@ func TestCheckThumbMinRes_DefaultValues(t *testing.T) {
 
 	a := artist.Artist{Name: "Test", ThumbExists: true, Path: dir}
 	// Zero config should default to 500x500
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil for 600x600 with default min 500, got %v", v)
 	}
@@ -279,7 +279,7 @@ func TestCheckFanartMinRes(t *testing.T) {
 
 	// Missing fanart: skip check
 	a := artist.Artist{Name: "Test", FanartExists: false}
-	if v := checker(&a, RuleConfig{}); v != nil {
+	if v := checker(context.Background(), &a, RuleConfig{}); v != nil {
 		t.Errorf("expected nil when FanartExists is false, got %v", v)
 	}
 
@@ -287,7 +287,7 @@ func TestCheckFanartMinRes(t *testing.T) {
 	dir := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir, "fanart.jpg"), 1920, 1080)
 	a = artist.Artist{Name: "Test", FanartExists: true, Path: dir}
-	if v := checker(&a, RuleConfig{MinWidth: 1920, MinHeight: 1080}); v != nil {
+	if v := checker(context.Background(), &a, RuleConfig{MinWidth: 1920, MinHeight: 1080}); v != nil {
 		t.Errorf("expected nil for 1920x1080 fanart, got %v", v)
 	}
 
@@ -295,7 +295,7 @@ func TestCheckFanartMinRes(t *testing.T) {
 	dir2 := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir2, "fanart.jpg"), 800, 450)
 	a2 := artist.Artist{Name: "Test2", FanartExists: true, Path: dir2}
-	v := checker(&a2, RuleConfig{MinWidth: 1920, MinHeight: 1080})
+	v := checker(context.Background(), &a2, RuleConfig{MinWidth: 1920, MinHeight: 1080})
 	if v == nil {
 		t.Error("expected violation for low-res fanart")
 	}
@@ -307,7 +307,7 @@ func TestCheckFanartMinRes(t *testing.T) {
 	dir3 := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir3, "fanart.jpg"), 2000, 1200)
 	a3 := artist.Artist{Name: "Test3", FanartExists: true, Path: dir3}
-	if v := checker(&a3, RuleConfig{}); v != nil {
+	if v := checker(context.Background(), &a3, RuleConfig{}); v != nil {
 		t.Errorf("expected nil for 2000x1200 with default 1920x1080, got %v", v)
 	}
 }
@@ -318,7 +318,7 @@ func TestCheckFanartAspect(t *testing.T) {
 
 	// Missing fanart: skip
 	a := artist.Artist{Name: "Test", FanartExists: false}
-	if v := checker(&a, RuleConfig{}); v != nil {
+	if v := checker(context.Background(), &a, RuleConfig{}); v != nil {
 		t.Errorf("expected nil when FanartExists is false, got %v", v)
 	}
 
@@ -326,7 +326,7 @@ func TestCheckFanartAspect(t *testing.T) {
 	dir := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir, "fanart.jpg"), 1920, 1080)
 	a = artist.Artist{Name: "Test", FanartExists: true, Path: dir}
-	if v := checker(&a, RuleConfig{AspectRatio: 16.0 / 9.0, Tolerance: 0.1}); v != nil {
+	if v := checker(context.Background(), &a, RuleConfig{AspectRatio: 16.0 / 9.0, Tolerance: 0.1}); v != nil {
 		t.Errorf("expected nil for 16:9 fanart, got %v", v)
 	}
 
@@ -334,7 +334,7 @@ func TestCheckFanartAspect(t *testing.T) {
 	dir2 := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir2, "fanart.jpg"), 1000, 1000)
 	a2 := artist.Artist{Name: "Test2", FanartExists: true, Path: dir2}
-	v := checker(&a2, RuleConfig{AspectRatio: 16.0 / 9.0, Tolerance: 0.1})
+	v := checker(context.Background(), &a2, RuleConfig{AspectRatio: 16.0 / 9.0, Tolerance: 0.1})
 	if v == nil {
 		t.Error("expected violation for square fanart with 16:9 check")
 	}
@@ -349,7 +349,7 @@ func TestCheckLogoMinRes(t *testing.T) {
 
 	// Missing logo: skip
 	a := artist.Artist{Name: "Test", LogoExists: false}
-	if v := checker(&a, RuleConfig{}); v != nil {
+	if v := checker(context.Background(), &a, RuleConfig{}); v != nil {
 		t.Errorf("expected nil when LogoExists is false, got %v", v)
 	}
 
@@ -357,7 +357,7 @@ func TestCheckLogoMinRes(t *testing.T) {
 	dir := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir, "logo.png"), 500, 200)
 	a = artist.Artist{Name: "Test", LogoExists: true, Path: dir}
-	if v := checker(&a, RuleConfig{MinWidth: 400}); v != nil {
+	if v := checker(context.Background(), &a, RuleConfig{MinWidth: 400}); v != nil {
 		t.Errorf("expected nil for 500px logo, got %v", v)
 	}
 
@@ -365,7 +365,7 @@ func TestCheckLogoMinRes(t *testing.T) {
 	dir2 := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir2, "logo.png"), 200, 100)
 	a2 := artist.Artist{Name: "Test2", LogoExists: true, Path: dir2}
-	v := checker(&a2, RuleConfig{MinWidth: 400})
+	v := checker(context.Background(), &a2, RuleConfig{MinWidth: 400})
 	if v == nil {
 		t.Error("expected violation for 200px logo with 400px minimum")
 	}
@@ -377,19 +377,19 @@ func TestCheckLogoMinRes(t *testing.T) {
 	dir3 := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir3, "logo.png"), 500, 200)
 	a3 := artist.Artist{Name: "Test3", LogoExists: true, Path: dir3}
-	if v := checker(&a3, RuleConfig{}); v != nil {
+	if v := checker(context.Background(), &a3, RuleConfig{}); v != nil {
 		t.Errorf("expected nil for 500px with default 400px minimum, got %v", v)
 	}
 }
 
 func TestCheckBannerExists(t *testing.T) {
 	a := artist.Artist{Name: "Test", BannerExists: true}
-	if v := checkBannerExists(&a, RuleConfig{}); v != nil {
+	if v := checkBannerExists(context.Background(), &a, RuleConfig{}); v != nil {
 		t.Errorf("expected nil for artist with banner, got %v", v)
 	}
 
 	a.BannerExists = false
-	v := checkBannerExists(&a, RuleConfig{})
+	v := checkBannerExists(context.Background(), &a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation for artist without banner")
 	}
@@ -407,7 +407,7 @@ func TestCheckBannerMinRes(t *testing.T) {
 
 	// Missing banner: skip
 	a := artist.Artist{Name: "Test", BannerExists: false}
-	if v := checker(&a, RuleConfig{}); v != nil {
+	if v := checker(context.Background(), &a, RuleConfig{}); v != nil {
 		t.Errorf("expected nil when BannerExists is false, got %v", v)
 	}
 
@@ -415,7 +415,7 @@ func TestCheckBannerMinRes(t *testing.T) {
 	dir := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir, "banner.jpg"), 1000, 185)
 	a = artist.Artist{Name: "Test", BannerExists: true, Path: dir}
-	if v := checker(&a, RuleConfig{MinWidth: 1000, MinHeight: 185}); v != nil {
+	if v := checker(context.Background(), &a, RuleConfig{MinWidth: 1000, MinHeight: 185}); v != nil {
 		t.Errorf("expected nil for 1000x185 banner, got %v", v)
 	}
 
@@ -423,7 +423,7 @@ func TestCheckBannerMinRes(t *testing.T) {
 	dir2 := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir2, "banner.jpg"), 500, 100)
 	a2 := artist.Artist{Name: "Test2", BannerExists: true, Path: dir2}
-	v := checker(&a2, RuleConfig{MinWidth: 1000, MinHeight: 185})
+	v := checker(context.Background(), &a2, RuleConfig{MinWidth: 1000, MinHeight: 185})
 	if v == nil {
 		t.Error("expected violation for small banner")
 	}
@@ -435,7 +435,7 @@ func TestCheckBannerMinRes(t *testing.T) {
 	dir3 := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir3, "banner.jpg"), 1200, 200)
 	a3 := artist.Artist{Name: "Test3", BannerExists: true, Path: dir3}
-	if v := checker(&a3, RuleConfig{}); v != nil {
+	if v := checker(context.Background(), &a3, RuleConfig{}); v != nil {
 		t.Errorf("expected nil for 1200x200 with default 1000x185, got %v", v)
 	}
 }
@@ -453,7 +453,7 @@ func TestCheckExtraneousImages(t *testing.T) {
 	checker := e.makeExtraneousImagesChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{Severity: "warning"})
+	v := checker(context.Background(), &a, RuleConfig{Severity: "warning"})
 	if v == nil {
 		t.Fatal("expected violation for extraneous images")
 	}
@@ -475,7 +475,7 @@ func TestCheckExtraneousImages_NoExtraneous(t *testing.T) {
 	checker := e.makeExtraneousImagesChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil for directory with only canonical files, got %v", v)
 	}
@@ -494,7 +494,7 @@ func TestCheckExtraneousImages_NumberedFanart(t *testing.T) {
 	checker := e.makeExtraneousImagesChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil (numbered fanart should be whitelisted), got: %s", v.Message)
 	}
@@ -513,7 +513,7 @@ func TestCheckExtraneousImages_NumberedFanartWithGaps(t *testing.T) {
 	checker := e.makeExtraneousImagesChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil (numbered fanart with gaps should be whitelisted), got: %s", v.Message)
 	}
@@ -532,7 +532,7 @@ func TestCheckExtraneousImages_BackdropNaming(t *testing.T) {
 	checker := e.makeExtraneousImagesChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil (backdrop numbered variants should be whitelisted), got: %s", v.Message)
 	}
@@ -550,7 +550,7 @@ func TestCheckExtraneousImages_NonStandardNameFlagged(t *testing.T) {
 	checker := e.makeExtraneousImagesChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation for non-standard 'backdrop_old.jpg'")
 	}
@@ -564,7 +564,7 @@ func TestCheckExtraneousImages_EmptyPath(t *testing.T) {
 	checker := e.makeExtraneousImagesChecker()
 
 	a := artist.Artist{Name: "Test", Path: ""}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil for empty path, got %v", v)
 	}
@@ -726,7 +726,7 @@ func TestCheckArtistIDMismatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v := checkArtistIDMismatch(&tt.artist, tt.cfg)
+			v := checkArtistIDMismatch(context.Background(), &tt.artist, tt.cfg)
 			if (v == nil) != tt.wantNil {
 				t.Errorf("checkArtistIDMismatch = %v, wantNil = %v", v, tt.wantNil)
 			}
@@ -788,7 +788,7 @@ func TestCheckBackdropSequencing_Contiguous(t *testing.T) {
 	checker := e.makeBackdropSequencingChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil for contiguous sequence, got: %s", v.Message)
 	}
@@ -804,7 +804,7 @@ func TestCheckBackdropSequencing_WithGap(t *testing.T) {
 	checker := e.makeBackdropSequencingChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation for gap in sequence")
 	}
@@ -827,7 +827,7 @@ func TestCheckBackdropSequencing_NumberedOnlyNoPrimary(t *testing.T) {
 	checker := e.makeBackdropSequencingChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation when primary file is missing and only numbered variants exist")
 	}
@@ -846,7 +846,7 @@ func TestCheckBackdropSequencing_SingleNumberedOnly(t *testing.T) {
 	checker := e.makeBackdropSequencingChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation for single numbered file without primary")
 	}
@@ -860,7 +860,7 @@ func TestCheckBackdropSequencing_SingleFile(t *testing.T) {
 	checker := e.makeBackdropSequencingChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil for single fanart file, got: %s", v.Message)
 	}
@@ -925,7 +925,7 @@ func TestCheckBackdropMinCount_Satisfied(t *testing.T) {
 	checker := e.makeBackdropMinCountChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{MinCount: 2})
+	v := checker(context.Background(), &a, RuleConfig{MinCount: 2})
 	if v != nil {
 		t.Errorf("expected nil when count meets minimum, got: %s", v.Message)
 	}
@@ -939,7 +939,7 @@ func TestCheckBackdropMinCount_BelowMinimum(t *testing.T) {
 	checker := e.makeBackdropMinCountChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{MinCount: 3})
+	v := checker(context.Background(), &a, RuleConfig{MinCount: 3})
 	if v == nil {
 		t.Fatal("expected violation when count is below minimum")
 	}
@@ -958,7 +958,7 @@ func TestCheckBackdropMinCount_NoBackdrops(t *testing.T) {
 	checker := e.makeBackdropMinCountChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{MinCount: 1})
+	v := checker(context.Background(), &a, RuleConfig{MinCount: 1})
 	if v == nil {
 		t.Fatal("expected violation when no backdrops exist")
 	}
@@ -975,7 +975,7 @@ func TestCheckBackdropMinCount_DefaultMinCount(t *testing.T) {
 	checker := e.makeBackdropMinCountChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{MinCount: 0})
+	v := checker(context.Background(), &a, RuleConfig{MinCount: 0})
 	if v == nil {
 		t.Fatal("expected violation with default min count and no backdrops")
 	}
@@ -991,7 +991,7 @@ func TestCheckBackdropMinCount_ExactlyAtMinimum(t *testing.T) {
 	checker := e.makeBackdropMinCountChecker()
 
 	a := artist.Artist{Name: "Test", Path: dir}
-	v := checker(&a, RuleConfig{MinCount: 3})
+	v := checker(context.Background(), &a, RuleConfig{MinCount: 3})
 	if v != nil {
 		t.Errorf("expected nil when count equals minimum, got: %s", v.Message)
 	}
@@ -1040,13 +1040,13 @@ func TestCheckBackdropMinCount_DBPath(t *testing.T) {
 	a := artist.Artist{ID: "a1", Name: "Test DB Path", Path: ""}
 
 	// Should pass: 3 fanart rows >= minCount 2.
-	v := checker(&a, RuleConfig{MinCount: 2})
+	v := checker(context.Background(), &a, RuleConfig{MinCount: 2})
 	if v != nil {
 		t.Errorf("expected nil when DB count meets minimum, got: %s", v.Message)
 	}
 
 	// Should fail: 3 fanart rows < minCount 5.
-	v = checker(&a, RuleConfig{MinCount: 5})
+	v = checker(context.Background(), &a, RuleConfig{MinCount: 5})
 	if v == nil {
 		t.Fatal("expected violation when DB count is below minimum")
 	}
@@ -1066,7 +1066,7 @@ func TestCheckLogoPadding_ExcessPadding(t *testing.T) {
 	e := newTestEngine()
 	checker := e.makeLogoPaddingChecker()
 	a := artist.Artist{Name: "Test", LogoExists: true, Path: dir}
-	v := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v == nil {
 		t.Fatal("expected violation for logo with 72% padding")
 	}
@@ -1087,7 +1087,7 @@ func TestCheckLogoPadding_BelowThreshold(t *testing.T) {
 	e := newTestEngine()
 	checker := e.makeLogoPaddingChecker()
 	a := artist.Artist{Name: "Test", LogoExists: true, Path: dir}
-	v := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v != nil {
 		t.Errorf("expected nil for logo with 14.5%% padding, got %v", v)
 	}
@@ -1100,7 +1100,7 @@ func TestCheckLogoPadding_NoPadding(t *testing.T) {
 	e := newTestEngine()
 	checker := e.makeLogoPaddingChecker()
 	a := artist.Artist{Name: "Test", LogoExists: true, Path: dir}
-	v := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v != nil {
 		t.Errorf("expected nil for logo with no padding, got %v", v)
 	}
@@ -1110,7 +1110,7 @@ func TestCheckLogoPadding_NoLogo(t *testing.T) {
 	e := newTestEngine()
 	checker := e.makeLogoPaddingChecker()
 	a := artist.Artist{Name: "Test", LogoExists: false, Path: t.TempDir()}
-	v := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v != nil {
 		t.Errorf("expected nil when logo does not exist, got %v", v)
 	}
@@ -1120,7 +1120,7 @@ func TestCheckLogoPadding_NoPath(t *testing.T) {
 	e := newTestEngine()
 	checker := e.makeLogoPaddingChecker()
 	a := artist.Artist{Name: "Test", LogoExists: true, Path: ""}
-	v := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v != nil {
 		t.Errorf("expected nil when path is empty, got %v", v)
 	}
@@ -1136,7 +1136,7 @@ func TestCheckLogoPadding_DefaultThreshold(t *testing.T) {
 	e := newTestEngine()
 	checker := e.makeLogoPaddingChecker()
 	a := artist.Artist{Name: "Test", LogoExists: true, Path: dir}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation with default threshold (15%)")
 	}
@@ -1179,7 +1179,7 @@ func TestCheckLogoPadding_JPEGWhitespace(t *testing.T) {
 	e := newTestEngine()
 	checker := e.makeLogoPaddingChecker()
 	a := artist.Artist{Name: "Test", LogoExists: true, Path: dir}
-	v := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v == nil {
 		t.Fatal("expected violation for JPEG logo with whitespace padding")
 	}
@@ -1200,7 +1200,7 @@ func TestLogoBoundsCache_HitAfterFirstEval(t *testing.T) {
 	a := artist.Artist{Name: "Test", LogoExists: true, Path: dir}
 
 	// First call: cache miss, image is decoded and result stored.
-	v := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v == nil {
 		t.Fatal("expected violation on first call")
 	}
@@ -1219,7 +1219,7 @@ func TestLogoBoundsCache_HitAfterFirstEval(t *testing.T) {
 	}
 
 	// Second call: must use cached result (same violation, no re-decode).
-	v2 := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v2 := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v2 == nil {
 		t.Fatal("expected violation on second call (from cache)")
 	}
@@ -1252,7 +1252,7 @@ func TestLogoBoundsCache_MtimeInvalidation(t *testing.T) {
 	a := artist.Artist{Name: "Test", LogoExists: true, Path: dir}
 
 	// First call: populates the cache.
-	v1 := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v1 := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v1 == nil {
 		t.Fatal("expected violation on first call")
 	}
@@ -1280,7 +1280,7 @@ func TestLogoBoundsCache_MtimeInvalidation(t *testing.T) {
 		t.Log("old mtime entry was already evicted (acceptable)")
 	}
 
-	v2 := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v2 := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v2 != nil {
 		t.Errorf("expected nil violation after replacing with padding-free PNG, got: %s", v2.Message)
 	}
@@ -1591,7 +1591,7 @@ func TestCheckers_EmptyPath_DBDimensions(t *testing.T) {
 			checker := tt.checker(e)
 			a := tt.artistFn(artistID)
 
-			v := checker(a, tt.cfg)
+			v := checker(context.Background(), a, tt.cfg)
 			if v == nil {
 				t.Fatalf("expected violation for %s with DB dimensions %dx%d and empty Path", tt.ruleID, tt.w, tt.h)
 			}
@@ -1686,7 +1686,7 @@ func TestCheckers_EmptyPath_DBDimensions_Pass(t *testing.T) {
 			checker := tt.checker(e)
 			a := tt.artistFn(artistID)
 
-			v := checker(a, tt.cfg)
+			v := checker(context.Background(), a, tt.cfg)
 			if v != nil {
 				t.Errorf("expected nil (passing rule), got violation: %s", v.Message)
 			}
@@ -1757,7 +1757,7 @@ func TestCheckLogoPadding_APIFetch_ExcessPadding(t *testing.T) {
 	checker := e.makeLogoPaddingChecker()
 
 	a := artist.Artist{ID: "api-001", Name: "API Artist", LogoExists: true, Path: ""}
-	v := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v == nil {
 		t.Fatal("expected violation for API-fetched logo with 72% padding")
 	}
@@ -1782,7 +1782,7 @@ func TestCheckLogoPadding_APIFetch_BelowThreshold(t *testing.T) {
 	checker := e.makeLogoPaddingChecker()
 
 	a := artist.Artist{ID: "api-002", Name: "API Artist 2", LogoExists: true, Path: ""}
-	v := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v != nil {
 		t.Errorf("expected nil for API logo with 14.5%% padding, got %v", v)
 	}
@@ -1801,7 +1801,7 @@ func TestCheckLogoPadding_APIFetch_CachesBytes(t *testing.T) {
 	a := artist.Artist{ID: "api-003", Name: "Cache Test", LogoExists: true, Path: ""}
 
 	// First call: fetches from the mock.
-	v1 := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v1 := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v1 == nil {
 		t.Fatal("expected violation on first API call")
 	}
@@ -1810,7 +1810,7 @@ func TestCheckLogoPadding_APIFetch_CachesBytes(t *testing.T) {
 	}
 
 	// Second call: should use cached bytes, not fetch again.
-	v2 := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v2 := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v2 == nil {
 		t.Fatal("expected violation on second API call (from cache)")
 	}
@@ -1826,7 +1826,7 @@ func TestCheckLogoPadding_APIFetch_FetchError(t *testing.T) {
 	checker := e.makeLogoPaddingChecker()
 
 	a := artist.Artist{ID: "api-004", Name: "Error Artist", LogoExists: true, Path: ""}
-	v := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v != nil {
 		t.Errorf("expected nil when API fetch fails, got %v", v)
 	}
@@ -1837,7 +1837,7 @@ func TestCheckLogoPadding_NoPathNoFetcher(t *testing.T) {
 	e := newTestEngine()
 	checker := e.makeLogoPaddingChecker()
 	a := artist.Artist{ID: "nf-001", Name: "No Fetch", LogoExists: true, Path: ""}
-	v := checker(&a, RuleConfig{ThresholdPercent: 15})
+	v := checker(context.Background(), &a, RuleConfig{ThresholdPercent: 15})
 	if v != nil {
 		t.Errorf("expected nil when no path and no fetcher, got %v", v)
 	}
@@ -2144,7 +2144,7 @@ func TestExtraneousImagesChecker_DispatchesToDB(t *testing.T) {
 	e := &Engine{db: db, logger: slog.Default()}
 	checker := e.makeExtraneousImagesChecker()
 	a := artist.Artist{ID: "art-20", Name: "Dispatch Test", Path: ""}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation from DB path when Path is empty")
 	}
@@ -2164,7 +2164,7 @@ func TestBackdropSequencingChecker_DispatchesToDB(t *testing.T) {
 	e := &Engine{db: db, logger: slog.Default()}
 	checker := e.makeBackdropSequencingChecker()
 	a := artist.Artist{ID: "art-21", Name: "Dispatch Test 2", Path: ""}
-	v := checker(&a, RuleConfig{})
+	v := checker(context.Background(), &a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation from DB path when Path is empty")
 	}

--- a/internal/rule/engine.go
+++ b/internal/rule/engine.go
@@ -12,7 +12,17 @@ import (
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/library"
 	"github.com/sydlexius/stillwater/internal/platform"
+	"github.com/sydlexius/stillwater/internal/provider"
 )
+
+// MetadataProvider abstracts the subset of provider.Orchestrator that the
+// language-preference rule needs. It is used by the name_language_pref
+// checker to fetch a localized name candidate for comparison against the
+// stored artist Name and SortName. Wired by SetMetadataProvider; when nil
+// the checker degrades to a no-op rather than failing evaluation.
+type MetadataProvider interface {
+	FetchMetadata(ctx context.Context, mbid, name string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error)
+}
 
 // ruleCacheTTL is how long the in-memory rule list cache is considered fresh.
 // A short TTL (5 s) eliminates the N+1 DB query pattern under concurrent load
@@ -104,6 +114,12 @@ type Engine struct {
 	// have no local filesystem path (API-only imports from Emby/Jellyfin).
 	imageFetcher PlatformImageFetcher
 
+	// metadataProvider is used by the name_language_pref checker and fixer
+	// to fetch the best-matching localized alias for an artist. When nil,
+	// the checker silently no-ops (returns nil violations) so evaluation
+	// remains stable in test or stripped-down environments.
+	metadataProvider MetadataProvider
+
 	// apiImageCacheMu guards apiImageCache.
 	apiImageCacheMu sync.Mutex
 	// apiImageCache stores raw image bytes fetched via the platform API. This
@@ -149,7 +165,24 @@ func NewEngine(service *Service, db *sql.DB, platformService *platform.Service, 
 	e.checkers[RuleBackdropSequencing] = e.makeBackdropSequencingChecker()
 	e.checkers[RuleBackdropMinCount] = e.makeBackdropMinCountChecker()
 	e.checkers[RuleLogoPadding] = e.makeLogoPaddingChecker()
+	e.checkers[RuleNameLanguagePref] = e.makeNameLanguagePrefChecker()
 	return e
+}
+
+// SetMetadataProvider attaches a metadata provider (typically the
+// provider.Orchestrator) to the engine. The name_language_pref checker
+// uses it to fetch localized aliases for comparison against the stored
+// artist Name and SortName. Pass nil to disable the rule (its checker
+// will return nil for every artist).
+func (e *Engine) SetMetadataProvider(p MetadataProvider) {
+	e.metadataProvider = p
+}
+
+// MetadataProvider returns the engine's metadata provider, or nil if none
+// is configured. The name_language_pref fixer uses this to perform the
+// alias lookup and promotion.
+func (e *Engine) MetadataProvider() MetadataProvider {
+	return e.metadataProvider
 }
 
 // cachedRules returns the rule list from the in-memory cache when it is still
@@ -323,7 +356,7 @@ func (e *Engine) Evaluate(ctx context.Context, a *artist.Artist) (*EvaluationRes
 
 		result.RulesTotal++
 
-		v := checker(a, r.Config)
+		v := checker(ctx, a, r.Config)
 		if v != nil {
 			// Use severity from rule config if the checker did not set it
 			if v.Severity == "" {

--- a/internal/rule/fixers_language.go
+++ b/internal/rule/fixers_language.go
@@ -41,10 +41,9 @@ func (f *NameLanguageFixer) CanFix(v *Violation) bool {
 // The orchestrator is invoked with the request context so the MusicBrainz
 // adapter sees the user's language preferences and returns a localized name.
 //
-// Updates to Name and SortName are paired: when the alias has a non-empty
-// SortName different from the canonical, both fields are updated together.
-// When the alias has only a Name (no SortName), only Name is updated and
-// SortName is preserved (the MB adapter applies the same rule).
+// Name and SortName are updated independently: SortName is changed only when
+// the alias supplies a non-empty SortName different from the stored value.
+// Otherwise only Name is updated and SortName is preserved.
 func (f *NameLanguageFixer) Fix(ctx context.Context, a *artist.Artist, v *Violation) (*FixResult, error) {
 	if a.MusicBrainzID == "" {
 		return &FixResult{

--- a/internal/rule/fixers_language.go
+++ b/internal/rule/fixers_language.go
@@ -1,0 +1,131 @@
+package rule
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// NameLanguageFixer promotes a localized MusicBrainz alias into the artist's
+// Name and SortName fields when the user's language preferences point at a
+// higher-priority alias than the canonical name. Used by the
+// name_language_pref rule.
+//
+// The fixer relies on the orchestrator (the same dependency used by
+// MetadataFixer) to fetch artist metadata; the MusicBrainz adapter performs
+// the actual alias scoring and promotion when the request context carries
+// language preferences (provider.WithMetadataLanguages).
+type NameLanguageFixer struct {
+	orchestrator MetadataProvider
+	logger       *slog.Logger
+}
+
+// NewNameLanguageFixer creates a NameLanguageFixer. The orchestrator is the
+// same provider.Orchestrator passed to other metadata fixers.
+func NewNameLanguageFixer(orchestrator MetadataProvider, logger *slog.Logger) *NameLanguageFixer {
+	return &NameLanguageFixer{orchestrator: orchestrator, logger: logger}
+}
+
+// CanFix reports whether this fixer handles the given violation. Only the
+// name_language_pref rule is supported.
+func (f *NameLanguageFixer) CanFix(v *Violation) bool {
+	return v.RuleID == RuleNameLanguagePref
+}
+
+// Fix promotes the best-matching localized alias to a.Name and a.SortName.
+// The orchestrator is invoked with the request context so the MusicBrainz
+// adapter sees the user's language preferences and returns a localized name.
+//
+// Updates to Name and SortName are paired: when the alias has a non-empty
+// SortName different from the canonical, both fields are updated together.
+// When the alias has only a Name (no SortName), only Name is updated and
+// SortName is preserved (the MB adapter applies the same rule).
+func (f *NameLanguageFixer) Fix(ctx context.Context, a *artist.Artist, v *Violation) (*FixResult, error) {
+	if a.MusicBrainzID == "" {
+		return &FixResult{
+			RuleID:  RuleNameLanguagePref,
+			Fixed:   false,
+			Message: fmt.Sprintf("artist %s has no MusicBrainz ID", a.Name),
+		}, nil
+	}
+	if a.Locked {
+		return &FixResult{
+			RuleID:  RuleNameLanguagePref,
+			Fixed:   false,
+			Message: fmt.Sprintf("artist %s is locked", a.Name),
+		}, nil
+	}
+	if f.orchestrator == nil {
+		return &FixResult{
+			RuleID:  RuleNameLanguagePref,
+			Fixed:   false,
+			Message: "metadata orchestrator not configured",
+		}, nil
+	}
+	if len(provider.MetadataLanguages(ctx)) == 0 {
+		return &FixResult{
+			RuleID:  RuleNameLanguagePref,
+			Fixed:   false,
+			Message: "no language preferences set; cannot promote localized name",
+		}, nil
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	result, err := f.orchestrator.FetchMetadata(fetchCtx, a.MusicBrainzID, a.Name, a.ProviderIDMap())
+	if err != nil {
+		return nil, fmt.Errorf("fetching metadata: %w", err)
+	}
+	if result == nil || result.Metadata == nil {
+		return &FixResult{
+			RuleID:  RuleNameLanguagePref,
+			Fixed:   false,
+			Message: fmt.Sprintf("no metadata returned for %s", a.Name),
+		}, nil
+	}
+
+	bestName := strings.TrimSpace(result.Metadata.Name)
+	bestSort := strings.TrimSpace(result.Metadata.SortName)
+
+	// Treat the orchestrator's already-localized values as the source of
+	// truth: they were chosen using the same MatchLanguagePreference scoring
+	// as the checker, so trusting them keeps the two paths consistent.
+	nameDiff := bestName != "" && bestName != a.Name
+	sortDiff := bestSort != "" && bestSort != a.SortName
+
+	if !nameDiff && !sortDiff {
+		return &FixResult{
+			RuleID:  RuleNameLanguagePref,
+			Fixed:   false,
+			Message: fmt.Sprintf("no localized alias differs from current name for %s", a.Name),
+		}, nil
+	}
+
+	oldName := a.Name
+	oldSort := a.SortName
+	if nameDiff {
+		a.Name = bestName
+	}
+	if sortDiff {
+		a.SortName = bestSort
+	}
+
+	f.logger.Info("name_language_pref: promoted localized name",
+		slog.String("artist_id", a.ID),
+		slog.String("from_name", oldName),
+		slog.String("to_name", a.Name),
+		slog.String("from_sort", oldSort),
+		slog.String("to_sort", a.SortName))
+
+	return &FixResult{
+		RuleID:  RuleNameLanguagePref,
+		Fixed:   true,
+		Message: fmt.Sprintf("promoted localized name '%s' (sort '%s') for %s", a.Name, a.SortName, oldName),
+	}, nil
+}

--- a/internal/rule/fixers_language_test.go
+++ b/internal/rule/fixers_language_test.go
@@ -1,0 +1,155 @@
+package rule
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+func TestNameLanguageFixer_CanFix(t *testing.T) {
+	f := &NameLanguageFixer{}
+	if !f.CanFix(&Violation{RuleID: RuleNameLanguagePref}) {
+		t.Error("NameLanguageFixer should handle name_language_pref")
+	}
+	if f.CanFix(&Violation{RuleID: RuleBioExists}) {
+		t.Error("NameLanguageFixer should not handle bio_exists")
+	}
+}
+
+func TestNameLanguageFixer_Fix(t *testing.T) {
+	tests := []struct {
+		name      string
+		artist    artist.Artist
+		stub      *stubMetadataProvider
+		ctx       context.Context
+		wantFixed bool
+		wantName  string
+		wantSort  string
+	}{
+		{
+			name:   "promotes both name and sort name",
+			artist: artist.Artist{Name: "Mecano", SortName: "Mecano", MusicBrainzID: "mbid-1"},
+			stub: &stubMetadataProvider{
+				metadata: &provider.ArtistMetadata{Name: "Mecano (band)", SortName: "Mecano, Band"},
+			},
+			ctx:       provider.WithMetadataLanguages(context.Background(), []string{"es", "en"}),
+			wantFixed: true,
+			wantName:  "Mecano (band)",
+			wantSort:  "Mecano, Band",
+		},
+		{
+			name:   "promotes name only when sort matches",
+			artist: artist.Artist{Name: "BTS", SortName: "BTS", MusicBrainzID: "mbid-2"},
+			stub: &stubMetadataProvider{
+				metadata: &provider.ArtistMetadata{Name: "Bangtan Sonyeondan", SortName: "BTS"},
+			},
+			ctx:       provider.WithMetadataLanguages(context.Background(), []string{"ko", "en"}),
+			wantFixed: true,
+			wantName:  "Bangtan Sonyeondan",
+			wantSort:  "BTS",
+		},
+		{
+			name:   "no-op when localized name matches",
+			artist: artist.Artist{Name: "Rammstein", SortName: "Rammstein", MusicBrainzID: "mbid-3"},
+			stub: &stubMetadataProvider{
+				metadata: &provider.ArtistMetadata{Name: "Rammstein", SortName: "Rammstein"},
+			},
+			ctx:       provider.WithMetadataLanguages(context.Background(), []string{"de", "en"}),
+			wantFixed: false,
+			wantName:  "Rammstein",
+			wantSort:  "Rammstein",
+		},
+		{
+			name:      "skips when MBID is empty",
+			artist:    artist.Artist{Name: "X", MusicBrainzID: ""},
+			stub:      &stubMetadataProvider{},
+			ctx:       provider.WithMetadataLanguages(context.Background(), []string{"de"}),
+			wantFixed: false,
+			wantName:  "X",
+		},
+		{
+			name:      "skips when artist is locked",
+			artist:    artist.Artist{Name: "X", MusicBrainzID: "mbid", Locked: true},
+			stub:      &stubMetadataProvider{},
+			ctx:       provider.WithMetadataLanguages(context.Background(), []string{"de"}),
+			wantFixed: false,
+			wantName:  "X",
+		},
+		{
+			name:      "skips when no language preferences",
+			artist:    artist.Artist{Name: "X", MusicBrainzID: "mbid"},
+			stub:      &stubMetadataProvider{},
+			ctx:       context.Background(),
+			wantFixed: false,
+			wantName:  "X",
+		},
+		{
+			name:   "not-fixed when FetchResult has nil Metadata",
+			artist: artist.Artist{Name: "X", MusicBrainzID: "mbid-nil"},
+			stub: &stubMetadataProvider{
+				metadata: nil,
+			},
+			ctx:       provider.WithMetadataLanguages(context.Background(), []string{"de"}),
+			wantFixed: false,
+			wantName:  "X",
+		},
+		{
+			name:   "promotes sort name only when name matches",
+			artist: artist.Artist{Name: "Rammstein", SortName: "rammstein", MusicBrainzID: "mbid-sort"},
+			stub: &stubMetadataProvider{
+				metadata: &provider.ArtistMetadata{Name: "Rammstein", SortName: "Rammstein"},
+			},
+			ctx:       provider.WithMetadataLanguages(context.Background(), []string{"de"}),
+			wantFixed: true,
+			wantName:  "Rammstein",
+			wantSort:  "Rammstein",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := NewNameLanguageFixer(tt.stub, testLogger())
+			a := tt.artist // copy for mutation
+			fr, err := f.Fix(tt.ctx, &a, &Violation{RuleID: RuleNameLanguagePref})
+			if err != nil {
+				t.Fatalf("Fix returned error: %v", err)
+			}
+			if fr.Fixed != tt.wantFixed {
+				t.Errorf("Fixed = %v, want %v (msg: %s)", fr.Fixed, tt.wantFixed, fr.Message)
+			}
+			if a.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", a.Name, tt.wantName)
+			}
+			if tt.wantSort != "" && a.SortName != tt.wantSort {
+				t.Errorf("SortName = %q, want %q", a.SortName, tt.wantSort)
+			}
+		})
+	}
+}
+
+func TestNameLanguageFixer_Fix_FetchError(t *testing.T) {
+	stub := &stubMetadataProvider{err: errors.New("upstream 503")}
+	f := NewNameLanguageFixer(stub, testLogger())
+	a := &artist.Artist{Name: "X", MusicBrainzID: "mbid"}
+	ctx := provider.WithMetadataLanguages(context.Background(), []string{"de"})
+	_, err := f.Fix(ctx, a, &Violation{RuleID: RuleNameLanguagePref})
+	if err == nil {
+		t.Fatal("expected error from Fix when fetch fails")
+	}
+}
+
+func TestNameLanguageFixer_Fix_NilOrchestrator(t *testing.T) {
+	f := &NameLanguageFixer{logger: testLogger()}
+	a := &artist.Artist{Name: "X", MusicBrainzID: "mbid"}
+	ctx := provider.WithMetadataLanguages(context.Background(), []string{"de"})
+	fr, err := f.Fix(ctx, a, &Violation{RuleID: RuleNameLanguagePref})
+	if err != nil {
+		t.Fatalf("Fix returned error: %v", err)
+	}
+	if fr.Fixed {
+		t.Error("expected Fixed=false when orchestrator is nil")
+	}
+}

--- a/internal/rule/fs_categorization_test.go
+++ b/internal/rule/fs_categorization_test.go
@@ -41,6 +41,7 @@ func TestIsFilesystemDependent(t *testing.T) {
 		RuleImageDuplicate,
 		RuleBackdropSequencing,
 		RuleBackdropMinCount,
+		RuleNameLanguagePref,
 	}
 	for _, id := range apiRules {
 		if IsFilesystemDependent(id) {
@@ -79,6 +80,7 @@ func TestAllDefaultRulesAreCategorized(t *testing.T) {
 		RuleImageDuplicate:        true,
 		RuleBackdropSequencing:    true,
 		RuleBackdropMinCount:      true,
+		RuleNameLanguagePref:      true,
 	}
 
 	for _, r := range defaultRules {

--- a/internal/rule/lang_script.go
+++ b/internal/rule/lang_script.go
@@ -1,0 +1,135 @@
+package rule
+
+import (
+	"strings"
+	"unicode"
+)
+
+const (
+	scriptLatin      = "latin"
+	scriptHan        = "han"
+	scriptHiragana   = "hiragana"
+	scriptKatakana   = "katakana"
+	scriptHangul     = "hangul"
+	scriptCyrillic   = "cyrillic"
+	scriptArabic     = "arabic"
+	scriptHebrew     = "hebrew"
+	scriptGreek      = "greek"
+	scriptDevanagari = "devanagari"
+	scriptThai       = "thai"
+	scriptUnknown    = "unknown"
+)
+
+var scriptTables = []struct {
+	name  string
+	table *unicode.RangeTable
+}{
+	{scriptLatin, unicode.Latin},
+	{scriptHan, unicode.Han},
+	{scriptHiragana, unicode.Hiragana},
+	{scriptKatakana, unicode.Katakana},
+	{scriptHangul, unicode.Hangul},
+	{scriptCyrillic, unicode.Cyrillic},
+	{scriptArabic, unicode.Arabic},
+	{scriptHebrew, unicode.Hebrew},
+	{scriptGreek, unicode.Greek},
+	{scriptDevanagari, unicode.Devanagari},
+	{scriptThai, unicode.Thai},
+}
+
+// dominantScript returns the Unicode script that accounts for the most
+// letter/symbol runes in s. Whitespace, digits, and punctuation are ignored.
+// Returns scriptUnknown when no classifiable runes are found.
+func dominantScript(s string) string {
+	counts := make(map[string]int, len(scriptTables))
+	total := 0
+	for _, r := range s {
+		if unicode.IsSpace(r) || unicode.IsDigit(r) || unicode.IsPunct(r) || unicode.IsSymbol(r) {
+			continue
+		}
+		for _, st := range scriptTables {
+			if unicode.Is(st.table, r) {
+				counts[st.name]++
+				total++
+				break
+			}
+		}
+	}
+	if total == 0 {
+		return scriptUnknown
+	}
+	best := scriptUnknown
+	bestN := 0
+	for name, n := range counts {
+		if n > bestN {
+			best = name
+			bestN = n
+		}
+	}
+	return best
+}
+
+// localeScripts maps a BCP-47 language prefix to the set of scripts that
+// are expected for text in that language. Japanese is special: names can be
+// in Han (kanji), Hiragana, or Katakana, all of which are valid.
+var localeScripts = map[string][]string{
+	"en": {scriptLatin},
+	"es": {scriptLatin},
+	"de": {scriptLatin},
+	"fr": {scriptLatin},
+	"it": {scriptLatin},
+	"pt": {scriptLatin},
+	"nl": {scriptLatin},
+	"sv": {scriptLatin},
+	"no": {scriptLatin},
+	"da": {scriptLatin},
+	"fi": {scriptLatin},
+	"pl": {scriptLatin},
+	"cs": {scriptLatin},
+	"sk": {scriptLatin},
+	"hu": {scriptLatin},
+	"ro": {scriptLatin},
+	"tr": {scriptLatin},
+	"id": {scriptLatin},
+	"ms": {scriptLatin},
+	"vi": {scriptLatin},
+	"tl": {scriptLatin},
+	"ja": {scriptHan, scriptHiragana, scriptKatakana},
+	"zh": {scriptHan},
+	"ko": {scriptHangul, scriptHan},
+	"ru": {scriptCyrillic},
+	"uk": {scriptCyrillic},
+	"be": {scriptCyrillic},
+	"bg": {scriptCyrillic},
+	"sr": {scriptCyrillic, scriptLatin},
+	"ar": {scriptArabic},
+	"fa": {scriptArabic},
+	"he": {scriptHebrew},
+	"el": {scriptGreek},
+	"hi": {scriptDevanagari},
+	"th": {scriptThai},
+}
+
+// scriptMatchesAnyLocale returns true when the given script is expected for
+// at least one of the BCP-47 locale tags in prefs.
+func scriptMatchesAnyLocale(script string, prefs []string) bool {
+	if script == scriptUnknown {
+		return true
+	}
+	for _, p := range prefs {
+		lang := strings.SplitN(strings.ToLower(strings.TrimSpace(p)), "-", 2)[0]
+		allowed, ok := localeScripts[lang]
+		if !ok {
+			// Unmapped locales default to Latin (the most common script
+			// worldwide). This prevents false-positive violations for the
+			// 100+ Latin-script languages not explicitly listed.
+			allowed = []string{scriptLatin}
+		}
+		for _, s := range allowed {
+			if script == s {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/rule/lang_script.go
+++ b/internal/rule/lang_script.go
@@ -113,13 +113,59 @@ var localeScripts = map[string][]string{
 	"th": {scriptThai},
 }
 
+// iso15924ToScript maps ISO 15924 script codes (as used in BCP-47 script
+// subtags like "sr-Latn" or "zh-Hant") to our internal script constants.
+// Only scripts we detect via dominantScript are included.
+var iso15924ToScript = map[string]string{
+	"latn": scriptLatin,
+	"hani": scriptHan,
+	"hans": scriptHan,
+	"hant": scriptHan,
+	"hira": scriptHiragana,
+	"kana": scriptKatakana,
+	"hang": scriptHangul,
+	"kore": scriptHangul,
+	"cyrl": scriptCyrillic,
+	"arab": scriptArabic,
+	"hebr": scriptHebrew,
+	"grek": scriptGreek,
+	"deva": scriptDevanagari,
+	"thai": scriptThai,
+}
+
+// parseBCP47Script extracts the explicit ISO 15924 script subtag from a
+// BCP-47 tag (e.g. "sr-Latn" -> "latn", "zh-Hant-TW" -> "hant"). Returns
+// the empty string when no script subtag is present. The script subtag is
+// always a 4-letter segment; language is 2-3 letters and region is 2
+// letters or 3 digits, so the 4-letter position after the language is
+// unambiguous.
+func parseBCP47Script(tag string) string {
+	parts := strings.Split(strings.ToLower(strings.TrimSpace(tag)), "-")
+	for _, p := range parts[1:] {
+		if len(p) == 4 {
+			return p
+		}
+	}
+	return ""
+}
+
 // scriptMatchesAnyLocale returns true when the given script is expected for
-// at least one of the BCP-47 locale tags in prefs.
+// at least one of the BCP-47 locale tags in prefs. Explicit script subtags
+// (sr-Latn, zh-Hant, etc.) are honored directly; otherwise the base language
+// maps through localeScripts.
 func scriptMatchesAnyLocale(script string, prefs []string) bool {
 	if script == scriptUnknown {
 		return true
 	}
 	for _, p := range prefs {
+		// Honor an explicit BCP-47 script subtag first: "sr-Latn" must
+		// mean Latin only, not Serbia's default [cyrillic, latin] set.
+		if sub := parseBCP47Script(p); sub != "" {
+			if mapped, ok := iso15924ToScript[sub]; ok && mapped == script {
+				return true
+			}
+			continue
+		}
 		lang := strings.SplitN(strings.ToLower(strings.TrimSpace(p)), "-", 2)[0]
 		allowed, ok := localeScripts[lang]
 		if !ok {

--- a/internal/rule/lang_script.go
+++ b/internal/rule/lang_script.go
@@ -58,11 +58,14 @@ func dominantScript(s string) string {
 	if total == 0 {
 		return scriptUnknown
 	}
+	// Iterate scriptTables (fixed order) instead of the counts map (random
+	// order) so mixed-script ties resolve deterministically to the script
+	// listed first in scriptTables.
 	best := scriptUnknown
 	bestN := 0
-	for name, n := range counts {
-		if n > bestN {
-			best = name
+	for _, st := range scriptTables {
+		if n := counts[st.name]; n > bestN {
+			best = st.name
 			bestN = n
 		}
 	}

--- a/internal/rule/lang_script.go
+++ b/internal/rule/lang_script.go
@@ -120,10 +120,10 @@ func scriptMatchesAnyLocale(script string, prefs []string) bool {
 		lang := strings.SplitN(strings.ToLower(strings.TrimSpace(p)), "-", 2)[0]
 		allowed, ok := localeScripts[lang]
 		if !ok {
-			// Unmapped locales default to Latin (the most common script
-			// worldwide). This prevents false-positive violations for the
-			// 100+ Latin-script languages not explicitly listed.
-			allowed = []string{scriptLatin}
+			// Unmapped locales are treated as permissive: any script matches.
+			// This avoids false positives for languages not in the map (e.g.
+			// Macedonian, Mongolian, Tajik use Cyrillic but are not listed).
+			return true
 		}
 		for _, s := range allowed {
 			if script == s {

--- a/internal/rule/lang_script_test.go
+++ b/internal/rule/lang_script_test.go
@@ -1,0 +1,72 @@
+package rule
+
+import "testing"
+
+func TestDominantScript(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"latin name", "Rammstein", scriptLatin},
+		{"kanji name", "\u5c3e\u5d0e\u8c4a", scriptHan},
+		{"hiragana name", "\u3072\u3089\u304c\u306a", scriptHiragana},
+		{"katakana name", "\u30d0\u30d3\u30e1\u30bf\u30eb", scriptKatakana},
+		{"hangul name", "\ubc29\ud0c4\uc18c\ub144\ub2e8", scriptHangul},
+		{"cyrillic name", "\u0420\u0430\u043c\u043c\u0448\u0442\u0430\u0439\u043d", scriptCyrillic},
+		{"arabic name", "\u0641\u064a\u0631\u0648\u0632", scriptArabic},
+		{"greek name", "\u039c\u03af\u03ba\u03b7\u03c2", scriptGreek},
+		{"devanagari name", "\u0939\u093f\u0902\u0926\u0940", scriptDevanagari},
+		{"thai name", "\u0e44\u0e17\u0e22", scriptThai},
+		{"hebrew name", "\u05e2\u05d1\u05e8\u05d9\u05ea", scriptHebrew},
+		{"mixed latin-kanji prefers dominant", "X\u5c3e\u5d0e\u8c4a", scriptHan},
+		{"digits and spaces ignored", "  123  ", scriptUnknown},
+		{"empty string", "", scriptUnknown},
+		{"latin with numbers", "Blink-182", scriptLatin},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dominantScript(tt.input)
+			if got != tt.want {
+				t.Errorf("dominantScript(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScriptMatchesAnyLocale(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+		prefs  []string
+		want   bool
+	}{
+		{"latin matches english", scriptLatin, []string{"en"}, true},
+		{"latin matches german", scriptLatin, []string{"de"}, true},
+		{"han matches japanese", scriptHan, []string{"ja"}, true},
+		{"hiragana matches japanese", scriptHiragana, []string{"ja"}, true},
+		{"katakana matches japanese", scriptKatakana, []string{"ja"}, true},
+		{"han matches chinese", scriptHan, []string{"zh"}, true},
+		{"hangul matches korean", scriptHangul, []string{"ko"}, true},
+		{"cyrillic matches russian", scriptCyrillic, []string{"ru"}, true},
+		{"han does not match english", scriptHan, []string{"en"}, false},
+		{"latin does not match japanese", scriptLatin, []string{"ja"}, false},
+		{"hangul does not match english", scriptHangul, []string{"en-US", "en"}, false},
+		{"unknown always matches", scriptUnknown, []string{"en"}, true},
+		{"second pref matches", scriptCyrillic, []string{"en", "ru"}, true},
+		{"locale tag stripped", scriptLatin, []string{"en-US", "en-GB"}, true},
+		{"unmapped locale defaults to latin", scriptLatin, []string{"xx"}, true},
+		{"serbian latin", scriptLatin, []string{"sr"}, true},
+		{"serbian cyrillic", scriptCyrillic, []string{"sr"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scriptMatchesAnyLocale(tt.script, tt.prefs)
+			if got != tt.want {
+				t.Errorf("scriptMatchesAnyLocale(%q, %v) = %v, want %v", tt.script, tt.prefs, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/rule/lang_script_test.go
+++ b/internal/rule/lang_script_test.go
@@ -56,7 +56,8 @@ func TestScriptMatchesAnyLocale(t *testing.T) {
 		{"unknown always matches", scriptUnknown, []string{"en"}, true},
 		{"second pref matches", scriptCyrillic, []string{"en", "ru"}, true},
 		{"locale tag stripped", scriptLatin, []string{"en-US", "en-GB"}, true},
-		{"unmapped locale defaults to latin", scriptLatin, []string{"xx"}, true},
+		{"unmapped locale is permissive (matches any script)", scriptLatin, []string{"xx"}, true},
+		{"unmapped locale matches cyrillic too", scriptCyrillic, []string{"mk"}, true},
 		{"serbian latin", scriptLatin, []string{"sr"}, true},
 		{"serbian cyrillic", scriptCyrillic, []string{"sr"}, true},
 	}

--- a/internal/rule/lang_script_test.go
+++ b/internal/rule/lang_script_test.go
@@ -60,6 +60,11 @@ func TestScriptMatchesAnyLocale(t *testing.T) {
 		{"unmapped locale matches cyrillic too", scriptCyrillic, []string{"mk"}, true},
 		{"serbian latin", scriptLatin, []string{"sr"}, true},
 		{"serbian cyrillic", scriptCyrillic, []string{"sr"}, true},
+		{"sr-Latn accepts latin only", scriptLatin, []string{"sr-Latn"}, true},
+		{"sr-Latn rejects cyrillic", scriptCyrillic, []string{"sr-Latn"}, false},
+		{"sr-Cyrl accepts cyrillic only", scriptCyrillic, []string{"sr-Cyrl"}, true},
+		{"sr-Cyrl rejects latin", scriptLatin, []string{"sr-Cyrl"}, false},
+		{"zh-Hant with region accepts han", scriptHan, []string{"zh-Hant-TW"}, true},
 	}
 
 	for _, tt := range tests {

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -227,7 +227,7 @@ var defaultRules = []Rule{
 	{
 		ID:             RuleNameLanguagePref,
 		Name:           "Artist name matches preferred language",
-		Description:    "Flags artists whose stored Name or SortName does not match the user's preferred metadata languages when MusicBrainz publishes a primary alias in a higher-priority preferred locale. In manual mode, click Fix to promote the localized alias. In auto mode, the alias is promoted automatically during evaluation.",
+		Description:    "Flags artists whose stored Name or SortName does not match the user's preferred metadata languages. When MusicBrainz provides a preferred-locale alias, the violation is fixable and Fix/auto mode can promote it; otherwise the violation is informational and can be edited manually or dismissed.",
 		Category:       "metadata",
 		Enabled:        false,
 		AutomationMode: AutomationModeManual,

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -40,6 +40,7 @@ const (
 	RuleBackdropSequencing    = "backdrop_sequencing"
 	RuleBackdropMinCount      = "backdrop_min_count"
 	RuleLogoPadding           = "logo_padding"
+	RuleNameLanguagePref      = "name_language_pref"
 
 	// Deprecated rule IDs kept for migration. These rules have been merged
 	// into other rules but may still have violations in the database.
@@ -222,6 +223,15 @@ var defaultRules = []Rule{
 		Enabled:        false,
 		AutomationMode: AutomationModeManual,
 		Config:         RuleConfig{ThresholdPercent: 15, TrimMargin: 2, Severity: "info"},
+	},
+	{
+		ID:             RuleNameLanguagePref,
+		Name:           "Artist name matches preferred language",
+		Description:    "Flags artists whose stored Name or SortName does not match the user's preferred metadata languages when MusicBrainz publishes a primary alias in a higher-priority preferred locale. In manual mode, click Fix to promote the localized alias. In auto mode, the alias is promoted automatically during evaluation.",
+		Category:       "metadata",
+		Enabled:        false,
+		AutomationMode: AutomationModeManual,
+		Config:         RuleConfig{Severity: "warning"},
 	},
 }
 

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -924,6 +924,7 @@ func GroupViolations(violations []RuleViolation, groupBy string) []ViolationGrou
 			"extraneous": "image",
 			"bio":        "metadata",
 			"artist":     "metadata",
+			"name":       "metadata",
 		}
 		for prefix, cat := range prefixMap {
 			if len(ruleID) >= len(prefix) && ruleID[:len(prefix)] == prefix {


### PR DESCRIPTION
## Summary
- New `name_language_pref` rule that flags artists whose stored Name is in a script not matching the user's preferred metadata languages
- Unicode script detection (Han/Hiragana/Katakana vs Latin, Cyrillic vs Latin, etc.) as the primary signal; Latin-vs-Latin out of scope for v1
- Fixable violations (MB alias available) get a Fix button; unfixable ones surface as informational
- Checker signature now carries `context.Context`, eliminating the `evalCtx` stash/mutex race condition
- 10s timeout on orchestrator calls in both checker and fixer
- Per-artist and bulk-action handlers now inject metadata language preferences

Closes #961

## Test plan
- [x] `go test -race ./internal/rule/...` (23s, all pass)
- [x] `go test -race ./internal/api/...` (149s, all pass)
- [x] `bash scripts/pre-push-gate.sh` (all hard checks pass)
- [x] `/pr-review-toolkit:review-pr` findings addressed (ctx race, fixer timeout, unmapped locales, logging levels, test gaps)
- [x] Manual UAT: Japanese-named artist flagged with English prefs, violation persisted and visible via API
- [ ] Notification page discoverability depends on #1098 (search/filter) -- filed as follow-up

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a name-language-preference check with dominant-script detection, locale-aware matching, and an optional fixer that can promote localized artist names; rule is registered but disabled by default.

* **Bug Fixes**
  * Metadata language preferences now propagate into request and background evaluation/fix flows so checks and fixes respect user language settings.

* **Tests**
  * Added comprehensive unit tests for the checker, fixer, script-detection, and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->