### PR TITLE
fix(provider): gate member-alias script-skip on non-Latin-only prefs (#1137)

### DIFF
--- a/internal/provider/lang_script.go
+++ b/internal/provider/lang_script.go
@@ -205,6 +205,46 @@ func ScriptMatchesAnyLocale(script string, prefs []string) bool {
 	return false
 }
 
+// LocaleExpectsOnlyNonLatinScript reports whether the BCP-47 tag's expected
+// script set excludes Latin. This is the condition under which an
+// "already-in-preferred-script" optimization can safely skip work: if the
+// pref could also be satisfied by a Latin-form alias, skipping loses the
+// chance to promote typography/spelling/capitalization refinements that the
+// alias provides.
+//
+// The rule: a tag returns true iff its resolved script set (from an explicit
+// BCP-47 script subtag when present, else from the base language's entry in
+// localeScripts) is both non-empty and contains no Latin script. Empty,
+// unmapped, and Latin-containing tags return false. The "unmapped returns
+// false" default is deliberately conservative: without positive evidence
+// that the pref excludes Latin, we do not authorize a Latin-canonical skip.
+func LocaleExpectsOnlyNonLatinScript(tag string) bool {
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		return false
+	}
+	// Explicit BCP-47 script subtag wins, consistent with the precedence in
+	// ScriptMatchesAnyLocale and ScriptSatisfiesLocale.
+	if sub := ParseBCP47Script(tag); sub != "" {
+		mapped, ok := iso15924ToScript[sub]
+		if !ok {
+			return false
+		}
+		return mapped != ScriptLatin
+	}
+	lang := strings.SplitN(strings.ToLower(tag), "-", 2)[0]
+	allowed, ok := localeScripts[lang]
+	if !ok {
+		return false
+	}
+	for _, s := range allowed {
+		if s == ScriptLatin {
+			return false
+		}
+	}
+	return true
+}
+
 // ScriptSatisfiesLocale reports whether the dominant script of s is a
 // positive match for at least one locale in prefs. Unlike
 // ScriptMatchesAnyLocale, this returns false for unclassifiable input and for

--- a/internal/provider/lang_script_test.go
+++ b/internal/provider/lang_script_test.go
@@ -151,3 +151,71 @@ func TestScriptSatisfiesLocale(t *testing.T) {
 		})
 	}
 }
+
+func TestLocaleExpectsOnlyNonLatinScript(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want bool
+	}{
+		// Latin-family locales: Latin is expected, so a Latin alias can still
+		// improve the canonical. Skip must NOT be authorized.
+		{"english base", "en", false},
+		{"english region", "en-US", false},
+		{"german", "de", false},
+		{"french", "fr", false},
+		{"spanish", "es", false},
+
+		// Non-Latin-only locales: skip IS authorized.
+		{"japanese", "ja", true},
+		{"japanese region", "ja-JP", true},
+		{"chinese", "zh", true},
+		{"korean", "ko", true},
+		{"russian", "ru", true},
+		{"arabic", "ar", true},
+		{"hebrew", "he", true},
+		{"greek", "el", true},
+		{"hindi", "hi", true},
+		{"thai", "th", true},
+
+		// Mixed-script locale: Latin IS in the allowed set, so skip is NOT
+		// authorized (conservative fetch protects typography improvements).
+		{"serbian mixed", "sr", false},
+
+		// Explicit BCP-47 script subtag takes precedence over base language.
+		{"serbian latin subtag", "sr-Latn", false},
+		{"serbian cyrillic subtag", "sr-Cyrl", true},
+		{"chinese traditional subtag", "zh-Hant", true},
+		{"chinese simplified subtag", "zh-Hans", true},
+		{"english explicit latin subtag", "en-Latn", false},
+
+		// Empty and unmapped inputs return false (no positive evidence).
+		{"empty tag", "", false},
+		{"whitespace only", "   ", false},
+		{"unmapped locale", "xx", false},
+		{"unmapped with region", "xx-YY", false},
+
+		// Script subtag that is not 4 alpha chars is ignored (per
+		// ParseBCP47Script contract). "de-1901" falls through to base "de"
+		// which is Latin -> false.
+		{"german variant 1901", "de-1901", false},
+
+		// Unmapped script subtag (exists in BCP-47 but not in our
+		// iso15924ToScript table). Conservative: return false.
+		{"unmapped script subtag", "en-Zzzz", false},
+
+		// Case normalization: base-language branch lowercases before map
+		// lookup, so uppercase input must resolve identically to lowercase.
+		{"uppercase japanese base", "JA", true},
+		{"uppercase english region", "EN-US", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LocaleExpectsOnlyNonLatinScript(tt.tag)
+			if got != tt.want {
+				t.Errorf("LocaleExpectsOnlyNonLatinScript(%q) = %v, want %v", tt.tag, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -159,14 +159,18 @@ func newMemberAliasCache() *memberAliasCache {
 // are resolved in sequence.
 //
 // Optimization: when a member's canonical name is already in a script
-// satisfying the user's TOP language preference, the alias fetch is skipped.
-// Matching only the first preference (not the full list) preserves the
-// opportunity to promote a higher-preference alias when the canonical name
-// happens to match a secondary preference. For a band whose roster mostly
-// shares the canonical-name script with the top preference (a Japanese band
-// under a [ja, ...] preference, for example), this skips most members and
-// brings the 1 req/sec rate-limited per-refresh cost down by roughly the
-// same proportion.
+// satisfying the user's TOP language preference AND that preference expects
+// only non-Latin scripts, the alias fetch is skipped. The non-Latin gate is
+// required because Latin-family prefs (en, es, de, fr, sr, ...) can still
+// benefit from alias promotion even when the canonical is already Latin:
+// MusicBrainz aliases carry typography, capitalization, and spelling
+// refinements that a Latin-form canonical may lack (issue #1137). Matching
+// only the first preference (not the full list) preserves the opportunity to
+// promote a higher-preference alias when the canonical happens to match a
+// secondary preference. For a band whose roster mostly shares the
+// canonical-name script with a non-Latin top preference (a Japanese band
+// under a [ja, ...] preference, for example), this still skips most members
+// and preserves the 1 req/sec rate-limit win the optimization was built for.
 func (a *Adapter) localizeMembers(ctx context.Context, members []provider.MemberInfo, langPrefs []string, cache *memberAliasCache) {
 	topPref := ""
 	if len(langPrefs) > 0 {
@@ -181,11 +185,14 @@ func (a *Adapter) localizeMembers(ctx context.Context, members []provider.Member
 		}
 
 		// Skip alias fetch when the canonical name is already in a script
-		// that matches the user's top language preference. ScriptSatisfiesLocale
-		// returns false for unknown scripts and empty preferences, so we only
-		// skip when we have positive evidence of a match.
-		if topPref != "" && provider.ScriptSatisfiesLocale(m.Name, []string{topPref}) {
-			a.logger.Debug("skipping member alias fetch (canonical already in preferred script)",
+		// that matches the user's top language preference AND that preference
+		// is non-Latin-only. The LocaleExpectsOnlyNonLatinScript guard keeps
+		// Latin-family prefs out of the skip path so typography/spelling
+		// refinements in Latin aliases can still be promoted (#1137).
+		if topPref != "" &&
+			provider.LocaleExpectsOnlyNonLatinScript(topPref) &&
+			provider.ScriptSatisfiesLocale(m.Name, []string{topPref}) {
+			a.logger.Debug("skipping member alias fetch (canonical already in preferred non-Latin script)",
 				slog.String("member_mbid", mbid),
 				slog.String("member_name", m.Name),
 				slog.String("top_pref", topPref))

--- a/internal/provider/musicbrainz/musicbrainz_test.go
+++ b/internal/provider/musicbrainz/musicbrainz_test.go
@@ -1585,6 +1585,74 @@ func TestLocalizeMembers_DoesNotSkipWhenCanonicalMatchesOnlySecondaryPref(t *tes
 	}
 }
 
+// TestLocalizeMembers_PromotesLatinAliasUnderLatinPref is the #1137 regression
+// witness. Before the fix, the script-skip optimization fired whenever the
+// canonical name's script matched the top pref's expected script -- which
+// incorrectly included Latin-canonical members under a Latin-family top pref
+// (e.g. Tokyo Ska Paradise Orchestra's "NARGO" under ["en"]). The skip
+// suppressed the alias fetch, so typography/spelling/capitalization
+// refinements available in MusicBrainz en-locale aliases were never promoted.
+//
+// The fix gates the skip on LocaleExpectsOnlyNonLatinScript(topPref): under a
+// Latin-family pref, a Latin alias can still meaningfully improve the name, so
+// the fetch must proceed.
+func TestLocalizeMembers_PromotesLatinAliasUnderLatinPref(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(loadFixture(t, "member_nargo.json"))
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	ctx := provider.WithMetadataLanguages(context.Background(), []string{"en"})
+
+	members := []provider.MemberInfo{
+		{MBID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", Name: "NARGO"},
+	}
+
+	a.localizeMembers(ctx, members, []string{"en"}, newMemberAliasCache())
+
+	if got := hits.Load(); got != 1 {
+		t.Errorf("expected 1 fetch (en pref must not skip Latin-canonical fetch), got %d", got)
+	}
+	if members[0].Name != "Nargo" {
+		t.Errorf("expected en primary alias promotion, got %q", members[0].Name)
+	}
+}
+
+// TestLocalizeMembers_EmptyLangPrefsStillFetches verifies that an empty
+// langPrefs slice keeps localizeMembers on the safe path: topPref defaults to
+// "", the skip guard's topPref != "" check fails, and the alias fetch
+// proceeds. This protects against a future refactor that replaces the guarded
+// init with an unguarded langPrefs[0] index, which would panic on an empty
+// slice. selectMemberAlias returns false under nil prefs so no promotion
+// occurs, but the fetch still runs to exercise the alias-cache plumbing.
+func TestLocalizeMembers_EmptyLangPrefsStillFetches(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(loadFixture(t, "member_nargo.json"))
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	members := []provider.MemberInfo{
+		{MBID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", Name: "NARGO"},
+	}
+
+	a.localizeMembers(context.Background(), members, []string{}, newMemberAliasCache())
+
+	if got := hits.Load(); got != 1 {
+		t.Errorf("expected 1 fetch (empty prefs must not trigger skip), got %d", got)
+	}
+	if members[0].Name != "NARGO" {
+		t.Errorf("expected canonical preserved (no promotion under empty prefs), got %q", members[0].Name)
+	}
+}
+
 // TestLocalizeMembers_PreservesNonMBIDMembers asserts that members without
 // an MBID (user-added entries that have not been matched to MusicBrainz)
 // keep whatever name they arrived with. Localization only runs for members

--- a/internal/provider/musicbrainz/testdata/member_nargo.json
+++ b/internal/provider/musicbrainz/testdata/member_nargo.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  "type": "Person",
+  "name": "NARGO",
+  "sort-name": "NARGO",
+  "aliases": [
+    {
+      "name": "Nargo",
+      "sort-name": "Nargo",
+      "type": "Artist name",
+      "locale": "en",
+      "primary": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #1137.

- Adds `provider.LocaleExpectsOnlyNonLatinScript` helper that reports whether a BCP-47 tag's resolved script set excludes Latin.
- Gates the `localizeMembers` script-skip optimization (#1118) on that helper, so the skip only fires when the top pref could not be satisfied by a Latin-form alias.
- Preserves the Japanese-band rate-limit win that #1118 was built for; Latin-family prefs (en, de, fr, es, sr, ...) now always fetch aliases so typography/spelling refinements can be promoted.

## Regression witness

`TestLocalizeMembers_PromotesLatinAliasUnderLatinPref` mirrors the Tokyo Ska Paradise Orchestra repro from the issue: Latin canonical `NARGO`, MBID, `[en]` prefs, MusicBrainz en primary alias `Nargo`. Pre-fix: 0 fetches, canonical retained. Post-fix: 1 fetch, promoted to `Nargo`. The dual assertion (fetch count AND promoted name) catches both axes of the regression independently.

## Helper semantics

| Input | Result | Why |
|-------|--------|-----|
| `en`, `de`, `fr`, `es`, ... | `false` | Latin-family; alias can still refine typography |
| `ja`, `zh`, `ko`, `ru`, `ar`, `he`, `el`, `hi`, `th`, `uk`, `be`, `bg`, `fa` | `true` | Non-Latin-only; skip is safe |
| `sr` | `false` | Mixed Cyrillic+Latin set; conservative fetch |
| `sr-Latn`, `en-Latn` | `false` | Explicit Latin subtag |
| `sr-Cyrl`, `zh-Hant`, `zh-Hans` | `true` | Explicit non-Latin subtag |
| empty, unmapped (`xx`), malformed (`de-1901`), unknown subtag (`en-Zzzz`) | `false` | Conservative: no positive evidence to authorize skip |

## Test plan

- [x] `TestLocaleExpectsOnlyNonLatinScript` table (28 cases) covers base languages, explicit script subtags, mixed-script locales, empty/whitespace/unmapped inputs, malformed variant (`de-1901`), unknown script subtag (`en-Zzzz`), and uppercase normalization
- [x] `TestLocalizeMembers_PromotesLatinAliasUnderLatinPref` regression witness (Tokyo Ska Paradise Orchestra scenario)
- [x] `TestLocalizeMembers_EmptyLangPrefsStillFetches` guards against a future refactor replacing the guarded `topPref = ""` init with an unguarded `langPrefs[0]` index
- [x] Existing `TestLocalizeMembers_SkipsFetchWhenCanonicalInPreferredScript` (JA band under `[ja, fr, en]`) still passes, confirming the rate-limit optimization is preserved
- [x] `go test -race ./internal/provider/...` green
- [x] `bash scripts/pre-push-gate.sh` clean; patch coverage 100% on `lang_script.go`, 94.3% on `musicbrainz.go`
- [ ] Manual UAT: refresh Tokyo Ska Paradise Orchestra (MBID `986d20d1-0b70-48b1-879e-1ea1436feb23`) under `["en-US", "en-GB", "en"]`; verify members pick up their en primary aliases

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale-script detection to distinguish between Latin and non-Latin script preferences, ensuring alias-fetching optimizations apply correctly based on locale configuration for more accurate metadata handling.

* **Tests**
  * Added comprehensive test coverage for locale-script behavior, including edge cases with empty preferences and various script combinations to verify correct alias promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->