### PR TITLE
refactor(langpref): extract ordered language preference repository (#952 slice 1)

### DIFF
--- a/internal/api/handlers_preferences.go
+++ b/internal/api/handlers_preferences.go
@@ -3,13 +3,13 @@ package api
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/sydlexius/stillwater/internal/api/middleware"
+	"github.com/sydlexius/stillwater/internal/langpref"
 	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/web/templates"
 )
@@ -151,12 +151,12 @@ func normalizePageSize(raw string) string {
 // normalizeMetadataLanguages validates and re-encodes a stored metadata_languages
 // value. Invalid or empty values fall back to MetadataLanguagesDefault. This is
 // the read-path counterpart to validateMetadataLanguages (used on write).
+//
+// Implementation lives in the langpref package; this thin wrapper is kept so
+// existing api-package call sites continue to compile. Prefer
+// langpref.NormalizeJSON in new code.
 func normalizeMetadataLanguages(raw string) string {
-	canonical, ok := validateMetadataLanguages(raw)
-	if !ok {
-		return MetadataLanguagesDefault
-	}
-	return canonical
+	return langpref.NormalizeJSON(raw)
 }
 
 // isMetadataLanguagesKey reports whether key is the metadata_languages preference key.
@@ -169,138 +169,38 @@ func isMetadataLanguagesKey(key string) bool {
 
 // MetadataLanguagesDefault is the default value for the metadata_languages
 // preference when no user preference is stored.
-const MetadataLanguagesDefault = `["en"]`
+//
+// Deprecated: use langpref.DefaultJSON in new code.
+const MetadataLanguagesDefault = langpref.DefaultJSON
 
 // MetadataLanguagesMaxEntries limits how many language tags a user can store.
-const MetadataLanguagesMaxEntries = 20
+//
+// Deprecated: use langpref.MaxEntries in new code.
+const MetadataLanguagesMaxEntries = langpref.MaxEntries
 
 // validateMetadataLanguages checks that raw is a valid JSON array of BCP 47
 // language tags and returns the canonical JSON encoding together with whether
 // the value is valid.
+//
+// Implementation lives in the langpref package; this thin wrapper is kept so
+// existing api-package call sites continue to compile. Prefer
+// langpref.ValidateJSON in new code.
 func validateMetadataLanguages(raw string) (string, bool) {
-	var tags []string
-	if err := json.Unmarshal([]byte(raw), &tags); err != nil {
+	canonical, _, ok := langpref.ValidateJSON(raw)
+	if !ok {
 		return "", false
 	}
-	if len(tags) == 0 || len(tags) > MetadataLanguagesMaxEntries {
-		return "", false
-	}
-	seen := make(map[string]bool, len(tags))
-	normalized := make([]string, 0, len(tags))
-	for _, tag := range tags {
-		if tag == "" || !isValidLanguageTag(tag) {
-			return "", false
-		}
-		canon := normalizeLanguageTag(tag)
-		lower := strings.ToLower(canon)
-		if seen[lower] {
-			return "", false
-		}
-		seen[lower] = true
-		normalized = append(normalized, canon)
-	}
-	// Re-encode to canonical JSON with normalized casing.
-	canonical, err := json.Marshal(normalized)
-	if err != nil {
-		return "", false
-	}
-	return string(canonical), true
-}
-
-// isValidLanguageTag performs a lightweight check that s looks like a BCP 47
-// language tag (e.g. "en", "en-GB", "zh-Hant-TW"). The primary language subtag
-// must be 2-3 ASCII letters (ISO 639). Subsequent subtags are 1-8 alphanumeric
-// characters separated by hyphens.
-func isValidLanguageTag(s string) bool {
-	// 100-byte cap is a generous upper bound for any valid BCP 47 tag
-	// (including extended/private-use subtags) while still bounding input
-	// at the API boundary.
-	if len(s) == 0 || len(s) > 100 {
-		return false
-	}
-	parts := strings.Split(s, "-")
-	// Primary language subtag: must be 2-3 letters.
-	primary := parts[0]
-	if len(primary) < 2 || len(primary) > 3 {
-		return false
-	}
-	for _, c := range primary {
-		if !isASCIILetter(c) {
-			return false
-		}
-	}
-	// Subsequent subtags: 1-8 ASCII alphanumeric characters.
-	for _, p := range parts[1:] {
-		if len(p) == 0 || len(p) > 8 {
-			return false
-		}
-		for _, c := range p {
-			if !isASCIILetter(c) && !isASCIIDigit(c) {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func isASCIILetter(c rune) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
-}
-
-func isASCIIDigit(c rune) bool {
-	return c >= '0' && c <= '9'
-}
-
-// normalizeLanguageTag applies BCP 47 canonical casing: lowercase language,
-// title-case script (4 letters), uppercase region (2 letters).
-// e.g. "EN-gb" -> "en-GB", "zh-hant-tw" -> "zh-Hant-TW".
-// Extension subtags (introduced by a singleton letter like "u" or "t") are
-// preserved verbatim because their internal structure follows different rules.
-func normalizeLanguageTag(tag string) string {
-	parts := strings.Split(tag, "-")
-	// Primary language subtag: always lowercase.
-	parts[0] = strings.ToLower(parts[0])
-	for i := 1; i < len(parts); i++ {
-		p := parts[i]
-		// A single-letter subtag (a-w, y) is a BCP 47 singleton that starts
-		// an extension sequence. Stop applying casing rules from here onward
-		// because extension subtag semantics are extension-defined.
-		if len(p) == 1 && isASCIILetter(rune(p[0])) && p[0] != 'x' && p[0] != 'X' {
-			// Lowercase the singleton itself per convention, keep the rest as-is.
-			parts[i] = strings.ToLower(p)
-			break
-		}
-		// Private-use prefix "x" also stops structural casing.
-		if (p[0] == 'x' || p[0] == 'X') && len(p) == 1 {
-			parts[i] = "x"
-			break
-		}
-		switch {
-		case len(p) == 4:
-			// Script subtag: title-case (e.g. "Hant", "Latn").
-			parts[i] = strings.ToUpper(p[:1]) + strings.ToLower(p[1:])
-		case len(p) == 2 && isASCIILetter(rune(p[0])):
-			// Region subtag: uppercase (e.g. "GB", "TW").
-			parts[i] = strings.ToUpper(p)
-		default:
-			// Variant or other subtag: lowercase by convention.
-			parts[i] = strings.ToLower(p)
-		}
-	}
-	return strings.Join(parts, "-")
+	return canonical, true
 }
 
 // parseMetadataLanguages parses a stored metadata_languages JSON string into
 // a slice of language tags. Returns nil on parse failure.
+//
+// Implementation lives in the langpref package; this thin wrapper is kept so
+// existing api-package call sites continue to compile. Prefer langpref.ParseJSON
+// in new code.
 func parseMetadataLanguages(raw string) []string {
-	if raw == "" {
-		return nil
-	}
-	var tags []string
-	if err := json.Unmarshal([]byte(raw), &tags); err != nil {
-		return nil
-	}
-	return tags
+	return langpref.ParseJSON(raw)
 }
 
 // injectMetadataLanguages loads the user's metadata_languages preference from
@@ -312,25 +212,18 @@ func (r *Router) injectMetadataLanguages(ctx context.Context) context.Context {
 	if userID == "" {
 		return ctx
 	}
-
-	var raw string
-	err := r.db.QueryRowContext(ctx,
-		`SELECT value FROM user_preferences WHERE user_id = ? AND key = ?`,
-		userID, PrefMetadataLanguages).Scan(&raw)
+	// Delegate to the langpref repository, which is the single source of
+	// truth for validation, normalization, and the default fallback.
+	repo := langpref.NewRepository(r.db)
+	langs, err := repo.Get(ctx, userID)
 	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			r.logger.Warn("querying metadata_languages preference, using default",
-				"user_id", userID, "error", err)
-		}
-		raw = MetadataLanguagesDefault
-	}
-
-	// Normalize stored tags so providers always receive canonical, deduplicated,
-	// bounded tags -- even if the DB row predates normalization.
-	normalized := normalizeMetadataLanguages(raw)
-	langs := parseMetadataLanguages(normalized)
-	if len(langs) == 0 {
-		langs = parseMetadataLanguages(MetadataLanguagesDefault)
+		// A Get error only surfaces for unexpected database failures
+		// (missing rows and malformed values both return the default
+		// without error). Log and fall back to the default rather than
+		// failing the request.
+		r.logger.Warn("querying metadata_languages preference, using default",
+			"user_id", userID, "error", err)
+		langs = langpref.DefaultTags()
 	}
 	return provider.WithMetadataLanguages(ctx, langs)
 }

--- a/internal/api/handlers_preferences_test.go
+++ b/internal/api/handlers_preferences_test.go
@@ -1049,18 +1049,6 @@ func TestValidateMetadataLanguages(t *testing.T) {
 	}
 }
 
-func TestIsValidLanguageTag(t *testing.T) {
-	valid := []string{"en", "en-GB", "zh-Hant-TW", "ja", "fr", "eng"}
-	invalid := []string{"", "en@gb", "en gb", "a-", "-en", "toooooolong123456789012345678901234567", "123", "1", "a"}
-
-	for _, s := range valid {
-		if !isValidLanguageTag(s) {
-			t.Errorf("expected %q to be valid", s)
-		}
-	}
-	for _, s := range invalid {
-		if isValidLanguageTag(s) {
-			t.Errorf("expected %q to be invalid", s)
-		}
-	}
-}
+// NOTE: the low-level tag validator has moved to the internal/langpref
+// package and is covered by TestValidate there. The api-package surface
+// we care about here is validateMetadataLanguages, tested above.

--- a/internal/langpref/langpref.go
+++ b/internal/langpref/langpref.go
@@ -1,0 +1,211 @@
+// Package langpref owns the user's ordered metadata-language preference
+// list. It provides validation, canonical normalization, and a small
+// repository API over the user_preferences table so providers, rule
+// engines, and UI can all consume a single source of truth.
+//
+// The stored format is a JSON array of BCP 47 language tags (for example
+// ["en-GB", "en", "ja"]). Order is meaningful: earlier entries are
+// higher-priority. Duplicates (case-insensitive) are rejected at the
+// validation boundary.
+//
+// The package intentionally does not depend on any other internal package
+// so it can be imported by providers, the API layer, and the settings
+// import/export layer without cycles.
+package langpref
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// PreferenceKey is the row key used in the user_preferences table.
+const PreferenceKey = "metadata_languages"
+
+// DefaultJSON is the canonical JSON value returned when no preference is
+// stored for a user, or when a stored value is unparsable. Keep this in
+// sync with DefaultTags.
+const DefaultJSON = `["en"]`
+
+// MaxEntries caps how many language tags a user can store. The limit is
+// intentionally generous; it exists purely to bound input at the API
+// boundary.
+const MaxEntries = 20
+
+// MaxTagLength bounds a single BCP 47 tag including extended and
+// private-use subtags. 100 bytes is well above the longest valid tag.
+const MaxTagLength = 100
+
+// DefaultTags returns a fresh copy of the default tag list. Callers may
+// mutate the returned slice without affecting other callers.
+func DefaultTags() []string {
+	return []string{"en"}
+}
+
+// Validate checks whether tags is a well-formed ordered language
+// preference list and returns a canonically normalized copy. The returned
+// slice preserves input order. Rules:
+//
+//  1. At least one tag, at most MaxEntries.
+//  2. Every tag must be a syntactically valid BCP 47 language tag.
+//  3. Tags are canonicalized (lowercase language, Title-case script,
+//     UPPERCASE region).
+//  4. Duplicates (comparing canonical lowercase form) are rejected.
+//
+// Validate never mutates the input slice.
+func Validate(tags []string) ([]string, bool) {
+	if len(tags) == 0 || len(tags) > MaxEntries {
+		return nil, false
+	}
+	seen := make(map[string]bool, len(tags))
+	normalized := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if tag == "" || !isValidLanguageTag(tag) {
+			return nil, false
+		}
+		canon := normalizeTag(tag)
+		lower := strings.ToLower(canon)
+		if seen[lower] {
+			return nil, false
+		}
+		seen[lower] = true
+		normalized = append(normalized, canon)
+	}
+	return normalized, true
+}
+
+// ValidateJSON parses raw as a JSON array of language tags, validates,
+// and returns the canonical JSON encoding plus the parsed slice. The
+// returned JSON uses canonical casing and preserves the input order.
+func ValidateJSON(raw string) (string, []string, bool) {
+	var tags []string
+	if err := json.Unmarshal([]byte(raw), &tags); err != nil {
+		return "", nil, false
+	}
+	canonical, ok := Validate(tags)
+	if !ok {
+		return "", nil, false
+	}
+	enc, err := json.Marshal(canonical)
+	if err != nil {
+		return "", nil, false
+	}
+	return string(enc), canonical, true
+}
+
+// NormalizeJSON is the read-path counterpart to ValidateJSON. It returns
+// the canonical JSON form if raw validates, otherwise DefaultJSON. Use
+// this when reading persisted values so stale or manually edited rows
+// always return a clean value to callers.
+func NormalizeJSON(raw string) string {
+	canonical, _, ok := ValidateJSON(raw)
+	if !ok {
+		return DefaultJSON
+	}
+	return canonical
+}
+
+// ParseJSON parses a persisted JSON array into a slice of tags. Returns
+// nil on parse failure. Callers that need validation should use
+// ValidateJSON instead.
+func ParseJSON(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	var tags []string
+	if err := json.Unmarshal([]byte(raw), &tags); err != nil {
+		return nil
+	}
+	return tags
+}
+
+// EncodeJSON encodes tags as a canonical JSON array. The caller is
+// responsible for passing an already-validated slice; if validation is
+// needed, use ValidateJSON instead.
+func EncodeJSON(tags []string) (string, error) {
+	b, err := json.Marshal(tags)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// isValidLanguageTag performs a lightweight structural check against
+// BCP 47 tags such as "en", "en-GB", or "zh-Hant-TW". The primary
+// language subtag must be 2-3 ASCII letters (ISO 639). Subsequent
+// subtags are 1-8 alphanumeric characters separated by hyphens.
+func isValidLanguageTag(s string) bool {
+	if len(s) == 0 || len(s) > MaxTagLength {
+		return false
+	}
+	parts := strings.Split(s, "-")
+	primary := parts[0]
+	if len(primary) < 2 || len(primary) > 3 {
+		return false
+	}
+	for _, c := range primary {
+		if !isASCIILetter(c) {
+			return false
+		}
+	}
+	for _, p := range parts[1:] {
+		if len(p) == 0 || len(p) > 8 {
+			return false
+		}
+		for _, c := range p {
+			if !isASCIILetter(c) && !isASCIIDigit(c) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isASCIILetter(c rune) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isASCIIDigit(c rune) bool {
+	return c >= '0' && c <= '9'
+}
+
+// normalizeTag applies BCP 47 canonical casing: lowercase language,
+// Title-case script (4 letters), uppercase region (2 letters). For
+// example: "EN-gb" becomes "en-GB"; "zh-hant-tw" becomes "zh-Hant-TW".
+//
+// Extension subtags (those introduced by a singleton letter other than
+// "x") and private-use subtags (introduced by "x") preserve their
+// internal subtag casing per convention because their internal
+// structure follows different rules.
+func normalizeTag(tag string) string {
+	parts := strings.Split(tag, "-")
+	// Primary language subtag: always lowercase.
+	parts[0] = strings.ToLower(parts[0])
+	for i := 1; i < len(parts); i++ {
+		p := parts[i]
+		// A single-letter subtag (a-w, y) is a BCP 47 singleton that
+		// starts an extension sequence. Stop applying casing rules from
+		// here onward because extension subtag semantics are
+		// extension-defined.
+		if len(p) == 1 && isASCIILetter(rune(p[0])) && p[0] != 'x' && p[0] != 'X' {
+			parts[i] = strings.ToLower(p)
+			break
+		}
+		// Private-use prefix "x" also stops structural casing.
+		if (p[0] == 'x' || p[0] == 'X') && len(p) == 1 {
+			parts[i] = "x"
+			break
+		}
+		switch {
+		case len(p) == 4:
+			// Script subtag: Title-case (e.g. "Hant", "Latn").
+			parts[i] = strings.ToUpper(p[:1]) + strings.ToLower(p[1:])
+		case len(p) == 2 && isASCIILetter(rune(p[0])):
+			// Region subtag: uppercase (e.g. "GB", "TW").
+			parts[i] = strings.ToUpper(p)
+		default:
+			// Variant or other subtag: lowercase by convention.
+			parts[i] = strings.ToLower(p)
+		}
+	}
+	return strings.Join(parts, "-")
+}

--- a/internal/langpref/langpref_test.go
+++ b/internal/langpref/langpref_test.go
@@ -1,0 +1,248 @@
+package langpref
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+		ok    bool
+	}{
+		{
+			name:  "single language",
+			input: []string{"en"},
+			want:  []string{"en"},
+			ok:    true,
+		},
+		{
+			name:  "multiple tags preserve order",
+			input: []string{"ja", "en-GB", "fr"},
+			want:  []string{"ja", "en-GB", "fr"},
+			ok:    true,
+		},
+		{
+			name:  "canonicalize casing",
+			input: []string{"EN-gb", "ZH-hant-tw", "JA"},
+			want:  []string{"en-GB", "zh-Hant-TW", "ja"},
+			ok:    true,
+		},
+		{
+			name:  "nil slice rejected",
+			input: nil,
+			want:  nil,
+			ok:    false,
+		},
+		{
+			name:  "empty slice rejected",
+			input: []string{},
+			want:  nil,
+			ok:    false,
+		},
+		{
+			name:  "over max rejected",
+			input: tooManyTags(),
+			want:  nil,
+			ok:    false,
+		},
+		{
+			name:  "empty tag rejected",
+			input: []string{"en", ""},
+			want:  nil,
+			ok:    false,
+		},
+		{
+			name:  "invalid character rejected",
+			input: []string{"en@GB"},
+			want:  nil,
+			ok:    false,
+		},
+		{
+			name:  "duplicate exact rejected",
+			input: []string{"en", "en"},
+			want:  nil,
+			ok:    false,
+		},
+		{
+			name:  "duplicate case-insensitive rejected",
+			input: []string{"en-GB", "EN-gb"},
+			want:  nil,
+			ok:    false,
+		},
+		{
+			name:  "primary subtag too short rejected",
+			input: []string{"e"},
+			want:  nil,
+			ok:    false,
+		},
+		{
+			name:  "primary subtag too long rejected",
+			input: []string{"engl"},
+			want:  nil,
+			ok:    false,
+		},
+		{
+			name:  "subtag over 8 chars rejected",
+			input: []string{"en-verylongregion"},
+			want:  nil,
+			ok:    false,
+		},
+		{
+			name:  "overall length cap",
+			input: []string{"aaaaaaaaa-bbbbbbbbb-ccccccccc-ddddddddd"},
+			want:  nil,
+			ok:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := Validate(tc.input)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v (input=%v)", ok, tc.ok, tc.input)
+			}
+			if ok && !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Validate(%v) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidate_DoesNotMutateInput(t *testing.T) {
+	input := []string{"EN-gb", "JA"}
+	snapshot := append([]string(nil), input...)
+	if _, ok := Validate(input); !ok {
+		t.Fatal("expected valid input")
+	}
+	if !reflect.DeepEqual(input, snapshot) {
+		t.Errorf("Validate mutated its input: got %v, want %v", input, snapshot)
+	}
+}
+
+func TestValidateJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantJSON  string
+		wantSlice []string
+		ok        bool
+	}{
+		{
+			name:      "canonical single",
+			input:     `["en"]`,
+			wantJSON:  `["en"]`,
+			wantSlice: []string{"en"},
+			ok:        true,
+		},
+		{
+			name:      "normalizes casing",
+			input:     `["EN-gb","JA"]`,
+			wantJSON:  `["en-GB","ja"]`,
+			wantSlice: []string{"en-GB", "ja"},
+			ok:        true,
+		},
+		{
+			name:  "invalid JSON",
+			input: `not json`,
+			ok:    false,
+		},
+		{
+			name:  "empty array",
+			input: `[]`,
+			ok:    false,
+		},
+		{
+			name:  "duplicate",
+			input: `["en","en"]`,
+			ok:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotJSON, gotSlice, ok := ValidateJSON(tc.input)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v (input=%q)", ok, tc.ok, tc.input)
+			}
+			if !ok {
+				return
+			}
+			if gotJSON != tc.wantJSON {
+				t.Errorf("JSON = %q, want %q", gotJSON, tc.wantJSON)
+			}
+			if !reflect.DeepEqual(gotSlice, tc.wantSlice) {
+				t.Errorf("slice = %v, want %v", gotSlice, tc.wantSlice)
+			}
+		})
+	}
+}
+
+func TestNormalizeJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"valid returns canonical", `["EN-gb","JA"]`, `["en-GB","ja"]`},
+		{"already canonical unchanged", `["en"]`, `["en"]`},
+		{"invalid falls back to default", `not json`, DefaultJSON},
+		{"empty falls back to default", `[]`, DefaultJSON},
+		{"duplicates fall back to default", `["en","EN"]`, DefaultJSON},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeJSON(tc.input); got != tc.want {
+				t.Errorf("NormalizeJSON(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{"valid", `["en","ja"]`, []string{"en", "ja"}},
+		{"empty string returns nil", "", nil},
+		{"invalid JSON returns nil", `not json`, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseJSON(tc.input)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ParseJSON(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultTags_FreshCopy(t *testing.T) {
+	a := DefaultTags()
+	b := DefaultTags()
+	if &a[0] == &b[0] {
+		t.Fatal("DefaultTags must return a fresh slice on each call")
+	}
+	a[0] = "mutated"
+	if DefaultTags()[0] != "en" {
+		t.Error("mutating the returned slice leaked back into the default")
+	}
+}
+
+// tooManyTags returns MaxEntries+1 distinct valid tags to exercise the
+// upper bound of Validate.
+func tooManyTags() []string {
+	// Generate unique tags: "aa", "ab", ... past MaxEntries.
+	out := make([]string, 0, MaxEntries+1)
+	for i := 0; i <= MaxEntries; i++ {
+		// Two-letter tag: first letter 'a'..'j', second 'a'..
+		first := byte('a' + (i / 10))
+		second := byte('a' + (i % 10))
+		out = append(out, string([]byte{first, second}))
+	}
+	return out
+}

--- a/internal/langpref/repository.go
+++ b/internal/langpref/repository.go
@@ -1,0 +1,121 @@
+package langpref
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// ErrInvalid is returned by Set when the provided tag list fails
+// validation. Callers that render HTTP errors should translate this to
+// HTTP 400.
+var ErrInvalid = errors.New("langpref: invalid language tag list")
+
+// Repository persists and retrieves a user's ordered metadata language
+// preference list from the user_preferences table.
+//
+// The repository does not own the database; callers construct it with
+// an already-opened *sql.DB so it can participate in the same connection
+// pool as the rest of the application.
+type Repository struct {
+	db *sql.DB
+}
+
+// NewRepository constructs a Repository backed by db. The caller retains
+// ownership of db.
+func NewRepository(db *sql.DB) *Repository {
+	return &Repository{db: db}
+}
+
+// Get returns the ordered language preference list for userID. If no row
+// is stored, or if the stored value fails validation, the default list
+// ({"en"}) is returned. The returned slice is a fresh copy; the caller
+// may mutate it freely.
+//
+// An error is returned only for unexpected database failures. A missing
+// row or a malformed stored value are both treated as "no preference
+// stored" and return the default.
+func (r *Repository) Get(ctx context.Context, userID string) ([]string, error) {
+	if userID == "" {
+		return DefaultTags(), nil
+	}
+
+	var raw string
+	err := r.db.QueryRowContext(ctx,
+		`SELECT value FROM user_preferences WHERE user_id = ? AND key = ?`,
+		userID, PreferenceKey,
+	).Scan(&raw)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return DefaultTags(), nil
+		}
+		return nil, fmt.Errorf("langpref: querying preference for user %s: %w", userID, err)
+	}
+
+	// Even if the stored JSON is malformed, return the default rather
+	// than an error. This mirrors the read-path robustness used
+	// throughout the preferences layer: a single bad row should never
+	// block metadata fetches.
+	if _, parsed, ok := ValidateJSON(raw); ok {
+		return parsed, nil
+	}
+	return DefaultTags(), nil
+}
+
+// Set persists the given ordered language preference list for userID.
+// The tags are validated and canonicalized before writing. Order is
+// preserved exactly; duplicates (case-insensitive) are rejected.
+//
+// Returns ErrInvalid when tags fail validation. Returns any database
+// error wrapped with context on other failures.
+func (r *Repository) Set(ctx context.Context, userID string, tags []string) error {
+	if userID == "" {
+		return fmt.Errorf("langpref: user id is required")
+	}
+	canonical, ok := Validate(tags)
+	if !ok {
+		return ErrInvalid
+	}
+	encoded, err := EncodeJSON(canonical)
+	if err != nil {
+		// Validate already guarantees JSON-encodable content, so this
+		// is a belt-and-braces check.
+		return fmt.Errorf("langpref: encoding validated tags: %w", err)
+	}
+
+	_, err = r.db.ExecContext(ctx,
+		`INSERT INTO user_preferences (user_id, key, value, updated_at)
+		 VALUES (?, ?, ?, datetime('now'))
+		 ON CONFLICT(user_id, key) DO UPDATE SET
+		     value = excluded.value,
+		     updated_at = excluded.updated_at`,
+		userID, PreferenceKey, encoded,
+	)
+	if err != nil {
+		return fmt.Errorf("langpref: writing preference for user %s: %w", userID, err)
+	}
+	return nil
+}
+
+// GetRaw returns the raw JSON value stored for userID, or DefaultJSON
+// when no row exists or the stored value is malformed. This is the
+// JSON-string counterpart to Get. It is convenient for HTTP handlers
+// that pass the value straight back to the client without reparsing.
+func (r *Repository) GetRaw(ctx context.Context, userID string) (string, error) {
+	if userID == "" {
+		return DefaultJSON, nil
+	}
+	var raw string
+	err := r.db.QueryRowContext(ctx,
+		`SELECT value FROM user_preferences WHERE user_id = ? AND key = ?`,
+		userID, PreferenceKey,
+	).Scan(&raw)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return DefaultJSON, nil
+		}
+		return "", fmt.Errorf("langpref: querying preference for user %s: %w", userID, err)
+	}
+	return NormalizeJSON(raw), nil
+}

--- a/internal/langpref/repository_test.go
+++ b/internal/langpref/repository_test.go
@@ -1,0 +1,240 @@
+package langpref
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"reflect"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// setupTestDB builds an in-memory SQLite database with the single
+// user_preferences table the Repository depends on. The schema mirrors
+// the real migration so behavior matches production.
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("opening test db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	// SQLite drivers default to a connection pool that can interleave
+	// writes; pin to one connection to match the production settings.
+	db.SetMaxOpenConns(1)
+
+	_, err = db.ExecContext(context.Background(), `
+		CREATE TABLE IF NOT EXISTS user_preferences (
+			user_id    TEXT NOT NULL,
+			key        TEXT NOT NULL,
+			value      TEXT NOT NULL,
+			updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+			PRIMARY KEY (user_id, key)
+		)
+	`)
+	if err != nil {
+		t.Fatalf("creating user_preferences table: %v", err)
+	}
+	return db
+}
+
+func TestRepository_Get_DefaultWhenMissing(t *testing.T) {
+	repo := NewRepository(setupTestDB(t))
+	got, err := repo.Get(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	want := []string{"en"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Get = %v, want %v", got, want)
+	}
+}
+
+func TestRepository_Get_EmptyUserIDReturnsDefault(t *testing.T) {
+	repo := NewRepository(setupTestDB(t))
+	got, err := repo.Get(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	want := []string{"en"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Get = %v, want %v", got, want)
+	}
+}
+
+func TestRepository_RoundTrip_PreservesOrder(t *testing.T) {
+	repo := NewRepository(setupTestDB(t))
+	ctx := context.Background()
+	userID := "user-1"
+
+	input := []string{"ja", "en-GB", "fr", "zh-Hant-TW"}
+	if err := repo.Set(ctx, userID, input); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	got, err := repo.Get(ctx, userID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !reflect.DeepEqual(got, input) {
+		t.Errorf("Get after Set = %v, want %v (order must be preserved)", got, input)
+	}
+}
+
+func TestRepository_Set_Canonicalizes(t *testing.T) {
+	repo := NewRepository(setupTestDB(t))
+	ctx := context.Background()
+	userID := "user-1"
+
+	if err := repo.Set(ctx, userID, []string{"EN-gb", "ZH-hant-tw"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := repo.Get(ctx, userID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	want := []string{"en-GB", "zh-Hant-TW"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Get = %v, want canonicalized %v", got, want)
+	}
+}
+
+func TestRepository_Set_Overwrites(t *testing.T) {
+	repo := NewRepository(setupTestDB(t))
+	ctx := context.Background()
+	userID := "user-1"
+
+	if err := repo.Set(ctx, userID, []string{"en"}); err != nil {
+		t.Fatalf("Set first: %v", err)
+	}
+	if err := repo.Set(ctx, userID, []string{"ja", "en"}); err != nil {
+		t.Fatalf("Set second: %v", err)
+	}
+	got, err := repo.Get(ctx, userID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	want := []string{"ja", "en"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Get after overwrite = %v, want %v", got, want)
+	}
+}
+
+func TestRepository_Set_RejectsDuplicates(t *testing.T) {
+	repo := NewRepository(setupTestDB(t))
+	err := repo.Set(context.Background(), "user-1", []string{"en", "EN"})
+	if !errors.Is(err, ErrInvalid) {
+		t.Errorf("Set with duplicates: got err %v, want ErrInvalid", err)
+	}
+}
+
+func TestRepository_Set_RejectsEmpty(t *testing.T) {
+	repo := NewRepository(setupTestDB(t))
+	err := repo.Set(context.Background(), "user-1", nil)
+	if !errors.Is(err, ErrInvalid) {
+		t.Errorf("Set with empty slice: got err %v, want ErrInvalid", err)
+	}
+}
+
+func TestRepository_Set_RejectsInvalidTag(t *testing.T) {
+	repo := NewRepository(setupTestDB(t))
+	err := repo.Set(context.Background(), "user-1", []string{"en@GB"})
+	if !errors.Is(err, ErrInvalid) {
+		t.Errorf("Set with invalid tag: got err %v, want ErrInvalid", err)
+	}
+}
+
+func TestRepository_Set_RejectsEmptyUserID(t *testing.T) {
+	repo := NewRepository(setupTestDB(t))
+	err := repo.Set(context.Background(), "", []string{"en"})
+	if err == nil {
+		t.Error("Set with empty user id: expected error, got nil")
+	}
+}
+
+func TestRepository_Get_MalformedRowReturnsDefault(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	// Write a malformed row directly, bypassing validation. The read
+	// path must still return a sane default rather than an error.
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO user_preferences (user_id, key, value) VALUES (?, ?, ?)`,
+		"user-1", PreferenceKey, "this is not json")
+	if err != nil {
+		t.Fatalf("seeding malformed row: %v", err)
+	}
+
+	got, err := repo.Get(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	want := []string{"en"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Get with malformed row = %v, want default %v", got, want)
+	}
+}
+
+func TestRepository_GetRaw_DefaultWhenMissing(t *testing.T) {
+	repo := NewRepository(setupTestDB(t))
+	got, err := repo.GetRaw(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("GetRaw: %v", err)
+	}
+	if got != DefaultJSON {
+		t.Errorf("GetRaw = %q, want %q", got, DefaultJSON)
+	}
+}
+
+func TestRepository_GetRaw_NormalizesStored(t *testing.T) {
+	db := setupTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	// Insert a row with non-canonical casing directly. GetRaw must
+	// return the canonical form.
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO user_preferences (user_id, key, value) VALUES (?, ?, ?)`,
+		"user-1", PreferenceKey, `["EN-gb","JA"]`)
+	if err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+
+	got, err := repo.GetRaw(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("GetRaw: %v", err)
+	}
+	want := `["en-GB","ja"]`
+	if got != want {
+		t.Errorf("GetRaw = %q, want %q", got, want)
+	}
+}
+
+func TestRepository_MultipleUsersIsolated(t *testing.T) {
+	repo := NewRepository(setupTestDB(t))
+	ctx := context.Background()
+
+	if err := repo.Set(ctx, "alice", []string{"en", "fr"}); err != nil {
+		t.Fatalf("Set alice: %v", err)
+	}
+	if err := repo.Set(ctx, "bob", []string{"ja"}); err != nil {
+		t.Fatalf("Set bob: %v", err)
+	}
+
+	alice, err := repo.Get(ctx, "alice")
+	if err != nil {
+		t.Fatalf("Get alice: %v", err)
+	}
+	bob, err := repo.Get(ctx, "bob")
+	if err != nil {
+		t.Fatalf("Get bob: %v", err)
+	}
+	if !reflect.DeepEqual(alice, []string{"en", "fr"}) {
+		t.Errorf("alice = %v", alice)
+	}
+	if !reflect.DeepEqual(bob, []string{"ja"}) {
+		t.Errorf("bob = %v", bob)
+	}
+}


### PR DESCRIPTION
## Summary

First of three planned slices for #952 (ordered language preference list). Extracts a clean `internal/langpref/` package with `Repository.Get`/`Set`/`GetRaw` plus validation helpers. Backend-only refactor -- no user-visible change, no schema change (reuses Wave 5 schema), no provider wiring touched yet.

- New package `internal/langpref/` owns the authoritative read + write path for the ordered preference list
- Validation centralized (BCP 47 tag shape, dedup, max length)
- Existing callers continue to use their previous entry points; the new Repository is additive
- Zero internal package dependencies in `internal/langpref/`, enforced structurally, so subsequent slices can pull it in without import cycles

## Scope (what is NOT in this PR)

- **Slice b (follow-up):** provider update pass to consume the ordered preference list across all metadata providers. Will also eliminate the `PrefMetadataLanguages` / `langpref.PreferenceKey` duplication that currently exists in `handlers_preferences.go:30` as a deprecated shim.
- **Slice c (follow-up):** UI in Settings for ordering the preference list.

Both follow-up slices are held until this lands.

## Coverage

84.8% on `internal/langpref/`. Two code paths uncovered (flagged as suggestions, not blockers): `isASCIIDigit` for secondary subtag validation, and the `default:` branch of `normalizeTag` for long non-region variant subtags. Both are BCP 47 structural edge cases; neither affects the public API surface.

Overall patch coverage well above the 70% gate threshold.

## Test plan

- [x] `bash scripts/pre-push-gate.sh` passes (verified locally)
- [x] `/pr-review-toolkit:review-pr` clean (0 critical, 0 important, 3 non-blocking suggestions)
- [x] `go test -race ./internal/langpref/...` passes (44 tests)
- [ ] CI green on PR
- [ ] CodeRabbit review clean

Part of #952 (slice 1 of 3). Follow-ups: slice b (providers), slice c (UI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized language preference system with enhanced validation capabilities. Improved error handling for invalid or missing language preferences, which now gracefully fall back to the system default. Language tags undergo comprehensive validation including duplicate detection, length constraints, structural validation, and case normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
