### PR TITLE
feat(rule): per-artist rule_results storage (slice 1 of #699)

### DIFF
--- a/internal/api/handlers_report.go
+++ b/internal/api/handlers_report.go
@@ -275,16 +275,30 @@ func (r *Router) handleReportCompliance(w http.ResponseWriter, req *http.Request
 		return
 	}
 
+	// Issue #699: batch-load per-artist pass/fail counts from rule_results.
+	// A failure here is logged but non-fatal: the compliance grid still
+	// renders with violation data, and the new counts fall back to zero so
+	// the UI is not blocked when rule_results is empty (fresh install, or
+	// an artist whose first Run Rules pass has not finished).
+	resultCounts, rcErr := r.ruleService.GetRuleResultCounts(ctx, ids)
+	if rcErr != nil {
+		r.logger.Warn("loading rule_result counts for compliance report", "error", rcErr)
+		resultCounts = map[string]rule.RuleResultCount{}
+	}
+
 	rows := make([]templates.ComplianceRow, len(artists))
 	for i, a := range artists {
 		vs := violations[a.ID]
 		if vs == nil {
 			vs = make([]rule.Violation, 0)
 		}
+		counts := resultCounts[a.ID]
 		rows[i] = templates.ComplianceRow{
-			Artist:      a,
-			HealthScore: a.HealthScore,
-			Violations:  vs,
+			Artist:              a,
+			HealthScore:         a.HealthScore,
+			Violations:          vs,
+			RulesPassedCount:    counts.Passed,
+			RulesEvaluatedCount: counts.Evaluated,
 		}
 	}
 

--- a/internal/api/handlers_report_test.go
+++ b/internal/api/handlers_report_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -263,6 +264,88 @@ func TestHandleReportCompliance(t *testing.T) {
 	if int(total) != 2 {
 		t.Errorf("total = %d, want 2", int(total))
 	}
+}
+
+// TestHandleReportCompliance_IncludesRulesPassedCount covers the #699 slice 1
+// addition: each compliance row now carries rules_passed_count and
+// rules_evaluated_count, sourced from the rule_results table. Rows for
+// artists with no stored outcomes should default to zero so the field is
+// always present in the response (stable for clients that rely on its
+// existence).
+func TestHandleReportCompliance_IncludesRulesPassedCount(t *testing.T) {
+	r, artistSvc := testRouter(t)
+	ctx := context.Background()
+
+	passing := addTestArtist(t, artistSvc, "Passing Artist")
+	partial := addTestArtist(t, artistSvc, "Partial Artist")
+	// Seed rule_results rows directly: passing artist has 3 pass rows,
+	// partial artist has 2 pass + 1 fail.
+	now := time.Now().UTC()
+	for _, rid := range []string{rule.RuleNFOExists, rule.RuleThumbExists, rule.RuleFanartExists} {
+		if err := r.ruleService.UpsertRuleResultPass(ctx, passing.ID, rid, now); err != nil {
+			t.Fatalf("seeding pass %s: %v", rid, err)
+		}
+	}
+	if err := r.ruleService.UpsertRuleResultPass(ctx, partial.ID, rule.RuleNFOExists, now); err != nil {
+		t.Fatalf("seeding partial pass 1: %v", err)
+	}
+	if err := r.ruleService.UpsertRuleResultPass(ctx, partial.ID, rule.RuleThumbExists, now); err != nil {
+		t.Fatalf("seeding partial pass 2: %v", err)
+	}
+	// Simulate a fail by inserting directly (skips the transactional pair
+	// that would also write a violation; this keeps the test focused on
+	// the compliance handler aggregating rule_results correctly).
+	if _, err := testRuleResultsDBFromRouter(r).ExecContext(ctx, `
+		INSERT INTO rule_results (artist_id, rule_id, passed, evaluated_at, first_failed_at)
+		VALUES (?, ?, 0, ?, ?)`,
+		partial.ID, rule.RuleFanartExists,
+		now.Format("2006-01-02T15:04:05Z"),
+		now.Format("2006-01-02T15:04:05Z")); err != nil {
+		t.Fatalf("seeding partial fail: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/reports/compliance?page=1&page_size=10", nil)
+	w := httptest.NewRecorder()
+	r.handleReportCompliance(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp struct {
+		Rows []struct {
+			Artist struct {
+				ID string `json:"id"`
+			} `json:"artist"`
+			RulesPassedCount    int `json:"rules_passed_count"`
+			RulesEvaluatedCount int `json:"rules_evaluated_count"`
+		} `json:"rows"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if len(resp.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(resp.Rows))
+	}
+
+	byID := make(map[string]struct{ passed, evaluated int }, len(resp.Rows))
+	for _, row := range resp.Rows {
+		byID[row.Artist.ID] = struct{ passed, evaluated int }{row.RulesPassedCount, row.RulesEvaluatedCount}
+	}
+	if got := byID[passing.ID]; got.passed != 3 || got.evaluated != 3 {
+		t.Errorf("passing artist counts = %+v, want {passed:3, evaluated:3}", got)
+	}
+	if got := byID[partial.ID]; got.passed != 2 || got.evaluated != 3 {
+		t.Errorf("partial artist counts = %+v, want {passed:2, evaluated:3}", got)
+	}
+}
+
+// testRuleResultsDBFromRouter pulls the *sql.DB out of the Router's
+// RuleService for raw inserts. Kept here so the backdoor stays local to
+// this test rather than exporting an accessor from the package.
+func testRuleResultsDBFromRouter(r *Router) interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+} {
+	return r.db
 }
 
 func TestSanitizeCSV(t *testing.T) {

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -4763,6 +4763,12 @@ paths:
                     type: array
                     items:
                       type: object
+                      required:
+                        - artist
+                        - health_score
+                        - violations
+                        - rules_passed_count
+                        - rules_evaluated_count
                       properties:
                         artist:
                           type: object

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -4787,12 +4787,15 @@ paths:
                           description: |
                             Number of enabled rules the artist currently passes,
                             taken from the rule_results table (issue #699). Zero
-                            when the artist has not yet been evaluated.
+                            when no rule_results rows exist for the artist, or
+                            when count lookup is unavailable.
                         rules_evaluated_count:
                           type: integer
                           description: |
                             Total number of rules the artist has an outcome row
-                            for, taken from the rule_results table. The ratio
+                            for, taken from the rule_results table. Zero when no
+                            rule_results rows exist for the artist, or when
+                            count lookup is unavailable. The ratio
                             rules_passed_count / rules_evaluated_count is the
                             coarse "rules satisfied" signal for this artist.
                     description: Compliance report rows.

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -4763,6 +4763,32 @@ paths:
                     type: array
                     items:
                       type: object
+                      properties:
+                        artist:
+                          type: object
+                          description: Artist record.
+                        health_score:
+                          type: number
+                          format: float
+                          description: Stored health score for the artist (0-100).
+                        violations:
+                          type: array
+                          items:
+                            type: object
+                          description: Active violations (open, pending_choice) for the artist.
+                        rules_passed_count:
+                          type: integer
+                          description: |
+                            Number of enabled rules the artist currently passes,
+                            taken from the rule_results table (issue #699). Zero
+                            when the artist has not yet been evaluated.
+                        rules_evaluated_count:
+                          type: integer
+                          description: |
+                            Total number of rules the artist has an outcome row
+                            for, taken from the rule_results table. The ratio
+                            rules_passed_count / rules_evaluated_count is the
+                            coarse "rules satisfied" signal for this artist.
                     description: Compliance report rows.
                   total:
                     type: integer

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -75,15 +75,22 @@ func backfillRuleResultsFromViolations(db *sql.DB) error {
 	ctx := context.Background()
 	// Use INSERT OR IGNORE so re-running Migrate is a no-op once the rows
 	// exist. The PRIMARY KEY (artist_id, rule_id) enforces idempotency.
+	// The JOINs filter out orphaned rule_violations rows whose artist or
+	// rule no longer exists. Without them a single stale violation would
+	// abort the whole INSERT on a FK violation (rule_results has FKs to
+	// artists and rules) and leave the backfill half-applied, aborting
+	// migration and blocking startup.
 	_, err := db.ExecContext(ctx, `
 		INSERT OR IGNORE INTO rule_results (
 			artist_id, rule_id, passed, violation_id, evaluated_at,
 			violation_message, first_failed_at
 		)
 		SELECT
-			artist_id, rule_id, 0, id, updated_at, message, created_at
-		FROM rule_violations
-		WHERE status IN ('open', 'pending_choice')
+			rv.artist_id, rv.rule_id, 0, rv.id, rv.updated_at, rv.message, rv.created_at
+		FROM rule_violations rv
+		JOIN artists a ON a.id = rv.artist_id
+		JOIN rules r ON r.id = rv.rule_id
+		WHERE rv.status IN ('open', 'pending_choice')
 	`)
 	if err != nil {
 		return fmt.Errorf("inserting rule_results backfill rows: %w", err)

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -47,6 +47,47 @@ func Migrate(db *sql.DB) error {
 		return fmt.Errorf("ensuring connection columns: %w", err)
 	}
 
+	// Issue #699: seed rule_results rows for every open / pending_choice
+	// violation already in the database. Without this, pre-existing
+	// violations would have a missing first_failed_at until the next
+	// pipeline pass re-evaluated the artist, losing the "how long has
+	// this been broken" signal. INSERT OR IGNORE makes this idempotent
+	// on every startup: once a (artist_id, rule_id) row exists, repeat
+	// runs are cheap no-ops.
+	if err := backfillRuleResultsFromViolations(db); err != nil {
+		return fmt.Errorf("backfilling rule_results from violations: %w", err)
+	}
+
+	return nil
+}
+
+// backfillRuleResultsFromViolations seeds rule_results rows for every
+// currently-active violation (open or pending_choice) that does not already
+// have a row. Historical dismissed / resolved violations are skipped: they
+// are no longer authoritative outcomes, and the next Run Rules pass will
+// fill in fresh pass/fail rows via the pipeline's UpsertRuleResultPass and
+// the transactional UpsertViolation writes.
+//
+// The INSERT carries rule_violations.created_at into first_failed_at so the
+// "how long has this been broken" signal survives the backfill, rather than
+// resetting to "now" and losing history.
+func backfillRuleResultsFromViolations(db *sql.DB) error {
+	ctx := context.Background()
+	// Use INSERT OR IGNORE so re-running Migrate is a no-op once the rows
+	// exist. The PRIMARY KEY (artist_id, rule_id) enforces idempotency.
+	_, err := db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO rule_results (
+			artist_id, rule_id, passed, violation_id, evaluated_at,
+			violation_message, first_failed_at
+		)
+		SELECT
+			artist_id, rule_id, 0, id, updated_at, message, created_at
+		FROM rule_violations
+		WHERE status IN ('open', 'pending_choice')
+	`)
+	if err != nil {
+		return fmt.Errorf("inserting rule_results backfill rows: %w", err)
+	}
 	return nil
 }
 

--- a/internal/database/migrations/001_initial_schema.sql
+++ b/internal/database/migrations/001_initial_schema.sql
@@ -356,6 +356,29 @@ CREATE INDEX idx_rule_violations_status ON rule_violations(status);
 CREATE INDEX idx_rule_violations_created_at ON rule_violations(created_at);
 CREATE INDEX idx_rule_violations_resolved_at ON rule_violations(resolved_at);
 
+-- Per-(artist, rule) evaluation outcome row (issue #699). rule_violations only
+-- records failures; rule_results records every evaluation so reports can
+-- answer "how many rules does artist X pass?" without re-running Evaluate.
+-- Rows are upserted by the pipeline (fixer.go processArtist) and the
+-- health subscriber's evaluateArtist path. On disable or rule delete the
+-- rows are purged; violation rows link back here via violation_id so a
+-- deleted violation clears the link without nuking the pass/fail history.
+CREATE TABLE IF NOT EXISTS rule_results (
+    artist_id         TEXT    NOT NULL REFERENCES artists(id)           ON DELETE CASCADE,
+    rule_id           TEXT    NOT NULL REFERENCES rules(id)             ON DELETE CASCADE,
+    passed            INTEGER NOT NULL DEFAULT 0,
+    violation_id      TEXT             REFERENCES rule_violations(id)   ON DELETE SET NULL,
+    evaluated_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+    violation_message TEXT,
+    first_failed_at   TEXT,
+    last_passed_at    TEXT,
+    PRIMARY KEY (artist_id, rule_id)
+);
+CREATE INDEX idx_rule_results_rule_id      ON rule_results(rule_id);
+CREATE INDEX idx_rule_results_artist_id    ON rule_results(artist_id);
+CREATE INDEX idx_rule_results_passed       ON rule_results(passed);
+CREATE INDEX idx_rule_results_evaluated_at ON rule_results(evaluated_at);
+
 -- =============================================================================
 -- Health tracking
 -- =============================================================================
@@ -511,6 +534,7 @@ VALUES ('extraneous_images', 'Extraneous image files', 'Detects non-canonical im
 DROP TABLE IF EXISTS user_preferences;
 DROP TABLE IF EXISTS bulk_job_items;
 DROP TABLE IF EXISTS bulk_jobs;
+DROP TABLE IF EXISTS rule_results;
 DROP TABLE IF EXISTS rule_violations;
 DROP TABLE IF EXISTS rules;
 DROP TABLE IF EXISTS health_history;

--- a/internal/rule/engine.go
+++ b/internal/rule/engine.go
@@ -355,6 +355,7 @@ func (e *Engine) Evaluate(ctx context.Context, a *artist.Artist) (*EvaluationRes
 		}
 
 		result.RulesTotal++
+		result.RulesConsidered = append(result.RulesConsidered, r.ID)
 
 		v := checker(ctx, a, r.Config)
 		if v != nil {

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -182,16 +182,6 @@ func (p *Pipeline) RunRuleScoped(ctx context.Context, ruleID string, scope RunSc
 			return false
 		}
 
-		// Track which rules produced violations so the pass-side
-		// UpsertRuleResultPass call below skips them (they are handled
-		// transactionally by UpsertViolation).
-		violated := make(map[string]struct{}, len(eval.Violations))
-		for j := range eval.Violations {
-			if eval.Violations[j].RuleID == ruleID {
-				violated[eval.Violations[j].RuleID] = struct{}{}
-			}
-		}
-
 		for j := range eval.Violations {
 			v := &eval.Violations[j]
 			if v.RuleID != ruleID {
@@ -305,18 +295,27 @@ func (p *Pipeline) RunRuleScoped(ctx context.Context, ruleID string, scope RunSc
 			}
 		}
 
-		// Issue #699: persist the pass row when the single rule we ran
-		// was actually considered for this artist (enabled, not skipped
-		// by filesystem-missing gating) and produced no violation.
-		passFilter := func(rid string) bool { return rid == ruleID }
-		if !p.persistPassResults(ctx, a, eval.RulesConsidered, violated, startedAt, passFilter) {
+		// Issue #699 propagation fix: derive the pass/fail skip-set from
+		// the POST-fix evaluation, not the pre-fix snapshot. A rule the
+		// fixer just repaired still appears in the pre-fix Violations
+		// slice, so using that set would suppress its pass row for this
+		// run. updateHealthScore re-evaluates the artist anyway (to
+		// recompute the health score), so we reuse that result.
+		postEval, persistOKHealth := p.updateHealthScore(ctx, a, perRuleDirty)
+		if !persistOKHealth {
 			persistOK = false
 		}
-
-		// Re-evaluate and persist health score (and any in-memory
-		// changes fixers made) in a single write, then publish.
-		if !p.updateHealthScore(ctx, a, perRuleDirty) {
-			persistOK = false
+		if postEval != nil {
+			postViolated := make(map[string]struct{}, len(postEval.Violations))
+			for j := range postEval.Violations {
+				postViolated[postEval.Violations[j].RuleID] = struct{}{}
+			}
+			// Single-rule scope: only persist the pass row for the
+			// specific rule this invocation evaluated.
+			passFilter := func(rid string) bool { return rid == ruleID }
+			if !p.persistPassResults(ctx, a, postEval.RulesConsidered, postViolated, startedAt, passFilter) {
+				persistOK = false
+			}
 		}
 		p.publishAccumulated(ctx, a, perRuleMetadata, perRuleImages)
 		return persistOK
@@ -386,13 +385,6 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 
 	// Cache rule lookups to avoid repeated DB queries.
 	ruleCache := map[string]*Rule{}
-
-	// Track which rules produced violations so the pass-side write below
-	// only writes pass rows for rules that actually passed (issue #699).
-	violated := make(map[string]struct{}, len(eval.Violations))
-	for j := range eval.Violations {
-		violated[eval.Violations[j].RuleID] = struct{}{}
-	}
 
 	for j := range eval.Violations {
 		v := &eval.Violations[j]
@@ -515,10 +507,18 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 		}
 	}
 
-	// Issue #699: persist pass rows for every rule that was considered
-	// but did not produce a violation. When categoryFilter is set we only
-	// mirror the category into rule_results so RunImageRulesForArtist does
-	// not claim the artist "passes" metadata rules it never actually ran.
+	// Issue #699 propagation fix: derive the pass/fail skip-set from the
+	// POST-fix evaluation returned by updateHealthScore. A rule the fixer
+	// just repaired would otherwise stay in the pre-fix violation snapshot
+	// and be suppressed from the pass rows written below.
+	postEval, persistOKHealth := p.updateHealthScore(ctx, a, artistDirty)
+	if !persistOKHealth {
+		persistOK = false
+	}
+
+	// When categoryFilter is set we only mirror the category into
+	// rule_results so RunImageRulesForArtist does not claim the artist
+	// "passes" metadata rules it never actually ran.
 	var passFilter func(rid string) bool
 	if categoryFilter != "" {
 		passFilter = func(rid string) bool {
@@ -538,15 +538,16 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 			return r.Category == categoryFilter
 		}
 	}
-	if !p.persistPassResults(ctx, a, eval.RulesConsidered, violated, startedAt, passFilter) {
-		persistOK = false
+	if postEval != nil {
+		postViolated := make(map[string]struct{}, len(postEval.Violations))
+		for j := range postEval.Violations {
+			postViolated[postEval.Violations[j].RuleID] = struct{}{}
+		}
+		if !p.persistPassResults(ctx, a, postEval.RulesConsidered, postViolated, startedAt, passFilter) {
+			persistOK = false
+		}
 	}
 
-	// Re-evaluate and persist health score (and any in-memory
-	// changes fixers made) in a single write, then publish.
-	if !p.updateHealthScore(ctx, a, artistDirty) {
-		persistOK = false
-	}
 	p.publishAccumulated(ctx, a, metadataFixed, fixedImageTypes)
 	// Stamp rules_evaluated_at only when categoryFilter is empty (every
 	// enabled rule was considered) AND every persistence step succeeded.
@@ -599,13 +600,6 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 		if err != nil {
 			p.logger.Warn("evaluating artist", "artist", a.Name, "error", err)
 			return false
-		}
-
-		// Track which rules produced violations so the pass-side write
-		// below skips them (fails are handled by UpsertViolation).
-		violated := make(map[string]struct{}, len(eval.Violations))
-		for j := range eval.Violations {
-			violated[eval.Violations[j].RuleID] = struct{}{}
 		}
 
 		for j := range eval.Violations {
@@ -729,17 +723,23 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 			}
 		}
 
-		// Issue #699: RunAllScoped evaluates every enabled rule, so every
-		// non-violated rule in eval.RulesConsidered is a legitimate pass
-		// and gets a passed=1 rule_results row.
-		if !p.persistPassResults(ctx, a, eval.RulesConsidered, violated, startedAt, nil) {
+		// Issue #699 propagation fix: derive the pass/fail skip-set from
+		// the POST-fix evaluation returned by updateHealthScore so rules
+		// repaired during this pass are recorded as passed=1 in the same
+		// run. Using the pre-fix violation snapshot would suppress them
+		// until the next evaluation.
+		postEval, persistOKHealth := p.updateHealthScore(ctx, a, perArtistDirty)
+		if !persistOKHealth {
 			persistOK = false
 		}
-
-		// Re-evaluate and persist health score (and any in-memory
-		// changes fixers made) in a single write, then publish.
-		if !p.updateHealthScore(ctx, a, perArtistDirty) {
-			persistOK = false
+		if postEval != nil {
+			postViolated := make(map[string]struct{}, len(postEval.Violations))
+			for j := range postEval.Violations {
+				postViolated[postEval.Violations[j].RuleID] = struct{}{}
+			}
+			if !p.persistPassResults(ctx, a, postEval.RulesConsidered, postViolated, startedAt, nil) {
+				persistOK = false
+			}
 		}
 		p.publishAccumulated(ctx, a, perArtistMetadata, perArtistImages)
 		return persistOK
@@ -956,7 +956,10 @@ func (p *Pipeline) FixViolation(ctx context.Context, violationID string) (*FixRe
 		if err := p.ruleService.ResolveViolation(ctx, rv.ID); err != nil {
 			return nil, fmt.Errorf("resolving violation after fix: %w", err)
 		}
-		p.updateHealthScore(ctx, a, false)
+		// FixViolation operates on a single violation and does not own
+		// rule_results writes (the pipeline's RunRule/RunAll paths do),
+		// so we discard the post-fix evaluation result here.
+		_, _ = p.updateHealthScore(ctx, a, false)
 		p.publishAfterFix(ctx, a, fr)
 	}
 
@@ -1112,21 +1115,26 @@ func (p *Pipeline) publishAccumulated(ctx context.Context, a *artist.Artist, met
 }
 
 // updateHealthScore re-evaluates the artist and persists the score. Returns
-// true when the artist row reached the DB cleanly, false when the Update
-// failed or was intentionally skipped. The walker uses the bool to decide
-// whether to stamp rules_evaluated_at: a failed persist must leave the
-// artist in the dirty set so the next pass retries.
+// the post-fix evaluation (nil when Evaluate failed) and a bool that is true
+// only when the artist row reached the DB cleanly. The walker uses the bool
+// to decide whether to stamp rules_evaluated_at: a failed persist must leave
+// the artist in the dirty set so the next pass retries.
+//
+// The returned EvaluationResult is consumed by the pass-row writer so
+// rule_results reflects the POST-fix state of the artist -- a rule the
+// fixer just repaired shows up as passed=1 in the same run, and a rule
+// that started passing but failed mid-run is written as a fail (issue #699).
 //
 // When mustPersist is true, the artist is persisted even if health
 // evaluation fails, to flush in-memory changes made by fixers. In that
 // case the caller relies on the returned bool to detect the transient
 // persist failure.
-func (p *Pipeline) updateHealthScore(ctx context.Context, a *artist.Artist, mustPersist bool) bool {
+func (p *Pipeline) updateHealthScore(ctx context.Context, a *artist.Artist, mustPersist bool) (*EvaluationResult, bool) {
 	eval, err := p.engine.Evaluate(ctx, a)
 	if err != nil {
 		p.logger.Warn("re-evaluating health score", "artist", a.Name, "error", err)
 		if !mustPersist {
-			return false
+			return nil, false
 		}
 	} else {
 		a.HealthScore = eval.HealthScore
@@ -1141,7 +1149,7 @@ func (p *Pipeline) updateHealthScore(ctx context.Context, a *artist.Artist, must
 	// happened to round into the next second after startedAt).
 	if err := p.artistService.UpdateAfterRuleEvaluation(ctx, a); err != nil {
 		p.logger.Error("persisting artist after fixes", "artist", a.Name, "error", err)
-		return false
+		return eval, false
 	}
-	return true
+	return eval, true
 }

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -172,11 +172,24 @@ func (p *Pipeline) RunRuleScoped(ctx context.Context, ruleID string, scope RunSc
 		// leave the artist dirty for retry; silently stamping it clean
 		// would hide the dropped violation until the next mutation.
 		persistOK := true
+		// startedAt is captured before evaluation so every rule_results
+		// row written during this pass shares a timestamp (issue #699).
+		startedAt := time.Now().UTC()
 
 		eval, err := p.engine.Evaluate(ctx, a)
 		if err != nil {
 			p.logger.Warn("evaluating artist", "artist", a.Name, "error", err)
 			return false
+		}
+
+		// Track which rules produced violations so the pass-side
+		// UpsertRuleResultPass call below skips them (they are handled
+		// transactionally by UpsertViolation).
+		violated := make(map[string]struct{}, len(eval.Violations))
+		for j := range eval.Violations {
+			if eval.Violations[j].RuleID == ruleID {
+				violated[eval.Violations[j].RuleID] = struct{}{}
+			}
 		}
 
 		for j := range eval.Violations {
@@ -292,6 +305,14 @@ func (p *Pipeline) RunRuleScoped(ctx context.Context, ruleID string, scope RunSc
 			}
 		}
 
+		// Issue #699: persist the pass row when the single rule we ran
+		// was actually considered for this artist (enabled, not skipped
+		// by filesystem-missing gating) and produced no violation.
+		passFilter := func(rid string) bool { return rid == ruleID }
+		if !p.persistPassResults(ctx, a, eval.RulesConsidered, violated, startedAt, passFilter) {
+			persistOK = false
+		}
+
 		// Re-evaluate and persist health score (and any in-memory
 		// changes fixers made) in a single write, then publish.
 		if !p.updateHealthScore(ctx, a, perRuleDirty) {
@@ -365,6 +386,13 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 
 	// Cache rule lookups to avoid repeated DB queries.
 	ruleCache := map[string]*Rule{}
+
+	// Track which rules produced violations so the pass-side write below
+	// only writes pass rows for rules that actually passed (issue #699).
+	violated := make(map[string]struct{}, len(eval.Violations))
+	for j := range eval.Violations {
+		violated[eval.Violations[j].RuleID] = struct{}{}
+	}
 
 	for j := range eval.Violations {
 		v := &eval.Violations[j]
@@ -487,6 +515,33 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 		}
 	}
 
+	// Issue #699: persist pass rows for every rule that was considered
+	// but did not produce a violation. When categoryFilter is set we only
+	// mirror the category into rule_results so RunImageRulesForArtist does
+	// not claim the artist "passes" metadata rules it never actually ran.
+	var passFilter func(rid string) bool
+	if categoryFilter != "" {
+		passFilter = func(rid string) bool {
+			r, ok := ruleCache[rid]
+			if !ok {
+				// Not cached means no violation used this rule lookup;
+				// fall back to a direct fetch so we respect the filter.
+				fetched, err := p.ruleService.GetByID(ctx, rid)
+				if err != nil {
+					p.logger.Warn("fetching rule for pass filter",
+						"rule_id", rid, "artist", a.Name, "error", err)
+					return false
+				}
+				ruleCache[rid] = fetched
+				r = fetched
+			}
+			return r.Category == categoryFilter
+		}
+	}
+	if !p.persistPassResults(ctx, a, eval.RulesConsidered, violated, startedAt, passFilter) {
+		persistOK = false
+	}
+
 	// Re-evaluate and persist health score (and any in-memory
 	// changes fixers made) in a single write, then publish.
 	if !p.updateHealthScore(ctx, a, artistDirty) {
@@ -536,11 +591,21 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 		// artist in the dirty set for retry instead of masking dropped
 		// violations until the next mutation.
 		persistOK := true
+		// startedAt captured pre-Evaluate so every rule_results pass row
+		// written during this pass shares a timestamp (issue #699).
+		startedAt := time.Now().UTC()
 
 		eval, err := p.engine.Evaluate(ctx, a)
 		if err != nil {
 			p.logger.Warn("evaluating artist", "artist", a.Name, "error", err)
 			return false
+		}
+
+		// Track which rules produced violations so the pass-side write
+		// below skips them (fails are handled by UpsertViolation).
+		violated := make(map[string]struct{}, len(eval.Violations))
+		for j := range eval.Violations {
+			violated[eval.Violations[j].RuleID] = struct{}{}
 		}
 
 		for j := range eval.Violations {
@@ -662,6 +727,13 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 				p.logger.Warn("persisting fix result violation", "rule_id", v.RuleID, "artist", a.Name, "error", err)
 				persistOK = false
 			}
+		}
+
+		// Issue #699: RunAllScoped evaluates every enabled rule, so every
+		// non-violated rule in eval.RulesConsidered is a legitimate pass
+		// and gets a passed=1 rule_results row.
+		if !p.persistPassResults(ctx, a, eval.RulesConsidered, violated, startedAt, nil) {
+			persistOK = false
 		}
 
 		// Re-evaluate and persist health score (and any in-memory
@@ -922,6 +994,45 @@ func (p *Pipeline) ClearRuleCache() {
 	p.ruleCacheMu.Lock()
 	p.ruleCache = nil
 	p.ruleCacheMu.Unlock()
+}
+
+// persistPassResults writes a passed=1 rule_results row for every rule the
+// engine considered that did not appear in the violation set. The pipeline
+// owns this write (not Engine.Evaluate) because only the pipeline knows when
+// an evaluation is authoritative enough to persist outcomes; browse-path GET
+// evaluations (handleEvaluateArtist) must not double as writers. Issue #699
+// slice 1.
+//
+// consideredFilter is applied before the violation diff so single-rule runs
+// (RunRule / RunRuleScoped) only write pass rows for the specific rule they
+// evaluated, not for every rule the engine happened to consider.
+//
+// Returns true when every pass write succeeded. Failures are warn-logged and
+// fold into the caller's persistOK flag so the artist stays dirty and the
+// next pass retries, mirroring how violation-write failures are handled.
+func (p *Pipeline) persistPassResults(
+	ctx context.Context,
+	a *artist.Artist,
+	rulesConsidered []string,
+	violated map[string]struct{},
+	evaluatedAt time.Time,
+	consideredFilter func(ruleID string) bool,
+) bool {
+	ok := true
+	for _, rid := range rulesConsidered {
+		if consideredFilter != nil && !consideredFilter(rid) {
+			continue
+		}
+		if _, isViolation := violated[rid]; isViolation {
+			continue
+		}
+		if err := p.ruleService.UpsertRuleResultPass(ctx, a.ID, rid, evaluatedAt); err != nil {
+			p.logger.Warn("persisting pass result",
+				"rule_id", rid, "artist", a.Name, "error", err)
+			ok = false
+		}
+	}
+	return ok
 }
 
 // findFixer returns the first registered fixer that can handle the violation, or nil.

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -516,35 +516,51 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 		persistOK = false
 	}
 
-	// When categoryFilter is set we only mirror the category into
-	// rule_results so RunImageRulesForArtist does not claim the artist
-	// "passes" metadata rules it never actually ran.
-	var passFilter func(rid string) bool
-	if categoryFilter != "" {
-		passFilter = func(rid string) bool {
-			r, ok := ruleCache[rid]
-			if !ok {
-				// Not cached means no violation used this rule lookup;
-				// fall back to a direct fetch so we respect the filter.
-				fetched, err := p.ruleService.GetByID(ctx, rid)
-				if err != nil {
-					p.logger.Warn("fetching rule for pass filter",
-						"rule_id", rid, "artist", a.Name, "error", err)
-					return false
-				}
-				ruleCache[rid] = fetched
-				r = fetched
-			}
-			return r.Category == categoryFilter
-		}
-	}
 	if postEval != nil {
 		postViolated := make(map[string]struct{}, len(postEval.Violations))
 		for j := range postEval.Violations {
 			postViolated[postEval.Violations[j].RuleID] = struct{}{}
 		}
-		if !p.persistPassResults(ctx, a, postEval.RulesConsidered, postViolated, startedAt, passFilter) {
-			persistOK = false
+
+		// When categoryFilter is set we only mirror the category into
+		// rule_results so RunImageRulesForArtist does not claim the artist
+		// "passes" metadata rules it never actually ran. Precomputing the
+		// allowed-ID set (vs evaluating the category per passFilter call)
+		// lets us treat a GetByID failure as a persistence failure instead
+		// of silently dropping the rule from the pass set, which would
+		// leave the artist clean but without a pass row (CR #3114616841).
+		var passFilter func(rid string) bool
+		filterReady := true
+		if categoryFilter != "" {
+			allowedIDs := make(map[string]struct{}, len(postEval.RulesConsidered))
+			for _, rid := range postEval.RulesConsidered {
+				r, ok := ruleCache[rid]
+				if !ok {
+					fetched, err := p.ruleService.GetByID(ctx, rid)
+					if err != nil {
+						p.logger.Warn("fetching rule for pass filter",
+							"rule_id", rid, "artist", a.Name, "error", err)
+						filterReady = false
+						persistOK = false
+						break
+					}
+					ruleCache[rid] = fetched
+					r = fetched
+				}
+				if r.Category == categoryFilter {
+					allowedIDs[rid] = struct{}{}
+				}
+			}
+			passFilter = func(rid string) bool {
+				_, ok := allowedIDs[rid]
+				return ok
+			}
+		}
+
+		if filterReady {
+			if !p.persistPassResults(ctx, a, postEval.RulesConsidered, postViolated, startedAt, passFilter) {
+				persistOK = false
+			}
 		}
 	}
 
@@ -1154,7 +1170,11 @@ func (p *Pipeline) updateHealthScore(ctx context.Context, a *artist.Artist, must
 	// happened to round into the next second after startedAt).
 	if err := p.artistService.UpdateAfterRuleEvaluation(ctx, a); err != nil {
 		p.logger.Error("persisting artist after fixes", "artist", a.Name, "error", err)
-		return eval, false
+		// Return nil eval so callers that gate pass-row writes on
+		// `postEval != nil` cannot upsert passed=1 from in-memory fix
+		// state that never reached the artist row (CR review-body
+		// 4144589645). rule_results must not lead the stored artist.
+		return nil, false
 	}
 	return eval, authoritative
 }

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -1131,6 +1131,11 @@ func (p *Pipeline) publishAccumulated(ctx context.Context, a *artist.Artist, met
 // persist failure.
 func (p *Pipeline) updateHealthScore(ctx context.Context, a *artist.Artist, mustPersist bool) (*EvaluationResult, bool) {
 	eval, err := p.engine.Evaluate(ctx, a)
+	// authoritative is only true when the post-fix evaluation succeeded;
+	// returning true after a failed Evaluate would let callers stamp
+	// rules_evaluated_at and treat the run as clean even though eval is nil
+	// and no pass rows can be written this pass.
+	authoritative := err == nil
 	if err != nil {
 		p.logger.Warn("re-evaluating health score", "artist", a.Name, "error", err)
 		if !mustPersist {
@@ -1151,5 +1156,5 @@ func (p *Pipeline) updateHealthScore(ctx context.Context, a *artist.Artist, must
 		p.logger.Error("persisting artist after fixes", "artist", a.Name, "error", err)
 		return eval, false
 	}
-	return eval, true
+	return eval, authoritative
 }

--- a/internal/rule/health_subscriber.go
+++ b/internal/rule/health_subscriber.go
@@ -209,17 +209,45 @@ func (h *HealthSubscriber) evaluateArtist(ctx context.Context, artistID string) 
 		h.logger.Warn("health subscriber: persisting health score", "artist_id", artistID, "artist", a.Name, "error", err)
 	}
 
-	// Issue #699: write pass rows for rules the artist satisfies. Skip
-	// rules that produced a violation; those are persisted by the pipeline
-	// path that calls UpsertViolation (which writes the sibling fail row
-	// transactionally).
+	// Issue #699: write pass rows for rules the artist satisfies, and a
+	// compensating fail row for rules the subscriber sees as newly violated.
+	//
+	// The subscriber runs from non-pipeline paths (artist.Service.UpdateArtist
+	// fires ArtistUpdated; the pipeline's transactional UpsertViolation does
+	// NOT run on that path). Without the fail write below, a rule that had a
+	// prior pass row and now fails would keep the stale passed=1 row until
+	// the next Run Rules pass, masking the newly-broken state in the
+	// compliance report. We reuse UpsertViolation so the violation row and
+	// the sibling rule_results fail row land in a single transaction.
 	if h.engine.service != nil {
-		violated := make(map[string]struct{}, len(result.Violations))
+		violationByRule := make(map[string]*Violation, len(result.Violations))
 		for i := range result.Violations {
-			violated[result.Violations[i].RuleID] = struct{}{}
+			v := &result.Violations[i]
+			violationByRule[v.RuleID] = v
 		}
 		for _, rid := range result.RulesConsidered {
-			if _, bad := violated[rid]; bad {
+			v, violated := violationByRule[rid]
+			if violated {
+				// Compensating fail write: the rule is currently
+				// violated on this subscriber-driven evaluation.
+				// UpsertViolation stamps both rule_violations (the
+				// authoritative active-violation row) and the
+				// rule_results fail row atomically, so a pre-existing
+				// passed=1 row is flipped to passed=0 in the same
+				// transaction, eliminating the stale-pass window.
+				rv := &RuleViolation{
+					RuleID:     rid,
+					ArtistID:   artistID,
+					ArtistName: a.Name,
+					Severity:   v.Severity,
+					Message:    v.Message,
+					Fixable:    v.Fixable,
+					Status:     ViolationStatusOpen,
+				}
+				if err := h.engine.service.UpsertViolation(ctx, rv); err != nil {
+					h.logger.Warn("health subscriber: persisting fail result",
+						"artist_id", artistID, "artist", a.Name, "rule_id", rid, "error", err)
+				}
 				continue
 			}
 			if err := h.engine.service.UpsertRuleResultPass(ctx, artistID, rid, evaluatedAt); err != nil {

--- a/internal/rule/health_subscriber.go
+++ b/internal/rule/health_subscriber.go
@@ -184,6 +184,13 @@ func (h *HealthSubscriber) processPending(ctx context.Context) {
 
 // evaluateArtist loads an artist by ID, runs the rule engine, and persists
 // the updated health score. Errors are logged but not propagated.
+//
+// Issue #699: this is the only evaluation path outside the pipeline that
+// should own per-rule result persistence. After Evaluate returns we write
+// passed=1 rule_results rows for every rule that passed. Failing rules are
+// NOT written here: fails land transactionally via the paired UpsertViolation
+// call performed by the pipeline, so the health subscriber must not
+// duplicate that write (it does not know the violation_id).
 func (h *HealthSubscriber) evaluateArtist(ctx context.Context, artistID string) {
 	a, err := h.artistService.GetByID(ctx, artistID)
 	if err != nil {
@@ -191,6 +198,7 @@ func (h *HealthSubscriber) evaluateArtist(ctx context.Context, artistID string) 
 		return
 	}
 
+	evaluatedAt := time.Now().UTC()
 	result, err := h.engine.Evaluate(ctx, a)
 	if err != nil {
 		h.logger.Warn("health subscriber: evaluating artist", "artist_id", artistID, "artist", a.Name, "error", err)
@@ -199,5 +207,25 @@ func (h *HealthSubscriber) evaluateArtist(ctx context.Context, artistID string) 
 
 	if err := h.artistService.UpdateHealthScore(ctx, artistID, result.HealthScore); err != nil {
 		h.logger.Warn("health subscriber: persisting health score", "artist_id", artistID, "artist", a.Name, "error", err)
+	}
+
+	// Issue #699: write pass rows for rules the artist satisfies. Skip
+	// rules that produced a violation; those are persisted by the pipeline
+	// path that calls UpsertViolation (which writes the sibling fail row
+	// transactionally).
+	if h.engine.service != nil {
+		violated := make(map[string]struct{}, len(result.Violations))
+		for i := range result.Violations {
+			violated[result.Violations[i].RuleID] = struct{}{}
+		}
+		for _, rid := range result.RulesConsidered {
+			if _, bad := violated[rid]; bad {
+				continue
+			}
+			if err := h.engine.service.UpsertRuleResultPass(ctx, artistID, rid, evaluatedAt); err != nil {
+				h.logger.Warn("health subscriber: persisting pass result",
+					"artist_id", artistID, "artist", a.Name, "rule_id", rid, "error", err)
+			}
+		}
 	}
 }

--- a/internal/rule/model.go
+++ b/internal/rule/model.go
@@ -75,13 +75,19 @@ type ImageCandidate struct {
 }
 
 // EvaluationResult holds the outcome of running all rules against an artist.
+//
+// RulesConsidered is the ordered list of rule IDs the engine actually ran
+// (enabled, registered checker, not skipped for a filesystem-missing artist).
+// Callers that persist pass/fail results (issue #699) diff this set against
+// Violations to learn which rules passed without re-querying the rule list.
 type EvaluationResult struct {
-	ArtistID    string      `json:"artist_id"`
-	ArtistName  string      `json:"artist_name"`
-	Violations  []Violation `json:"violations"`
-	RulesPassed int         `json:"rules_passed"`
-	RulesTotal  int         `json:"rules_total"`
-	HealthScore float64     `json:"health_score"`
+	ArtistID        string      `json:"artist_id"`
+	ArtistName      string      `json:"artist_name"`
+	Violations      []Violation `json:"violations"`
+	RulesPassed     int         `json:"rules_passed"`
+	RulesTotal      int         `json:"rules_total"`
+	HealthScore     float64     `json:"health_score"`
+	RulesConsidered []string    `json:"-"` // not serialized; consumed by persistence paths
 }
 
 // HealthSnapshot represents a recorded library health score.
@@ -120,6 +126,38 @@ type RuleViolation struct {
 	ResolvedAt  *time.Time       `json:"resolved_at,omitempty"`
 	CreatedAt   time.Time        `json:"created_at"`
 	UpdatedAt   time.Time        `json:"updated_at"`
+}
+
+// RuleResult represents a persisted per-artist, per-rule evaluation outcome
+// stored in the rule_results table (issue #699). A row is written for every
+// (artist, rule) pair that has been evaluated at least once: passed=1 marks a
+// rule the artist currently satisfies, passed=0 marks an active violation
+// (violation_id links to the corresponding rule_violations row).
+//
+// FirstFailedAt is preserved across repeated failures (COALESCE on fail) so
+// reports can answer "how long has this rule been failing?" without scanning
+// rule_violations history. LastPassedAt is stamped each time the row
+// transitions to passed=1 so callers can see when the artist most recently
+// satisfied the rule.
+type RuleResult struct {
+	ArtistID         string     `json:"artist_id"`
+	RuleID           string     `json:"rule_id"`
+	Passed           bool       `json:"passed"`
+	ViolationID      string     `json:"violation_id,omitempty"`
+	EvaluatedAt      time.Time  `json:"evaluated_at"`
+	ViolationMessage string     `json:"violation_message,omitempty"`
+	FirstFailedAt    *time.Time `json:"first_failed_at,omitempty"`
+	LastPassedAt     *time.Time `json:"last_passed_at,omitempty"`
+}
+
+// RuleResultCount aggregates per-artist pass/fail counts for the compliance
+// report (issue #699 slice 1). Evaluated is the total number of rule_results
+// rows for the artist; Passed is the subset with passed=1. The ratio
+// Passed/Evaluated is the coarse "rules satisfied" signal surfaced on the
+// /reports/compliance endpoint.
+type RuleResultCount struct {
+	Passed    int `json:"passed"`
+	Evaluated int `json:"evaluated"`
 }
 
 // ViolationListParams controls filtering, sorting, and grouping of violations.

--- a/internal/rule/pipeline_results_test.go
+++ b/internal/rule/pipeline_results_test.go
@@ -36,6 +36,9 @@ func disableAllRulesExcept(t *testing.T, db *sql.DB, keep ...string) {
 			toDisable = append(toDisable, id)
 		}
 	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterating rules: %v", err)
+	}
 	for _, id := range toDisable {
 		if _, err := db.ExecContext(context.Background(),
 			`UPDATE rules SET enabled = 0 WHERE id = ?`, id); err != nil {

--- a/internal/rule/pipeline_results_test.go
+++ b/internal/rule/pipeline_results_test.go
@@ -98,6 +98,89 @@ func TestPipeline_WritesPassResults(t *testing.T) {
 	}
 }
 
+// TestPipeline_FixFlipsFailToPassInSameRun exercises the propagation fix for
+// CR comment 3114386788: a rule that starts failing and is auto-fixed mid-run
+// must end the pass with passed=1 in rule_results for the same evaluation. The
+// prior implementation froze the skip-set from the pre-fix Violations slice,
+// so a repaired rule never got a pass row written until the next Run Rules
+// pass re-evaluated the artist. Drive this via NFOFixer (creates artist.nfo
+// and flips a.NFOExists to true), then assert rule_results shows Passed=true
+// after a single RunAllScoped invocation.
+func TestPipeline_FixFlipsFailToPassInSameRun(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	artistSvc := artist.NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	// Keep only the nfo_exists rule enabled so the test focuses on the
+	// fail-to-pass transition without noise from other checkers.
+	disableAllRulesExcept(t, db, RuleNFOExists)
+	// Seeded defaults use automation_mode=manual, which the pipeline
+	// treats as "discover candidates only; never apply". NFOFixer does
+	// not implement CandidateDiscoverer, so in manual mode the fix is
+	// skipped and the rule stays failing. Force auto so the fixer runs.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE rules SET automation_mode = ? WHERE id = ?`,
+		AutomationModeAuto, RuleNFOExists); err != nil {
+		t.Fatalf("setting automation_mode=auto: %v", err)
+	}
+
+	a := &artist.Artist{
+		Name:      "Fix Flips Pass",
+		SortName:  "Fix Flips Pass",
+		Path:      t.TempDir(), // dir exists, artist.nfo does not -> initial fail
+		NFOExists: false,
+		LibraryID: "lib-test", // nonSharedFSCheck returns SharedFSNone unconditionally
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	// Real NFOFixer: writes artist.nfo and sets a.NFOExists=true so the
+	// post-fix engine.Evaluate call inside updateHealthScore observes the
+	// repair. The fixer needs a SharedFSCheck that reports non-shared so
+	// the write is allowed.
+	nfoFixer := &NFOFixer{fsCheck: nonSharedFSCheck()}
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{nfoFixer}, nil, testLogger())
+
+	runResult, err := pipeline.RunAllScoped(ctx, RunScopeAll)
+	if err != nil {
+		t.Fatalf("RunAllScoped: %v", err)
+	}
+	if runResult.FixesSucceeded != 1 {
+		t.Fatalf("FixesSucceeded = %d, want 1 (NFOFixer should have repaired the violation)", runResult.FixesSucceeded)
+	}
+
+	// rule_results for this (artist, rule) pair must show passed=1 even
+	// though the pre-fix Violations slice contained this rule. That is
+	// the whole point of deriving the pass skip-set from the post-fix
+	// evaluation.
+	results, err := ruleSvc.GetRuleResultsForArtist(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetRuleResultsForArtist: %v", err)
+	}
+	var found bool
+	for _, r := range results {
+		if r.RuleID != RuleNFOExists {
+			continue
+		}
+		found = true
+		if !r.Passed {
+			t.Errorf("rule_results.passed = false for rule that was fixed this run, want true")
+		}
+		if r.LastPassedAt == nil {
+			t.Errorf("rule_results.last_passed_at = nil after in-run fix, want set")
+		}
+	}
+	if !found {
+		t.Fatalf("no rule_results row for %s after fix-in-run (want one with passed=1)", RuleNFOExists)
+	}
+}
+
 func TestPipeline_WritesFailResultLinkedToViolation(t *testing.T) {
 	db := setupTestDB(t)
 	ruleSvc := NewService(db)

--- a/internal/rule/pipeline_results_test.go
+++ b/internal/rule/pipeline_results_test.go
@@ -1,0 +1,284 @@
+package rule
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/database"
+)
+
+// disableAllRulesExcept marks every rule disabled except those in keep so
+// the pipeline only evaluates a controlled subset. This keeps the test focused
+// on the rule_results persistence boundary, not on whether the mock artist
+// satisfies the complete built-in rule set.
+func disableAllRulesExcept(t *testing.T, db *sql.DB, keep ...string) {
+	t.Helper()
+	keepSet := make(map[string]bool, len(keep))
+	for _, id := range keep {
+		keepSet[id] = true
+	}
+	rows, err := db.QueryContext(context.Background(), `SELECT id FROM rules`)
+	if err != nil {
+		t.Fatalf("listing rules: %v", err)
+	}
+	defer rows.Close() //nolint:errcheck
+	var toDisable []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scanning rule id: %v", err)
+		}
+		if !keepSet[id] {
+			toDisable = append(toDisable, id)
+		}
+	}
+	for _, id := range toDisable {
+		if _, err := db.ExecContext(context.Background(),
+			`UPDATE rules SET enabled = 0 WHERE id = ?`, id); err != nil {
+			t.Fatalf("disabling rule %s: %v", id, err)
+		}
+	}
+}
+
+func TestPipeline_WritesPassResults(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	artistSvc := artist.NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	// Keep only two rules that the minimal-NFO artist satisfies.
+	disableAllRulesExcept(t, db, RuleNFOExists, RuleNFOHasMBID)
+
+	a := &artist.Artist{
+		Name:          "Pass All Rules",
+		SortName:      "Pass All Rules",
+		Path:          t.TempDir(),
+		NFOExists:     true, // checkNFOExists reads this flag
+		MusicBrainzID: "abc-123",
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, nil, nil, testLogger())
+
+	if _, err := pipeline.RunAllScoped(ctx, RunScopeAll); err != nil {
+		t.Fatalf("RunAllScoped: %v", err)
+	}
+
+	// Both enabled rules should have a passed=1 row for this artist.
+	results, err := ruleSvc.GetRuleResultsForArtist(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetRuleResultsForArtist: %v", err)
+	}
+	byRule := make(map[string]RuleResult, len(results))
+	for _, r := range results {
+		byRule[r.RuleID] = r
+	}
+	for _, rid := range []string{RuleNFOExists, RuleNFOHasMBID} {
+		got, ok := byRule[rid]
+		if !ok {
+			t.Errorf("missing rule_result for %s", rid)
+			continue
+		}
+		if !got.Passed {
+			t.Errorf("%s passed = false, want true", rid)
+		}
+		if got.LastPassedAt == nil {
+			t.Errorf("%s last_passed_at = nil, want set", rid)
+		}
+	}
+}
+
+func TestPipeline_WritesFailResultLinkedToViolation(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	artistSvc := artist.NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	// Keep only nfo_exists enabled; the artist has an empty path so it fails.
+	disableAllRulesExcept(t, db, RuleNFOExists)
+
+	a := &artist.Artist{
+		Name:     "Fail NFO",
+		SortName: "Fail NFO",
+		Path:     t.TempDir(), // dir exists but no NFO
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	// No fixer registered: the pipeline will persist the violation as open.
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, nil, nil, testLogger())
+
+	if _, err := pipeline.RunAllScoped(ctx, RunScopeAll); err != nil {
+		t.Fatalf("RunAllScoped: %v", err)
+	}
+
+	// The fail rule_results row must link to the corresponding violation.
+	var ruleResultViolationID sql.NullString
+	var passedInt int
+	if err := db.QueryRowContext(ctx, `
+		SELECT passed, violation_id FROM rule_results
+		WHERE artist_id = ? AND rule_id = ?`,
+		a.ID, RuleNFOExists).Scan(&passedInt, &ruleResultViolationID); err != nil {
+		t.Fatalf("querying rule_result: %v", err)
+	}
+	if passedInt != 0 {
+		t.Errorf("passed = %d, want 0 for failing rule", passedInt)
+	}
+	if !ruleResultViolationID.Valid || ruleResultViolationID.String == "" {
+		t.Fatalf("violation_id is NULL on fail row")
+	}
+
+	var violationID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT id FROM rule_violations
+		WHERE artist_id = ? AND rule_id = ? AND status = ?`,
+		a.ID, RuleNFOExists, ViolationStatusOpen).Scan(&violationID); err != nil {
+		t.Fatalf("querying rule_violations: %v", err)
+	}
+	if ruleResultViolationID.String != violationID {
+		t.Errorf("rule_results.violation_id = %q, want %q",
+			ruleResultViolationID.String, violationID)
+	}
+}
+
+func TestHealthSubscriber_WritesResultsOnArtistUpdated(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	artistSvc := artist.NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	disableAllRulesExcept(t, db, RuleNFOExists, RuleNFOHasMBID)
+
+	a := &artist.Artist{
+		Name:          "Health Sub Test",
+		SortName:      "Health Sub Test",
+		Path:          t.TempDir(),
+		NFOExists:     true,
+		MusicBrainzID: "abc-123",
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	sub := NewHealthSubscriber(engine, artistSvc, testLogger())
+
+	// Invoke evaluateArtist directly (bypasses the debounce ticker) so the
+	// assertions run synchronously without needing the goroutine.
+	sub.evaluateArtist(ctx, a.ID)
+
+	results, err := ruleSvc.GetRuleResultsForArtist(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetRuleResultsForArtist: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("rule_results rows = %d, want 2 (one per enabled rule)", len(results))
+	}
+	for _, r := range results {
+		if !r.Passed {
+			t.Errorf("rule %s passed = false, want true", r.RuleID)
+		}
+	}
+}
+
+func TestBackfill_SeedsFirstFailedAtFromViolationCreatedAt(t *testing.T) {
+	// Open a fresh, raw DB: the shared template already has Migrate applied
+	// with the new backfill step, so to exercise the backfill itself we
+	// need to simulate the "v1 instance with pre-existing violations but
+	// no rule_results yet" state.
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "backfill.db")
+	raw, err := database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening raw db: %v", err)
+	}
+	t.Cleanup(func() { _ = raw.Close() })
+
+	// Apply the full schema via Migrate so rule_results exists, then
+	// wipe its rows (simulating a DB whose 001 ran before #699 shipped).
+	if err := database.Migrate(raw); err != nil {
+		t.Fatalf("running migrations: %v", err)
+	}
+	if _, err := raw.ExecContext(context.Background(),
+		`DELETE FROM rule_results`); err != nil {
+		t.Fatalf("clearing rule_results: %v", err)
+	}
+
+	// Seed an artist, a rule, and an open violation with an old created_at.
+	seededCreatedAt := "2025-01-15T08:30:00Z"
+	if _, err := raw.ExecContext(context.Background(), `
+		INSERT INTO artists (id, name, path) VALUES ('a1', 'A', '')`); err != nil {
+		t.Fatalf("inserting artist: %v", err)
+	}
+	if _, err := raw.ExecContext(context.Background(), `
+		INSERT INTO rules (id, name, description, category, enabled, automation_mode, config)
+		VALUES ('r1', 'R1', 'desc', 'nfo', 1, 'auto', '{}')`); err != nil {
+		t.Fatalf("inserting rule: %v", err)
+	}
+	if _, err := raw.ExecContext(context.Background(), `
+		INSERT INTO rule_violations (id, rule_id, artist_id, artist_name, severity, message, fixable, status, created_at, updated_at)
+		VALUES ('v1', 'r1', 'a1', 'A', 'warning', 'bad', 0, 'open', ?, ?)`,
+		seededCreatedAt, seededCreatedAt); err != nil {
+		t.Fatalf("inserting violation: %v", err)
+	}
+
+	// Re-run Migrate: the backfill must fill in the missing rule_results
+	// row and preserve the original created_at as first_failed_at.
+	if err := database.Migrate(raw); err != nil {
+		t.Fatalf("re-running migrations: %v", err)
+	}
+
+	var firstFailedAt sql.NullString
+	if err := raw.QueryRowContext(context.Background(), `
+		SELECT first_failed_at FROM rule_results
+		WHERE artist_id = 'a1' AND rule_id = 'r1'`).Scan(&firstFailedAt); err != nil {
+		t.Fatalf("querying rule_results: %v", err)
+	}
+	if !firstFailedAt.Valid {
+		t.Fatalf("first_failed_at is NULL; backfill did not seed it")
+	}
+	if firstFailedAt.String != seededCreatedAt {
+		t.Errorf("first_failed_at = %q, want %q (must mirror violation.created_at)",
+			firstFailedAt.String, seededCreatedAt)
+	}
+
+	// Re-running Migrate a third time must be idempotent (no error, and
+	// the existing row is not clobbered by another INSERT).
+	preUpdate := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
+	if _, err := raw.ExecContext(context.Background(), `
+		UPDATE rule_results SET last_passed_at = ?
+		WHERE artist_id = 'a1' AND rule_id = 'r1'`, preUpdate); err != nil {
+		t.Fatalf("touching rule_results: %v", err)
+	}
+	if err := database.Migrate(raw); err != nil {
+		t.Fatalf("third Migrate: %v", err)
+	}
+	var lastPassedAt sql.NullString
+	if err := raw.QueryRowContext(context.Background(), `
+		SELECT last_passed_at FROM rule_results
+		WHERE artist_id = 'a1' AND rule_id = 'r1'`).Scan(&lastPassedAt); err != nil {
+		t.Fatalf("querying rule_results post-re-Migrate: %v", err)
+	}
+	if !lastPassedAt.Valid || lastPassedAt.String != preUpdate {
+		t.Errorf("last_passed_at = %+v, want preserved %q (INSERT OR IGNORE should not clobber)",
+			lastPassedAt, preUpdate)
+	}
+}

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -460,6 +460,16 @@ func (s *Service) Update(ctx context.Context, r *Rule) error {
 		); cleanupErr != nil {
 			return fmt.Errorf("cleaning up violations after disable: %w", cleanupErr)
 		}
+		// Full delete of rule_results on disable (not status-filtered like
+		// rule_violations): the rule no longer runs, so no existing row is
+		// authoritative until the rule is re-enabled and re-evaluated.
+		// Without this the per-rule dashboard would keep surfacing stale
+		// pass/fail counts for an inactive rule.
+		if _, cleanupErr := s.db.ExecContext(ctx,
+			`DELETE FROM rule_results WHERE rule_id = ?`, r.ID,
+		); cleanupErr != nil {
+			return fmt.Errorf("cleaning up rule_results after disable: %w", cleanupErr)
+		}
 	}
 	return nil
 }
@@ -744,8 +754,15 @@ func (s *Service) GetLatestHealthSnapshot(ctx context.Context) (*HealthSnapshot,
 	return snap, nil
 }
 
-// UpsertViolation inserts or updates a rule violation in the notifications store.
-// Uses (rule_id, artist_id) as the natural key for upsert.
+// UpsertViolation inserts or updates a rule violation in the notifications
+// store, and atomically writes the sibling rule_results row that records
+// "this (artist, rule) pair currently fails" (issue #699 slice 1). Both
+// writes happen inside a single transaction so a pipeline pass never leaves
+// the two tables disagreeing about whether a rule is failing.
+//
+// The rule_results row uses COALESCE on first_failed_at so the "how long has
+// this been broken" timestamp survives across repeated fails. The violation
+// row continues to use (rule_id, artist_id) as its natural upsert key.
 func (s *Service) UpsertViolation(ctx context.Context, v *RuleViolation) error {
 	if v.ID == "" {
 		v.ID = uuid.New().String()
@@ -755,7 +772,19 @@ func (s *Service) UpsertViolation(ctx context.Context, v *RuleViolation) error {
 		v.CreatedAt = v.UpdatedAt
 	}
 
-	_, err := s.db.ExecContext(ctx, `
+	// Resolved / dismissed violations leave rule_results alone: a resolved
+	// violation means the rule is no longer failing, and the next pipeline
+	// pass will stamp the pass row via UpsertRuleResultPass. Writing fail
+	// rows for them would be wrong (and would re-arm first_failed_at).
+	writeResultRow := v.Status == ViolationStatusOpen || v.Status == ViolationStatusPendingChoice
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning upsert-violation transaction: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO rule_violations (id, rule_id, artist_id, artist_name, severity, message, fixable, status, candidates, dismissed_at, resolved_at, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(rule_id, artist_id) DO UPDATE SET
@@ -771,9 +800,18 @@ func (s *Service) UpsertViolation(ctx context.Context, v *RuleViolation) error {
 	`, v.ID, v.RuleID, v.ArtistID, v.ArtistName, v.Severity, v.Message,
 		dbutil.BoolToInt(v.Fixable), v.Status, marshalCandidates(v.Candidates),
 		dbutil.NilableTime(v.DismissedAt), dbutil.NilableTime(v.ResolvedAt),
-		v.CreatedAt.Format(time.RFC3339), v.UpdatedAt.Format(time.RFC3339))
-	if err != nil {
+		v.CreatedAt.Format(time.RFC3339), v.UpdatedAt.Format(time.RFC3339)); err != nil {
 		return fmt.Errorf("upserting violation: %w", err)
+	}
+
+	if writeResultRow {
+		if err := upsertRuleResultFailExec(ctx, tx, v.ArtistID, v.RuleID, v.ID, v.Message, v.UpdatedAt); err != nil {
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing upsert-violation transaction: %w", err)
 	}
 	return nil
 }

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -804,6 +804,20 @@ func (s *Service) UpsertViolation(ctx context.Context, v *RuleViolation) error {
 		return fmt.Errorf("upserting violation: %w", err)
 	}
 
+	// On repeat failures, the ON CONFLICT branch above preserves the
+	// existing rule_violations.id and ignores the fresh v.ID we generated.
+	// If we pass the fresh (non-persisted) v.ID to upsertRuleResultFailExec,
+	// the rule_results.violation_id FK points at a row that does not exist
+	// and the transaction rolls back. Re-read the persisted id inside the
+	// same tx and sync v.ID so the result-row write lands cleanly and the
+	// caller observes the authoritative id.
+	if err := tx.QueryRowContext(ctx,
+		`SELECT id FROM rule_violations WHERE rule_id = ? AND artist_id = ?`,
+		v.RuleID, v.ArtistID,
+	).Scan(&v.ID); err != nil {
+		return fmt.Errorf("loading persisted violation id: %w", err)
+	}
+
 	if writeResultRow {
 		if err := upsertRuleResultFailExec(ctx, tx, v.ArtistID, v.RuleID, v.ID, v.Message, v.UpdatedAt); err != nil {
 			return err

--- a/internal/rule/service_test.go
+++ b/internal/rule/service_test.go
@@ -306,6 +306,68 @@ func TestUpdate_DisabledClearsActiveViolations(t *testing.T) {
 	}
 }
 
+// TestUpdate_DisabledClearsRuleResults verifies the rule_results cleanup
+// added alongside the #1141 violation cleanup: when a rule flips to
+// enabled=false, every stored rule_results row for that rule is purged so
+// the per-rule dashboard does not surface stale pass/fail counts. Sibling
+// rules must be untouched by the scoped delete.
+func TestUpdate_DisabledClearsRuleResults(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	if err := svc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+
+	// Seed artists referenced by the pass rows we write below.
+	for _, id := range []string{"a1", "a2", "a3"} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artists (id, name, path) VALUES (?, ?, '')`,
+			id, "Artist "+id); err != nil {
+			t.Fatalf("inserting artist %s: %v", id, err)
+		}
+	}
+
+	ruleID := RuleNFOExists
+	otherID := RuleFanartExists
+	now := time.Now().UTC()
+	// Seed rule_results rows for the target rule (pass rows) and the
+	// sibling rule (one pass row). Only target-rule rows should be deleted.
+	for _, id := range []string{"a1", "a2", "a3"} {
+		if err := svc.UpsertRuleResultPass(ctx, id, ruleID, now); err != nil {
+			t.Fatalf("UpsertRuleResultPass(%s, %s): %v", id, ruleID, err)
+		}
+	}
+	if err := svc.UpsertRuleResultPass(ctx, "a1", otherID, now); err != nil {
+		t.Fatalf("UpsertRuleResultPass(a1, %s): %v", otherID, err)
+	}
+
+	r, err := svc.GetByID(ctx, ruleID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	r.Enabled = false
+	if err := svc.Update(ctx, r); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	countFor := func(rid string) int {
+		var n int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM rule_results WHERE rule_id = ?`, rid).Scan(&n); err != nil {
+			t.Fatalf("counting rule_results for %s: %v", rid, err)
+		}
+		return n
+	}
+	if got := countFor(ruleID); got != 0 {
+		t.Errorf("rule_results rows for disabled rule = %d, want 0", got)
+	}
+	if got := countFor(otherID); got != 1 {
+		t.Errorf("sibling rule_results rows = %d, want 1 (cleanup should be rule-scoped)", got)
+	}
+}
+
 // TestUpdate_EnabledLeavesActiveViolations is the negative companion: the
 // cleanup must only fire on disable, never on a plain enabled=true update
 // (e.g. config or automation_mode edits that keep the rule active).

--- a/internal/rule/sqlite_rule_results.go
+++ b/internal/rule/sqlite_rule_results.go
@@ -1,0 +1,296 @@
+package rule
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// nullableString turns an empty string into a SQL NULL so nullable TEXT
+// columns (violation_id, violation_message) do not round-trip as "".
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// ruleResultUpsertExecer is the minimum surface required to upsert a
+// rule_results row. Both *sql.DB and *sql.Tx satisfy it, which lets
+// UpsertRuleResultFail run inside a caller's existing transaction (see
+// Service.UpsertViolation) without duplicating the SQL.
+type ruleResultUpsertExecer interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+// UpsertRuleResultPass records that the given artist currently satisfies the
+// given rule. The row is keyed by (artist_id, rule_id); on conflict we flip
+// passed to 1, clear violation_id / violation_message / first_failed_at
+// (the failure has been resolved), and bump last_passed_at to evaluatedAt so
+// callers can see when the most recent successful evaluation happened.
+//
+// evaluatedAt is taken from the caller (typically the start timestamp of a
+// pipeline pass or health-subscriber evaluation) so every row written during
+// one artist evaluation shares a timestamp; that makes it cheap to find all
+// rows touched by a single pass without joining on a separate run table.
+func (s *Service) UpsertRuleResultPass(ctx context.Context, artistID, ruleID string, evaluatedAt time.Time) error {
+	ts := evaluatedAt.UTC().Format(time.RFC3339)
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO rule_results (
+			artist_id, rule_id, passed, violation_id, evaluated_at,
+			violation_message, first_failed_at, last_passed_at
+		) VALUES (?, ?, 1, NULL, ?, NULL, NULL, ?)
+		ON CONFLICT(artist_id, rule_id) DO UPDATE SET
+			passed            = 1,
+			violation_id      = NULL,
+			evaluated_at      = excluded.evaluated_at,
+			violation_message = NULL,
+			first_failed_at   = NULL,
+			last_passed_at    = excluded.last_passed_at
+	`, artistID, ruleID, ts, ts)
+	if err != nil {
+		return fmt.Errorf("upserting rule_result pass: %w", err)
+	}
+	return nil
+}
+
+// UpsertRuleResultFail records that the given artist currently violates the
+// given rule. violationID is the rule_violations.id from the paired upsert
+// so reports can join back to the violation row. first_failed_at is
+// preserved across repeated failures via COALESCE(existing, excluded) so
+// the "how long has this been broken" signal survives repeated evaluations.
+//
+// Accepts any execer (DB or Tx) so Service.UpsertViolation can invoke it
+// inside its transaction and keep the violation + result writes atomic.
+func upsertRuleResultFailExec(
+	ctx context.Context,
+	exec ruleResultUpsertExecer,
+	artistID, ruleID, violationID, message string,
+	evaluatedAt time.Time,
+) error {
+	ts := evaluatedAt.UTC().Format(time.RFC3339)
+	_, err := exec.ExecContext(ctx, `
+		INSERT INTO rule_results (
+			artist_id, rule_id, passed, violation_id, evaluated_at,
+			violation_message, first_failed_at, last_passed_at
+		) VALUES (?, ?, 0, ?, ?, ?, ?, NULL)
+		ON CONFLICT(artist_id, rule_id) DO UPDATE SET
+			passed            = 0,
+			violation_id      = excluded.violation_id,
+			evaluated_at      = excluded.evaluated_at,
+			violation_message = excluded.violation_message,
+			first_failed_at   = COALESCE(rule_results.first_failed_at, excluded.first_failed_at)
+	`, artistID, ruleID, nullableString(violationID), ts, nullableString(message), ts)
+	if err != nil {
+		return fmt.Errorf("upserting rule_result fail: %w", err)
+	}
+	return nil
+}
+
+// UpsertRuleResultFail is the package-level entry point used by callers that
+// do not already hold a transaction. Internal transactional callers (like
+// Service.UpsertViolation) use upsertRuleResultFailExec directly with their
+// *sql.Tx so both writes land atomically.
+func (s *Service) UpsertRuleResultFail(
+	ctx context.Context,
+	artistID, ruleID, violationID, message string,
+	evaluatedAt time.Time,
+) error {
+	return upsertRuleResultFailExec(ctx, s.db, artistID, ruleID, violationID, message, evaluatedAt)
+}
+
+// DeleteRuleResultsForRule removes every stored result for the given rule.
+// Called when a rule is disabled (Service.Update) so the per-rule dashboard
+// does not keep surfacing stale pass/fail rows for a rule that no longer
+// runs. A full delete (not status-filtered like rule_violations) is correct:
+// the rule is inactive, so no row is authoritative until it runs again.
+func (s *Service) DeleteRuleResultsForRule(ctx context.Context, ruleID string) error {
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM rule_results WHERE rule_id = ?`, ruleID); err != nil {
+		return fmt.Errorf("deleting rule_results for rule: %w", err)
+	}
+	return nil
+}
+
+// GetRuleResultsForArtist returns every persisted rule outcome for a single
+// artist. Rows are ordered by rule_id so callers can render a stable list.
+func (s *Service) GetRuleResultsForArtist(ctx context.Context, artistID string) ([]RuleResult, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT artist_id, rule_id, passed, violation_id, evaluated_at,
+		       violation_message, first_failed_at, last_passed_at
+		FROM rule_results
+		WHERE artist_id = ?
+		ORDER BY rule_id
+	`, artistID)
+	if err != nil {
+		return nil, fmt.Errorf("querying rule_results for artist: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var results []RuleResult
+	for rows.Next() {
+		var (
+			rr               RuleResult
+			passedInt        int
+			violationID      sql.NullString
+			evaluatedAt      string
+			violationMessage sql.NullString
+			firstFailedAt    sql.NullString
+			lastPassedAt     sql.NullString
+		)
+		if err := rows.Scan(&rr.ArtistID, &rr.RuleID, &passedInt, &violationID,
+			&evaluatedAt, &violationMessage, &firstFailedAt, &lastPassedAt); err != nil {
+			return nil, fmt.Errorf("scanning rule_result row: %w", err)
+		}
+		rr.Passed = passedInt != 0
+		if violationID.Valid {
+			rr.ViolationID = violationID.String
+		}
+		if violationMessage.Valid {
+			rr.ViolationMessage = violationMessage.String
+		}
+		if ts, ok := parseNullableTime(evaluatedAt); ok {
+			rr.EvaluatedAt = ts
+		}
+		if firstFailedAt.Valid {
+			if ts, ok := parseNullableTime(firstFailedAt.String); ok {
+				rr.FirstFailedAt = &ts
+			}
+		}
+		if lastPassedAt.Valid {
+			if ts, ok := parseNullableTime(lastPassedAt.String); ok {
+				rr.LastPassedAt = &ts
+			}
+		}
+		results = append(results, rr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating rule_result rows: %w", err)
+	}
+	return results, nil
+}
+
+// CountRuleResultsByRule returns per-rule pass / fail counts across every
+// artist. Intended for the rule-results dashboard (slice 2) and for the
+// TestCountRuleResultsByRule unit test that asserts the aggregate counts.
+func (s *Service) CountRuleResultsByRule(ctx context.Context) (map[string]RuleResultCount, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT rule_id, passed, COUNT(*)
+		FROM rule_results
+		GROUP BY rule_id, passed
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("counting rule_results by rule: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	counts := map[string]RuleResultCount{}
+	for rows.Next() {
+		var (
+			ruleID    string
+			passedInt int
+			count     int
+		)
+		if err := rows.Scan(&ruleID, &passedInt, &count); err != nil {
+			return nil, fmt.Errorf("scanning rule_results count row: %w", err)
+		}
+		c := counts[ruleID]
+		c.Evaluated += count
+		if passedInt != 0 {
+			c.Passed += count
+		}
+		counts[ruleID] = c
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating rule_results count rows: %w", err)
+	}
+	return counts, nil
+}
+
+// GetRuleResultCounts returns per-artist pass / evaluated counts for the
+// given artist IDs. Empty input returns an empty map. IDs are processed in
+// chunks of 500 so the per-query parameter count stays well under SQLite's
+// 999-parameter limit, mirroring GetViolationsForArtists.
+func (s *Service) GetRuleResultCounts(ctx context.Context, artistIDs []string) (map[string]RuleResultCount, error) {
+	if len(artistIDs) == 0 {
+		return map[string]RuleResultCount{}, nil
+	}
+
+	result := make(map[string]RuleResultCount, len(artistIDs))
+	const chunkSize = 500
+
+	for i := 0; i < len(artistIDs); i += chunkSize {
+		end := i + chunkSize
+		if end > len(artistIDs) {
+			end = len(artistIDs)
+		}
+		if err := s.queryRuleResultCountsChunk(ctx, artistIDs[i:end], result); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+// queryRuleResultCountsChunk executes a single chunk of artist IDs and
+// merges its aggregated counts into dest.
+func (s *Service) queryRuleResultCountsChunk(ctx context.Context, chunk []string, dest map[string]RuleResultCount) error {
+	placeholders := make([]string, len(chunk))
+	args := make([]any, 0, len(chunk))
+	for j, id := range chunk {
+		placeholders[j] = "?"
+		args = append(args, id)
+	}
+
+	//nolint:gosec // G202: only "?" placeholders concatenated, no user input
+	query := `SELECT artist_id, passed, COUNT(*)
+		FROM rule_results
+		WHERE artist_id IN (` + strings.Join(placeholders, ",") + `)
+		GROUP BY artist_id, passed`
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("querying rule_result counts: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	for rows.Next() {
+		var (
+			artistID  string
+			passedInt int
+			count     int
+		)
+		if err := rows.Scan(&artistID, &passedInt, &count); err != nil {
+			return fmt.Errorf("scanning rule_result count row: %w", err)
+		}
+		c := dest[artistID]
+		c.Evaluated += count
+		if passedInt != 0 {
+			c.Passed += count
+		}
+		dest[artistID] = c
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating rule_result count rows: %w", err)
+	}
+	return nil
+}
+
+// parseNullableTime parses a stored RFC3339 timestamp, returning false if the
+// input is empty or unparsable. Kept here (rather than pulling dbutil) so
+// the rule_results accessor doesn't bleed its time-format assumption into
+// every caller.
+func parseNullableTime(s string) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, true
+	}
+	// SQLite's datetime('now') default produces "YYYY-MM-DD HH:MM:SS"
+	// (no timezone). Accept that form too so backfill rows stay readable.
+	if t, err := time.Parse("2006-01-02 15:04:05", s); err == nil {
+		return t.UTC(), true
+	}
+	return time.Time{}, false
+}

--- a/internal/rule/sqlite_rule_results_test.go
+++ b/internal/rule/sqlite_rule_results_test.go
@@ -386,3 +386,143 @@ func TestUpsertViolation_WritesResultRowTransactionally(t *testing.T) {
 		t.Errorf("passed = %d after resolve upsert, want 0 (row should be left alone)", row2.passed)
 	}
 }
+
+// TestUpsertViolation_RollsBackWhenResultWriteFails proves the atomicity
+// contract behind UpsertViolation (CR comment 3114386792): if the
+// rule_results write inside the same transaction fails, the sibling
+// rule_violations insert must also roll back. Without the transactional
+// pairing, a caller would see an "active" violation with no corresponding
+// rule_results fail row, breaching the "both tables agree" invariant.
+//
+// We force a failure by installing a BEFORE INSERT trigger on rule_results
+// that raises via SQLite's RAISE(ABORT, ...). The trigger is dropped at
+// the end of the test so the shared DB remains usable for sibling cases.
+// TestGetRuleResultCounts covers the compliance-report aggregator used by
+// handlers_report to attach rules_passed_count / rules_evaluated_count to
+// each artist row. Exercises the chunked IN-clause path with a single
+// under-chunk batch, mixed pass/fail outcomes, and the empty-input fast path.
+func TestGetRuleResultCounts(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	// Empty input returns an empty map without querying.
+	empty, err := svc.GetRuleResultCounts(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetRuleResultCounts(nil): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("GetRuleResultCounts(nil) len = %d, want 0", len(empty))
+	}
+
+	// Two artists, two rules: a1 passes both, a2 fails one and passes the other.
+	for _, a := range []string{"a1", "a2"} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artists (id, name, path) VALUES (?, ?, '')`,
+			a, "Artist "+a); err != nil {
+			t.Fatalf("inserting %s: %v", a, err)
+		}
+	}
+	for _, r := range []string{"rA", "rB"} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO rules (id, name, description, category, enabled, automation_mode, config)
+			VALUES (?, ?, 'd', 'nfo', 1, 'auto', '{}')`, r, r); err != nil {
+			t.Fatalf("inserting rule %s: %v", r, err)
+		}
+	}
+	now := time.Now().UTC()
+	if err := svc.UpsertRuleResultPass(ctx, "a1", "rA", now); err != nil {
+		t.Fatalf("pass a1/rA: %v", err)
+	}
+	if err := svc.UpsertRuleResultPass(ctx, "a1", "rB", now); err != nil {
+		t.Fatalf("pass a1/rB: %v", err)
+	}
+	if err := svc.UpsertRuleResultPass(ctx, "a2", "rA", now); err != nil {
+		t.Fatalf("pass a2/rA: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO rule_violations (id, rule_id, artist_id, artist_name, severity, message, fixable, status)
+		VALUES ('v2B', 'rB', 'a2', 'Artist a2', 'warning', 'bad', 0, 'open')`); err != nil {
+		t.Fatalf("inserting violation: %v", err)
+	}
+	if err := svc.UpsertRuleResultFail(ctx, "a2", "rB", "v2B", "bad", now); err != nil {
+		t.Fatalf("fail a2/rB: %v", err)
+	}
+
+	counts, err := svc.GetRuleResultCounts(ctx, []string{"a1", "a2"})
+	if err != nil {
+		t.Fatalf("GetRuleResultCounts: %v", err)
+	}
+	if got := counts["a1"]; got.Passed != 2 || got.Evaluated != 2 {
+		t.Errorf("a1 counts = %+v, want {Passed:2, Evaluated:2}", got)
+	}
+	if got := counts["a2"]; got.Passed != 1 || got.Evaluated != 2 {
+		t.Errorf("a2 counts = %+v, want {Passed:1, Evaluated:2}", got)
+	}
+
+	// Unknown artist id returns the zero-value count rather than an error.
+	if got := counts["missing"]; got.Passed != 0 || got.Evaluated != 0 {
+		t.Errorf("missing counts = %+v, want zero", got)
+	}
+}
+
+func TestUpsertViolation_RollsBackWhenResultWriteFails(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedArtistAndRule(t, db, "a1", "r1")
+
+	// Install a trigger that aborts any INSERT into rule_results. The
+	// UpsertViolation call below must then roll back the in-flight
+	// rule_violations insert as well.
+	if _, err := db.ExecContext(ctx, `
+		CREATE TRIGGER rule_results_abort
+		BEFORE INSERT ON rule_results
+		BEGIN
+			SELECT RAISE(ABORT, 'forced-abort for rollback test');
+		END`); err != nil {
+		t.Fatalf("installing abort trigger: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := db.ExecContext(context.Background(),
+			`DROP TRIGGER IF EXISTS rule_results_abort`); err != nil {
+			t.Logf("dropping abort trigger: %v", err)
+		}
+	})
+
+	v := &RuleViolation{
+		RuleID:     "r1",
+		ArtistID:   "a1",
+		ArtistName: "Artist a1",
+		Severity:   "warning",
+		Message:    "bad",
+		Fixable:    true,
+		Status:     ViolationStatusOpen,
+	}
+	err := svc.UpsertViolation(ctx, v)
+	if err == nil {
+		t.Fatalf("UpsertViolation returned nil, want error from abort trigger")
+	}
+
+	// Both tables must be empty: the tx rolled back.
+	var violationCount int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM rule_violations WHERE rule_id = ? AND artist_id = ?`,
+		"r1", "a1").Scan(&violationCount); err != nil {
+		t.Fatalf("counting rule_violations: %v", err)
+	}
+	if violationCount != 0 {
+		t.Errorf("rule_violations rows = %d after rolled-back UpsertViolation, want 0", violationCount)
+	}
+
+	var resultCount int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM rule_results WHERE rule_id = ? AND artist_id = ?`,
+		"r1", "a1").Scan(&resultCount); err != nil {
+		t.Fatalf("counting rule_results: %v", err)
+	}
+	if resultCount != 0 {
+		t.Errorf("rule_results rows = %d after rolled-back UpsertViolation, want 0", resultCount)
+	}
+}

--- a/internal/rule/sqlite_rule_results_test.go
+++ b/internal/rule/sqlite_rule_results_test.go
@@ -449,7 +449,10 @@ func TestGetRuleResultCounts(t *testing.T) {
 		t.Fatalf("fail a2/rB: %v", err)
 	}
 
-	counts, err := svc.GetRuleResultCounts(ctx, []string{"a1", "a2"})
+	// "missing" is included in the input slice so we actually exercise the
+	// requested-but-unknown-artist path: the map lookup alone would just
+	// return Go's zero-value whether or not the service supports it.
+	counts, err := svc.GetRuleResultCounts(ctx, []string{"a1", "a2", "missing"})
 	if err != nil {
 		t.Fatalf("GetRuleResultCounts: %v", err)
 	}
@@ -461,6 +464,9 @@ func TestGetRuleResultCounts(t *testing.T) {
 	}
 
 	// Unknown artist id returns the zero-value count rather than an error.
+	// The current implementation omits keys that have no rule_result rows,
+	// so we assert on the map lookup's zero-value (Go semantics) rather
+	// than on key presence.
 	if got := counts["missing"]; got.Passed != 0 || got.Evaluated != 0 {
 		t.Errorf("missing counts = %+v, want zero", got)
 	}

--- a/internal/rule/sqlite_rule_results_test.go
+++ b/internal/rule/sqlite_rule_results_test.go
@@ -1,0 +1,388 @@
+package rule
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+)
+
+// seedArtistAndRule inserts a minimal artist + rule pair for rule_results
+// tests. rule_results has FK references to both; the rule row also has to
+// exist for the FK on rule_violations (which the UpsertViolation tx needs).
+//
+//nolint:unparam // artistID/ruleID vary across call sites in other tests.
+func seedArtistAndRule(t *testing.T, db *sql.DB, artistID, ruleID string) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artists (id, name, path) VALUES (?, ?, '')`,
+		artistID, "Artist "+artistID); err != nil {
+		t.Fatalf("inserting artist: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO rules (id, name, description, category, enabled, automation_mode, config)
+		VALUES (?, ?, 'desc', 'nfo', 1, 'auto', '{}')`,
+		ruleID, "Rule "+ruleID); err != nil {
+		t.Fatalf("inserting rule: %v", err)
+	}
+}
+
+// readResultRow reads the stored rule_results row for (artistID, ruleID).
+// Returns ok=false when no row exists so tests can assert presence/absence
+// without nil-pointer pitfalls.
+type storedResult struct {
+	passed        int
+	violationID   sql.NullString
+	evaluatedAt   string
+	message       sql.NullString
+	firstFailedAt sql.NullString
+	lastPassedAt  sql.NullString
+}
+
+//nolint:unparam // artistID/ruleID vary across call sites in other tests.
+func readResultRow(t *testing.T, db *sql.DB, artistID, ruleID string) (storedResult, bool) {
+	t.Helper()
+	var r storedResult
+	err := db.QueryRowContext(context.Background(), `
+		SELECT passed, violation_id, evaluated_at, violation_message,
+		       first_failed_at, last_passed_at
+		FROM rule_results
+		WHERE artist_id = ? AND rule_id = ?`,
+		artistID, ruleID).Scan(
+		&r.passed, &r.violationID, &r.evaluatedAt,
+		&r.message, &r.firstFailedAt, &r.lastPassedAt)
+	if err == sql.ErrNoRows {
+		return r, false
+	}
+	if err != nil {
+		t.Fatalf("reading rule_results row: %v", err)
+	}
+	return r, true
+}
+
+func TestUpsertRuleResultPass_Insert(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedArtistAndRule(t, db, "a1", "r1")
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+
+	if err := svc.UpsertRuleResultPass(ctx, "a1", "r1", now); err != nil {
+		t.Fatalf("UpsertRuleResultPass: %v", err)
+	}
+
+	row, ok := readResultRow(t, db, "a1", "r1")
+	if !ok {
+		t.Fatalf("expected rule_results row, got none")
+	}
+	if row.passed != 1 {
+		t.Errorf("passed = %d, want 1", row.passed)
+	}
+	if row.violationID.Valid {
+		t.Errorf("violation_id = %q, want NULL", row.violationID.String)
+	}
+	if row.message.Valid {
+		t.Errorf("violation_message = %q, want NULL", row.message.String)
+	}
+	if row.firstFailedAt.Valid {
+		t.Errorf("first_failed_at = %q, want NULL", row.firstFailedAt.String)
+	}
+	if !row.lastPassedAt.Valid {
+		t.Errorf("last_passed_at = NULL, want set on first pass")
+	}
+}
+
+func TestUpsertRuleResultPass_FailToPass(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedArtistAndRule(t, db, "a1", "r1")
+	// Seed an initial fail row so the pass upsert must flip it.
+	failAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := svc.UpsertRuleResultFail(ctx, "a1", "r1", "v1", "bad", failAt); err != nil {
+		t.Fatalf("seeding fail: %v", err)
+	}
+
+	passAt := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	if err := svc.UpsertRuleResultPass(ctx, "a1", "r1", passAt); err != nil {
+		t.Fatalf("UpsertRuleResultPass: %v", err)
+	}
+
+	row, ok := readResultRow(t, db, "a1", "r1")
+	if !ok {
+		t.Fatalf("expected rule_results row, got none")
+	}
+	if row.passed != 1 {
+		t.Errorf("passed = %d, want 1", row.passed)
+	}
+	if row.firstFailedAt.Valid {
+		t.Errorf("first_failed_at = %q, want NULL after fail-to-pass", row.firstFailedAt.String)
+	}
+	if row.violationID.Valid {
+		t.Errorf("violation_id = %q, want NULL after pass", row.violationID.String)
+	}
+	if !row.lastPassedAt.Valid {
+		t.Errorf("last_passed_at = NULL, want set after fail-to-pass")
+	}
+}
+
+func TestUpsertRuleResultFail_PassToFail(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedArtistAndRule(t, db, "a1", "r1")
+	passAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := svc.UpsertRuleResultPass(ctx, "a1", "r1", passAt); err != nil {
+		t.Fatalf("seeding pass: %v", err)
+	}
+
+	// Seed a violation row so the violation_id FK resolves.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO rule_violations (id, rule_id, artist_id, artist_name, severity, message, fixable, status)
+		VALUES ('v1', 'r1', 'a1', 'Artist a1', 'warning', 'bad', 0, 'open')`); err != nil {
+		t.Fatalf("seeding violation: %v", err)
+	}
+
+	failAt := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	if err := svc.UpsertRuleResultFail(ctx, "a1", "r1", "v1", "bad", failAt); err != nil {
+		t.Fatalf("UpsertRuleResultFail: %v", err)
+	}
+
+	row, ok := readResultRow(t, db, "a1", "r1")
+	if !ok {
+		t.Fatalf("expected rule_results row, got none")
+	}
+	if row.passed != 0 {
+		t.Errorf("passed = %d, want 0", row.passed)
+	}
+	if !row.firstFailedAt.Valid {
+		t.Errorf("first_failed_at = NULL, want set on pass-to-fail transition")
+	}
+	wantTs := failAt.Format(time.RFC3339)
+	if row.firstFailedAt.String != wantTs {
+		t.Errorf("first_failed_at = %q, want %q", row.firstFailedAt.String, wantTs)
+	}
+	if !row.violationID.Valid || row.violationID.String != "v1" {
+		t.Errorf("violation_id = %+v, want v1", row.violationID)
+	}
+}
+
+func TestUpsertRuleResultFail_FailToFail(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedArtistAndRule(t, db, "a1", "r1")
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO rule_violations (id, rule_id, artist_id, artist_name, severity, message, fixable, status)
+		VALUES ('v1', 'r1', 'a1', 'Artist a1', 'warning', 'bad', 0, 'open')`); err != nil {
+		t.Fatalf("seeding violation: %v", err)
+	}
+
+	first := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := svc.UpsertRuleResultFail(ctx, "a1", "r1", "v1", "still bad", first); err != nil {
+		t.Fatalf("first UpsertRuleResultFail: %v", err)
+	}
+
+	// Second fail: first_failed_at must be preserved by the COALESCE.
+	second := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	if err := svc.UpsertRuleResultFail(ctx, "a1", "r1", "v1", "still bad", second); err != nil {
+		t.Fatalf("second UpsertRuleResultFail: %v", err)
+	}
+
+	row, ok := readResultRow(t, db, "a1", "r1")
+	if !ok {
+		t.Fatalf("expected rule_results row, got none")
+	}
+	wantFirst := first.Format(time.RFC3339)
+	if row.firstFailedAt.String != wantFirst {
+		t.Errorf("first_failed_at = %q, want %q (must be preserved across repeated fails)",
+			row.firstFailedAt.String, wantFirst)
+	}
+	// evaluated_at should be the latest fail timestamp.
+	wantEval := second.Format(time.RFC3339)
+	if row.evaluatedAt != wantEval {
+		t.Errorf("evaluated_at = %q, want %q", row.evaluatedAt, wantEval)
+	}
+}
+
+func TestCountRuleResultsByRule(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	// Two rules, three artists, mixed outcomes.
+	for _, a := range []string{"a1", "a2", "a3"} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artists (id, name, path) VALUES (?, ?, '')`,
+			a, "Artist "+a); err != nil {
+			t.Fatalf("inserting %s: %v", a, err)
+		}
+	}
+	for _, r := range []string{"rA", "rB"} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO rules (id, name, description, category, enabled, automation_mode, config)
+			VALUES (?, ?, 'd', 'nfo', 1, 'auto', '{}')`,
+			r, "Rule "+r); err != nil {
+			t.Fatalf("inserting rule %s: %v", r, err)
+		}
+	}
+
+	now := time.Now().UTC()
+	// rA: a1 pass, a2 pass, a3 fail. Expected Passed=2, Evaluated=3.
+	if err := svc.UpsertRuleResultPass(ctx, "a1", "rA", now); err != nil {
+		t.Fatalf("pass a1/rA: %v", err)
+	}
+	if err := svc.UpsertRuleResultPass(ctx, "a2", "rA", now); err != nil {
+		t.Fatalf("pass a2/rA: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO rule_violations (id, rule_id, artist_id, artist_name, severity, message, fixable, status)
+		VALUES ('vA3', 'rA', 'a3', 'Artist a3', 'warning', 'bad', 0, 'open')`); err != nil {
+		t.Fatalf("inserting rA violation: %v", err)
+	}
+	if err := svc.UpsertRuleResultFail(ctx, "a3", "rA", "vA3", "bad", now); err != nil {
+		t.Fatalf("fail a3/rA: %v", err)
+	}
+	// rB: a1 fail only. Expected Passed=0, Evaluated=1.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO rule_violations (id, rule_id, artist_id, artist_name, severity, message, fixable, status)
+		VALUES ('vB1', 'rB', 'a1', 'Artist a1', 'warning', 'bad', 0, 'open')`); err != nil {
+		t.Fatalf("inserting rB violation: %v", err)
+	}
+	if err := svc.UpsertRuleResultFail(ctx, "a1", "rB", "vB1", "bad", now); err != nil {
+		t.Fatalf("fail a1/rB: %v", err)
+	}
+
+	counts, err := svc.CountRuleResultsByRule(ctx)
+	if err != nil {
+		t.Fatalf("CountRuleResultsByRule: %v", err)
+	}
+	if got := counts["rA"]; got.Passed != 2 || got.Evaluated != 3 {
+		t.Errorf("rA counts = %+v, want {Passed:2, Evaluated:3}", got)
+	}
+	if got := counts["rB"]; got.Passed != 0 || got.Evaluated != 1 {
+		t.Errorf("rB counts = %+v, want {Passed:0, Evaluated:1}", got)
+	}
+}
+
+func TestDeleteRuleResultsForRule(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	for _, a := range []string{"a1", "a2"} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artists (id, name, path) VALUES (?, ?, '')`, a, "A"); err != nil {
+			t.Fatalf("inserting %s: %v", a, err)
+		}
+	}
+	for _, r := range []string{"target", "sibling"} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO rules (id, name, description, category, enabled, automation_mode, config)
+			VALUES (?, ?, 'd', 'nfo', 1, 'auto', '{}')`, r, r); err != nil {
+			t.Fatalf("inserting rule %s: %v", r, err)
+		}
+	}
+	now := time.Now().UTC()
+	// Seed pass rows for both rules against both artists.
+	for _, r := range []string{"target", "sibling"} {
+		for _, a := range []string{"a1", "a2"} {
+			if err := svc.UpsertRuleResultPass(ctx, a, r, now); err != nil {
+				t.Fatalf("seeding %s/%s: %v", r, a, err)
+			}
+		}
+	}
+
+	if err := svc.DeleteRuleResultsForRule(ctx, "target"); err != nil {
+		t.Fatalf("DeleteRuleResultsForRule: %v", err)
+	}
+
+	countFor := func(ruleID string) int {
+		var n int
+		if err := db.QueryRow(
+			`SELECT COUNT(*) FROM rule_results WHERE rule_id = ?`, ruleID).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", ruleID, err)
+		}
+		return n
+	}
+	if got := countFor("target"); got != 0 {
+		t.Errorf("target rule rows = %d, want 0", got)
+	}
+	if got := countFor("sibling"); got != 2 {
+		t.Errorf("sibling rule rows = %d, want 2 (delete must be rule-scoped)", got)
+	}
+}
+
+func TestUpsertViolation_WritesResultRowTransactionally(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedArtistAndRule(t, db, "a1", "r1")
+
+	// Happy path: open violation upsert should write both rows atomically.
+	v := &RuleViolation{
+		RuleID:     "r1",
+		ArtistID:   "a1",
+		ArtistName: "Artist a1",
+		Severity:   "warning",
+		Message:    "bad",
+		Fixable:    true,
+		Status:     ViolationStatusOpen,
+	}
+	if err := svc.UpsertViolation(ctx, v); err != nil {
+		t.Fatalf("UpsertViolation: %v", err)
+	}
+
+	// Violation row exists.
+	var vCount int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM rule_violations WHERE rule_id = ? AND artist_id = ?`,
+		"r1", "a1").Scan(&vCount); err != nil {
+		t.Fatalf("counting violation rows: %v", err)
+	}
+	if vCount != 1 {
+		t.Errorf("violation rows = %d, want 1", vCount)
+	}
+
+	// rule_results row exists and links to the violation.
+	row, ok := readResultRow(t, db, "a1", "r1")
+	if !ok {
+		t.Fatalf("rule_results row missing after UpsertViolation")
+	}
+	if row.passed != 0 {
+		t.Errorf("passed = %d, want 0", row.passed)
+	}
+	if !row.violationID.Valid || row.violationID.String != v.ID {
+		t.Errorf("violation_id = %+v, want %s", row.violationID, v.ID)
+	}
+	if !row.message.Valid || row.message.String != "bad" {
+		t.Errorf("violation_message = %+v, want 'bad'", row.message)
+	}
+	if !row.firstFailedAt.Valid {
+		t.Errorf("first_failed_at = NULL, want set on first open violation")
+	}
+
+	// Resolved status should NOT upsert a fail row (it should leave the
+	// existing row alone; the paired ResolveViolation or next pipeline
+	// pass is responsible for flipping to passed=1).
+	resolved := *v
+	resolved.Status = ViolationStatusResolved
+	now := time.Now().UTC()
+	resolved.ResolvedAt = &now
+	if err := svc.UpsertViolation(ctx, &resolved); err != nil {
+		t.Fatalf("UpsertViolation (resolved): %v", err)
+	}
+	row2, ok := readResultRow(t, db, "a1", "r1")
+	if !ok {
+		t.Fatalf("rule_results row disappeared")
+	}
+	if row2.passed != 0 {
+		t.Errorf("passed = %d after resolve upsert, want 0 (row should be left alone)", row2.passed)
+	}
+}

--- a/web/templates/compliance.templ
+++ b/web/templates/compliance.templ
@@ -14,10 +14,19 @@ import (
 )
 
 // ComplianceRow represents one artist in the compliance report.
+//
+// RulesPassedCount / RulesEvaluatedCount (issue #699 slice 1) surface the
+// per-artist rule outcome counts stored in rule_results. Together they let
+// the UI render "passing 7 of 10 rules" without re-running Engine.Evaluate
+// on every request. When rule_results has no row for the artist yet (e.g.
+// before the first Run Rules pass after backfill seeds only active
+// violations), both counts are zero.
 type ComplianceRow struct {
-	Artist      artist.Artist    `json:"artist"`
-	HealthScore float64          `json:"health_score"`
-	Violations  []rule.Violation `json:"violations"`
+	Artist              artist.Artist    `json:"artist"`
+	HealthScore         float64          `json:"health_score"`
+	Violations          []rule.Violation `json:"violations"`
+	RulesPassedCount    int              `json:"rules_passed_count"`
+	RulesEvaluatedCount int              `json:"rules_evaluated_count"`
 }
 
 // ComplianceData holds the data for the compliance report page.

--- a/web/templates/compliance_templ.go
+++ b/web/templates/compliance_templ.go
@@ -22,10 +22,19 @@ import (
 )
 
 // ComplianceRow represents one artist in the compliance report.
+//
+// RulesPassedCount / RulesEvaluatedCount (issue #699 slice 1) surface the
+// per-artist rule outcome counts stored in rule_results. Together they let
+// the UI render "passing 7 of 10 rules" without re-running Engine.Evaluate
+// on every request. When rule_results has no row for the artist yet (e.g.
+// before the first Run Rules pass after backfill seeds only active
+// violations), both counts are zero.
 type ComplianceRow struct {
-	Artist      artist.Artist    `json:"artist"`
-	HealthScore float64          `json:"health_score"`
-	Violations  []rule.Violation `json:"violations"`
+	Artist              artist.Artist    `json:"artist"`
+	HealthScore         float64          `json:"health_score"`
+	Violations          []rule.Violation `json:"violations"`
+	RulesPassedCount    int              `json:"rules_passed_count"`
+	RulesEvaluatedCount int              `json:"rules_evaluated_count"`
 }
 
 // ComplianceData holds the data for the compliance report page.
@@ -151,7 +160,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(assets.ChartJS)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 108, Col: 30}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 117, Col: 30}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -164,7 +173,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.title"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 112, Col: 60}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 121, Col: 60}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -177,7 +186,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.subtitle"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 114, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 123, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -190,7 +199,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.run_rules"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 124, Col: 49}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 133, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -203,7 +212,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.running"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 125, Col: 51}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 134, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -216,7 +225,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.rule_evaluation_started"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 126, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 135, Col: 67}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -229,7 +238,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.already_running"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 127, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 136, Col: 67}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -242,7 +251,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.failed_to_start"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 128, Col: 64}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 137, Col: 64}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -255,7 +264,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.failed_to_start_evaluation"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 129, Col: 86}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 138, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -268,7 +277,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var12 string
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.rule_evaluation_failed"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 130, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 139, Col: 76}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -281,7 +290,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.rule_evaluation_idle"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 131, Col: 61}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 140, Col: 61}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -294,7 +303,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var14 string
 			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.rule_status_http_error"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 132, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 141, Col: 76}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 			if templ_7745c5c3_Err != nil {
@@ -307,7 +316,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var15 string
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.rule_status_network_error"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 133, Col: 82}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 142, Col: 82}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
@@ -320,7 +329,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var16 string
 			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.violations_none"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 134, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 143, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 			if templ_7745c5c3_Err != nil {
@@ -333,7 +342,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.violations_all_auto_fixed"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 135, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 144, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
@@ -346,7 +355,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.violations_found"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 136, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 145, Col: 67}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
@@ -359,7 +368,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var19 string
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.violations_found_auto_fixed"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 137, Col: 89}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 146, Col: 89}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
@@ -372,7 +381,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var20 string
 			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.confirm_run_title"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 138, Col: 61}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 147, Col: 61}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 			if templ_7745c5c3_Err != nil {
@@ -385,7 +394,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var21 string
 			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.confirm_run_body"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 139, Col: 59}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 148, Col: 59}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 			if templ_7745c5c3_Err != nil {
@@ -398,7 +407,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.confirm_run_body_estimate"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 140, Col: 77}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 149, Col: 77}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
@@ -411,7 +420,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.confirm_run_accept"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 141, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 150, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
@@ -424,7 +433,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var24 string
 			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.confirm_minute.one"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 142, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 151, Col: 67}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
@@ -437,7 +446,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.confirm_minute.other"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 143, Col: 71}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 152, Col: 71}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
@@ -450,7 +459,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var26 string
 			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.confirm_run_all_title"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 144, Col: 69}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 153, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
@@ -463,7 +472,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var27 string
 			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.confirm_run_all_body"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 145, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 154, Col: 67}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
@@ -476,7 +485,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var28 string
 			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.confirm_run_all_body_estimate"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 146, Col: 85}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 155, Col: 85}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
@@ -489,7 +498,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var29 string
 			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.confirm_run_all_accept"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 147, Col: 71}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 156, Col: 71}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 			if templ_7745c5c3_Err != nil {
@@ -502,7 +511,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var30 string
 			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.evaluated_summary"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 148, Col: 69}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 157, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
@@ -515,7 +524,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var31 string
 			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.evaluated_summary_all"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 149, Col: 77}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 158, Col: 77}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 			if templ_7745c5c3_Err != nil {
@@ -528,7 +537,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var32 string
 			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.run_rules"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 158, Col: 61}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 167, Col: 61}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 			if templ_7745c5c3_Err != nil {
@@ -541,7 +550,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var33 string
 			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.run_rules_all_tooltip"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 164, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 173, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
@@ -554,7 +563,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var34 string
 			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.run_rules_all"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 169, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 178, Col: 38}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
@@ -567,7 +576,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var35 string
 			templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(data.Search)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 193, Col: 25}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 202, Col: 25}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 			if templ_7745c5c3_Err != nil {
@@ -580,7 +589,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var36 string
 			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.search_artists"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 194, Col: 51}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 203, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 			if templ_7745c5c3_Err != nil {
@@ -608,7 +617,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 				var templ_7745c5c3_Var37 string
 				templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.all_libraries"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 214, Col: 91}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 223, Col: 91}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 				if templ_7745c5c3_Err != nil {
@@ -626,7 +635,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 					var templ_7745c5c3_Var38 string
 					templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(lib.ID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 216, Col: 30}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 225, Col: 30}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 					if templ_7745c5c3_Err != nil {
@@ -649,7 +658,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 					var templ_7745c5c3_Var39 string
 					templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(lib.Name)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 216, Col: 82}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 225, Col: 82}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 					if templ_7745c5c3_Err != nil {
@@ -682,7 +691,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var40 string
 			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.all_artists"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 229, Col: 112}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 238, Col: 112}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 			if templ_7745c5c3_Err != nil {
@@ -705,7 +714,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var41 string
 			templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.compliant"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 230, Col: 101}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 239, Col: 101}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 			if templ_7745c5c3_Err != nil {
@@ -728,7 +737,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var42 string
 			templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.non_compliant"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 231, Col: 113}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 240, Col: 113}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 			if templ_7745c5c3_Err != nil {
@@ -751,7 +760,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var43 string
 			templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.no_filter"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 242, Col: 83}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 251, Col: 83}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 			if templ_7745c5c3_Err != nil {
@@ -774,7 +783,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var44 string
 			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.missing_metadata"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 243, Col: 112}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 252, Col: 112}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 			if templ_7745c5c3_Err != nil {
@@ -797,7 +806,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var45 string
 			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "report.missing_type", img.ImageTermFor("thumb", data.ProfileName)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 244, Col: 158}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 253, Col: 158}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 			if templ_7745c5c3_Err != nil {
@@ -820,7 +829,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var46 string
 			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "report.missing_type", img.ImageTermFor("fanart", data.ProfileName)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 245, Col: 161}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 254, Col: 161}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 			if templ_7745c5c3_Err != nil {
@@ -843,7 +852,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var47 string
 			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "report.missing_type", img.ImageTermFor("logo", data.ProfileName)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 246, Col: 155}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 255, Col: 155}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 			if templ_7745c5c3_Err != nil {
@@ -866,7 +875,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var48 string
 			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "report.missing_type", img.ImageTermFor("banner", data.ProfileName)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 247, Col: 161}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 256, Col: 161}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 			if templ_7745c5c3_Err != nil {
@@ -889,7 +898,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var49 string
 			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.missing_mbid"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 248, Col: 110}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 257, Col: 110}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 			if templ_7745c5c3_Err != nil {
@@ -902,7 +911,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var50 string
 			templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.min_pct"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 257, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 266, Col: 45}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 			if templ_7745c5c3_Err != nil {
@@ -915,7 +924,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var51 string
 			templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(intOrEmpty(data.HealthScoreMin))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 258, Col: 46}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 267, Col: 46}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 			if templ_7745c5c3_Err != nil {
@@ -928,7 +937,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var52 string
 			templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.max_pct"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 272, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 281, Col: 45}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 			if templ_7745c5c3_Err != nil {
@@ -941,7 +950,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var53 string
 			templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(intOrEmpty(data.HealthScoreMax))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 273, Col: 46}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 282, Col: 46}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 			if templ_7745c5c3_Err != nil {
@@ -971,7 +980,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var54 templ.SafeURL
 			templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath() + complianceExportURL(data)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 293, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 302, Col: 66}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 			if templ_7745c5c3_Err != nil {
@@ -984,7 +993,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var55 string
 			templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.export_csv"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 299, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 308, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 			if templ_7745c5c3_Err != nil {
@@ -997,7 +1006,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var56 string
 			templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(data.Sort)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 304, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 313, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 			if templ_7745c5c3_Err != nil {
@@ -1010,7 +1019,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var57 string
 			templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(data.Order)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 305, Col: 77}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 314, Col: 77}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 			if templ_7745c5c3_Err != nil {
@@ -1031,7 +1040,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var58 string
 			templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.n_selected"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 311, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 320, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 			if templ_7745c5c3_Err != nil {
@@ -1044,7 +1053,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var59 string
 			templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.zero_selected"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 318, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 327, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 			if templ_7745c5c3_Err != nil {
@@ -1057,7 +1066,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var60 string
 			templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.one_selected"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 319, Col: 50}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 328, Col: 50}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 			if templ_7745c5c3_Err != nil {
@@ -1070,7 +1079,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var61 string
 			templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.n_selected"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 320, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 329, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
 			if templ_7745c5c3_Err != nil {
@@ -1083,7 +1092,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var62 string
 			templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.zero_selected"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 321, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 330, Col: 37}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 			if templ_7745c5c3_Err != nil {
@@ -1096,7 +1105,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var63 string
 			templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.fetch_metadata"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 328, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 337, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 			if templ_7745c5c3_Err != nil {
@@ -1109,7 +1118,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var64 string
 			templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.fetch_images"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 335, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 344, Col: 37}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 			if templ_7745c5c3_Err != nil {
@@ -1122,7 +1131,7 @@ func CompliancePage(assets AssetPaths, data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var65 string
 			templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.cancel"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 342, Col: 31}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 351, Col: 31}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
 			if templ_7745c5c3_Err != nil {
@@ -1228,7 +1237,7 @@ func ComplianceTable(data ComplianceData) templ.Component {
 		var templ_7745c5c3_Var67 string
 		templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.artist"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 421, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 430, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
 		if templ_7745c5c3_Err != nil {
@@ -1237,7 +1246,7 @@ func ComplianceTable(data ComplianceData) templ.Component {
 		var templ_7745c5c3_Var68 string
 		templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(sortIcon(data.Sort, "name", data.Order))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 421, Col: 75}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 430, Col: 75}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
 		if templ_7745c5c3_Err != nil {
@@ -1250,7 +1259,7 @@ func ComplianceTable(data ComplianceData) templ.Component {
 		var templ_7745c5c3_Var69 string
 		templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.score"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 432, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 441, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
 		if templ_7745c5c3_Err != nil {
@@ -1259,7 +1268,7 @@ func ComplianceTable(data ComplianceData) templ.Component {
 		var templ_7745c5c3_Var70 string
 		templ_7745c5c3_Var70, templ_7745c5c3_Err = templ.JoinStringErrs(sortIcon(data.Sort, "health_score", data.Order))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 432, Col: 82}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 441, Col: 82}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var70))
 		if templ_7745c5c3_Err != nil {
@@ -1272,7 +1281,7 @@ func ComplianceTable(data ComplianceData) templ.Component {
 		var templ_7745c5c3_Var71 string
 		templ_7745c5c3_Var71, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.metadata"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 435, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 444, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var71))
 		if templ_7745c5c3_Err != nil {
@@ -1285,7 +1294,7 @@ func ComplianceTable(data ComplianceData) templ.Component {
 		var templ_7745c5c3_Var72 string
 		templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(img.ImageTermFor("thumb", data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 438, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 447, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
 		if templ_7745c5c3_Err != nil {
@@ -1298,7 +1307,7 @@ func ComplianceTable(data ComplianceData) templ.Component {
 		var templ_7745c5c3_Var73 string
 		templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinStringErrs(img.ImageTermFor("fanart", data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 441, Col: 53}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 450, Col: 53}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
 		if templ_7745c5c3_Err != nil {
@@ -1311,7 +1320,7 @@ func ComplianceTable(data ComplianceData) templ.Component {
 		var templ_7745c5c3_Var74 string
 		templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(img.ImageTermFor("logo", data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 444, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 453, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
 		if templ_7745c5c3_Err != nil {
@@ -1324,7 +1333,7 @@ func ComplianceTable(data ComplianceData) templ.Component {
 		var templ_7745c5c3_Var75 string
 		templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.actions"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 450, Col: 33}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 459, Col: 33}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
 		if templ_7745c5c3_Err != nil {
@@ -1342,7 +1351,7 @@ func ComplianceTable(data ComplianceData) templ.Component {
 			var templ_7745c5c3_Var76 string
 			templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.no_artists"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 458, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 467, Col: 37}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
 			if templ_7745c5c3_Err != nil {
@@ -1403,7 +1412,7 @@ func complianceRow(row ComplianceRow, profileName string, basePath string) templ
 		var templ_7745c5c3_Var78 string
 		templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(row.Artist.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 478, Col: 25}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 487, Col: 25}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
 		if templ_7745c5c3_Err != nil {
@@ -1416,7 +1425,7 @@ func complianceRow(row ComplianceRow, profileName string, basePath string) templ
 		var templ_7745c5c3_Var79 templ.SafeURL
 		templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath + "/artists/" + row.Artist.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 484, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 493, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
 		if templ_7745c5c3_Err != nil {
@@ -1429,7 +1438,7 @@ func complianceRow(row ComplianceRow, profileName string, basePath string) templ
 		var templ_7745c5c3_Var80 string
 		templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(row.Artist.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 487, Col: 21}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 496, Col: 21}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
 		if templ_7745c5c3_Err != nil {
@@ -1464,7 +1473,7 @@ func complianceRow(row ComplianceRow, profileName string, basePath string) templ
 		var templ_7745c5c3_Var83 string
 		templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%.0f%%", row.HealthScore))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 492, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 501, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
 		if templ_7745c5c3_Err != nil {
@@ -1522,7 +1531,7 @@ func complianceRow(row ComplianceRow, profileName string, basePath string) templ
 			var templ_7745c5c3_Var84 templ.SafeURL
 			templ_7745c5c3_Var84, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath + "/artists/" + row.Artist.ID + "/nfo"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 514, Col: 75}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 523, Col: 75}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var84))
 			if templ_7745c5c3_Err != nil {
@@ -1535,7 +1544,7 @@ func complianceRow(row ComplianceRow, profileName string, basePath string) templ
 			var templ_7745c5c3_Var85 string
 			templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.changes"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 517, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 526, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
 			if templ_7745c5c3_Err != nil {
@@ -1583,7 +1592,7 @@ func ComplianceSummaryFragment(data ComplianceSummaryData) templ.Component {
 		var templ_7745c5c3_Var87 string
 		templ_7745c5c3_Var87, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "report.overall"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 530, Col: 93}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 539, Col: 93}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var87))
 		if templ_7745c5c3_Err != nil {
@@ -1618,7 +1627,7 @@ func ComplianceSummaryFragment(data ComplianceSummaryData) templ.Component {
 		var templ_7745c5c3_Var90 string
 		templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%.1f%%", data.Overall.Score))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 532, Col: 47}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 541, Col: 47}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
 		if templ_7745c5c3_Err != nil {
@@ -1631,7 +1640,7 @@ func ComplianceSummaryFragment(data ComplianceSummaryData) templ.Component {
 		var templ_7745c5c3_Var91 string
 		templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "report.x_of_y_compliant", data.Overall.CompliantArtists, data.Overall.TotalArtists))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 535, Col: 98}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 544, Col: 98}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
 		if templ_7745c5c3_Err != nil {
@@ -1649,7 +1658,7 @@ func ComplianceSummaryFragment(data ComplianceSummaryData) templ.Component {
 			var templ_7745c5c3_Var92 string
 			templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(lib.LibraryName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 541, Col: 100}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 550, Col: 100}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
 			if templ_7745c5c3_Err != nil {
@@ -1662,7 +1671,7 @@ func ComplianceSummaryFragment(data ComplianceSummaryData) templ.Component {
 			var templ_7745c5c3_Var93 string
 			templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(lib.LibraryName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 541, Col: 120}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 550, Col: 120}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
 			if templ_7745c5c3_Err != nil {
@@ -1697,7 +1706,7 @@ func ComplianceSummaryFragment(data ComplianceSummaryData) templ.Component {
 			var templ_7745c5c3_Var96 string
 			templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%.1f%%", lib.Score))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 543, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 552, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var96))
 			if templ_7745c5c3_Err != nil {
@@ -1710,7 +1719,7 @@ func ComplianceSummaryFragment(data ComplianceSummaryData) templ.Component {
 			var templ_7745c5c3_Var97 string
 			templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "report.x_of_y_compliant", lib.CompliantArtists, lib.TotalArtists))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 546, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 555, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
 			if templ_7745c5c3_Err != nil {
@@ -1767,7 +1776,7 @@ func coverageChartData(data ComplianceSummaryData) templ.Component {
 		var templ_7745c5c3_Var99 string
 		templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.JoinStringErrs(coverageChartJSON(data.Libraries, data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 561, Col: 110}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/compliance.templ`, Line: 570, Col: 110}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var99))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

- Adds a `rule_results` table keyed on `(artist_id, rule_id)` plus four indexes so reports can answer "how many of N rules does artist X pass?" without re-running `Engine.Evaluate`. Fails are written transactionally inside `UpsertViolation` (violation + result rows share one `BeginTx` body), passes are written by the three `processArtist` loops in `fixer.go` and by `health_subscriber.evaluateArtist`. Browse-path `handleEvaluateArtist` and the redundant second `Evaluate` in `updateHealthScore` remain read-only so the artist grid does not become a write amplifier.
- `UpsertViolation` now short-circuits for resolved / dismissed statuses so those transitions do not re-arm `first_failed_at`. Disable-rule cleanup in `Service.Update` now also runs `DELETE FROM rule_results WHERE rule_id = ?` so stale rows do not linger after a rule flips off. Startup backfill seeds `first_failed_at` from existing `rule_violations.created_at` (idempotent via `INSERT OR IGNORE`), preserving the "how long has this been broken" signal across the migration.
- User-visible value this slice: `/api/v1/reports/compliance` now returns `rules_passed_count` and `rules_evaluated_count` per artist, documented in `openapi.yaml`. Both default to zero when `rule_results` has no row yet, so existing clients keep working. Slice 2 (per-rule and per-artist drill-down endpoints) is deferred to a separate PR.

## Test plan

- [x] `go test -race -timeout 180s ./internal/rule/... ./internal/artist/... ./internal/database/...`
- [x] `go test -race -timeout 300s ./internal/api/...`
- [x] `make lint` (0 issues)
- [x] `make fmt` (clean)
- [x] `bash scripts/pre-push-gate.sh` (all hard checks passed)
- [x] `make check-openapi` (TestOpenAPIConsistency passes)
- [x] New unit tests: `TestUpsertRuleResultPass_Insert`, `TestUpsertRuleResultPass_FailToPass`, `TestUpsertRuleResultFail_PassToFail`, `TestUpsertRuleResultFail_FailToFail` (COALESCE preservation), `TestCountRuleResultsByRule`, `TestDeleteRuleResultsForRule`, `TestUpsertViolation_WritesResultRowTransactionally`.
- [x] New integration tests: `TestPipeline_WritesPassResults`, `TestPipeline_WritesFailResultLinkedToViolation`, `TestHealthSubscriber_WritesResultsOnArtistUpdated`, `TestBackfill_SeedsFirstFailedAtFromViolationCreatedAt`.
- [x] Service-level: `TestUpdate_DisabledClearsRuleResults` added alongside the existing `TestUpdate_DisabledClearsActiveViolations` (both pass).
- [x] API: `TestHandleReportCompliance_IncludesRulesPassedCount` extends existing compliance coverage.

Part of #699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compliance reports (API + UI) now show per-artist rules_passed_count and rules_evaluated_count; rule evaluation outcomes are persisted and backfilled at startup with consistent timestamps.

* **Bug Fixes**
  * Disabling a rule now removes its persisted results; violation upserts and result writes are transactional to prevent inconsistent state.

* **Tests**
  * Added broad tests for persistence, backfill, transactional behavior, and updated compliance API expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->