### PR TITLE
fix(rule): inject language preferences into scheduler context

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sydlexius/stillwater/internal/event"
 	"github.com/sydlexius/stillwater/internal/i18n"
 	"github.com/sydlexius/stillwater/internal/imagebridge"
+	"github.com/sydlexius/stillwater/internal/langpref"
 	"github.com/sydlexius/stillwater/internal/library"
 	"github.com/sydlexius/stillwater/internal/logging"
 	"github.com/sydlexius/stillwater/internal/maintenance"
@@ -417,6 +418,15 @@ func run() error {
 		}
 		if ruleScheduleMinutes >= 5 {
 			ruleScheduler = rule.NewScheduler(pipeline, ruleService, artistService, logger)
+			// Supply language preferences to scheduled rule evaluations.
+			// The HTTP-scoped injector (Router.injectMetadataLanguages)
+			// cannot run here because there is no user session in scope;
+			// the langpref repository picks the primary administrator's
+			// preferences so language-aware rules (e.g. name_language_pref)
+			// evaluate against the operator's configuration on the
+			// scheduled path too. See issue #1136.
+			langprefRepo := langpref.NewRepository(db)
+			ruleScheduler.SetLangPrefProvider(langprefRepo.EffectiveForBackground)
 		} else if ruleScheduleMinutes > 0 && ruleScheduleMinutes < 5 {
 			logger.Warn("rule scheduler interval too short (minimum 5 minutes); scheduler not started",
 				"minutes", ruleScheduleMinutes)

--- a/internal/langpref/repository.go
+++ b/internal/langpref/repository.go
@@ -102,9 +102,12 @@ func (r *Repository) Set(ctx context.Context, userID string, tags []string) erro
 // (e.g. the rule scheduler) should use when no HTTP user session is in
 // scope. The strategy is deterministic and small:
 //
-//  1. Pick the oldest active administrator. Protected administrators
-//     (bootstrap accounts that cannot be deactivated) win ties -- in a
-//     single-admin self-hosted deployment this is always the operator.
+//  1. Pick the primary active administrator. A protected administrator
+//     (the bootstrap account -- marked is_protected=1 because it cannot
+//     be deactivated or role-changed) always wins, regardless of age; in
+//     a self-hosted deployment this is the operator running the instance.
+//     Non-protected admins are broken down by oldest created_at, then by
+//     id for deterministic ties.
 //  2. Return that user's stored preferences via Get, which falls back to
 //     DefaultTags() when the row is absent or malformed.
 //  3. If no administrator row exists (fresh database, before bootstrap),

--- a/internal/langpref/repository.go
+++ b/internal/langpref/repository.go
@@ -98,6 +98,40 @@ func (r *Repository) Set(ctx context.Context, userID string, tags []string) erro
 	return nil
 }
 
+// EffectiveForBackground returns the preference list that background jobs
+// (e.g. the rule scheduler) should use when no HTTP user session is in
+// scope. The strategy is deterministic and small:
+//
+//  1. Pick the oldest active administrator. Protected administrators
+//     (bootstrap accounts that cannot be deactivated) win ties -- in a
+//     single-admin self-hosted deployment this is always the operator.
+//  2. Return that user's stored preferences via Get, which falls back to
+//     DefaultTags() when the row is absent or malformed.
+//  3. If no administrator row exists (fresh database, before bootstrap),
+//     return DefaultTags().
+//
+// A DB error returning the candidate user row is not fatal: the function
+// falls back to DefaultTags() so a transient failure never stalls a
+// scheduled rule evaluation. The same is true of Get errors on the found
+// user.
+func (r *Repository) EffectiveForBackground(ctx context.Context) []string {
+	var userID string
+	err := r.db.QueryRowContext(ctx, `
+		SELECT id FROM users
+		WHERE role = 'administrator' AND is_active = 1
+		ORDER BY is_protected DESC, created_at ASC, id ASC
+		LIMIT 1
+	`).Scan(&userID)
+	if err != nil || userID == "" {
+		return DefaultTags()
+	}
+	prefs, err := r.Get(ctx, userID)
+	if err != nil || len(prefs) == 0 {
+		return DefaultTags()
+	}
+	return prefs
+}
+
 // GetRaw returns the raw JSON value stored for userID, or DefaultJSON
 // when no row exists or the stored value is malformed. This is the
 // JSON-string counterpart to Get. It is convenient for HTTP handlers

--- a/internal/langpref/repository_test.go
+++ b/internal/langpref/repository_test.go
@@ -277,6 +277,31 @@ func TestRepository_EffectiveForBackground_PicksProtectedAdmin(t *testing.T) {
 	}
 }
 
+func TestRepository_EffectiveForBackground_ProtectedWinsAtSameAge(t *testing.T) {
+	db := setupTestDBWithUsers(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	// Same created_at: is_protected must break the tie in favor of the
+	// protected admin. This is the "protected breaks ties" case for
+	// deployments where multiple admins were created in the same tick.
+	insertUser(t, db, "u-plain", "alice", "administrator", 1, 0, "2026-01-01T00:00:00Z")
+	insertUser(t, db, "u-protected", "bootstrap", "administrator", 1, 1, "2026-01-01T00:00:00Z")
+
+	if err := repo.Set(ctx, "u-plain", []string{"fr"}); err != nil {
+		t.Fatalf("Set u-plain: %v", err)
+	}
+	if err := repo.Set(ctx, "u-protected", []string{"ja"}); err != nil {
+		t.Fatalf("Set u-protected: %v", err)
+	}
+
+	got := repo.EffectiveForBackground(ctx)
+	want := []string{"ja"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("EffectiveForBackground with tied created_at = %v, want protected admin's prefs %v", got, want)
+	}
+}
+
 func TestRepository_EffectiveForBackground_OldestAdminWhenNoneProtected(t *testing.T) {
 	db := setupTestDBWithUsers(t)
 	repo := NewRepository(db)

--- a/internal/langpref/repository_test.go
+++ b/internal/langpref/repository_test.go
@@ -212,6 +212,140 @@ func TestRepository_GetRaw_NormalizesStored(t *testing.T) {
 	}
 }
 
+// setupTestDBWithUsers extends setupTestDB with a users table matching the
+// production shape needed by EffectiveForBackground. Kept in-file so the
+// existing setupTestDB stays a minimal fixture for the rest of the suite.
+func setupTestDBWithUsers(t *testing.T) *sql.DB {
+	t.Helper()
+	db := setupTestDB(t)
+	_, err := db.ExecContext(context.Background(), `
+		CREATE TABLE IF NOT EXISTS users (
+			id            TEXT PRIMARY KEY,
+			username      TEXT NOT NULL UNIQUE,
+			role          TEXT NOT NULL DEFAULT 'operator',
+			is_active     INTEGER NOT NULL DEFAULT 1,
+			is_protected  INTEGER NOT NULL DEFAULT 0,
+			created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+		)
+	`)
+	if err != nil {
+		t.Fatalf("creating users table: %v", err)
+	}
+	return db
+}
+
+func insertUser(t *testing.T, db *sql.DB, id, username, role string, active, protected int, createdAt string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(),
+		`INSERT INTO users (id, username, role, is_active, is_protected, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		id, username, role, active, protected, createdAt)
+	if err != nil {
+		t.Fatalf("inserting user %s: %v", username, err)
+	}
+}
+
+func TestRepository_EffectiveForBackground_NoUsers(t *testing.T) {
+	repo := NewRepository(setupTestDBWithUsers(t))
+	got := repo.EffectiveForBackground(context.Background())
+	if !reflect.DeepEqual(got, DefaultTags()) {
+		t.Errorf("EffectiveForBackground with no users = %v, want %v", got, DefaultTags())
+	}
+}
+
+func TestRepository_EffectiveForBackground_PicksProtectedAdmin(t *testing.T) {
+	db := setupTestDBWithUsers(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	// Non-protected admin created first, protected admin created later.
+	// Protected wins regardless of created_at order.
+	insertUser(t, db, "u-first", "earlyadmin", "administrator", 1, 0, "2026-01-01T00:00:00Z")
+	insertUser(t, db, "u-protected", "bootstrap", "administrator", 1, 1, "2026-03-01T00:00:00Z")
+
+	if err := repo.Set(ctx, "u-first", []string{"fr"}); err != nil {
+		t.Fatalf("Set u-first: %v", err)
+	}
+	if err := repo.Set(ctx, "u-protected", []string{"en-US", "en-GB", "en"}); err != nil {
+		t.Fatalf("Set u-protected: %v", err)
+	}
+
+	got := repo.EffectiveForBackground(ctx)
+	want := []string{"en-US", "en-GB", "en"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("EffectiveForBackground = %v, want protected admin's prefs %v", got, want)
+	}
+}
+
+func TestRepository_EffectiveForBackground_OldestAdminWhenNoneProtected(t *testing.T) {
+	db := setupTestDBWithUsers(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	insertUser(t, db, "u-old", "alice", "administrator", 1, 0, "2026-01-15T00:00:00Z")
+	insertUser(t, db, "u-new", "bob", "administrator", 1, 0, "2026-02-15T00:00:00Z")
+
+	if err := repo.Set(ctx, "u-old", []string{"ja"}); err != nil {
+		t.Fatalf("Set u-old: %v", err)
+	}
+
+	got := repo.EffectiveForBackground(ctx)
+	want := []string{"ja"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("EffectiveForBackground = %v, want oldest admin's prefs %v", got, want)
+	}
+}
+
+func TestRepository_EffectiveForBackground_SkipsInactiveAdmins(t *testing.T) {
+	db := setupTestDBWithUsers(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	insertUser(t, db, "u-deactivated", "retired", "administrator", 0, 0, "2026-01-01T00:00:00Z")
+	insertUser(t, db, "u-active", "current", "administrator", 1, 0, "2026-02-01T00:00:00Z")
+
+	if err := repo.Set(ctx, "u-deactivated", []string{"fr"}); err != nil {
+		t.Fatalf("Set u-deactivated: %v", err)
+	}
+	if err := repo.Set(ctx, "u-active", []string{"de"}); err != nil {
+		t.Fatalf("Set u-active: %v", err)
+	}
+
+	got := repo.EffectiveForBackground(ctx)
+	want := []string{"de"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("EffectiveForBackground = %v, want active admin's prefs %v", got, want)
+	}
+}
+
+func TestRepository_EffectiveForBackground_SkipsOperators(t *testing.T) {
+	db := setupTestDBWithUsers(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	insertUser(t, db, "u-op", "operator", "operator", 1, 0, "2026-01-01T00:00:00Z")
+	if err := repo.Set(ctx, "u-op", []string{"zh"}); err != nil {
+		t.Fatalf("Set u-op: %v", err)
+	}
+
+	got := repo.EffectiveForBackground(ctx)
+	if !reflect.DeepEqual(got, DefaultTags()) {
+		t.Errorf("EffectiveForBackground = %v, want default %v (operators are not admins)", got, DefaultTags())
+	}
+}
+
+func TestRepository_EffectiveForBackground_AdminWithoutStoredPrefs_ReturnsDefault(t *testing.T) {
+	db := setupTestDBWithUsers(t)
+	repo := NewRepository(db)
+
+	insertUser(t, db, "u-admin", "admin", "administrator", 1, 1, "2026-01-01T00:00:00Z")
+
+	got := repo.EffectiveForBackground(context.Background())
+	if !reflect.DeepEqual(got, DefaultTags()) {
+		t.Errorf("EffectiveForBackground = %v, want %v (admin has no stored prefs)", got, DefaultTags())
+	}
+}
+
 func TestRepository_MultipleUsersIsolated(t *testing.T) {
 	repo := NewRepository(setupTestDB(t))
 	ctx := context.Background()

--- a/internal/rule/scheduler.go
+++ b/internal/rule/scheduler.go
@@ -7,7 +7,20 @@ import (
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/provider"
 )
+
+// LangPrefProvider supplies the ordered metadata-language preference list
+// to inject into scheduled rule evaluations. Background jobs have no HTTP
+// session and cannot go through the router's per-user injection path, so
+// the scheduler queries this callback once per tick and wraps the tick
+// context via provider.WithMetadataLanguages.
+//
+// Returning nil or an empty slice leaves the context untouched (the rule
+// will see no preferences and, for language-aware rules, skip). Callers
+// that want a safe default should return langpref.DefaultTags() rather
+// than nil.
+type LangPrefProvider func(context.Context) []string
 
 // SchedulerStatus holds scheduler state fields. The handler adds
 // scheduler_enabled before writing the JSON response.
@@ -31,6 +44,14 @@ type Scheduler struct {
 	mu         sync.RWMutex
 	lastRunAt  time.Time
 	nextTickAt time.Time
+
+	// langPrefs is optional. When set, the scheduler invokes it once per
+	// tick and wraps the tick context with the returned preferences so
+	// language-aware rules see the same metadata preferences as they would
+	// on the HTTP-scoped (per-user) path. Guarded by langPrefsMu so
+	// SetLangPrefProvider is race-safe alongside a running scheduler.
+	langPrefsMu sync.RWMutex
+	langPrefs   LangPrefProvider
 }
 
 // NewScheduler creates a rule scheduler. The artistService may be nil if
@@ -81,6 +102,22 @@ func (s *Scheduler) Start(ctx context.Context, interval time.Duration) {
 	}
 }
 
+// SetLangPrefProvider registers a callback invoked once per scheduled tick
+// whose result is injected into the tick context via
+// provider.WithMetadataLanguages. Pass nil to disable injection. Safe to
+// call before or after Start.
+//
+// Without a provider, the scheduler passes its tick context through to
+// pipeline.RunRule unchanged; language-aware rules (e.g. name_language_pref)
+// observe an empty preference list and skip. That matches the pre-#1136
+// behavior so the opt-in can be rolled out without breaking existing
+// deployments.
+func (s *Scheduler) SetLangPrefProvider(fn LangPrefProvider) {
+	s.langPrefsMu.Lock()
+	s.langPrefs = fn
+	s.langPrefsMu.Unlock()
+}
+
 // Reset restarts the scheduler timer. Call this after a manual rule run
 // so the next scheduled tick starts a full interval from now.
 func (s *Scheduler) Reset() {
@@ -113,6 +150,21 @@ func (s *Scheduler) Status() SchedulerStatus {
 
 func (s *Scheduler) runEnabledRules(ctx context.Context) {
 	s.logger.Info("rule scheduler running evaluation")
+
+	// Inject language preferences for language-aware rules. The HTTP path
+	// populates these from middleware.UserIDFromContext, which is not
+	// available on the background-job path; a provider callback closes
+	// the gap so scheduled ticks honor the same preferences.
+	s.langPrefsMu.RLock()
+	provideLangs := s.langPrefs
+	s.langPrefsMu.RUnlock()
+	if provideLangs != nil {
+		if prefs := provideLangs(ctx); len(prefs) > 0 {
+			ctx = provider.WithMetadataLanguages(ctx, prefs)
+			s.logger.Debug("scheduled evaluation using language preferences",
+				slog.Any("langs", prefs))
+		}
+	}
 
 	rules, err := s.ruleService.List(ctx)
 	if err != nil {

--- a/internal/rule/scheduler_test.go
+++ b/internal/rule/scheduler_test.go
@@ -3,11 +3,54 @@ package rule
 import (
 	"context"
 	"log/slog"
+	"reflect"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/provider"
 )
+
+// fakePipelineRunner captures the context passed to RunRule so tests can
+// assert that language preferences were injected before rule evaluation.
+// Other PipelineRunner methods are no-op stubs -- the scheduler only calls
+// RunRule.
+type fakePipelineRunner struct {
+	mu     sync.Mutex
+	ctxSeq []context.Context
+}
+
+func (f *fakePipelineRunner) RunRule(ctx context.Context, _ string) (*RunResult, error) {
+	f.mu.Lock()
+	f.ctxSeq = append(f.ctxSeq, ctx)
+	f.mu.Unlock()
+	return &RunResult{}, nil
+}
+
+func (f *fakePipelineRunner) RunForArtist(_ context.Context, _ *artist.Artist) (*RunResult, error) {
+	return &RunResult{}, nil
+}
+
+func (f *fakePipelineRunner) RunImageRulesForArtist(_ context.Context, _ *artist.Artist) (*RunResult, error) {
+	return &RunResult{}, nil
+}
+
+func (f *fakePipelineRunner) RunAll(_ context.Context) (*RunResult, error) {
+	return &RunResult{}, nil
+}
+
+func (f *fakePipelineRunner) FixViolation(_ context.Context, _ string) (*FixResult, error) {
+	return &FixResult{}, nil
+}
+
+func (f *fakePipelineRunner) capturedContexts() []context.Context {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]context.Context, len(f.ctxSeq))
+	copy(out, f.ctxSeq)
+	return out
+}
 
 func TestScheduler_Reset(t *testing.T) {
 	db := setupTestDB(t)
@@ -138,6 +181,123 @@ func TestScheduler_ContextCancellation(t *testing.T) {
 		// ok
 	case <-time.After(2 * time.Second):
 		t.Fatal("scheduler did not stop promptly on context cancellation")
+	}
+}
+
+func TestScheduler_SetLangPrefProvider_InjectsIntoRunRuleCtx(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	logger := slog.Default()
+
+	// Seed a single enabled rule so runEnabledRules has something to
+	// iterate. The PipelineRunner is a fake that only records the ctx it
+	// receives, so the rule's config never executes.
+	ctxInsert := context.Background()
+	// The template DB ships with seeded system rules. Clear them so the
+	// only enabled rule this tick sees is the one we insert, which keeps
+	// assertions (single RunRule invocation) tight.
+	if _, err := db.ExecContext(ctxInsert, `DELETE FROM rules`); err != nil {
+		t.Fatalf("clearing seeded rules: %v", err)
+	}
+	if _, err := db.ExecContext(ctxInsert, `
+		INSERT INTO rules (id, name, description, category, enabled)
+		VALUES (?, ?, ?, ?, 1)
+	`, "test-rule", "test", "", "metadata"); err != nil {
+		t.Fatalf("seeding rule: %v", err)
+	}
+
+	fake := &fakePipelineRunner{}
+	sched := NewScheduler(fake, ruleSvc, nil, logger)
+
+	want := []string{"en-US", "en-GB", "en"}
+	var providerCalls int
+	sched.SetLangPrefProvider(func(context.Context) []string {
+		providerCalls++
+		return want
+	})
+
+	sched.runEnabledRules(context.Background())
+
+	if providerCalls != 1 {
+		t.Errorf("LangPrefProvider calls = %d, want 1 per tick", providerCalls)
+	}
+
+	captured := fake.capturedContexts()
+	if len(captured) != 1 {
+		t.Fatalf("pipeline RunRule invocations = %d, want 1", len(captured))
+	}
+	got := provider.MetadataLanguages(captured[0])
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ctx lang prefs = %v, want %v", got, want)
+	}
+}
+
+func TestScheduler_NoLangPrefProvider_CtxLeftUnchanged(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	logger := slog.Default()
+
+	ctxInsert := context.Background()
+	// The template DB ships with seeded system rules. Clear them so the
+	// only enabled rule this tick sees is the one we insert, which keeps
+	// assertions (single RunRule invocation) tight.
+	if _, err := db.ExecContext(ctxInsert, `DELETE FROM rules`); err != nil {
+		t.Fatalf("clearing seeded rules: %v", err)
+	}
+	if _, err := db.ExecContext(ctxInsert, `
+		INSERT INTO rules (id, name, description, category, enabled)
+		VALUES (?, ?, ?, ?, 1)
+	`, "test-rule", "test", "", "metadata"); err != nil {
+		t.Fatalf("seeding rule: %v", err)
+	}
+
+	fake := &fakePipelineRunner{}
+	sched := NewScheduler(fake, ruleSvc, nil, logger)
+	// Do not call SetLangPrefProvider: the scheduler must behave as
+	// pre-#1136 (no injection) so existing deployments keep working.
+
+	sched.runEnabledRules(context.Background())
+
+	captured := fake.capturedContexts()
+	if len(captured) != 1 {
+		t.Fatalf("pipeline RunRule invocations = %d, want 1", len(captured))
+	}
+	if got := provider.MetadataLanguages(captured[0]); got != nil {
+		t.Errorf("ctx lang prefs = %v, want nil (no provider set)", got)
+	}
+}
+
+func TestScheduler_LangPrefProvider_EmptySliceDoesNotInject(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	logger := slog.Default()
+
+	ctxInsert := context.Background()
+	// The template DB ships with seeded system rules. Clear them so the
+	// only enabled rule this tick sees is the one we insert, which keeps
+	// assertions (single RunRule invocation) tight.
+	if _, err := db.ExecContext(ctxInsert, `DELETE FROM rules`); err != nil {
+		t.Fatalf("clearing seeded rules: %v", err)
+	}
+	if _, err := db.ExecContext(ctxInsert, `
+		INSERT INTO rules (id, name, description, category, enabled)
+		VALUES (?, ?, ?, ?, 1)
+	`, "test-rule", "test", "", "metadata"); err != nil {
+		t.Fatalf("seeding rule: %v", err)
+	}
+
+	fake := &fakePipelineRunner{}
+	sched := NewScheduler(fake, ruleSvc, nil, logger)
+	sched.SetLangPrefProvider(func(context.Context) []string { return nil })
+
+	sched.runEnabledRules(context.Background())
+
+	captured := fake.capturedContexts()
+	if len(captured) != 1 {
+		t.Fatalf("pipeline RunRule invocations = %d, want 1", len(captured))
+	}
+	if got := provider.MetadataLanguages(captured[0]); got != nil {
+		t.Errorf("ctx lang prefs = %v, want nil for empty provider result", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Closes #1136. Stops the 193k/day "no language preferences in context, skipping" log flood and makes `name_language_pref` actually evaluate on the scheduled path.
- Adds an opt-in `rule.Scheduler.SetLangPrefProvider` callback; `cmd/stillwater/main.go` wires it to `langpref.Repository.EffectiveForBackground`, which picks the oldest active administrator's stored preferences (protected admins win ties).
- No signature change to `rule.NewScheduler`: existing test call sites and any downstream forks that construct a Scheduler keep working, and a nil provider behaves exactly like pre-#1136.

## Why this is safe

- `LangPrefProvider` is opt-in and nil-tolerant; deployments that do not opt in see identical behavior to main today.
- `EffectiveForBackground` falls back to `DefaultTags()` on every error path, including DB failures, missing admins, and unparsable rows. A transient DB hiccup at tick time degrades to English rather than stalling evaluation.
- The lookup is `LIMIT 1` on a small indexed table and runs once per scheduler tick, not per artist.

## Test plan

- [x] `go test -race ./internal/langpref/ ./internal/rule/` (new: 6 `EffectiveForBackground` cases, 3 scheduler injection cases)
- [x] `go test -race ./internal/api/` (confirms HTTP path unaffected)
- [x] `bash scripts/pre-push-gate.sh` (all hard checks pass)
- [ ] Manual UAT: run scheduler on a fresh DB with `["en-US","en-GB","en"]` stored for admin; confirm `/tmp/stillwater.log` stops emitting the flood entry.

## Related

Filed alongside #1136 during UAT of #1118 (`feat/952b-provider-langpref-pass`). Does not touch #1118's tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background rule scheduler now injects language preferences so scheduled evaluations respect language-aware rule behavior.
* **Tests**
  * Added unit tests covering background language-preference selection and injection behavior to ensure deterministic preference selection and correct context propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->