### PR TITLE
fix(provider): persist language-promoted names end-to-end in refresh

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -507,13 +507,22 @@ func run() error {
 		}
 	}()
 
-	// Create HTTP server
+	// Create HTTP server.
+	//
+	// WriteTimeout must accommodate the full refresh response, including OOB
+	// HTMX fragments. A metadata refresh for a group artist with language
+	// preferences can run 30-60+ seconds: MusicBrainz's 1 req/sec rate limit
+	// means each member's alias fetch is one real second, so a ~20-member
+	// Japanese band under [ja, en] preferences exceeds 30s. A too-tight
+	// timeout kills the OOB stream after the status line is written, leaving
+	// the HTMX UI stuck on "Fetching Metadata..." even though the DB was
+	// updated successfully.
 	addr := fmt.Sprintf(":%d", cfg.Server.Port)
 	srv := &http.Server{
 		Addr:         addr,
 		Handler:      router.Handler(ctx),
 		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 30 * time.Second,
+		WriteTimeout: 180 * time.Second,
 		IdleTimeout:  60 * time.Second,
 	}
 

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -141,15 +141,23 @@ func (a *Adapter) GetArtist(ctx context.Context, mbid string) (*provider.ArtistM
 	return meta, nil
 }
 
+// memberAliasLookup is the per-member data we need from a MusicBrainz artist
+// lookup for localization: the alias list (for tagged-alias promotion) and
+// the sort-name (for romanization fallback when no alias wins).
+type memberAliasLookup struct {
+	aliases  []MBAlias
+	sortName string
+}
+
 // memberAliasCache is an in-memory, per-request cache of member MBID to
-// fetched aliases. It avoids refetching the same member when the same MBID
+// lookup results. It avoids refetching the same member when the same MBID
 // appears across multiple code paths during a single artist refresh.
 type memberAliasCache struct {
-	entries map[string][]MBAlias
+	entries map[string]memberAliasLookup
 }
 
 func newMemberAliasCache() *memberAliasCache {
-	return &memberAliasCache{entries: make(map[string][]MBAlias)}
+	return &memberAliasCache{entries: make(map[string]memberAliasLookup)}
 }
 
 // localizeMembers promotes each member's name to its best-matching alias for
@@ -199,7 +207,7 @@ func (a *Adapter) localizeMembers(ctx context.Context, members []provider.Member
 			continue
 		}
 
-		aliases, cached := cache.entries[mbid]
+		lookup, cached := cache.entries[mbid]
 		if !cached {
 			fetched, err := a.fetchMemberAliases(ctx, mbid)
 			if err != nil {
@@ -207,30 +215,70 @@ func (a *Adapter) localizeMembers(ctx context.Context, members []provider.Member
 					slog.String("member_mbid", mbid),
 					slog.String("member_name", m.Name),
 					slog.Any("err", err))
-				// Cache the failure as an empty slice so repeated members with
-				// the same MBID do not trigger redundant fetches.
-				cache.entries[mbid] = nil
+				// Cache the failure as a zero-value lookup so repeated members
+				// with the same MBID do not trigger redundant fetches.
+				cache.entries[mbid] = memberAliasLookup{}
 				continue
 			}
 			cache.entries[mbid] = fetched
-			aliases = fetched
+			lookup = fetched
 		}
 
-		bestAlias, ok := selectMemberAlias(aliases, langPrefs)
-		if !ok {
-			continue
+		// Try tagged-alias promotion first: a curator-added alias (especially a
+		// primary one) carries stronger intent than a sort-name heuristic.
+		if bestAlias, ok := selectMemberAlias(lookup.aliases, langPrefs); ok {
+			promoted := normalizeHyphens(bestAlias.Name)
+			if promoted != "" && promoted != m.Name {
+				a.logger.Debug("promoting localized member name",
+					slog.String("from", m.Name),
+					slog.String("to", promoted),
+					slog.String("locale", bestAlias.Locale),
+					slog.String("type", bestAlias.Type),
+					slog.Bool("primary", bestAlias.Primary))
+				m.Name = promoted
+				continue
+			}
 		}
-		promoted := normalizeHyphens(bestAlias.Name)
-		if promoted == "" || promoted == m.Name {
-			continue
+
+		// Fall back to the MB sort-name when no alias wins. MusicBrainz
+		// stores the curator-canonical romanization in sort-name for
+		// non-Latin artists even when they do not carry an explicit en
+		// alias (the common case: most Japanese band rosters on MB).
+		// Gating (all six must hold; every one prevents a specific
+		// false-positive promotion):
+		//   1. a top language preference must be set -- without one we
+		//      have no basis for choosing a script,
+		//   2. sort-name must be non-empty -- an empty MB sort-name carries
+		//      no signal,
+		//   3. canonical must be in a non-Latin script -- reversing a
+		//      Latin-to-Latin sort-name would just flip first/last for
+		//      Western artists (e.g. "Chris Martin" -> "Chris Martin"),
+		//   4. canonical script must not be Unknown -- DominantScript
+		//      returns Unknown for ambiguous/degenerate inputs, where a
+		//      best-guess promotion would be unsafe,
+		//   5. sort-name must itself be in Latin script -- MB occasionally
+		//      stores a non-Latin sort-name (e.g. "姓, 名"), in which case
+		//      the reversal heuristic does not produce a Latin result, and
+		//   6. the top pref must accept Latin -- rules out ja, zh, ko, etc.
+		//      where the user explicitly asked for the non-Latin form.
+		if topPref != "" && lookup.sortName != "" {
+			canonicalScript := provider.DominantScript(m.Name)
+			sortScript := provider.DominantScript(lookup.sortName)
+			if canonicalScript != provider.ScriptLatin &&
+				canonicalScript != provider.ScriptUnknown &&
+				sortScript == provider.ScriptLatin &&
+				provider.ScriptSatisfiesLocale(lookup.sortName, []string{topPref}) {
+				candidate := normalizeHyphens(romanizeFromSortName(lookup.sortName))
+				if candidate != "" && candidate != m.Name {
+					a.logger.Debug("promoting member name from MB sort-name",
+						slog.String("from", m.Name),
+						slog.String("to", candidate),
+						slog.String("sort_name", lookup.sortName),
+						slog.String("top_pref", topPref))
+					m.Name = candidate
+				}
+			}
 		}
-		a.logger.Debug("promoting localized member name",
-			slog.String("from", m.Name),
-			slog.String("to", promoted),
-			slog.String("locale", bestAlias.Locale),
-			slog.String("type", bestAlias.Type),
-			slog.Bool("primary", bestAlias.Primary))
-		m.Name = promoted
 	}
 }
 
@@ -294,10 +342,14 @@ func selectMemberAlias(aliases []MBAlias, langPrefs []string) (MBAlias, bool) {
 	return best, true
 }
 
-// fetchMemberAliases retrieves only the alias list for a given member MBID.
-// Uses the shared rate-limited doRequest path so the MusicBrainz 1 req/sec
-// policy is enforced across all provider traffic.
-func (a *Adapter) fetchMemberAliases(ctx context.Context, mbid string) ([]MBAlias, error) {
+// fetchMemberAliases retrieves the alias list and sort-name for a given
+// member MBID. Uses the shared rate-limited doRequest path so the
+// MusicBrainz 1 req/sec policy is enforced across all provider traffic.
+// Returns sort-name alongside aliases so localizeMembers can fall back to
+// the MB-published romanization for non-Latin canonical names when no
+// tagged alias is available (many MB artists have a Latin sort-name but no
+// explicit en alias).
+func (a *Adapter) fetchMemberAliases(ctx context.Context, mbid string) (memberAliasLookup, error) {
 	params := url.Values{
 		"inc": {"aliases"},
 		"fmt": {"json"},
@@ -309,14 +361,43 @@ func (a *Adapter) fetchMemberAliases(ctx context.Context, mbid string) ([]MBAlia
 
 	body, err := a.doRequest(ctx, reqURL)
 	if err != nil {
-		return nil, err
+		return memberAliasLookup{}, err
 	}
 
 	var resp MBArtist
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, fmt.Errorf("parsing member alias response: %w", err)
+		return memberAliasLookup{}, fmt.Errorf("parsing member alias response: %w", err)
 	}
-	return resp.Aliases, nil
+	return memberAliasLookup{aliases: resp.Aliases, sortName: resp.SortName}, nil
+}
+
+// romanizeFromSortName reverses a MusicBrainz sort-name from the curator
+// convention "Family, Given" to the display convention "Given Family".
+// MusicBrainz stores sort-name as the curator's canonical sort form; for
+// Japanese, Chinese, Korean, and other non-Latin-script artists it is
+// almost always a Latin romanization even when no en alias exists. This
+// lets us surface a usable Latin display name for Latin-family prefs
+// without requiring every MB entry to carry a dedicated alias.
+//
+// Single-token sort-names (no comma) and malformed inputs are returned
+// unchanged. Extra commas (rare: corporate names, disambiguations) cause
+// the function to bail and return the original so we never produce garbage
+// from a best-guess reversal.
+func romanizeFromSortName(sortName string) string {
+	trimmed := strings.TrimSpace(sortName)
+	if trimmed == "" {
+		return ""
+	}
+	parts := strings.Split(trimmed, ",")
+	if len(parts) != 2 {
+		return trimmed
+	}
+	family := strings.TrimSpace(parts[0])
+	given := strings.TrimSpace(parts[1])
+	if family == "" || given == "" {
+		return trimmed
+	}
+	return given + " " + family
 }
 
 // GetImages returns nil since MusicBrainz does not host artist images.

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -268,8 +268,9 @@ func (a *Adapter) localizeMembers(ctx context.Context, members []provider.Member
 				canonicalScript != provider.ScriptUnknown &&
 				sortScript == provider.ScriptLatin &&
 				provider.ScriptSatisfiesLocale(lookup.sortName, []string{topPref}) {
-				candidate := normalizeHyphens(romanizeFromSortName(lookup.sortName))
-				if candidate != "" && candidate != m.Name {
+				reversed, ok := romanizeFromSortName(lookup.sortName)
+				candidate := normalizeHyphens(reversed)
+				if ok && candidate != "" && candidate != m.Name {
 					a.logger.Debug("promoting member name from MB sort-name",
 						slog.String("from", m.Name),
 						slog.String("to", candidate),
@@ -379,25 +380,27 @@ func (a *Adapter) fetchMemberAliases(ctx context.Context, mbid string) (memberAl
 // lets us surface a usable Latin display name for Latin-family prefs
 // without requiring every MB entry to carry a dedicated alias.
 //
-// Single-token sort-names (no comma) and malformed inputs are returned
-// unchanged. Extra commas (rare: corporate names, disambiguations) cause
-// the function to bail and return the original so we never produce garbage
-// from a best-guess reversal.
-func romanizeFromSortName(sortName string) string {
+// Returns (reversed, true) only when the sort-name is a well-formed
+// two-part "Family, Given" with both parts non-empty. Any other shape
+// (empty, whitespace-only, single token, multi-comma, missing family or
+// given) returns ("", false) so the caller can treat malformed inputs as
+// "no fallback available" rather than promoting a raw sort-form like
+// "Smith, Jr., John" or "Family," into a display name.
+func romanizeFromSortName(sortName string) (string, bool) {
 	trimmed := strings.TrimSpace(sortName)
 	if trimmed == "" {
-		return ""
+		return "", false
 	}
 	parts := strings.Split(trimmed, ",")
 	if len(parts) != 2 {
-		return trimmed
+		return "", false
 	}
 	family := strings.TrimSpace(parts[0])
 	given := strings.TrimSpace(parts[1])
 	if family == "" || given == "" {
-		return trimmed
+		return "", false
 	}
-	return given + " " + family
+	return given + " " + family, true
 }
 
 // GetImages returns nil since MusicBrainz does not host artist images.

--- a/internal/provider/musicbrainz/musicbrainz_test.go
+++ b/internal/provider/musicbrainz/musicbrainz_test.go
@@ -1653,6 +1653,152 @@ func TestLocalizeMembers_EmptyLangPrefsStillFetches(t *testing.T) {
 	}
 }
 
+// TestLocalizeMembers_SortNameFallback exercises the romanization fallback:
+// when no tagged alias wins AND the canonical is in a non-Latin script AND
+// the MB sort-name is Latin AND the user's top pref accepts Latin, the
+// promoted display name is derived from the sort-name (reversed from MB's
+// "Family, Given" convention to "Given Family" display form). This covers
+// the common TSPO-style case where MB has a romanization in sort-name but
+// no dedicated en alias.
+func TestLocalizeMembers_SortNameFallback(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(loadFixture(t, "member_aoki.json"))
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	ctx := provider.WithMetadataLanguages(context.Background(), []string{"en"})
+
+	members := []provider.MemberInfo{
+		{MBID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", Name: "\u9752\u6728\u9054\u4e4b"},
+	}
+
+	a.localizeMembers(ctx, members, []string{"en"}, newMemberAliasCache())
+
+	if got := hits.Load(); got != 1 {
+		t.Errorf("expected 1 fetch, got %d", got)
+	}
+	if members[0].Name != "Tatsuyuki Aoki" {
+		t.Errorf("expected sort-name reversal to \"Tatsuyuki Aoki\", got %q", members[0].Name)
+	}
+}
+
+// TestLocalizeMembers_SortNameFallbackSkippedUnderNonLatinPref verifies the
+// inverse gate: when the user's top pref is non-Latin (ja, zh, ko, ...), a
+// Latin sort-name must NOT be promoted over a non-Latin canonical. The user
+// asked for Japanese, so Japanese is what they get even if MB has a
+// romanization they could read.
+func TestLocalizeMembers_SortNameFallbackSkippedUnderNonLatinPref(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(loadFixture(t, "member_aoki.json"))
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	ctx := provider.WithMetadataLanguages(context.Background(), []string{"ja"})
+
+	canonical := "\u9752\u6728\u9054\u4e4b"
+	members := []provider.MemberInfo{
+		{MBID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", Name: canonical},
+	}
+
+	a.localizeMembers(ctx, members, []string{"ja"}, newMemberAliasCache())
+
+	if members[0].Name != canonical {
+		t.Errorf("expected canonical preserved under ja pref, got %q", members[0].Name)
+	}
+}
+
+// TestLocalizeMembers_SortNameFallbackFiresUnderMixedScriptPref witnesses
+// the sr (Serbian) mixed-script case: Serbian allows both Cyrillic and Latin
+// by default (localeScripts["sr"] = {Cyrillic, Latin}), so a Cyrillic
+// canonical + Latin sort-name under [sr] pref satisfies all six gating
+// conditions and promotes via reversal. This is the intended behavior --
+// under a mixed-script pref the user has indicated they accept Latin output.
+// Locking it in protects against a future LocaleExpectsOnlyNonLatinScript or
+// ScriptSatisfiesLocale change silently flipping semantics for mixed-script
+// locales.
+func TestLocalizeMembers_SortNameFallbackFiresUnderMixedScriptPref(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(loadFixture(t, "member_cyrillic.json"))
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	ctx := provider.WithMetadataLanguages(context.Background(), []string{"sr"})
+
+	canonical := "\u041f\u0435\u0442\u0440\u043e\u0432\u0438\u045b"
+	members := []provider.MemberInfo{
+		{MBID: "dddddddd-dddd-dddd-dddd-dddddddddddd", Name: canonical},
+	}
+
+	a.localizeMembers(ctx, members, []string{"sr"}, newMemberAliasCache())
+
+	if members[0].Name != "Marko Petrovic" {
+		t.Errorf("expected sr mixed-script pref to promote Latin sort-name, got %q", members[0].Name)
+	}
+}
+
+// TestLocalizeMembers_SortNameFallbackNotAppliedToLatinCanonical verifies
+// the canonical-script gate: the reversal is a no-op for Latin canonicals
+// (where it would just flip first/last name for Western artists). Skipping
+// this case is the reason the fallback only fires for non-Latin canonicals.
+func TestLocalizeMembers_SortNameFallbackNotAppliedToLatinCanonical(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"cccccccc-cccc-cccc-cccc-cccccccccccc","type":"Person","name":"Chris Martin","sort-name":"Martin, Chris","aliases":[]}`))
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	ctx := provider.WithMetadataLanguages(context.Background(), []string{"en"})
+
+	members := []provider.MemberInfo{
+		{MBID: "cccccccc-cccc-cccc-cccc-cccccccccccc", Name: "Chris Martin"},
+	}
+
+	a.localizeMembers(ctx, members, []string{"en"}, newMemberAliasCache())
+
+	if members[0].Name != "Chris Martin" {
+		t.Errorf("expected Latin canonical untouched by sort-name fallback, got %q", members[0].Name)
+	}
+}
+
+// TestRomanizeFromSortName exercises the MusicBrainz sort-name reversal
+// helper. MB stores sort-name as "Family, Given"; display form is
+// "Given Family". Edge cases: no comma, empty, whitespace, multi-comma
+// (rare disambiguation or corporate sort forms) must not be mangled.
+func TestRomanizeFromSortName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"standard two-part", "Aoki, Tatsuyuki", "Tatsuyuki Aoki"},
+		{"whitespace around tokens", "  Yorke,   Thom  ", "Thom Yorke"},
+		{"single token (solo name)", "Madonna", "Madonna"},
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"multi-comma returns original", "Smith, Jr., John", "Smith, Jr., John"},
+		{"empty family", ", Given", ", Given"},
+		{"empty given", "Family,", "Family,"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := romanizeFromSortName(tt.in)
+			if got != tt.want {
+				t.Errorf("romanizeFromSortName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestLocalizeMembers_PreservesNonMBIDMembers asserts that members without
 // an MBID (user-added entries that have not been matched to MusicBrainz)
 // keep whatever name they arrived with. Localization only runs for members

--- a/internal/provider/musicbrainz/musicbrainz_test.go
+++ b/internal/provider/musicbrainz/musicbrainz_test.go
@@ -1771,29 +1771,34 @@ func TestLocalizeMembers_SortNameFallbackNotAppliedToLatinCanonical(t *testing.T
 
 // TestRomanizeFromSortName exercises the MusicBrainz sort-name reversal
 // helper. MB stores sort-name as "Family, Given"; display form is
-// "Given Family". Edge cases: no comma, empty, whitespace, multi-comma
-// (rare disambiguation or corporate sort forms) must not be mangled.
+// "Given Family". Only well-formed two-part sort-names return ok=true;
+// empty, whitespace-only, single-token, multi-comma, and partial inputs
+// return ("", false) so the caller can treat them as "no fallback
+// available" instead of promoting a raw sort-form like "Family," or
+// "Smith, Jr., John" into a display name.
 func TestRomanizeFromSortName(t *testing.T) {
 	tests := []struct {
-		name string
-		in   string
-		want string
+		name   string
+		in     string
+		want   string
+		wantOK bool
 	}{
-		{"standard two-part", "Aoki, Tatsuyuki", "Tatsuyuki Aoki"},
-		{"whitespace around tokens", "  Yorke,   Thom  ", "Thom Yorke"},
-		{"single token (solo name)", "Madonna", "Madonna"},
-		{"empty", "", ""},
-		{"whitespace only", "   ", ""},
-		{"multi-comma returns original", "Smith, Jr., John", "Smith, Jr., John"},
-		{"empty family", ", Given", ", Given"},
-		{"empty given", "Family,", "Family,"},
+		{"standard two-part", "Aoki, Tatsuyuki", "Tatsuyuki Aoki", true},
+		{"whitespace around tokens", "  Yorke,   Thom  ", "Thom Yorke", true},
+		{"single token rejected", "Madonna", "", false},
+		{"empty rejected", "", "", false},
+		{"whitespace only rejected", "   ", "", false},
+		{"multi-comma rejected", "Smith, Jr., John", "", false},
+		{"empty family rejected", ", Given", "", false},
+		{"empty given rejected", "Family,", "", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := romanizeFromSortName(tt.in)
-			if got != tt.want {
-				t.Errorf("romanizeFromSortName(%q) = %q, want %q", tt.in, got, tt.want)
+			got, ok := romanizeFromSortName(tt.in)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("romanizeFromSortName(%q) = (%q, %v), want (%q, %v)",
+					tt.in, got, ok, tt.want, tt.wantOK)
 			}
 		})
 	}

--- a/internal/provider/musicbrainz/testdata/member_aoki.json
+++ b/internal/provider/musicbrainz/testdata/member_aoki.json
@@ -1,0 +1,7 @@
+{
+  "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  "type": "Person",
+  "name": "\u9752\u6728\u9054\u4e4b",
+  "sort-name": "Aoki, Tatsuyuki",
+  "aliases": []
+}

--- a/internal/provider/musicbrainz/testdata/member_cyrillic.json
+++ b/internal/provider/musicbrainz/testdata/member_cyrillic.json
@@ -1,0 +1,7 @@
+{
+  "id": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+  "type": "Person",
+  "name": "\u041f\u0435\u0442\u0440\u043e\u0432\u0438\u045b",
+  "sort-name": "Petrovic, Marko",
+  "aliases": []
+}

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -202,6 +202,22 @@ func (o *Orchestrator) FetchMetadata(ctx context.Context, mbid, name string, pro
 	// populated from earlier per-provider enrichment).
 	extractProviderIDsFromURLs(result.Metadata)
 
+	// MusicBrainz is authoritative for artist Name and SortName: it owns the
+	// MBID and applies language-aware alias promotion inline on its meta.Name.
+	// The first-provider-wins merge in applyField would otherwise let an
+	// earlier-iterated provider (e.g. wikipedia during the biography field)
+	// lock in the canonical form, blocking MB's promoted value. Overwrite here
+	// so the language preference is honored. Mirrors the pattern in
+	// internal/scraper/executor.go's MB-authoritative override.
+	if mbResult, ok := cache[NameMusicBrainz]; ok && mbResult.err == nil && mbResult.meta != nil {
+		if mbResult.meta.Name != "" {
+			result.Metadata.Name = mbResult.meta.Name
+		}
+		if mbResult.meta.SortName != "" {
+			result.Metadata.SortName = mbResult.meta.SortName
+		}
+	}
+
 	// Record which providers were successfully queried so callers can update
 	// per-provider fetch timestamps on the artist record. Providers with
 	// transient errors (timeouts, 5xx) are excluded to avoid hiding outages

--- a/internal/provider/orchestrator_test.go
+++ b/internal/provider/orchestrator_test.go
@@ -137,6 +137,137 @@ func TestOrchestratorFallback(t *testing.T) {
 	}
 }
 
+// TestFetchMetadata_MBNameAuthoritative verifies that MusicBrainz's Name and
+// SortName win even when an earlier-iterated provider (e.g. wikipedia during
+// the biography field) has already populated result.Metadata.Name via the
+// first-provider-wins merge in applyField. MusicBrainz is the only provider
+// that applies language-aware alias promotion to Name, so its value must
+// survive when a user has metadata language preferences set; otherwise the
+// canonical (un-promoted) form from another provider locks in first and the
+// user-requested localized display name is silently dropped.
+func TestFetchMetadata_MBNameAuthoritative(t *testing.T) {
+	registry, settings := setupOrchestratorTest(t)
+
+	// Wikipedia: fires first via the default biography priority and returns
+	// the canonical (un-promoted) Name. In production this is what happens
+	// when the user's artist record holds a non-Latin canonical name -- the
+	// wikipedia adapter reads it from the input and echoes it back.
+	registry.Register(&mockProvider{
+		name: NameWikipedia,
+		getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+			return &ArtistMetadata{
+				Name:      "Canonical Name",
+				Biography: "About the artist.",
+			}, nil
+		},
+	})
+	// MusicBrainz: returns the promoted Latin Name (mirrors what the MB
+	// adapter's internal language-aware alias promotion produces when the
+	// user has Latin-family prefs and MB has a matching alias).
+	registry.Register(&mockProvider{
+		name: NameMusicBrainz,
+		getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+			return &ArtistMetadata{
+				Name:     "Promoted Name",
+				SortName: "Promoted Sort",
+				Genres:   []string{"rock"},
+			}, nil
+		},
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	orch := NewOrchestrator(registry, settings, logger)
+
+	result, err := orch.FetchMetadata(context.Background(), "test-mbid", "Canonical Name", nil)
+	if err != nil {
+		t.Fatalf("FetchMetadata: %v", err)
+	}
+
+	if result.Metadata.Name != "Promoted Name" {
+		t.Errorf("expected MB's Name to override earlier provider's Name, got %q", result.Metadata.Name)
+	}
+	if result.Metadata.SortName != "Promoted Sort" {
+		t.Errorf("expected MB's SortName to override, got %q", result.Metadata.SortName)
+	}
+}
+
+// TestFetchMetadata_MBNameAuthoritative_EmptyDoesNotClobber verifies the
+// override respects empty values: when MusicBrainz returns an empty Name
+// (error, not-found, or just no data), a Name already set by another
+// provider survives. Without this guard the override would erase a perfectly
+// good name on any refresh where MB is unreachable.
+func TestFetchMetadata_MBNameAuthoritative_EmptyDoesNotClobber(t *testing.T) {
+	registry, settings := setupOrchestratorTest(t)
+
+	registry.Register(&mockProvider{
+		name: NameWikipedia,
+		getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+			return &ArtistMetadata{
+				Name:      "Wikipedia Name",
+				Biography: "About the artist.",
+			}, nil
+		},
+	})
+	// MusicBrainz returns nothing (empty struct), simulating a provider that
+	// was queried successfully but had no data to contribute for Name.
+	registry.Register(&mockProvider{
+		name: NameMusicBrainz,
+		getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+			return &ArtistMetadata{Genres: []string{"rock"}}, nil
+		},
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	orch := NewOrchestrator(registry, settings, logger)
+
+	result, err := orch.FetchMetadata(context.Background(), "test-mbid", "Whatever", nil)
+	if err != nil {
+		t.Fatalf("FetchMetadata: %v", err)
+	}
+
+	if result.Metadata.Name != "Wikipedia Name" {
+		t.Errorf("expected wikipedia Name preserved when MB has none, got %q", result.Metadata.Name)
+	}
+}
+
+// TestFetchMetadata_MBNameAuthoritative_MBErrorDoesNotClobber verifies the
+// override respects provider errors: when MB returns an error (timeout, 5xx,
+// unreachable), its cached providerResult has err != nil and the override
+// must short-circuit, preserving a Name set by another provider. Without
+// this guard a transient MB outage would erase the artist's Name on every
+// affected refresh.
+func TestFetchMetadata_MBNameAuthoritative_MBErrorDoesNotClobber(t *testing.T) {
+	registry, settings := setupOrchestratorTest(t)
+
+	registry.Register(&mockProvider{
+		name: NameWikipedia,
+		getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+			return &ArtistMetadata{
+				Name:      "Wikipedia Name",
+				Biography: "About the artist.",
+			}, nil
+		},
+	})
+	registry.Register(&mockProvider{
+		name: NameMusicBrainz,
+		getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+			return nil, fmt.Errorf("musicbrainz timeout")
+		},
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	orch := NewOrchestrator(registry, settings, logger)
+
+	result, err := orch.FetchMetadata(context.Background(), "test-mbid", "Whatever", nil)
+	if err != nil {
+		t.Fatalf("FetchMetadata: %v", err)
+	}
+
+	if result.Metadata.Name != "Wikipedia Name" {
+		t.Errorf("expected wikipedia Name preserved on MB error, got %q", result.Metadata.Name)
+	}
+}
+
 // TestOrchestratorTagAggregation verifies that genres and moods are accumulated
 // across all providers with canonical spelling normalization and deduplication,
 // rather than stopping at the first provider with data.


### PR DESCRIPTION
## Summary

UAT on Tokyo Ska Paradise Orchestra under `["en-US", "en-GB", "en"]` preferences surfaced three independent bugs that together made the language-preference stack look broken even though the providers were fetching the right data. Each is fixed here.

Follow-up to #1137 (closed by #1144). Related tracking issue: #1145 for making the sort-name fallback configurable.

## What was broken

| Symptom | Root cause |
|---------|-----------|
| Artist name reverted to canonical (Japanese) after refresh even though MB promoted it to Latin | `provider.Orchestrator.applyField` merges `Name` with first-provider-wins; wikipedia runs before MusicBrainz for the `biography` field and locks in the canonical value before MB's language-promoted Name can land |
| UI stuck on "Fetching Metadata..." despite DB writes completing | `http.Server.WriteTimeout` of 30s killed the HTMX OOB fragment stream mid-response for any refresh exceeding 30s (easily reached: 1 req/sec MusicBrainz rate limit × ~20 members) |
| Most Japanese-canonical members displayed in Japanese script under en preferences | `localizeMembers` only consulted `aliases[]`; MB stores the curator-canonical romanization for non-Latin artists in the artist-level `sort-name` field, which the code never read |

## What this fixes

1. **MB-authoritative Name/SortName override** (`internal/provider/orchestrator.go`). After the per-field priority loop, unconditionally override `result.Metadata.Name` and `.SortName` with MusicBrainz's values when MB was queried successfully. Mirrors the existing pattern in `internal/scraper/executor.go:115-127`.

2. **WriteTimeout 30s -> 180s** (`cmd/stillwater/main.go`). Covers worst-case refresh latency for group artists with many members under language preferences, plus margin. Self-hosted context makes slowloris exposure a non-issue.

3. **Sort-name fallback in `localizeMembers`** (`internal/provider/musicbrainz/musicbrainz.go`). When the tagged-alias tier produces no winner AND the canonical is non-Latin AND MB's sort-name is Latin AND the user's top pref accepts Latin, synthesize the display name by reversing MB's `"Family, Given"` sort-name to display form `"Given Family"`. Six explicit gate conditions prevent false positives (e.g. flipping first/last for Western artists, promoting Latin under a Japanese pref). `memberAliasCache` value type changes from `[]MBAlias` to `memberAliasLookup{aliases, sortName}` so the per-member fetch carries sort-name alongside aliases.

## UAT result on Tokyo Ska Paradise Orchestra

All 18 members now surface readable Latin display names:

- 14 via sort-name fallback (Tatsuyuki Aoki, Rui Sugimura, Takashi Kato, Tsuyoshi Kawakami, etc.)
- 1 via tagged en primary alias (Hirokazu Asakura, the only member with a dedicated en alias)
- 4 correctly preserved as already-Latin canonicals (ASA-CHANG, Terrassy, GAMO, NARGO)

Artist name persists as `Tokyo Ska Paradise Orchestra` instead of reverting to the canonical `東京スカパラダイスオーケストラ`.

## Test plan

- [x] `TestFetchMetadata_MBNameAuthoritative` - MB's promoted Name overrides an earlier provider's canonical Name
- [x] `TestFetchMetadata_MBNameAuthoritative_EmptyDoesNotClobber` - empty MB Name does not erase another provider's Name
- [x] `TestFetchMetadata_MBNameAuthoritative_MBErrorDoesNotClobber` - MB error preserves another provider's Name (transient outage safety)
- [x] `TestLocalizeMembers_SortNameFallback` - Japanese canonical + Latin sort-name + en pref promotes to reversed sort-name
- [x] `TestLocalizeMembers_SortNameFallbackSkippedUnderNonLatinPref` - Japanese canonical under ja pref preserves canonical (user asked for ja)
- [x] `TestLocalizeMembers_SortNameFallbackNotAppliedToLatinCanonical` - Latin canonical under en pref skips reversal (no first/last flip)
- [x] `TestLocalizeMembers_SortNameFallbackFiresUnderMixedScriptPref` - sr (Cyrillic+Latin) pref accepts Latin sort-name for Cyrillic canonicals
- [x] `TestRomanizeFromSortName` - 8-case table covers empty, whitespace, single token, multi-comma, half-populated inputs
- [x] Existing `TestLocalizeMembers_*` scenarios (GAMO, Terrassy, Asakura, skip-under-preferred-script, secondary-pref match) still pass after the cache-type refactor
- [x] `go test -race ./...` green
- [x] `bash scripts/pre-push-gate.sh` clean; patch coverage 100% on both modified files (`musicbrainz.go`, `orchestrator.go`)
- [x] Manual UAT on TSPO confirmed all three fixes produce the expected end-to-end behavior

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fallback romanization of artist/member sort-names into display names when localized aliases are unavailable.

* **Improvements**
  * Increased HTTP write timeout from 30s to 180s for long-lived responses.
  * MusicBrainz-provided, language-aware names now override earlier provider name merges when available.

* **Tests**
  * Added tests and fixtures covering member name localization, romanization fallback, and orchestrator merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->