### PR TITLE
fix(rule): persist artist before resolving violation (#983)

### DIFF
--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -157,6 +157,31 @@ func NewServiceWithRepos(
 	}
 }
 
+// NewDefaultRepos constructs the default SQLite-backed repository set used by
+// NewService. It is exported so tests in sibling packages can wrap one or more
+// repositories with a decorator (e.g. to inject a forced Update failure) while
+// reusing the real implementations for the remaining interfaces, then build a
+// Service via NewServiceWithRepos. Returning the interface types (not the
+// concrete sqlite structs) keeps the call site honest about what the Service
+// actually depends on.
+func NewDefaultRepos(db *sql.DB) (
+	Repository,
+	ProviderIDRepository,
+	MemberRepository,
+	AliasRepository,
+	ImageRepository,
+	PlatformIDRepository,
+	CompletenessRepository,
+) {
+	return newSQLiteArtistRepo(db),
+		newSQLiteProviderIDRepo(db),
+		newSQLiteMemberRepo(db),
+		newSQLiteAliasRepo(db),
+		newSQLiteImageRepo(db),
+		newSQLitePlatformIDRepo(db),
+		newSQLiteCompletenessRepo(db)
+}
+
 // Create inserts a new artist and persists its provider IDs and image metadata.
 // If normalized data persistence fails, the artist row is deleted as a
 // best-effort rollback (CASCADE handles child tables).

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -167,6 +167,13 @@ func (p *Pipeline) RunRuleScoped(ctx context.Context, ruleID string, scope RunSc
 		var perRuleMetadata bool
 		var perRuleImages []string
 		var perRuleDirty bool
+		// resolvedRows collects violation upserts that should land with
+		// Status=ViolationStatusResolved. Issue #983: these are deferred
+		// until AFTER updateHealthScore persists the mutated artist --
+		// writing them inline meant the violation was marked resolved
+		// even when the trailing artist Update failed, silently dropping
+		// the fix.
+		var resolvedRows []*RuleViolation
 		// persistOK tracks whether every violation/health write for this
 		// artist reached the DB. A single transient failure is enough to
 		// leave the artist dirty for retry; silently stamping it clean
@@ -261,20 +268,42 @@ func (p *Pipeline) RunRuleScoped(ctx context.Context, ruleID string, scope RunSc
 			result.Results = append(result.Results, *fr)
 			result.FixesAttempted++
 
-			status := ViolationStatusOpen
+			// Issue #983: defer the resolved upsert until AFTER
+			// updateHealthScore persists the mutated artist. Writing
+			// ViolationStatusResolved inline would silently drop the
+			// fix when the trailing Update fails -- the violation row
+			// would say "resolved" but the artist row would be
+			// unchanged. Stash the resolved rows here and upsert them
+			// only once we know the artist row landed.
 			if fr.Fixed {
 				result.FixesSucceeded++
-				status = ViolationStatusResolved
 				perRuleDirty = true
 				if fr.ImageType != "" {
 					perRuleImages = append(perRuleImages, fr.ImageType)
 				} else {
 					perRuleMetadata = true
 				}
-			} else if len(fr.Candidates) > 0 {
-				status = ViolationStatusPendingChoice
+				resolvedRows = append(resolvedRows, &RuleViolation{
+					RuleID:     v.RuleID,
+					ArtistID:   a.ID,
+					ArtistName: a.Name,
+					Severity:   v.Severity,
+					Message:    v.Message,
+					Fixable:    true,
+					Candidates: fr.Candidates,
+				})
+				continue
 			}
 
+			// Non-resolved statuses (open / pending_choice) are safe
+			// to persist inline because they do not depend on the
+			// artist row being updated: an open violation simply
+			// records that work is still pending, and pending_choice
+			// records the candidate list the user must pick from.
+			status := ViolationStatusOpen
+			if len(fr.Candidates) > 0 {
+				status = ViolationStatusPendingChoice
+			}
 			rv := &RuleViolation{
 				RuleID:     v.RuleID,
 				ArtistID:   a.ID,
@@ -284,10 +313,6 @@ func (p *Pipeline) RunRuleScoped(ctx context.Context, ruleID string, scope RunSc
 				Fixable:    true,
 				Status:     status,
 				Candidates: fr.Candidates,
-			}
-			if status == ViolationStatusResolved {
-				now := time.Now().UTC()
-				rv.ResolvedAt = &now
 			}
 			if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
 				p.logger.Warn("persisting fix result violation", "rule_id", ruleID, "artist", a.Name, "error", err)
@@ -304,6 +329,22 @@ func (p *Pipeline) RunRuleScoped(ctx context.Context, ruleID string, scope RunSc
 		postEval, persistOKHealth := p.updateHealthScore(ctx, a, perRuleDirty)
 		if !persistOKHealth {
 			persistOK = false
+		}
+		// Issue #983: only mark violations resolved once the artist row
+		// persist succeeded. When persistOKHealth is false the artist
+		// mutation never reached the DB, so leaving the violations in
+		// their pre-fix state (open) keeps them in the queue for the next
+		// pass to retry instead of silently dropping the repair.
+		if persistOKHealth {
+			now := time.Now().UTC()
+			for _, rv := range resolvedRows {
+				rv.Status = ViolationStatusResolved
+				rv.ResolvedAt = &now
+				if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
+					p.logger.Warn("persisting resolved violation", "rule_id", rv.RuleID, "artist", a.Name, "error", err)
+					persistOK = false
+				}
+			}
 		}
 		if postEval != nil {
 			postViolated := make(map[string]struct{}, len(postEval.Violations))
@@ -373,6 +414,12 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 	var metadataFixed bool
 	var fixedImageTypes []string
 	var artistDirty bool // tracks whether the artist model was modified by a fixer
+	// resolvedRows collects violation upserts that should land with
+	// Status=ViolationStatusResolved. Issue #983: these are deferred until
+	// AFTER updateHealthScore persists the mutated artist -- writing them
+	// inline meant the violation was marked resolved even when the trailing
+	// artist Update failed, silently dropping the fix.
+	var resolvedRows []*RuleViolation
 	// persistOK gates the per-artist rules_evaluated_at stamp the same way
 	// the multi-artist walker does: any violation/health write failure must
 	// leave the artist dirty so the next pass retries.
@@ -473,20 +520,33 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 		result.Results = append(result.Results, *fr)
 		result.FixesAttempted++
 
-		status := ViolationStatusOpen
+		// Issue #983: defer the resolved upsert until AFTER
+		// updateHealthScore persists the mutated artist. See the
+		// matching comment in RunRuleScoped.processArtist.
 		if fr.Fixed {
 			result.FixesSucceeded++
-			status = ViolationStatusResolved
 			artistDirty = true
 			if fr.ImageType != "" {
 				fixedImageTypes = append(fixedImageTypes, fr.ImageType)
 			} else {
 				metadataFixed = true
 			}
-		} else if len(fr.Candidates) > 0 {
-			status = ViolationStatusPendingChoice
+			resolvedRows = append(resolvedRows, &RuleViolation{
+				RuleID:     v.RuleID,
+				ArtistID:   a.ID,
+				ArtistName: a.Name,
+				Severity:   v.Severity,
+				Message:    v.Message,
+				Fixable:    true,
+				Candidates: fr.Candidates,
+			})
+			continue
 		}
 
+		status := ViolationStatusOpen
+		if len(fr.Candidates) > 0 {
+			status = ViolationStatusPendingChoice
+		}
 		rv := &RuleViolation{
 			RuleID:     v.RuleID,
 			ArtistID:   a.ID,
@@ -496,10 +556,6 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 			Fixable:    true,
 			Status:     status,
 			Candidates: fr.Candidates,
-		}
-		if status == ViolationStatusResolved {
-			now := time.Now().UTC()
-			rv.ResolvedAt = &now
 		}
 		if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
 			p.logger.Warn("persisting fix result violation", "rule_id", v.RuleID, "artist", a.Name, "error", err)
@@ -514,6 +570,20 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 	postEval, persistOKHealth := p.updateHealthScore(ctx, a, artistDirty)
 	if !persistOKHealth {
 		persistOK = false
+	}
+	// Issue #983: only resolve violations once the artist row persist
+	// succeeded. A failed Update leaves the mutation in memory; marking
+	// the violation resolved would silently drop the fix.
+	if persistOKHealth {
+		now := time.Now().UTC()
+		for _, rv := range resolvedRows {
+			rv.Status = ViolationStatusResolved
+			rv.ResolvedAt = &now
+			if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
+				p.logger.Warn("persisting resolved violation", "rule_id", rv.RuleID, "artist", a.Name, "error", err)
+				persistOK = false
+			}
+		}
 	}
 
 	if postEval != nil {
@@ -603,6 +673,12 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 		var perArtistMetadata bool
 		var perArtistImages []string
 		var perArtistDirty bool
+		// resolvedRows collects violation upserts that should land with
+		// Status=ViolationStatusResolved. Issue #983: deferred until
+		// AFTER updateHealthScore persists the mutated artist so a
+		// failed artist Update does not silently mark the violation
+		// resolved while the actual fix never reached the DB.
+		var resolvedRows []*RuleViolation
 		// See RunRuleScoped's processArtist: persistOK gates the
 		// rules_evaluated_at stamp so a transient DB failure keeps the
 		// artist in the dirty set for retry instead of masking dropped
@@ -705,20 +781,33 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 			result.Results = append(result.Results, *fr)
 			result.FixesAttempted++
 
-			status := ViolationStatusOpen
+			// Issue #983: defer the resolved upsert until AFTER
+			// updateHealthScore persists the mutated artist. See the
+			// matching comment in RunRuleScoped.processArtist.
 			if fr.Fixed {
 				result.FixesSucceeded++
-				status = ViolationStatusResolved
 				perArtistDirty = true
 				if fr.ImageType != "" {
 					perArtistImages = append(perArtistImages, fr.ImageType)
 				} else {
 					perArtistMetadata = true
 				}
-			} else if len(fr.Candidates) > 0 {
-				status = ViolationStatusPendingChoice
+				resolvedRows = append(resolvedRows, &RuleViolation{
+					RuleID:     v.RuleID,
+					ArtistID:   a.ID,
+					ArtistName: a.Name,
+					Severity:   v.Severity,
+					Message:    v.Message,
+					Fixable:    true,
+					Candidates: fr.Candidates,
+				})
+				continue
 			}
 
+			status := ViolationStatusOpen
+			if len(fr.Candidates) > 0 {
+				status = ViolationStatusPendingChoice
+			}
 			rv := &RuleViolation{
 				RuleID:     v.RuleID,
 				ArtistID:   a.ID,
@@ -728,10 +817,6 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 				Fixable:    true,
 				Status:     status,
 				Candidates: fr.Candidates,
-			}
-			if status == ViolationStatusResolved {
-				now := time.Now().UTC()
-				rv.ResolvedAt = &now
 			}
 			if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
 				p.logger.Warn("persisting fix result violation", "rule_id", v.RuleID, "artist", a.Name, "error", err)
@@ -747,6 +832,21 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 		postEval, persistOKHealth := p.updateHealthScore(ctx, a, perArtistDirty)
 		if !persistOKHealth {
 			persistOK = false
+		}
+		// Issue #983: only resolve violations once the artist row
+		// persisted cleanly. A failed Update leaves the mutation in
+		// memory; marking the violation resolved anyway would silently
+		// drop the fix.
+		if persistOKHealth {
+			now := time.Now().UTC()
+			for _, rv := range resolvedRows {
+				rv.Status = ViolationStatusResolved
+				rv.ResolvedAt = &now
+				if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
+					p.logger.Warn("persisting resolved violation", "rule_id", rv.RuleID, "artist", a.Name, "error", err)
+					persistOK = false
+				}
+			}
 		}
 		if postEval != nil {
 			postViolated := make(map[string]struct{}, len(postEval.Violations))

--- a/internal/rule/fixer_persist_order_test.go
+++ b/internal/rule/fixer_persist_order_test.go
@@ -36,8 +36,15 @@ func (r *failingArtistRepo) Update(_ context.Context, _ *artist.Artist) error {
 // setting the artist's Biography field in-memory and reporting Fixed=true. The
 // real MetadataFixer relies on a provider chain; using a stub keeps the test
 // hermetic and focused on the persistence-order invariant.
+//
+// fixCalls counts Fix invocations so the test can prove the invariant was
+// actually exercised. Without it, the no-resolved-violation assertion would
+// pass vacuously when the production path short-circuits before calling the
+// fixer -- the #983 persist-failure path skips writing any violation row on
+// Fixed=true, so "zero resolved rows" is trivially satisfied.
 type mutatingBioFixer struct {
-	mutated string // value written into a.Biography on Fix
+	mutated  string // value written into a.Biography on Fix
+	fixCalls int
 }
 
 func (f *mutatingBioFixer) CanFix(v *Violation) bool {
@@ -45,6 +52,7 @@ func (f *mutatingBioFixer) CanFix(v *Violation) bool {
 }
 
 func (f *mutatingBioFixer) Fix(_ context.Context, a *artist.Artist, v *Violation) (*FixResult, error) {
+	f.fixCalls++
 	a.Biography = f.mutated
 	return &FixResult{
 		RuleID:  v.RuleID,
@@ -188,10 +196,24 @@ func TestPipeline_PersistFailureDoesNotResolveViolation(t *testing.T) {
 				t.Errorf("artist.Biography = %q, want empty (Update should have failed and mutation should not have landed)", reloaded.Biography)
 			}
 
+			// Guard against a vacuous pass: if the production code
+			// short-circuits before invoking the fixer (e.g. engine
+			// drift hides the violation from the walker), Assertion 2
+			// below would iterate zero rows and the test would pass
+			// without proving anything about the persist-before-resolve
+			// invariant. Requiring at least one Fix() call locks in
+			// "the walker actually reached the fix-and-persist path".
+			if fixer.fixCalls == 0 {
+				t.Fatalf("fixer was never invoked; the test did not exercise the persist-before-resolve invariant")
+			}
+
 			// Assertion 2: no violation row for this artist may be
 			// ViolationStatusResolved. The fixer reported Fixed=true,
 			// but the persist failed, so the pipeline MUST leave the
-			// violation unresolved so the next pass retries.
+			// violation unresolved so the next pass retries. Note that
+			// on persist failure the walker also skips writing the
+			// Resolved row entirely -- "no matching row" is a valid
+			// pass so long as no matching row is Resolved.
 			violations, err := ruleSvc.ListViolationsFiltered(ctx, ViolationListParams{ArtistID: a.ID})
 			if err != nil {
 				t.Fatalf("ListViolationsFiltered: %v", err)

--- a/internal/rule/fixer_persist_order_test.go
+++ b/internal/rule/fixer_persist_order_test.go
@@ -1,0 +1,219 @@
+package rule
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+)
+
+// failingArtistRepo wraps a real artist.Repository and forces Update to return
+// an error. Every other method delegates to the inner repo so normal test
+// setup (Create, GetByID, MarkDirty, etc.) still works. This lets the test
+// simulate a transient Update failure mid-pipeline without disturbing the rest
+// of the persistence surface.
+type failingArtistRepo struct {
+	artist.Repository
+}
+
+// errForcedUpdate is the sentinel returned from Update. The pipeline logs the
+// error and falls back to its log-and-continue contract, so tests assert on
+// observable state (violation status, artist row, rule_results) rather than on
+// the returned error.
+var errForcedUpdate = errors.New("forced update failure")
+
+// Update always fails. rules.Pipeline.updateHealthScore calls
+// UpdateAfterRuleEvaluation -> artist.Service.update -> Repository.Update, so
+// shadowing Update here is enough to simulate the persist failure that #983
+// describes.
+func (r *failingArtistRepo) Update(_ context.Context, _ *artist.Artist) error {
+	return errForcedUpdate
+}
+
+// mutatingBioFixer is a test-only Fixer that handles bio_exists violations by
+// setting the artist's Biography field in-memory and reporting Fixed=true. The
+// real MetadataFixer relies on a provider chain; using a stub keeps the test
+// hermetic and focused on the persistence-order invariant.
+type mutatingBioFixer struct {
+	mutated string // value written into a.Biography on Fix
+}
+
+func (f *mutatingBioFixer) CanFix(v *Violation) bool {
+	return v.RuleID == RuleBioExists
+}
+
+func (f *mutatingBioFixer) Fix(_ context.Context, a *artist.Artist, v *Violation) (*FixResult, error) {
+	a.Biography = f.mutated
+	return &FixResult{
+		RuleID:  v.RuleID,
+		Fixed:   true,
+		Message: "mutated by test fixer",
+	}, nil
+}
+
+// TestPipeline_PersistFailureDoesNotResolveViolation is the regression guard
+// for issue #983. All three walker entry points (RunForArtist, RunRule,
+// RunAll) used to mark the rule_violations row as ViolationStatusResolved
+// before calling updateHealthScore -- which is the one code path that
+// persists the mutated artist. When the artist Update failed, the violation
+// was already resolved and the artist row was unchanged: the fix silently
+// disappeared and the next pass had no record that anything was wrong.
+//
+// The table covers each entry point. For each one, the pipeline is wired with
+// a real SQLite DB, the rule pipeline and service running against a normal
+// rule.Service, and an artist.Service whose Repository is wrapped by
+// failingArtistRepo so every Update returns errForcedUpdate.
+//
+// Assertions:
+//  1. The artist row reloaded from the DB must NOT have the mutated Biography
+//     (the Update never reached the DB).
+//  2. The violation row must NOT be ViolationStatusResolved. Any pre-fix
+//     status (open) is acceptable -- the point is that the pipeline must not
+//     claim the violation is resolved when the underlying fix was not
+//     persisted.
+//  3. rules_evaluated_at must not be stamped. That invariant is already held
+//     by #698's persistOK flag; the assertion guards against regression.
+//
+// The entry-point API follows the existing log-and-continue contract (failures
+// are warn-logged, not returned), so we do not assert on returned errors.
+func TestPipeline_PersistFailureDoesNotResolveViolation(t *testing.T) {
+	cases := []struct {
+		name string
+		// run invokes the pipeline entry point under test. Some take an
+		// explicit artist pointer; others scan the whole catalog. The
+		// caller supplies whichever arguments the entry point needs.
+		run func(t *testing.T, p *Pipeline, a *artist.Artist)
+	}{
+		{
+			name: "RunForArtist",
+			run: func(t *testing.T, p *Pipeline, a *artist.Artist) {
+				t.Helper()
+				if _, err := p.RunForArtist(context.Background(), a); err != nil {
+					t.Fatalf("RunForArtist: %v", err)
+				}
+			},
+		},
+		{
+			name: "RunRule",
+			run: func(t *testing.T, p *Pipeline, _ *artist.Artist) {
+				t.Helper()
+				// Scope=all so the walker touches the seeded artist
+				// regardless of the dirty-tracker state (the forced
+				// Update failure prevents the normal "mark clean"
+				// pathway, but we also want the initial run to hit the
+				// artist even when it happens to be clean).
+				if _, err := p.RunRuleScoped(context.Background(), RuleBioExists, RunScopeAll); err != nil {
+					t.Fatalf("RunRuleScoped: %v", err)
+				}
+			},
+		},
+		{
+			name: "RunAll",
+			run: func(t *testing.T, p *Pipeline, _ *artist.Artist) {
+				t.Helper()
+				if _, err := p.RunAllScoped(context.Background(), RunScopeAll); err != nil {
+					t.Fatalf("RunAllScoped: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := setupTestDB(t)
+			ctx := context.Background()
+
+			// Seed the rule service and leave only bio_exists enabled
+			// in auto mode, so the mutating fixer runs and nothing
+			// else introduces noise.
+			ruleSvc := NewService(db)
+			if err := ruleSvc.SeedDefaults(ctx); err != nil {
+				t.Fatalf("SeedDefaults: %v", err)
+			}
+			disableAllRulesExcept(t, db, RuleBioExists)
+			if _, err := db.ExecContext(ctx,
+				`UPDATE rules SET automation_mode = ? WHERE id = ?`,
+				AutomationModeAuto, RuleBioExists); err != nil {
+				t.Fatalf("setting automation_mode=auto: %v", err)
+			}
+
+			// Build an artist.Service whose Repository wraps the real
+			// sqlite repo and fails every Update. The other six repos
+			// come straight from NewDefaultRepos so Create, provider
+			// persistence, etc. all work as normal during setup.
+			realArtists, providers, members, aliases, images, platformIDs, completeness := artist.NewDefaultRepos(db)
+			artistSvc := artist.NewServiceWithRepos(
+				&failingArtistRepo{Repository: realArtists},
+				providers, members, aliases, images, platformIDs, completeness,
+			)
+
+			// Seed a single artist with an empty biography so
+			// bio_exists reports a violation. Create goes straight
+			// through to the underlying repo's Create (the decorator
+			// only overrides Update), so the row is inserted as
+			// expected.
+			a := &artist.Artist{
+				Name:      "Persist Order " + tc.name,
+				SortName:  "Persist Order " + tc.name,
+				Path:      t.TempDir(),
+				Biography: "",
+			}
+			if err := artistSvc.Create(ctx, a); err != nil {
+				t.Fatalf("creating artist: %v", err)
+			}
+
+			// Force the artist into the dirty set so the incremental
+			// walker would pick it up too. The explicit mark is
+			// harmless for RunScopeAll callers.
+			if err := artistSvc.MarkDirty(ctx, a.ID, time.Now().UTC()); err != nil {
+				t.Fatalf("MarkDirty: %v", err)
+			}
+
+			engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+			fixer := &mutatingBioFixer{mutated: "mutated"}
+			pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{fixer}, nil, testLogger())
+
+			tc.run(t, pipeline, a)
+
+			// Assertion 1: the mutated Biography must never reach the
+			// DB. The failingArtistRepo refuses every Update, so the
+			// row we read back must still carry the empty biography.
+			reloaded, err := realArtists.GetByID(ctx, a.ID)
+			if err != nil {
+				t.Fatalf("reloading artist: %v", err)
+			}
+			if reloaded.Biography != "" {
+				t.Errorf("artist.Biography = %q, want empty (Update should have failed and mutation should not have landed)", reloaded.Biography)
+			}
+
+			// Assertion 2: no violation row for this artist may be
+			// ViolationStatusResolved. The fixer reported Fixed=true,
+			// but the persist failed, so the pipeline MUST leave the
+			// violation unresolved so the next pass retries.
+			violations, err := ruleSvc.ListViolationsFiltered(ctx, ViolationListParams{ArtistID: a.ID})
+			if err != nil {
+				t.Fatalf("ListViolationsFiltered: %v", err)
+			}
+			for _, v := range violations {
+				if v.RuleID != RuleBioExists {
+					continue
+				}
+				if v.Status == ViolationStatusResolved {
+					t.Errorf("violation for %s has Status=%q, want anything but %q -- resolve MUST NOT run before the artist Update succeeds",
+						v.RuleID, v.Status, ViolationStatusResolved)
+				}
+			}
+
+			// Assertion 3: rules_evaluated_at must still be nil. This
+			// is already protected by #698's persistOK flag; the
+			// check guards against a regression that would let the
+			// walker stamp the artist clean despite a transient DB
+			// failure on the main row.
+			if reloaded.RulesEvaluatedAt != nil {
+				t.Errorf("rules_evaluated_at = %v, want nil (walker must not stamp when persist failed)", reloaded.RulesEvaluatedAt)
+			}
+		})
+	}
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -520,15 +520,25 @@ func TestApplyConcurrentRace(t *testing.T) {
 	svc := buildTestService(t)
 	ctx := context.Background()
 
-	// Serve an empty release list so runApply exits immediately without
-	// touching the filesystem. The test only cares about the Apply return values.
+	// Hold the release fetch open so the winning goroutine's runApply
+	// stays in-flight (keeping applyRunning=1) until after both
+	// goroutines have raced through CompareAndSwap. Without the block,
+	// runApply can finish its fast-path (GetConfig -> empty release
+	// list -> defer Store(0)) before the second goroutine's Apply
+	// runs on a slow CI runner, leaving both CAS calls to succeed and
+	// the test to report "got 2/0".
 	releases := []map[string]interface{}{}
 	body, _ := json.Marshal(releases)
+	httpBlock := make(chan struct{})
+	var released sync.Once
+	unblock := func() { released.Do(func() { close(httpBlock) }) }
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-httpBlock
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(body)
 	}))
 	defer srv.Close()
+	defer unblock()
 	svc.SetHTTPClient(&http.Client{Transport: &rewriteHostTransport{base: srv.URL}})
 
 	errs := make([]error, 2)
@@ -558,7 +568,8 @@ func TestApplyConcurrentRace(t *testing.T) {
 		t.Errorf("expected 1 success and 1 ErrAlreadyRunning, got %d/%d", nils, blocked)
 	}
 
-	// Wait for the goroutine that did launch to finish so the test is clean.
+	// Release runApply so it can complete and drain its goroutine cleanly.
+	unblock()
 	waitForIdle(t, svc, 5*time.Second)
 }
 


### PR DESCRIPTION
## Summary

Closes #983.

Three walker entry points in the rule pipeline (`RunForArtist`, `RunRule`, `RunAll`) wrote `rule_violations.status = 'resolved'` BEFORE calling `updateHealthScore`, which is the one code path that persists the mutated artist (`UpdateAfterRuleEvaluation` -> `Repository.Update`). When the trailing Update failed (transient DB error, lock conflict, constraint), the violation row said `resolved` but the artist row was unchanged: the fix silently disappeared and the next pass had no signal that anything was wrong.

## Approach

- Collect fixed violations in a per-iteration `resolvedRows` slice.
- Write non-resolved statuses (`open`, `pending_choice`, `unfixable`) inline as before. They do not depend on the artist row landing.
- After `updateHealthScore` returns, check its existing `persistOK` bool. Only when the artist row persisted cleanly do we upsert the `resolved` status.
- On persist failure the violations stay at their pre-fix status (`open`) so the next walker pass retries and re-applies the in-memory fix.
- `updateHealthScore`'s returned bool already means "artist row reached the DB in this call" (it propagates the error from `UpdateAfterRuleEvaluation`), so no new signal is needed.

`FixViolation` (single-violation path) already persists-then-resolves and is not touched. No public signatures change; no schema changes; the three walker bodies are intentionally NOT refactored into a shared helper, per the plan.

The test file adds a `failingArtistRepo` decorator that wraps the real SQLite artist repository and returns `errors.New("forced update failure")` from every `Update`. Every other method delegates to the real repo so setup (`Create`, `MarkDirty`, `GetByID`) works normally. Table-driven across `RunForArtist`, `RunRule`, and `RunAll`. A small companion export `artist.NewDefaultRepos` was added so the test can build a `Service` via `NewServiceWithRepos` without re-implementing every sub-repo.

## Proof the bug existed

Running ONLY the new test against the unchanged production code (before the fix) fails on all three entry points:

```
2026/04/21 18:10:00 ERROR persisting artist after fixes component=fix-pipeline artist="Persist Order RunForArtist" error="forced update failure"
2026/04/21 18:10:00 ERROR persisting artist after fixes component=fix-pipeline artist="Persist Order RunRule" error="forced update failure"
2026/04/21 18:10:00 ERROR persisting artist after fixes component=fix-pipeline artist="Persist Order RunAll" error="forced update failure"
--- FAIL: TestPipeline_PersistFailureDoesNotResolveViolation (0.13s)
    --- FAIL: TestPipeline_PersistFailureDoesNotResolveViolation/RunForArtist (0.04s)
        fixer_persist_order_test.go:204: violation for bio_exists has Status="resolved", want anything but "resolved" -- resolve MUST NOT run before the artist Update succeeds
    --- FAIL: TestPipeline_PersistFailureDoesNotResolveViolation/RunRule (0.04s)
        fixer_persist_order_test.go:204: violation for bio_exists has Status="resolved", want anything but "resolved" -- resolve MUST NOT run before the artist Update succeeds
    --- FAIL: TestPipeline_PersistFailureDoesNotResolveViolation/RunAll (0.04s)
        fixer_persist_order_test.go:204: violation for bio_exists has Status="resolved", want anything but "resolved" -- resolve MUST NOT run before the artist Update succeeds
FAIL
FAIL    github.com/sydlexius/stillwater/internal/rule    0.669s
```

With the production fix applied the same test passes on all three entry points.

## Test plan

- [x] New table-driven regression test fails BEFORE fix and passes AFTER fix across `RunForArtist`, `RunRule`, `RunAll`.
- [x] `go test -race -count=1 ./internal/rule/... ./internal/artist/...` green.
- [x] `bash scripts/pre-push-gate.sh` green (tests, OpenAPI consistency, generated files, raw error leak check, breaking-change check, patch coverage).
- [x] No public API changes (signatures and interfaces unchanged).
- [x] No schema or migration changes.
- [x] `FixViolation` single-violation path is NOT touched (already orders correctly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal repository wiring to make real backend repos available for tests, enhancing maintainability and testability.

* **Tests**
  * Added regression coverage ensuring rule fixes are only marked resolved when the corresponding artist update is successfully persisted; verifies pipeline behavior when persistence fails.
  * Strengthened concurrency test for the updater to reliably reproduce and assert a single concurrent apply winner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->