### PR TITLE
fix(ci): migrate cosign sign-blob to --bundle output

### DIFF
--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -14,7 +14,7 @@ version: 2
 #   - docker_signs: no Docker artifacts produced here.
 #
 # Keeps cosign keyless signing of the checksums blob to match stable pipeline
-# behavior (checksums.txt.pem / .sig accompany every release).
+# behavior (checksums.txt.sig.bundle accompanies every release).
 
 before:
   hooks:

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -60,12 +60,11 @@ archives:
 # `id-token: write` on the calling workflow.
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sig.bundle"
     args:
       - sign-blob
-      - --new-bundle-format=false
-      - --output-certificate=${certificate}
-      - --output-signature=${signature}
+      - --new-bundle-format
+      - --bundle=${signature}
       - ${artifact}
       - --yes
     artifacts: checksum

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,12 +91,11 @@ docker_manifests:
 
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.sig.bundle"
     args:
       - sign-blob
-      - --new-bundle-format=false
-      - --output-certificate=${certificate}
-      - --output-signature=${signature}
+      - --new-bundle-format
+      - --bundle=${signature}
       - ${artifact}
       - --yes
     artifacts: checksum


### PR DESCRIPTION
## Summary

Follow-up to #1166, which failed at nightly time. Setting `--new-bundle-format=false` did **not** restore legacy behaviour as I'd assumed — cosign v3 treats that flag value as an *affirmative opt-out* and then rejects the deprecated `--output-signature` / `--output-certificate` flags, requiring one of `--bundle` or `--new-bundle-format` to be set explicitly.

This PR migrates the `signs:` stanza in both `.goreleaser.yml` and `.goreleaser.nightly.yml` to the new bundle format (the direction cosign is moving toward permanently):

- Drop `certificate:` field and `--output-certificate` / `--output-signature` args (all deprecated or ignored in v3 new-bundle mode).
- Add `signature: "${artifact}.sig.bundle"` so goreleaser publishes the bundle as a release artifact.
- Add `--new-bundle-format` and `--bundle=${signature}` to the cosign args.

## Failure observed

Nightly run [24756755089](https://github.com/sydlexius/stillwater/actions/runs/24756755089):

```
WARNING: --output-signature is deprecated when using --new-bundle-format and will be ignored
WARNING: --output-certificate is deprecated when using --new-bundle-format and will be ignored
Error: must provide --new-bundle-format or --bundle where applicable with --signing-config or --use-signing-config
```

## Downstream verification UX change

Release consumers previously verified with:

```
cosign verify-blob \
  --signature <file>.sig \
  --certificate <file>.pem \
  <file>
```

After this change, they verify with:

```
cosign verify-blob --bundle <file>.sig.bundle <file>
```

The cert is embedded inside the bundle rather than published as a separate artifact. No downstream docs/README currently describe verification, so no documentation update is needed in this PR.

Docker image signing (`docker_signs:`) is unaffected — it uses OCI registry attachments, not file output.

## Test plan

- [ ] Pre-push gate passes (YAML-only diff, no Go changes).
- [ ] After merge, delete the dangling `nightly-20260422` tag (already done during triage, listed here for completeness).
- [ ] After merge, trigger manual nightly run and confirm a `nightly-YYYYMMDD` release appears with per-arch binaries, `*.sig.bundle`, and `SHA256SUMS`.
- [ ] Next stable tag cut signs checksums in the new bundle format.

## Post-merge actions (reviewer runs)

1. `gh workflow run release-nightly.yml` to verify end-to-end.
2. If further nightly tags got created during triage, clean them up: `gh api -X DELETE /repos/sydlexius/stillwater/git/refs/tags/nightly-YYYYMMDD`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched release signing to produce signature bundles instead of separate certificate files.
  * Adjusted signing behavior and arguments to emit a bundled signature artifact and removed the prior certificate output.
  * Signing still targets checksum artifacts and continues to produce signing output as part of the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->