### PR TITLE
fix(ci): bump cosign to current stable in release workflows

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -137,7 +137,7 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
         with:
-          cosign-release: 'v2.4.1'
+          cosign-release: 'v3.0.6'
 
       # Checkout the tag we just created so GoReleaser resolves {{ .Version }}
       # from the tag rather than from the branch head.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
         with:
-          cosign-release: 'v2.4.1'
+          cosign-release: 'v3.0.6'
 
       # For stable tags (no -rc/-beta/-alpha suffix), force goreleaser to
       # compute the changelog from the previous *stable* tag, not the most


### PR DESCRIPTION
## Summary
- Bumps `sigstore/cosign-installer`'s `cosign-release` input from v2.4.1 to v3.0.6 in both release-nightly.yml and release.yml.
- Pre-empts the cosign-vs-goreleaser skew that failed nightly run 24707969374 and would have failed the next stable tag cut.
- Confirms Dependabot watches `github-actions` so future bumps self-serve.

## Context
goreleaser-action uses the installed cosign to verify the goreleaser release tarball it downloads. cosign v2.4.1 cannot parse goreleaser v2.15+'s certless sigstore bundle, so the action aborts before our build runs. Bumping cosign restores compatibility without changing our signing story — our own artifacts are still signed further downstream in the goreleaser config.

No goreleaser config changes needed: the `signs:` / `docker_signs:` blocks in `.goreleaser.yml` and `.goreleaser.nightly.yml` use `sign-blob`/`sign` with `--output-certificate`, `--output-signature`, and `--yes`, all of which are stable across cosign 2.4 → 3.x.

## Test plan
- [ ] actionlint (if installed) passes  — skipped locally (not installed), workflow diff is versions-only so risk is minimal
- [ ] Workflow diff is versions-only (no behaviour change)
- [ ] After merge, delete the dangling `nightly-20260421` tag (see Post-merge actions)
- [ ] After merge, wait for next scheduled nightly run (or manual workflow_dispatch) and confirm a `nightly-YYYYMMDD` release appears with per-arch binaries and SHA256SUMS
- [ ] Next stable tag cut produces a release as normal

## Post-merge actions (reviewer runs)
1. `gh api -X DELETE /repos/sydlexius/stillwater/git/refs/tags/nightly-20260421`
2. Optionally trigger a manual nightly run to verify immediately: `gh workflow run release-nightly.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release build tooling to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->