### PR TITLE
ci: add actionlint pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           DIRTY=$(git diff --name-only | grep -E '_templ\.go$' || true)
           if [ -n "$DIRTY" ]; then
             echo "Generated templ files are out of date:"
-            echo "$DIRTY" | sed 's/^/  /'
+            echo "  ${DIRTY//$'\n'/$'\n'  }"
             echo "Run 'templ generate' locally and commit the results."
             exit 1
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,11 @@ repos:
     hooks:
       - id: golangci-lint
 
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
   - repo: local
     hooks:
       - id: templ-generate


### PR DESCRIPTION
## Summary

- Adds `rhysd/actionlint` (pinned v1.7.12) to `.pre-commit-config.yaml`.
- Hook is auto-scoped to `.github/workflows/*.{yml,yaml}` so non-workflow commits are not slowed.
- Fixes one pre-existing SC2001 shellcheck finding in `ci.yml` so the hook passes cleanly on main.

Why v1.7.12: matches the actionlint version installed on the dev machine, so local and CI lint outputs stay identical.

## Test plan

- [x] `pre-commit run actionlint --all-files` green on the branch
- [x] All existing pre-commit hooks still pass on the commit (see commit output)
- [ ] CI passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow error output formatting
  * Added GitHub Actions linting to development pre-commit checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->