### PR TITLE
fix(maintenance): proactive exists_flag consistency scanner (#984)

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -281,6 +281,12 @@ func run() error {
 	// it when that filtering is enabled. Must be created before consumers.
 	expectedWrites := watcher.NewExpectedWrites()
 
+	// Derive the image cache directory once so the publisher, API router, and
+	// maintenance service all agree on where cached artist images live. If
+	// this convention ever becomes user-configurable, it only has to change
+	// here.
+	imageCacheDir := filepath.Join(filepath.Dir(cfg.Database.Path), "cache", "images")
+
 	// Create the publisher before the pipeline so it can be injected.
 	publisher := publish.New(publish.Deps{
 		ArtistService:      artistService,
@@ -289,7 +295,7 @@ func run() error {
 		NFOSettingsService: nfoSettingsService,
 		PlatformService:    platformService,
 		ExpectedWrites:     expectedWrites,
-		ImageCacheDir:      filepath.Join(filepath.Dir(cfg.Database.Path), "cache", "images"),
+		ImageCacheDir:      imageCacheDir,
 		Logger:             logger,
 	})
 
@@ -335,7 +341,7 @@ func run() error {
 	}
 
 	// Initialize maintenance service
-	maintenanceService := maintenance.NewService(db, cfg.Database.Path, logger)
+	maintenanceService := maintenance.NewService(db, cfg.Database.Path, imageCacheDir, logger)
 
 	// Initialize settings export/import service; attach rule and scraper services
 	// so their configurations are included in export/import payloads.
@@ -487,7 +493,7 @@ func run() error {
 		BasePath:           cfg.Server.BasePath,
 		BasePathFromEnv:    cfg.Server.BasePathFromEnv,
 		StaticFS:           static.FS,
-		ImageCacheDir:      filepath.Join(filepath.Dir(cfg.Database.Path), "cache", "images"),
+		ImageCacheDir:      imageCacheDir,
 		Publisher:          publisher,
 		RuleScheduler:      ruleScheduler,
 		I18nBundle:         i18nBundle,
@@ -550,6 +556,18 @@ func run() error {
 		if maintEnabled {
 			go maintenanceService.StartScheduler(ctx, time.Duration(maintHours)*time.Hour)
 		}
+	}
+
+	// Start proactive exists_flag consistency scanner (default: every 1 hour).
+	// Reads interval from settings; falls back to 1h to guard against restart loops.
+	// startupDelay gives DB migrations and health bootstrap a chance to settle
+	// before the scanner walks artist_images.
+	{
+		existsFlagHours := getDBIntSetting(db, "exists_flag_scan.interval_hours", 1)
+		if existsFlagHours <= 0 {
+			existsFlagHours = 1
+		}
+		go maintenanceService.StartExistsFlagScanner(ctx, time.Duration(existsFlagHours)*time.Hour, 10*time.Second)
 	}
 
 	// Start session cleanup goroutine

--- a/internal/maintenance/maintenance.go
+++ b/internal/maintenance/maintenance.go
@@ -3,10 +3,15 @@ package maintenance
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"time"
+
+	img "github.com/sydlexius/stillwater/internal/image"
 )
 
 // Status holds database maintenance status information.
@@ -28,18 +33,42 @@ type ScheduleConfig struct {
 
 // Service provides database maintenance operations.
 type Service struct {
-	db     *sql.DB
-	dbPath string
-	logger *slog.Logger
+	db            *sql.DB
+	dbPath        string
+	imageCacheDir string
+	logger        *slog.Logger
 }
 
-// NewService creates a maintenance service.
-func NewService(db *sql.DB, dbPath string, logger *slog.Logger) *Service {
+// NewService creates a maintenance service. imageCacheDir is the directory
+// where platform-sourced artist images are cached for artists without a
+// filesystem path. It is derived once in cmd/stillwater/main.go and shared
+// with publish.New and api.NewRouter so all three consumers agree on where
+// cached images live -- passing a different value here would silently diverge
+// the scanner from the writers.
+func NewService(db *sql.DB, dbPath string, imageCacheDir string, logger *slog.Logger) *Service {
 	return &Service{
-		db:     db,
-		dbPath: dbPath,
-		logger: logger.With(slog.String("component", "maintenance")),
+		db:            db,
+		dbPath:        dbPath,
+		imageCacheDir: imageCacheDir,
+		logger:        logger.With(slog.String("component", "maintenance")),
 	}
+}
+
+// artistImageDir returns the directory where images for an artist are stored,
+// using the same resolution as Router.imageDir (internal/api/handlers_image.go)
+// and Publisher.ImageDir (internal/publish/publisher.go): prefer the artist's
+// library path, otherwise fall back to <imageCacheDir>/<artistID>. Returns ""
+// when neither resolves; the scanner treats that as "cannot verify" and skips
+// the row rather than clearing, so a misconfigured cache dir does not wipe
+// flags for every cache-only artist.
+func (s *Service) artistImageDir(artistPath, artistID string) string {
+	if artistPath != "" {
+		return artistPath
+	}
+	if s.imageCacheDir != "" && artistID != "" {
+		return filepath.Join(s.imageCacheDir, artistID)
+	}
+	return ""
 }
 
 // Status returns current database maintenance status.
@@ -113,6 +142,158 @@ func (s *Service) Vacuum(ctx context.Context) error {
 	}
 	s.logger.Info("vacuum complete")
 	return nil
+}
+
+// ScanExistsFlags walks all artist_images rows where exists_flag=1, checks
+// each row's image directory on disk, and clears the flag for rows whose
+// files have genuinely vanished. Rows where the directory cannot be examined
+// reliably (permission denied, I/O error, stale NFS handle, unresolvable
+// path) are skipped rather than cleared, so a transient filesystem flake
+// cannot wipe flags for thousands of artists at once.
+//
+// The scan uses the default image naming patterns. It is intentionally
+// conservative: it only clears a flag when the directory is confirmed
+// reachable AND none of the naming-pattern candidates exist under it.
+func (s *Service) ScanExistsFlags(ctx context.Context) error {
+	// Query all rows where exists_flag=1, joining artists to get the path and ID
+	// so we can reconstruct the image directory without an external dependency.
+	// Close errors on read-only cursors are not actionable -- the query is
+	// already done by the time we close -- so we suppress the lint here.
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT ai.artist_id, ai.image_type, ai.slot_index, a.path
+		FROM artist_images ai
+		JOIN artists a ON ai.artist_id = a.id
+		WHERE ai.exists_flag = 1`)
+	if err != nil {
+		return fmt.Errorf("querying exists_flag rows: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only cursor, no actionable close error
+
+	type staleRow struct {
+		artistID  string
+		imageType string
+		slotIndex int
+	}
+	// Drain the cursor into a slice before issuing any update statement.
+	// modernc.org/sqlite uses a single-writer pool, so holding this SELECT
+	// cursor open while executing writes on the same *sql.DB would serialize
+	// badly (or deadlock in pathological cases). Two-phase is not an
+	// optimization here; it is a correctness requirement under the pure-Go
+	// driver.
+	var stale []staleRow
+	checked, skipped := 0, 0
+
+	for rows.Next() {
+		var artistID, imageType, artistPath string
+		var slotIndex int
+		if err := rows.Scan(&artistID, &imageType, &slotIndex, &artistPath); err != nil {
+			return fmt.Errorf("scanning exists_flag row: %w", err)
+		}
+		checked++
+
+		dir := s.artistImageDir(artistPath, artistID)
+		if dir == "" {
+			// No resolvable path and no cache-dir fallback (misconfigured or
+			// both inputs empty). Can't verify either way -- skip rather than
+			// clear, so configuration gaps do not corrupt flags.
+			s.logger.Warn("exists_flag scan: unresolvable image dir, skipping",
+				slog.String("artist_id", artistID),
+				slog.String("image_type", imageType))
+			skipped++
+			continue
+		}
+
+		// Stat the directory before asking FindExistingImage to probe files
+		// inside it. FindExistingImage collapses any stat error to "not found",
+		// so without this guard a permission-denied directory or an unmounted
+		// NFS share would clear every flag under it.
+		if _, statErr := os.Stat(dir); statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
+			s.logger.Warn("exists_flag scan: cannot stat artist dir, skipping",
+				slog.String("artist_id", artistID),
+				slog.String("dir", dir),
+				slog.Any("error", statErr))
+			skipped++
+			continue
+		}
+
+		patterns := img.FileNamesForType(img.DefaultFileNames, imageType)
+		if _, found := img.FindExistingImage(dir, patterns); !found {
+			stale = append(stale, staleRow{artistID, imageType, slotIndex})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating exists_flag rows: %w", err)
+	}
+
+	cleared, failed := 0, 0
+	for _, r := range stale {
+		_, err := s.db.ExecContext(ctx, `
+			UPDATE artist_images SET exists_flag = 0
+			WHERE artist_id = ? AND image_type = ? AND slot_index = ?`,
+			r.artistID, r.imageType, r.slotIndex)
+		if err != nil {
+			// The whole point of the scanner is to clear these flags; a failed
+			// UPDATE means a stale flag persists, which is the exact defect
+			// this scanner exists to prevent. Surface at Error, not Warn.
+			s.logger.Error("exists_flag scan: UPDATE failed, flag remains stale",
+				slog.String("artist_id", r.artistID),
+				slog.String("image_type", r.imageType),
+				slog.Int("slot_index", r.slotIndex),
+				slog.Any("error", err))
+			failed++
+			continue
+		}
+		cleared++
+	}
+
+	s.logger.Info("exists_flag consistency scan complete",
+		slog.Int("checked", checked),
+		slog.Int("cleared", cleared),
+		slog.Int("skipped", skipped),
+		slog.Int("failed", failed))
+	return nil
+}
+
+// StartExistsFlagScanner runs ScanExistsFlags once at startup (after
+// startupDelay, so DB migrations and other boot-time I/O don't contend with
+// it) and then on a fixed interval until the context is canceled.
+//
+// The startup scan matters because stale exists_flag=1 rows manifest as
+// broken image icons and backdrop 404s on the very first page load after a
+// restart; waiting a full interval to catch up leaves the UI broken in the
+// interim.
+//
+// startupDelay is a parameter (not a constant) so tests can drive it in
+// milliseconds rather than waiting 10 seconds per test.
+func (s *Service) StartExistsFlagScanner(ctx context.Context, interval, startupDelay time.Duration) {
+	s.logger.Info("exists_flag scanner started",
+		slog.String("interval", interval.String()),
+		slog.String("startup_delay", startupDelay.String()))
+
+	select {
+	case <-ctx.Done():
+		s.logger.Info("exists_flag scanner stopped")
+		return
+	case <-time.After(startupDelay):
+	}
+	if err := s.ScanExistsFlags(ctx); err != nil {
+		s.logger.Error("initial exists_flag scan failed", slog.Any("error", err))
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("exists_flag scanner stopped")
+			return
+		case <-ticker.C:
+			if err := s.ScanExistsFlags(ctx); err != nil {
+				s.logger.Error("exists_flag scan failed", slog.Any("error", err))
+			}
+		}
+	}
 }
 
 // StartScheduler runs optimize on a fixed interval until the context is canceled.

--- a/internal/maintenance/maintenance_test.go
+++ b/internal/maintenance/maintenance_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -38,9 +39,45 @@ func setupTestDB(t *testing.T) (*sql.DB, string) {
 	return db, dbPath
 }
 
+// setupTestDBWithImages creates a DB with the artists and artist_images tables
+// in addition to the standard settings table.
+func setupTestDBWithImages(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	db, dbPath := setupTestDB(t)
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`CREATE TABLE IF NOT EXISTS artists (
+			id   TEXT NOT NULL PRIMARY KEY,
+			path TEXT NOT NULL DEFAULT ''
+		)`,
+		`CREATE TABLE IF NOT EXISTS artist_images (
+			id           TEXT NOT NULL PRIMARY KEY,
+			artist_id    TEXT NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+			image_type   TEXT NOT NULL,
+			slot_index   INTEGER NOT NULL DEFAULT 0,
+			exists_flag  INTEGER NOT NULL DEFAULT 0,
+			low_res      INTEGER NOT NULL DEFAULT 0,
+			placeholder  TEXT NOT NULL DEFAULT '',
+			width        INTEGER NOT NULL DEFAULT 0,
+			height       INTEGER NOT NULL DEFAULT 0,
+			phash        TEXT NOT NULL DEFAULT '',
+			file_format  TEXT NOT NULL DEFAULT '',
+			source       TEXT NOT NULL DEFAULT '',
+			last_written_at TEXT NOT NULL DEFAULT '',
+			locked       INTEGER NOT NULL DEFAULT 0,
+			UNIQUE(artist_id, image_type, slot_index)
+		)`,
+	} {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			t.Fatalf("setup images tables: %v", err)
+		}
+	}
+	return db, dbPath
+}
+
 func TestStatus(t *testing.T) {
 	db, dbPath := setupTestDB(t)
-	svc := NewService(db, dbPath, slog.Default())
+	svc := NewService(db, dbPath, "", slog.Default())
 
 	st, err := svc.Status(context.Background())
 	if err != nil {
@@ -69,7 +106,7 @@ func TestStatus(t *testing.T) {
 
 func TestOptimize(t *testing.T) {
 	db, dbPath := setupTestDB(t)
-	svc := NewService(db, dbPath, slog.Default())
+	svc := NewService(db, dbPath, "", slog.Default())
 
 	// Insert some data to make optimize meaningful
 	ctx := context.Background()
@@ -91,7 +128,7 @@ func TestOptimize(t *testing.T) {
 
 func TestVacuum(t *testing.T) {
 	db, dbPath := setupTestDB(t)
-	svc := NewService(db, dbPath, slog.Default())
+	svc := NewService(db, dbPath, "", slog.Default())
 
 	// Insert and delete data to create freeable space
 	ctx := context.Background()
@@ -117,7 +154,7 @@ func TestVacuum(t *testing.T) {
 
 func TestGetBoolSetting(t *testing.T) {
 	db, dbPath := setupTestDB(t)
-	svc := NewService(db, dbPath, slog.Default())
+	svc := NewService(db, dbPath, "", slog.Default())
 
 	// Default when not set
 	if !svc.getBoolSetting(context.Background(), "nonexistent", true) {
@@ -140,7 +177,7 @@ func TestGetBoolSetting(t *testing.T) {
 
 func TestGetIntSetting(t *testing.T) {
 	db, dbPath := setupTestDB(t)
-	svc := NewService(db, dbPath, slog.Default())
+	svc := NewService(db, dbPath, "", slog.Default())
 
 	// Default when not set
 	if v := svc.getIntSetting(context.Background(), "nonexistent", 42); v != 42 {
@@ -152,5 +189,278 @@ func TestGetIntSetting(t *testing.T) {
 	db.ExecContext(ctx, "INSERT INTO settings (key, value) VALUES ('test.int', '12')") //nolint:errcheck
 	if v := svc.getIntSetting(context.Background(), "test.int", 0); v != 12 {
 		t.Errorf("expected 12, got %d", v)
+	}
+}
+
+// TestScanExistsFlags verifies that ScanExistsFlags clears exists_flag for
+// rows whose image files are missing and leaves rows with real files untouched.
+func TestScanExistsFlags(t *testing.T) {
+	db, dbPath := setupTestDBWithImages(t)
+	// Inject an explicit cache dir so the "no path" scenario exercises the
+	// cache-dir fallback branch in artistImageDir rather than the degenerate
+	// "unconfigured cache dir" branch.
+	cacheDir := t.TempDir()
+	svc := NewService(db, dbPath, cacheDir, slog.Default())
+	ctx := context.Background()
+
+	// Create a real image directory with a valid file so we can verify the
+	// scan does NOT clear a flag when the file actually exists.
+	realDir := t.TempDir()
+	realFile := filepath.Join(realDir, "folder.jpg")
+	if err := os.WriteFile(realFile, []byte("img"), 0o644); err != nil {
+		t.Fatalf("creating real image file: %v", err)
+	}
+
+	// Seed artists: real path, missing path, and no path (cache-dir fallback).
+	for _, a := range []struct {
+		id   string
+		path string
+	}{
+		{"artist-real", realDir},
+		{"artist-missing", "/tmp/does-not-exist-in-tests"},
+		{"artist-nocache", ""},
+	} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artists (id, path) VALUES (?, ?)`, a.id, a.path,
+		); err != nil {
+			t.Fatalf("seeding artist %s: %v", a.id, err)
+		}
+	}
+
+	// Seed artist_images rows.
+	// Row 1: real file exists      -- flag must NOT be cleared.
+	// Row 2: missing path (ENOENT) -- flag MUST be cleared.
+	// Row 3: cache dir miss        -- flag MUST be cleared (cache dir
+	//                                 exists but artist subdir doesn't,
+	//                                 so FindExistingImage sees ENOENT).
+	// Row 4: exists_flag=0         -- must remain untouched (not even checked).
+	for _, row := range []struct {
+		id        string
+		artistID  string
+		imageType string
+		exists    int
+	}{
+		{"img-real", "artist-real", "thumb", 1},
+		{"img-missing", "artist-missing", "thumb", 1},
+		{"img-nocache", "artist-nocache", "fanart", 1},
+		{"img-zero", "artist-real", "fanart", 0},
+	} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artist_images (id, artist_id, image_type, slot_index, exists_flag)
+			 VALUES (?, ?, ?, 0, ?)`,
+			row.id, row.artistID, row.imageType, row.exists,
+		); err != nil {
+			t.Fatalf("seeding artist_image %s: %v", row.id, err)
+		}
+	}
+
+	if err := svc.ScanExistsFlags(ctx); err != nil {
+		t.Fatalf("ScanExistsFlags: %v", err)
+	}
+
+	// Helper: read exists_flag for a given image ID.
+	flagFor := func(id string) int {
+		var f int
+		if err := db.QueryRowContext(ctx,
+			`SELECT exists_flag FROM artist_images WHERE id = ?`, id).Scan(&f); err != nil {
+			t.Fatalf("reading flag for %s: %v", id, err)
+		}
+		return f
+	}
+
+	// Real file: flag must remain 1.
+	if got := flagFor("img-real"); got != 1 {
+		t.Errorf("img-real: expected exists_flag=1 (file present), got %d", got)
+	}
+	// Missing path: flag must be cleared to 0.
+	if got := flagFor("img-missing"); got != 0 {
+		t.Errorf("img-missing: expected exists_flag=0 (file absent), got %d", got)
+	}
+	// Cache dir miss: flag must be cleared to 0.
+	if got := flagFor("img-nocache"); got != 0 {
+		t.Errorf("img-nocache: expected exists_flag=0 (no cache dir), got %d", got)
+	}
+	// Already-zero row: must remain 0 and not have been re-touched.
+	if got := flagFor("img-zero"); got != 0 {
+		t.Errorf("img-zero: expected exists_flag=0 (was already 0), got %d", got)
+	}
+}
+
+// TestScanExistsFlagsEmpty verifies ScanExistsFlags succeeds on an empty table.
+func TestScanExistsFlagsEmpty(t *testing.T) {
+	db, dbPath := setupTestDBWithImages(t)
+	svc := NewService(db, dbPath, "", slog.Default())
+	if err := svc.ScanExistsFlags(context.Background()); err != nil {
+		t.Fatalf("ScanExistsFlags on empty table: %v", err)
+	}
+}
+
+// TestScanExistsFlagsUnresolvableDirSkips verifies that a row with no artist
+// path and no cache-dir fallback is SKIPPED (flag preserved) rather than
+// cleared. This matters in prod because a misconfigured imageCacheDir would
+// otherwise silently corrupt flags for every cache-only artist.
+func TestScanExistsFlagsUnresolvableDirSkips(t *testing.T) {
+	db, dbPath := setupTestDBWithImages(t)
+	// imageCacheDir="" makes the fallback unresolvable.
+	svc := NewService(db, dbPath, "", slog.Default())
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artists (id, path) VALUES ('a-unresolvable', '')`); err != nil {
+		t.Fatalf("seed artist: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artist_images (id, artist_id, image_type, slot_index, exists_flag)
+		 VALUES ('i-unresolvable', 'a-unresolvable', 'thumb', 0, 1)`); err != nil {
+		t.Fatalf("seed image: %v", err)
+	}
+
+	if err := svc.ScanExistsFlags(ctx); err != nil {
+		t.Fatalf("ScanExistsFlags: %v", err)
+	}
+
+	var flag int
+	if err := db.QueryRowContext(ctx,
+		`SELECT exists_flag FROM artist_images WHERE id = 'i-unresolvable'`).Scan(&flag); err != nil {
+		t.Fatalf("reading flag: %v", err)
+	}
+	if flag != 1 {
+		t.Errorf("unresolvable-dir row: expected exists_flag=1 (skipped), got %d", flag)
+	}
+}
+
+// TestArtistImageDir exercises all three branches of the directory-resolution
+// helper, including the defensive "return empty" fallback that the scanner
+// uses as the signal to skip a row. Covering all branches here lets the
+// integration tests above focus on scan behavior rather than permutations of
+// this helper.
+func TestArtistImageDir(t *testing.T) {
+	db, dbPath := setupTestDB(t)
+	cacheDir := "/var/lib/stillwater/cache/images"
+	svc := NewService(db, dbPath, cacheDir, slog.Default())
+
+	tests := []struct {
+		name       string
+		artistPath string
+		artistID   string
+		want       string
+	}{
+		{"artist path takes precedence", "/music/library/Tycho", "abc123", "/music/library/Tycho"},
+		{"cache-dir fallback joins artistID", "", "abc123", filepath.Join(cacheDir, "abc123")},
+		{"unresolvable: empty path + empty cache dir", "", "abc123", ""},
+		{"unresolvable: empty path + empty artistID", "", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.name == "unresolvable: empty path + empty cache dir" {
+				got := NewService(db, dbPath, "", slog.Default()).artistImageDir(tc.artistPath, tc.artistID)
+				if got != tc.want {
+					t.Errorf("artistImageDir(%q, %q) = %q, want %q", tc.artistPath, tc.artistID, got, tc.want)
+				}
+				return
+			}
+			got := svc.artistImageDir(tc.artistPath, tc.artistID)
+			if got != tc.want {
+				t.Errorf("artistImageDir(%q, %q) = %q, want %q", tc.artistPath, tc.artistID, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStartExistsFlagScanner_RunsStartupAndTick verifies the scanner performs
+// its initial scan after startupDelay and then continues on the ticker. The
+// test seeds a stale exists_flag=1 row, runs the scanner with millisecond
+// timings, and confirms the flag is cleared before the scanner is canceled.
+func TestStartExistsFlagScanner_RunsStartupAndTick(t *testing.T) {
+	db, dbPath := setupTestDBWithImages(t)
+	svc := NewService(db, dbPath, "", slog.Default())
+	ctx := context.Background()
+
+	// Seed one artist with a path that doesn't exist; exists_flag=1 should
+	// be cleared by the first scan.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artists (id, path) VALUES ('a1', '/nope-does-not-exist')`); err != nil {
+		t.Fatalf("seed artist: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artist_images (id, artist_id, image_type, slot_index, exists_flag)
+		 VALUES ('i1', 'a1', 'thumb', 0, 1)`); err != nil {
+		t.Fatalf("seed image: %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		svc.StartExistsFlagScanner(runCtx, 10*time.Millisecond, 10*time.Millisecond)
+		close(done)
+	}()
+
+	// Poll for the flag to go to 0 (proves the startup scan ran).
+	deadline := time.Now().Add(3 * time.Second)
+	cleared := false
+	for time.Now().Before(deadline) {
+		var flag int
+		if err := db.QueryRowContext(ctx,
+			`SELECT exists_flag FROM artist_images WHERE id = 'i1'`).Scan(&flag); err == nil && flag == 0 {
+			cleared = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !cleared {
+		cancel()
+		<-done
+		t.Fatal("exists_flag was not cleared within 3s")
+	}
+
+	// Re-stamp exists_flag=1 and wait for the ticker to clear it again, to
+	// prove the loop (not just the startup scan) is running.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE artist_images SET exists_flag = 1 WHERE id = 'i1'`); err != nil {
+		t.Fatalf("restamp: %v", err)
+	}
+	tickDeadline := time.Now().Add(3 * time.Second)
+	tickCleared := false
+	for time.Now().Before(tickDeadline) {
+		var flag int
+		if err := db.QueryRowContext(ctx,
+			`SELECT exists_flag FROM artist_images WHERE id = 'i1'`).Scan(&flag); err == nil && flag == 0 {
+			tickCleared = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scanner did not stop within 2s of cancel")
+	}
+	if !tickCleared {
+		t.Fatal("ticker did not re-run scan within 3s of re-stamping flag")
+	}
+}
+
+// TestStartExistsFlagScanner_CanceledDuringStartupDelay verifies the scanner
+// exits cleanly when the context is canceled before startupDelay elapses,
+// without attempting any scan or starting the ticker loop.
+func TestStartExistsFlagScanner_CanceledDuringStartupDelay(t *testing.T) {
+	db, dbPath := setupTestDBWithImages(t)
+	svc := NewService(db, dbPath, "", slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		// Long startupDelay; we'll cancel before it elapses.
+		svc.StartExistsFlagScanner(ctx, time.Hour, 30*time.Second)
+		close(done)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scanner did not stop within 2s of cancel during startup delay")
 	}
 }

--- a/internal/maintenance/maintenance_test.go
+++ b/internal/maintenance/maintenance_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -326,6 +327,82 @@ func TestScanExistsFlagsUnresolvableDirSkips(t *testing.T) {
 	}
 	if flag != 1 {
 		t.Errorf("unresolvable-dir row: expected exists_flag=1 (skipped), got %d", flag)
+	}
+}
+
+// TestScanExistsFlagsStatErrorSkips verifies that when os.Stat on the image
+// directory fails with an error other than fs.ErrNotExist (e.g. permission
+// denied from an unreadable parent), the scanner SKIPS the row and preserves
+// the flag rather than treating the stat failure as "file absent". This is
+// the critical safety guard identified during pre-push review -- without it,
+// a single permission-denied directory would wipe flags for every artist
+// under it on the next scheduled scan.
+func TestScanExistsFlagsStatErrorSkips(t *testing.T) {
+	// The chmod 0o000 trick is Unix-only. Windows uses ACLs and Go's os.Chmod
+	// maps differently; skip rather than fake it.
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o000 semantics are Unix-specific")
+	}
+	// Running as root bypasses permission bits entirely, so the stat would
+	// succeed and the branch we want to exercise never fires.
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses permission bits; cannot trigger EACCES")
+	}
+
+	db, dbPath := setupTestDBWithImages(t)
+	svc := NewService(db, dbPath, "", slog.Default())
+	ctx := context.Background()
+
+	// Create parent dir with a real child dir inside, then drop the parent's
+	// execute bit so traversal (needed to stat the child) fails with EACCES.
+	parent := t.TempDir()
+	child := filepath.Join(parent, "unreadable-artist")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("mkdir child: %v", err)
+	}
+	if err := os.Chmod(parent, 0o000); err != nil {
+		t.Fatalf("chmod parent: %v", err)
+	}
+	// Restore permissions on cleanup so t.TempDir can remove the tree.
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	// Seed the artist pointing at the unreadable child dir with a stale flag.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artists (id, path) VALUES ('a-eacces', ?)`, child); err != nil {
+		t.Fatalf("seed artist: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artist_images (id, artist_id, image_type, slot_index, exists_flag)
+		 VALUES ('i-eacces', 'a-eacces', 'thumb', 0, 1)`); err != nil {
+		t.Fatalf("seed image: %v", err)
+	}
+
+	if err := svc.ScanExistsFlags(ctx); err != nil {
+		t.Fatalf("ScanExistsFlags: %v", err)
+	}
+
+	var flag int
+	if err := db.QueryRowContext(ctx,
+		`SELECT exists_flag FROM artist_images WHERE id = 'i-eacces'`).Scan(&flag); err != nil {
+		t.Fatalf("reading flag: %v", err)
+	}
+	if flag != 1 {
+		t.Errorf("stat-error row: expected exists_flag=1 (skipped), got %d; non-ENOENT stat errors must not clear flags", flag)
+	}
+}
+
+// TestScanExistsFlagsCanceledContext verifies that a canceled context causes
+// the top-level SELECT to fail with an error, which ScanExistsFlags returns
+// to its caller rather than proceeding with an incomplete scan.
+func TestScanExistsFlagsCanceledContext(t *testing.T) {
+	db, dbPath := setupTestDBWithImages(t)
+	svc := NewService(db, dbPath, "", slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := svc.ScanExistsFlags(ctx); err == nil {
+		t.Fatal("expected error from canceled context, got nil")
 	}
 }
 

--- a/internal/maintenance/maintenance_test.go
+++ b/internal/maintenance/maintenance_test.go
@@ -3,6 +3,7 @@ package maintenance
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/database"
 	_ "modernc.org/sqlite"
 )
 
@@ -40,38 +42,26 @@ func setupTestDB(t *testing.T) (*sql.DB, string) {
 	return db, dbPath
 }
 
-// setupTestDBWithImages creates a DB with the artists and artist_images tables
-// in addition to the standard settings table.
+// setupTestDBWithImages opens a fresh SQLite DB and applies the project's
+// production migrations so the test exercises the same schema the running
+// service would see. Hand-rolling the subset of tables we touch here would
+// silently drift when 001_initial_schema.sql gains a new NOT NULL column on
+// artist_images or artists, so we run the real migration end-to-end.
 func setupTestDBWithImages(t *testing.T) (*sql.DB, string) {
 	t.Helper()
-	db, dbPath := setupTestDB(t)
-	ctx := context.Background()
-	for _, stmt := range []string{
-		`CREATE TABLE IF NOT EXISTS artists (
-			id   TEXT NOT NULL PRIMARY KEY,
-			path TEXT NOT NULL DEFAULT ''
-		)`,
-		`CREATE TABLE IF NOT EXISTS artist_images (
-			id           TEXT NOT NULL PRIMARY KEY,
-			artist_id    TEXT NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
-			image_type   TEXT NOT NULL,
-			slot_index   INTEGER NOT NULL DEFAULT 0,
-			exists_flag  INTEGER NOT NULL DEFAULT 0,
-			low_res      INTEGER NOT NULL DEFAULT 0,
-			placeholder  TEXT NOT NULL DEFAULT '',
-			width        INTEGER NOT NULL DEFAULT 0,
-			height       INTEGER NOT NULL DEFAULT 0,
-			phash        TEXT NOT NULL DEFAULT '',
-			file_format  TEXT NOT NULL DEFAULT '',
-			source       TEXT NOT NULL DEFAULT '',
-			last_written_at TEXT NOT NULL DEFAULT '',
-			locked       INTEGER NOT NULL DEFAULT 0,
-			UNIQUE(artist_id, image_type, slot_index)
-		)`,
-	} {
-		if _, err := db.ExecContext(ctx, stmt); err != nil {
-			t.Fatalf("setup images tables: %v", err)
-		}
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("opening test db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if _, err := db.ExecContext(context.Background(), "PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("enabling WAL: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("applying migrations: %v", err)
 	}
 	return db, dbPath
 }
@@ -212,17 +202,22 @@ func TestScanExistsFlags(t *testing.T) {
 		t.Fatalf("creating real image file: %v", err)
 	}
 
+	// Build a deterministic missing-path under t.TempDir() rather than a
+	// hardcoded absolute path: the latter would flake on any host that happens
+	// to have "/tmp/does-not-exist-in-tests" present.
+	missingPath := filepath.Join(t.TempDir(), "missing")
+
 	// Seed artists: real path, missing path, and no path (cache-dir fallback).
 	for _, a := range []struct {
 		id   string
 		path string
 	}{
 		{"artist-real", realDir},
-		{"artist-missing", "/tmp/does-not-exist-in-tests"},
+		{"artist-missing", missingPath},
 		{"artist-nocache", ""},
 	} {
 		if _, err := db.ExecContext(ctx,
-			`INSERT INTO artists (id, path) VALUES (?, ?)`, a.id, a.path,
+			`INSERT INTO artists (id, name, path) VALUES (?, ?, ?)`, a.id, a.id, a.path,
 		); err != nil {
 			t.Fatalf("seeding artist %s: %v", a.id, err)
 		}
@@ -307,7 +302,7 @@ func TestScanExistsFlagsUnresolvableDirSkips(t *testing.T) {
 	ctx := context.Background()
 
 	if _, err := db.ExecContext(ctx,
-		`INSERT INTO artists (id, path) VALUES ('a-unresolvable', '')`); err != nil {
+		`INSERT INTO artists (id, name, path) VALUES ('a-unresolvable', 'a-unresolvable', '')`); err != nil {
 		t.Fatalf("seed artist: %v", err)
 	}
 	if _, err := db.ExecContext(ctx,
@@ -368,7 +363,7 @@ func TestScanExistsFlagsStatErrorSkips(t *testing.T) {
 
 	// Seed the artist pointing at the unreadable child dir with a stale flag.
 	if _, err := db.ExecContext(ctx,
-		`INSERT INTO artists (id, path) VALUES ('a-eacces', ?)`, child); err != nil {
+		`INSERT INTO artists (id, name, path) VALUES ('a-eacces', 'a-eacces', ?)`, child); err != nil {
 		t.Fatalf("seed artist: %v", err)
 	}
 	if _, err := db.ExecContext(ctx,
@@ -401,8 +396,15 @@ func TestScanExistsFlagsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	if err := svc.ScanExistsFlags(ctx); err == nil {
+	err := svc.ScanExistsFlags(ctx)
+	if err == nil {
 		t.Fatal("expected error from canceled context, got nil")
+	}
+	// Assert the cancellation cause specifically so a future regression that
+	// fails ScanExistsFlags for an unrelated reason (e.g. a closed DB) cannot
+	// masquerade as a passing "respects cancel" test.
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }
 
@@ -453,10 +455,13 @@ func TestStartExistsFlagScanner_RunsStartupAndTick(t *testing.T) {
 	svc := NewService(db, dbPath, "", slog.Default())
 	ctx := context.Background()
 
-	// Seed one artist with a path that doesn't exist; exists_flag=1 should
-	// be cleared by the first scan.
+	// Seed one artist with a path under t.TempDir() that we never create;
+	// exists_flag=1 should be cleared by the first scan. Using t.TempDir()
+	// instead of a hardcoded absolute path keeps the test deterministic
+	// regardless of host filesystem state.
+	missingPath := filepath.Join(t.TempDir(), "missing")
 	if _, err := db.ExecContext(ctx,
-		`INSERT INTO artists (id, path) VALUES ('a1', '/nope-does-not-exist')`); err != nil {
+		`INSERT INTO artists (id, name, path) VALUES ('a1', 'a1', ?)`, missingPath); err != nil {
 		t.Fatalf("seed artist: %v", err)
 	}
 	if _, err := db.ExecContext(ctx,
@@ -521,15 +526,35 @@ func TestStartExistsFlagScanner_RunsStartupAndTick(t *testing.T) {
 // TestStartExistsFlagScanner_CanceledDuringStartupDelay verifies the scanner
 // exits cleanly when the context is canceled before startupDelay elapses,
 // without attempting any scan or starting the ticker loop.
+//
+// Proving prompt exit is not sufficient: a regression that runs an immediate
+// scan and then exited on cancel would also satisfy that. To guard the
+// "startup delay must block all scanning" contract, seed a stale exists_flag=1
+// row pointing at a missing path and assert it is still 1 after the scanner
+// exits. If any scan had run, the row would have been cleared.
 func TestStartExistsFlagScanner_CanceledDuringStartupDelay(t *testing.T) {
 	db, dbPath := setupTestDBWithImages(t)
 	svc := NewService(db, dbPath, "", slog.Default())
+	ctx := context.Background()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	// Seed a stale row whose image directory does not exist, so any scan that
+	// did run would clear the flag.
+	missingPath := filepath.Join(t.TempDir(), "missing")
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artists (id, name, path) VALUES ('a-startup', 'a-startup', ?)`, missingPath); err != nil {
+		t.Fatalf("seed artist: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artist_images (id, artist_id, image_type, slot_index, exists_flag)
+		 VALUES ('i-startup', 'a-startup', 'thumb', 0, 1)`); err != nil {
+		t.Fatalf("seed image: %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
 	go func() {
 		// Long startupDelay; we'll cancel before it elapses.
-		svc.StartExistsFlagScanner(ctx, time.Hour, 30*time.Second)
+		svc.StartExistsFlagScanner(runCtx, time.Hour, 30*time.Second)
 		close(done)
 	}()
 
@@ -539,5 +564,15 @@ func TestStartExistsFlagScanner_CanceledDuringStartupDelay(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("scanner did not stop within 2s of cancel during startup delay")
+	}
+
+	// The scanner must not have run any scan during the startup delay.
+	var flag int
+	if err := db.QueryRowContext(ctx,
+		`SELECT exists_flag FROM artist_images WHERE id = 'i-startup'`).Scan(&flag); err != nil {
+		t.Fatalf("reading flag: %v", err)
+	}
+	if flag != 1 {
+		t.Errorf("startup-delay contract: expected exists_flag=1 (no scan ran), got %d", flag)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds a proactive `ScanExistsFlags` pass to the maintenance service that walks every `artist_images` row with `exists_flag = 1`, resolves the expected image directory the same way `Router.imageDir` and `Publisher.ImageDir` do, and clears the flag when the files are genuinely gone. Runs once at startup (after a short settle delay) and then on a DB-configurable interval (`exists_flag_scan.interval_hours`, default `1`).
- Introduces a **skip-don't-clear** policy for rows where the directory cannot be examined reliably (permission denied, stale NFS handle, I/O error, unresolvable path). This prevents a transient filesystem flake from wiping flags for thousands of artists in a single scan.
- Hoists the image-cache-directory computation to a single site in `cmd/stillwater/main.go` and injects it into the publisher, API router, and maintenance service. All three now share one source of truth for "where cached images live," so the convention cannot drift silently if it ever becomes user-configurable.

## Why this is safe

The scanner only clears a flag when:
1. The row's image directory resolves to a non-empty path (artist path, else `<imageCacheDir>/<artistID>`), AND
2. `os.Stat(dir)` succeeds OR returns `fs.ErrNotExist` (not some other error), AND
3. `img.FindExistingImage(dir, patterns)` reports no match under the default naming patterns.

Otherwise the row is logged at Warn and skipped. Per-row `UPDATE` failures are logged at Error (the scanner's whole purpose is to clear these; a failed write means the defect persists).

## Follow-up

The root of the transient-filesystem risk is that `img.FindExistingImage` collapses *all* stat errors to `found = false`. This PR works around it at the scanner boundary; a follow-up should tighten `FindExistingImage`'s signature to distinguish `ErrNotExist` from other errors, which would benefit the reactive clear path in `handleServeImage` and the opportunistic clear in `handleRandomBackdrop` too. Filing as a separate issue.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./internal/maintenance/...` passes (8 tests incl. lifecycle, cancel-during-startup, all three `artistImageDir` branches)
- [x] `bash scripts/pre-push-gate.sh` clean; patch coverage 78.1% (threshold 70%)
- [x] Pre-push review agents: code-reviewer, pr-test-analyzer, comment-analyzer, silent-failure-hunter (critical finding on `FindExistingImage` error-discrimination mitigated at the scanner boundary + follow-up issue)
- [ ] Post-merge UAT: restart Stillwater, delete a fanart file manually, wait ~10s, verify the corresponding `exists_flag` is cleared without hitting any API endpoint

Closes #984

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background maintenance scanner that periodically verifies artist image records and clears stale/missing entries to keep image listings consistent.

* **Chores**
  * Centralized image cache directory handling for more reliable image lookup and maintenance.

* **Tests**
  * Expanded test coverage for image maintenance, scanner lifecycle, and directory-resolution behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->