### PR TITLE
fix(rule): prevent pipeline self-writeback from re-marking artist dirty

### DIFF
--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -390,6 +390,30 @@ func (s *Service) Count(ctx context.Context, params CountParams) (int, error) {
 // each field that changed. History recording is best-effort: failures are
 // logged but do not cause the update to fail.
 func (s *Service) Update(ctx context.Context, a *Artist) error {
+	return s.update(ctx, a, true)
+}
+
+// UpdateAfterRuleEvaluation persists the artist without stamping dirty_since.
+// Intended for the rule pipeline's own writeback (health score, fixer-applied
+// fields) at the end of an evaluation pass: the pipeline is about to stamp
+// rules_evaluated_at and the artist is by definition freshly evaluated, so
+// marking it dirty would race the stamp.
+//
+// Concretely, both dirty_since and rules_evaluated_at are stored via
+// time.RFC3339 (second precision). The walker captures startedAt before fn
+// runs and uses it as the stamp. If markDirtyBestEffort inside a regular
+// Update happened to cross a wall-clock second boundary relative to
+// startedAt, dirty_since would land one second after rules_evaluated_at and
+// the artist would re-appear in ListDirtyIDs immediately, flaking the next
+// scheduled sweep. Skipping the dirty mark on the pipeline's self-writeback
+// closes that race without weakening the protection for external mutations:
+// those still go through Update (or the event bus DirtySubscriber) and get
+// dirty_since stamped normally.
+func (s *Service) UpdateAfterRuleEvaluation(ctx context.Context, a *Artist) error {
+	return s.update(ctx, a, false)
+}
+
+func (s *Service) update(ctx context.Context, a *Artist, markDirty bool) error {
 	// Snapshot the old state before writing, so we can diff after the update.
 	var old *Artist
 	if s.history != nil {
@@ -408,7 +432,9 @@ func (s *Service) Update(ctx context.Context, a *Artist) error {
 		return err
 	}
 
-	s.markDirtyBestEffort(ctx, a.ID)
+	if markDirty {
+		s.markDirtyBestEffort(ctx, a.ID)
+	}
 
 	// Record field-level changes after the successful update.
 	if s.history != nil && old != nil {

--- a/internal/artist/sqlite_dirty_test.go
+++ b/internal/artist/sqlite_dirty_test.go
@@ -272,3 +272,91 @@ func TestUpdate_DoesNotClobberDirtyTracking(t *testing.T) {
 		t.Fatalf("ListDirtyIDs after Update = %v, want [%s]", ids, a.ID)
 	}
 }
+
+// TestUpdateAfterRuleEvaluation_DoesNotStampDirty pins the invariant that
+// the rule pipeline's self-writeback path must not re-mark the artist dirty.
+// If this regressed to calling markDirtyBestEffort, dirty_since would land
+// one wall-clock second after the walker's startedAt on RFC3339 boundaries
+// and the artist would re-appear in ListDirtyIDs immediately, flaking the
+// scheduled sweep.
+func TestUpdateAfterRuleEvaluation_DoesNotStampDirty(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	a := testArtist("Post-Evaluation", "/music/post-eval")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Simulate the walker having just stamped rules_evaluated_at; the
+	// artist is clean and must stay clean across the pipeline's own
+	// health-score writeback.
+	evalAt := time.Now().UTC()
+	if err := svc.MarkRulesEvaluated(ctx, a.ID, evalAt); err != nil {
+		t.Fatalf("MarkRulesEvaluated: %v", err)
+	}
+
+	loaded, err := svc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	loaded.Biography = "health-score writeback"
+	if err := svc.UpdateAfterRuleEvaluation(ctx, loaded); err != nil {
+		t.Fatalf("UpdateAfterRuleEvaluation: %v", err)
+	}
+
+	reread, err := svc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID after UpdateAfterRuleEvaluation: %v", err)
+	}
+	if reread.DirtySince != nil {
+		t.Fatalf("dirty_since = %v, want nil (UpdateAfterRuleEvaluation must not stamp)", reread.DirtySince)
+	}
+	if reread.Biography != "health-score writeback" {
+		t.Fatalf("Biography = %q, want the written value (Update body must still run)", reread.Biography)
+	}
+
+	ids, err := svc.ListDirtyIDs(ctx)
+	if err != nil {
+		t.Fatalf("ListDirtyIDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("ListDirtyIDs = %v, want []; UpdateAfterRuleEvaluation must not re-dirty the artist", ids)
+	}
+}
+
+// TestUpdate_DoesStampDirty is the companion to the test above: a regular
+// Update must stamp dirty_since so external mutations (API handlers,
+// scanners, bulk executor) still schedule a re-evaluation. Together these
+// two tests pin the boundary between external and self-writeback paths.
+func TestUpdate_DoesStampDirty(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	a := testArtist("External Mutation", "/music/external")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := svc.MarkRulesEvaluated(ctx, a.ID, time.Now().UTC()); err != nil {
+		t.Fatalf("MarkRulesEvaluated: %v", err)
+	}
+
+	loaded, err := svc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	loaded.Biography = "external write"
+	if err := svc.Update(ctx, loaded); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	reread, err := svc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID after Update: %v", err)
+	}
+	if reread.DirtySince == nil {
+		t.Fatalf("dirty_since was not stamped by Update; external mutations must re-schedule evaluation")
+	}
+}

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -1022,7 +1022,13 @@ func (p *Pipeline) updateHealthScore(ctx context.Context, a *artist.Artist, must
 		now := time.Now().UTC()
 		a.HealthEvaluatedAt = &now
 	}
-	if err := p.artistService.Update(ctx, a); err != nil {
+	// UpdateAfterRuleEvaluation (not Update) so the pipeline's own writeback
+	// does not stamp dirty_since. The walker is about to stamp
+	// rules_evaluated_at with startedAt, and a regular Update would race
+	// that stamp at second-precision boundaries (see service.go docs and
+	// #698 follow-up: the scheduler test flaked on CI when dirty_since
+	// happened to round into the next second after startedAt).
+	if err := p.artistService.UpdateAfterRuleEvaluation(ctx, a); err != nil {
 		p.logger.Error("persisting artist after fixes", "artist", a.Name, "error", err)
 		return false
 	}


### PR DESCRIPTION
## Summary

- Flaky `TestScheduler_StampsRulesEvaluated` on CI: walker captured `startedAt` before `fn(a)`, stamped `rules_evaluated_at = startedAt` after; inside `fn`, `updateHealthScore` routed through `artist.Service.Update` which called `markDirtyBestEffort` with a fresh `time.Now()`. Both timestamps serialize via `time.RFC3339` (second precision), so when the dirty mark straddled a wall-clock second boundary relative to `startedAt`, `dirty_since > rules_evaluated_at` became true and the artist re-appeared in `ListDirtyIDs` immediately.
- Add `artist.Service.UpdateAfterRuleEvaluation`, a sibling of `Update` that skips `markDirtyBestEffort`, and route `Pipeline.updateHealthScore` through it. External mutations (API handlers, scanner, bulk executor, single-violation `FixViolation`) still go through `Update` and keep stamping `dirty_since` — the walker's `startedAt` capture already protects the external-race window.
- Pins the invariant with two new tests in `sqlite_dirty_test.go`: `UpdateAfterRuleEvaluation` leaves `dirty_since` nil; plain `Update` stamps it.

## Test plan

- [x] `go test -race -run TestScheduler_StampsRulesEvaluated -count=50 ./internal/rule/` — green
- [x] `go test -race -run "TestUpdate_DoesStampDirty|TestUpdateAfterRuleEvaluation_DoesNotStampDirty|TestUpdate_DoesNotClobberDirtyTracking" ./internal/artist/` — green
- [x] `bash scripts/pre-push-gate.sh` — all hard checks passed
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rule-evaluation updates no longer mark records as "dirty", preventing unnecessary re-processing and duplicate re-evaluations after internal health-score updates.

* **Tests**
  * Added tests covering dirty-tracking boundaries to ensure internal rule writes and external updates behave correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #1154
