### PR TITLE
build(release): nightly GoReleaser workflow for updater dev channel

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,0 +1,195 @@
+name: Release Nightly
+
+# Nightly GoReleaser pipeline that publishes per-arch binaries + checksums.txt
+# as a GitHub Release, so the self-updater's `nightly` channel (#639 / #1111)
+# has concrete assets to resolve against. Sibling to:
+#   - .github/workflows/release.yml  -- stable/rc pipeline (tag-triggered)
+#   - .github/workflows/nightly.yml  -- nightly Docker image to GHCR
+#
+# Tag format: nightly-YYYYMMDD (dated, immutable, UTC).
+# Retention:  keeps the 14 most recent nightly releases + tags; older are pruned.
+
+on:
+  schedule:
+    # 06:00 UTC daily. Offset from the nightly Docker workflow (00:00 UTC) so
+    # the two do not contend for the same runner minute and so nightly binaries
+    # are produced after the Docker image already rolled.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  # Do not cancel an in-flight nightly when a second one starts: releases are
+  # side-effecting (tags, GitHub Releases, cosign) and we never want two runs
+  # racing to publish the same date.
+  group: release-nightly
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release Nightly
+    # Only run against main. Guards a stray workflow_dispatch against a branch.
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create tags and GitHub Releases
+      packages: write   # parity with stable; harmless if unused
+      id-token: write   # cosign keyless signing of checksums
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check for new commits since last nightly
+        id: guard
+        run: |
+          set -euo pipefail
+          # Find the most recent nightly-* tag (by tag date).
+          last_tag=$(git tag --list 'nightly-*' --sort=-creatordate | head -n1 || true)
+          if [ -z "$last_tag" ]; then
+            echo "No prior nightly tag found; proceeding with first nightly."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          count=$(git rev-list --count "${last_tag}..HEAD")
+          echo "Last nightly: $last_tag"
+          echo "Commits since last nightly: $count"
+          if [ "$count" -eq 0 ]; then
+            echo "No new commits on main since $last_tag; skipping nightly release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute nightly tag
+        id: tag
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          # UTC date; immutable per day. If a same-day tag already exists
+          # (e.g. manual workflow_dispatch after the cron already ran), bail
+          # cleanly rather than clobbering a published release.
+          tag="nightly-$(date -u +%Y%m%d)"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
+            echo "Tag $tag already exists; aborting to avoid overwriting an existing nightly release." >&2
+            exit 1
+          fi
+          echo "Planned tag: $tag"
+
+      # Create an annotated tag via the GitHub REST API. Tags authored by the
+      # Git Data API using the GITHUB_TOKEN are signed automatically with
+      # GitHub's github-actions[bot] GPG key, so the release carries the
+      # "Verified" badge (per memory: feedback_signed_annotated_tags.md).
+      #
+      # This repo has no GPG_PRIVATE_KEY secret provisioned -- stable releases
+      # are tagged locally on the maintainer's workstation via `git tag -s`.
+      # Using the Git Data API is the zero-secret path to a signed tag in CI.
+      - name: Create signed annotated tag (via GitHub API)
+        id: create_tag
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          sha=$(git rev-parse HEAD)
+          echo "Tagging $sha as $TAG"
+
+          # 1. Create the annotated tag object.
+          tag_obj=$(gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/git/tags" \
+            -f "tag=${TAG}" \
+            -f "message=Stillwater nightly ${TAG}" \
+            -f "object=${sha}" \
+            -f "type=commit" \
+            --jq '.sha')
+
+          # 2. Create the ref pointing at the tag object.
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f "ref=refs/tags/${TAG}" \
+            -f "sha=${tag_obj}"
+
+          # 3. Fetch the tag locally so GoReleaser sees it.
+          git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          # Best-effort log of the tag verification output. Verification will
+          # typically fail on the runner (no GitHub GPG pubkey imported); this
+          # is informational only, so swallow errors.
+          { git tag -v "${TAG}" 2>&1 || true; } | head -n 20
+
+      - name: Set up Go
+        if: steps.guard.outputs.skip != 'true'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install cosign
+        if: steps.guard.outputs.skip != 'true'
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          cosign-release: 'v2.4.1'
+
+      # Checkout the tag we just created so GoReleaser resolves {{ .Version }}
+      # from the tag rather than from the branch head.
+      - name: Checkout tag
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git checkout --detach "refs/tags/${TAG}"
+
+      - name: Run GoReleaser
+        if: steps.guard.outputs.skip != 'true'
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7
+        with:
+          distribution: goreleaser
+          version: latest
+          # --skip=validate is required because nightly-YYYYMMDD is not a
+          # semver tag; GoReleaser's default guard would reject it otherwise.
+          args: release --clean --config .goreleaser.nightly.yml --skip=validate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Retention: keep the 14 most recent nightly releases (and their tags);
+      # delete everything older. Only touches `nightly-*` refs; non-nightly
+      # tags (v*.*.*) are never enumerated. Only runs after a successful
+      # release; if the release step failed we do not want to prune stale
+      # nightlies that a rollback might still need to reference.
+      - name: Prune old nightly releases
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KEEP: 14
+        run: |
+          set -euo pipefail
+          # List all nightly-* releases, newest first by creation.
+          mapfile -t nightly < <(gh release list \
+            --limit 200 \
+            --json tagName,createdAt \
+            --jq '[.[] | select(.tagName | startswith("nightly-"))] | sort_by(.createdAt) | reverse | .[].tagName')
+
+          total=${#nightly[@]}
+          echo "Total nightly releases: $total (keeping newest $KEEP)"
+
+          if [ "$total" -le "$KEEP" ]; then
+            echo "Nothing to prune."
+            exit 0
+          fi
+
+          # Delete the oldest (total - KEEP) releases, and their tags.
+          for tag in "${nightly[@]:$KEEP}"; do
+            echo "Deleting release + tag: $tag"
+            gh release delete "$tag" --yes --cleanup-tag || \
+              echo "warning: failed to delete $tag (already gone?)"
+          done

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -1,0 +1,122 @@
+version: 2
+
+# Nightly GoReleaser configuration.
+#
+# Mirrors the stable `.goreleaser.yml` asset layout (per-arch binary archives
+# and a checksums file) so the updater's "nightly" channel can resolve a
+# release published by `.github/workflows/release-nightly.yml` and verify
+# downloads via checksums.txt exactly like it does for stable releases.
+#
+# Intentionally omits:
+#   - dockers / docker_manifests: nightly Docker images are built by
+#     `.github/workflows/nightly.yml` (amd64 only, `ghcr.io/.../stillwater:nightly`).
+#     Duplicating them here would double-publish and race the existing job.
+#   - docker_signs: no Docker artifacts produced here.
+#
+# Keeps cosign keyless signing of the checksums blob to match stable pipeline
+# behavior (checksums.txt.pem / .sig accompany every release).
+
+before:
+  hooks:
+    - go install github.com/a-h/templ/cmd/templ@latest
+    - templ generate
+    - >-
+      sh -c 'curl -sL
+      https://github.com/tailwindlabs/tailwindcss/releases/download/v4.2.0/tailwindcss-linux-x64
+      -o /tmp/tailwindcss && chmod +x /tmp/tailwindcss &&
+      /tmp/tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minify'
+
+builds:
+  - id: stillwater
+    main: ./cmd/stillwater
+    binary: stillwater
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -s -w
+      - -X github.com/sydlexius/stillwater/internal/version.Version={{ .Version }}
+      - -X github.com/sydlexius/stillwater/internal/version.Commit={{ .ShortCommit }}
+      - -X github.com/sydlexius/stillwater/internal/version.Date={{ .Date }}
+
+archives:
+  - id: default
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+# Match stable: cosign keyless-signs the checksums artifact. Requires
+# `id-token: write` on the calling workflow.
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - --output-certificate=${certificate}
+      - --output-signature=${signature}
+      - ${artifact}
+      - --yes
+    artifacts: checksum
+    output: true
+
+changelog:
+  sort: asc
+  use: github
+  groups:
+    - title: Breaking Changes
+      regexp: '(?i)^(?:.*!:|BREAKING(?: CHANGE)?:)'
+      order: 0
+    - title: Features
+      regexp: '^feat(\(.+\))?:'
+      order: 1
+    - title: Bug Fixes
+      regexp: '^fix(\(.+\))?:'
+      order: 2
+    - title: Performance
+      regexp: '^perf(\(.+\))?:'
+      order: 3
+    - title: Refactoring
+      regexp: '^refactor(\(.+\))?:'
+      order: 4
+    - title: Other
+      order: 999
+  filters:
+    exclude:
+      - '^chore:'
+      - '^docs:'
+      - '^ci:'
+      - '^style:'
+      - '^test:'
+      - Merge pull request
+      - Merge branch
+
+release:
+  github:
+    owner: sydlexius
+    name: stillwater
+  # Nightly builds are always prereleases and never "latest".
+  prerelease: true
+  make_latest: false
+  name_template: "Nightly {{ .Tag }}"
+  header: |
+    ## Stillwater Nightly {{ .Tag }}
+
+    > Automated nightly build from `main`. Intended for the updater's
+    > `nightly` channel and early testers. No stability guarantees.
+  footer: |
+    {{- if .PreviousTag }}
+    **Full Changelog:** [{{ .PreviousTag }}...{{ .Tag }}](https://github.com/sydlexius/stillwater/compare/{{ .PreviousTag }}...{{ .Tag }})
+    {{- else }}
+    **Full Changelog:** [{{ .Tag }}](https://github.com/sydlexius/stillwater/releases/tag/{{ .Tag }})
+    {{- end }}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Static assets (CSS, JavaScript, fonts, images) are embedded in the binary. No ad
 
 #### Nightly builds
 
-A dated nightly release (`nightly-YYYYMMDD`) is published from `main` every day there are new commits, and is the default target for the in-app updater's nightly channel. Nightly builds are intended for testers and are not recommended for production use.
+A dated nightly release (`nightly-YYYYMMDD`) is published from `main` every day there are new commits. These builds are intended for testers and are available for manual download only; in-app updater support for a nightly channel is tracked in #1111. Nightly builds are not recommended for production use.
 
 ### Docker Run
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ go install github.com/sydlexius/stillwater/cmd/stillwater@latest
 
 Static assets (CSS, JavaScript, fonts, images) are embedded in the binary. No additional files are required.
 
+#### Nightly builds
+
+A dated nightly release (`nightly-YYYYMMDD`) is published from `main` every day there are new commits, and is the default target for the in-app updater's nightly channel. Nightly builds are intended for testers and are not recommended for production use.
+
 ### Docker Run
 
 Pull and run the image with a single command:


### PR DESCRIPTION
## Summary

- New `.github/workflows/release-nightly.yml` publishes a dated nightly GitHub Release (`nightly-YYYYMMDD`) from `main` at 06:00 UTC with per-arch binaries and a checksums file, matching the stable pipeline's asset layout so the self-updater's nightly channel (#1111) can resolve and verify downloads.
- New `.goreleaser.nightly.yml` mirrors the stable GoReleaser build/archives/checksum/cosign config. Dockers and docker_manifests are intentionally omitted because `.github/workflows/nightly.yml` already publishes the nightly Docker image; duplicating would double-publish.
- README gets a one-paragraph "Nightly builds" subsection noting the channel exists.

## Design notes

- **Option A (sibling workflow)** picked as directed. Keeps `nightly.yml` focused on its Docker-only job and leaves `release.yml` untouched.
- **Tag format** `nightly-YYYYMMDD` (UTC). Immutable per day. Matches the updater's existing `binaryAssetName` logic (`stillwater_<tag-without-v>_<os>_<arch>.tar.gz`).
- **Signed tags:** the repo has no `GPG_PRIVATE_KEY` secret (stable tags are signed on the maintainer's workstation). The workflow creates the annotated tag via the GitHub Git Data REST API, which GitHub auto-signs with the `github-actions[bot]` GPG key, producing the Verified badge. This satisfies the "signed annotated tags" project rule without adding a new secret.
- **No-op guard:** if `git rev-list last-nightly..HEAD` is empty, the subsequent steps are skipped via `if:` gating.
- **Retention:** keeps the 14 most recent `nightly-*` releases + tags via `gh release list` + `gh release delete --cleanup-tag`. Non-nightly tags are never enumerated.
- **Concurrency:** `release-nightly` group with `cancel-in-progress: false` so two runs cannot race on the same date.
- **GoReleaser flags:** `--skip=validate` is required because `nightly-YYYYMMDD` is not a semver tag.

## Test plan

Full exercise requires either the scheduled run or a manual `workflow_dispatch` on `main` post-merge; neither is possible pre-merge. What has been done locally:

- [x] `goreleaser check --config .goreleaser.nightly.yml` parses successfully (same deprecation warnings as the stable config; out of scope to migrate).
- [x] YAML parses cleanly for both files.
- [x] All four action `uses:` lines are pinned to 40-char commit SHAs with inline version tags (project CI rule).
- [x] Shell scripts use `set -euo pipefail`; variables are quoted; `|| true` is bounded to a single informational command.
- [x] No em-dashes, no emoji, no `paths-ignore`.
- [ ] Post-merge: run the workflow via `gh workflow run release-nightly.yml --ref main` and confirm a `nightly-YYYYMMDD` release is published with `stillwater_nightly-YYYYMMDD_linux_amd64.tar.gz` and a `checksums.txt`.
- [ ] Post-merge on day 2: confirm the no-op guard skips when `main` has no new commits since the prior nightly tag.
- [ ] After 15 daily runs (or manual dry-run): confirm the retention step prunes the 15th-oldest nightly release and its tag.

## Out of scope

- Updater code (`internal/updater/updater.go`, `handlers_updater.go`) is tracked in #1111.
- Settings UI channel option is tracked in #1111.
- Cosign/minisign beyond what the stable pipeline already does.

Closes #1123.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dated nightly builds are available for testers, published daily when there are new commits and also triggerable manually.
  * Nightlies produce platform-specific binaries (major OS/architectures) with signed checksums and are distributed as prerelease downloads.
  * Older nightly releases are automatically pruned, keeping recent history manageable.

* **Documentation**
  * README updated with guidance on nightly builds and their intended use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->