### PR TITLE
fix(rule): set scheduler lastRunAt before health snapshot write

### DIFF
--- a/internal/rule/scheduler.go
+++ b/internal/rule/scheduler.go
@@ -147,6 +147,12 @@ func (s *Scheduler) runEnabledRules(ctx context.Context) {
 		"fixes_succeeded", totalResult.FixesSucceeded,
 	)
 
+	// Record lastRunAt before the health snapshot so Status() reflects the
+	// completed evaluation even if the snapshot write is slow or fails.
+	s.mu.Lock()
+	s.lastRunAt = time.Now().UTC()
+	s.mu.Unlock()
+
 	// Record health snapshot after the run completes
 	if s.artistService != nil && s.ruleService != nil {
 		stats, err := s.artistService.GetHealthStats(ctx, "")
@@ -158,8 +164,4 @@ func (s *Scheduler) runEnabledRules(ctx context.Context) {
 			}
 		}
 	}
-
-	s.mu.Lock()
-	s.lastRunAt = time.Now().UTC()
-	s.mu.Unlock()
 }


### PR DESCRIPTION
## Summary

- Flaky `TestScheduler_Status_AfterRun` (CI run [24539999624](https://github.com/sydlexius/stillwater/actions/runs/24539999624/job/71743563933)) traced to a real race in `internal/rule/scheduler.go`: `lastRunAt` was updated only after the health-snapshot DB write, so a slow write left `Status()` returning a zero timestamp even though the evaluation had completed (visible in the CI log just before the failure).
- Move the `lastRunAt` update to run immediately after the evaluation-complete log, before the best-effort snapshot write. Semantics now match the JSON field name (`last_evaluation_at`): it records when the evaluation finished, not when telemetry finished.
- Bug landed in #709 (2026-03-26) when `Status()` and the snapshot were introduced together.

## Test plan

- [x] `go test -race -run 'TestScheduler_' -count=5 ./internal/rule/` passes 5 iterations
- [x] Full `go test ./...` green locally
- [x] `TestOpenAPIConsistency` green
- [x] Local review toolkit: no critical or important findings

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of rule evaluation completion timestamps to reflect actual completion time, ensuring the status reflects evaluation completion regardless of health snapshot recording performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->