### PR TITLE
fix(ci): pass --new-bundle-format=false to cosign sign-blob

### DIFF
--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -63,6 +63,7 @@ signs:
     certificate: "${artifact}.pem"
     args:
       - sign-blob
+      - --new-bundle-format=false
       - --output-certificate=${certificate}
       - --output-signature=${signature}
       - ${artifact}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -94,6 +94,7 @@ signs:
     certificate: "${artifact}.pem"
     args:
       - sign-blob
+      - --new-bundle-format=false
       - --output-certificate=${certificate}
       - --output-signature=${signature}
       - ${artifact}


### PR DESCRIPTION
## Summary

- Follow-up to #1164. The cosign v2.4.1 → v3.0.6 bump fixed goreleaser-action's ability to verify the goreleaser tarball, but the **inner** cosign invocation (goreleaser's `signs:` stanza running `cosign sign-blob`) still failed.
- Cosign v3 flipped the sign-blob default from legacy separate-files output (`.sig` + `.pem`) to a single new-format bundle. In new-bundle mode, `--output-signature` and `--output-certificate` are silently ignored and `--bundle=<path>` becomes required.
- Without `--bundle`, cosign tried to open `""` and failed: `create bundle file: open : no such file or directory`.
- This PR adds `--new-bundle-format=false` to both `signs:` stanzas, restoring legacy behaviour and preserving the existing `.sig` + `.pem` verification UX for downstream consumers.

## Context

Observed in nightly run [24755688643](https://github.com/sydlexius/stillwater/actions/runs/24755688643):

```
WARNING: --output-signature is deprecated when using --new-bundle-format and will be ignored
WARNING: --output-certificate is deprecated when using --new-bundle-format and will be ignored
Generating ephemeral keys...
Using payload from: dist/stillwater_nightly-20260422_checksums.txt
Signing artifact...
Error: signing dist/...: create bundle file: open : no such file or directory
```

`docker_signs:` uses `cosign sign` (OCI registry-based) and is unaffected.

## Test plan

- [ ] Workflow-agnostic change (goreleaser config only); no local smoke is meaningful.
- [ ] After merge, trigger manual nightly run (`gh workflow run release-nightly.yml`) and confirm a `nightly-YYYYMMDD` release appears with binaries, `*.sig`, `*.pem`, and `SHA256SUMS`.
- [ ] Next stable tag cut still signs checksums in legacy format.

## Follow-up

`--new-bundle-format=false` is a stopgap; cosign will eventually remove the legacy path entirely. Migrating to `--bundle=<path>` output + updated verification docs should be tracked as a separate issue (not urgent — the `false` flag is explicitly supported for exactly this transition).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated signing configuration for release artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->