### PR TITLE
fix(providers): extract WikidataID from MB URLs and accept QIDs in Wikidata lookup (#1158)

### DIFF
--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -934,6 +934,7 @@ func EnrichProviderIDs(meta *ArtistMetadata, providerIDs map[ProviderName]string
 		URLs:       meta.URLs,
 		DiscogsID:  meta.DiscogsID,
 		DeezerID:   meta.DeezerID,
+		WikidataID: meta.WikidataID,
 		AllMusicID: meta.AllMusicID,
 		SpotifyID:  meta.SpotifyID,
 	}
@@ -951,6 +952,18 @@ func EnrichProviderIDs(meta *ArtistMetadata, providerIDs map[ProviderName]string
 	if scratch.DeezerID != "" {
 		if current := providerIDs[NameDeezer]; current == "" {
 			providerIDs[NameDeezer] = scratch.DeezerID
+		}
+	}
+	// Wikidata URLs from MusicBrainz carry the Q-item ID directly
+	// (e.g. "https://www.wikidata.org/wiki/Q175044"). Propagating this
+	// into providerIDs lets the orchestrator call Wikidata by QID instead
+	// of MBID, which is important when the Wikidata entity does not have
+	// its P434 (MusicBrainz artist ID) property populated. The P434-based
+	// SPARQL lookup returns no bindings in that case, so a pre-resolved
+	// QID is the only reliable path.
+	if scratch.WikidataID != "" {
+		if current := providerIDs[NameWikidata]; current == "" {
+			providerIDs[NameWikidata] = scratch.WikidataID
 		}
 	}
 	if scratch.AllMusicID != "" {

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -17,6 +17,13 @@ import (
 // whitespace, quote, or end of string.
 var sensitiveParamRe = regexp.MustCompile(`(?i)(api_?key|token|secret|password|authorization)=([^&\s"']+)`)
 
+// wikidataQIDRe matches a well-formed Wikidata Q-item identifier. Callers that
+// accept a last-path-segment as a QID must validate against this to avoid
+// propagating malformed values like "Qabc" or "Qspecial:Random" through
+// providerIDs, which would otherwise drive a failed direct-entity SPARQL and
+// mask the MBID fallback.
+var wikidataQIDRe = regexp.MustCompile(`^Q[0-9]+$`)
+
 // ScrubError removes sensitive query parameter values (API keys, tokens, passwords)
 // from error strings before they are written to logs. Provider errors may contain
 // full request URLs with credentials in query parameters (e.g. Fanart.tv includes
@@ -200,7 +207,7 @@ func (o *Orchestrator) FetchMetadata(ctx context.Context, mbid, name string, pro
 
 	// Final backfill pass for the merged metadata (catches any IDs not yet
 	// populated from earlier per-provider enrichment).
-	extractProviderIDsFromURLs(result.Metadata)
+	ExtractProviderIDsFromURLs(result.Metadata)
 
 	// MusicBrainz is authoritative for artist Name and SortName: it owns the
 	// MBID and applies language-aware alias promotion inline on its meta.Name.
@@ -938,7 +945,7 @@ func EnrichProviderIDs(meta *ArtistMetadata, providerIDs map[ProviderName]string
 		AllMusicID: meta.AllMusicID,
 		SpotifyID:  meta.SpotifyID,
 	}
-	extractProviderIDsFromURLs(scratch)
+	ExtractProviderIDsFromURLs(scratch)
 
 	// Only set IDs that are not already populated. We preserve non-empty
 	// stored IDs because the caller's existing ID is authoritative.
@@ -978,7 +985,7 @@ func EnrichProviderIDs(meta *ArtistMetadata, providerIDs map[ProviderName]string
 	}
 }
 
-// extractProviderIDsFromURLs backfills provider IDs from URL relations returned
+// ExtractProviderIDsFromURLs backfills provider IDs from URL relations returned
 // by MusicBrainz when the IDs are not yet set.
 //
 // MusicBrainz URL relations look like:
@@ -988,7 +995,7 @@ func EnrichProviderIDs(meta *ArtistMetadata, providerIDs map[ProviderName]string
 //	wikidata: "https://www.wikidata.org/wiki/Q44190"       -> "Q44190"
 //	deezer:   "https://www.deezer.com/artist/3106"         -> "3106"
 //	allmusic: "https://www.allmusic.com/artist/mn0000505828" -> "mn0000505828"
-func extractProviderIDsFromURLs(meta *ArtistMetadata) {
+func ExtractProviderIDsFromURLs(meta *ArtistMetadata) {
 	if meta == nil {
 		return
 	}
@@ -1018,7 +1025,7 @@ func extractProviderIDsFromURLs(meta *ArtistMetadata) {
 			}
 			if idx := strings.LastIndex(u, "/"); idx >= 0 {
 				candidate := u[idx+1:]
-				if len(candidate) > 1 && candidate[0] == 'Q' {
+				if wikidataQIDRe.MatchString(candidate) {
 					meta.WikidataID = candidate
 				}
 			}

--- a/internal/provider/orchestrator_test.go
+++ b/internal/provider/orchestrator_test.go
@@ -2414,3 +2414,60 @@ func TestOrchestratorPopulatedFields_DedupAcrossProviders(t *testing.T) {
 		t.Errorf("expected genres aggregated across both providers, got %v", result.Metadata.Genres)
 	}
 }
+
+// TestEnrichProviderIDs_ExtractsWikidataID verifies that a Wikidata URL
+// relation returned by MusicBrainz is extracted into providerIDs so that
+// subsequent Wikidata calls can look up the entity by its QID directly
+// (required when the Wikidata entity lacks a P434 cross-link).
+func TestEnrichProviderIDs_ExtractsWikidataID(t *testing.T) {
+	providerIDs := make(map[ProviderName]string)
+	meta := &ArtistMetadata{
+		URLs: map[string]string{
+			"wikidata": "https://www.wikidata.org/wiki/Q175044",
+		},
+	}
+
+	EnrichProviderIDs(meta, providerIDs)
+
+	if got := providerIDs[NameWikidata]; got != "Q175044" {
+		t.Errorf("providerIDs[NameWikidata] = %q, want %q", got, "Q175044")
+	}
+}
+
+// TestEnrichProviderIDs_IgnoresMalformedWikidataURL verifies that URLs that
+// do not end in a Q-item ID (e.g. Special:Random pages) do not populate the
+// Wikidata provider ID.
+func TestEnrichProviderIDs_IgnoresMalformedWikidataURL(t *testing.T) {
+	providerIDs := make(map[ProviderName]string)
+	meta := &ArtistMetadata{
+		URLs: map[string]string{
+			"wikidata": "https://www.wikidata.org/wiki/Special:Random",
+		},
+	}
+
+	EnrichProviderIDs(meta, providerIDs)
+
+	if got, ok := providerIDs[NameWikidata]; ok && got != "" {
+		t.Errorf("providerIDs[NameWikidata] = %q, want unset/empty", got)
+	}
+}
+
+// TestEnrichProviderIDs_PreservesExistingWikidataID verifies that a pre-existing
+// Wikidata ID in providerIDs is not overwritten by URL extraction, matching
+// the first-write-wins behavior used for the other providers.
+func TestEnrichProviderIDs_PreservesExistingWikidataID(t *testing.T) {
+	providerIDs := map[ProviderName]string{
+		NameWikidata: "Q999999",
+	}
+	meta := &ArtistMetadata{
+		URLs: map[string]string{
+			"wikidata": "https://www.wikidata.org/wiki/Q175044",
+		},
+	}
+
+	EnrichProviderIDs(meta, providerIDs)
+
+	if got := providerIDs[NameWikidata]; got != "Q999999" {
+		t.Errorf("providerIDs[NameWikidata] = %q, want pre-existing %q", got, "Q999999")
+	}
+}

--- a/internal/provider/orchestrator_test.go
+++ b/internal/provider/orchestrator_test.go
@@ -1063,7 +1063,7 @@ func TestExtractProviderIDsFromURLs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			meta := &ArtistMetadata{URLs: tt.urls}
-			extractProviderIDsFromURLs(meta)
+			ExtractProviderIDsFromURLs(meta)
 			if meta.DiscogsID != tt.wantDiscogsID {
 				t.Errorf("DiscogsID: got %q, want %q", meta.DiscogsID, tt.wantDiscogsID)
 			}
@@ -1097,7 +1097,7 @@ func TestExtractProviderIDsFromURLs(t *testing.T) {
 				"spotify":  "https://open.spotify.com/artist/4Z8W4fKeB5YxbusRsdQVPb",
 			},
 		}
-		extractProviderIDsFromURLs(meta)
+		ExtractProviderIDsFromURLs(meta)
 		if meta.DiscogsID != "existing" {
 			t.Errorf("DiscogsID was overwritten: got %q", meta.DiscogsID)
 		}
@@ -2469,5 +2469,50 @@ func TestEnrichProviderIDs_PreservesExistingWikidataID(t *testing.T) {
 
 	if got := providerIDs[NameWikidata]; got != "Q999999" {
 		t.Errorf("providerIDs[NameWikidata] = %q, want pre-existing %q", got, "Q999999")
+	}
+}
+
+// TestExtractProviderIDsFromURLs_RejectsInvalidQID verifies that the Wikidata
+// URL parser requires a well-formed Q-item identifier (Q followed by digits).
+// Addresses the CodeRabbit review finding on PR #1177: before this hardening,
+// a URL like /wiki/Qabc or /wiki/Qspecial:Random would accept "Qabc" or
+// "Qspecial:Random" as a "QID" and propagate it into providerIDs, which would
+// then drive a failed direct-entity SPARQL and mask the MBID fallback path.
+func TestExtractProviderIDsFromURLs_RejectsInvalidQID(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{"alpha chars", "https://www.wikidata.org/wiki/Qabc"},
+		{"mixed alphanum", "https://www.wikidata.org/wiki/Q12a34"},
+		{"colon suffix", "https://www.wikidata.org/wiki/Q123:suffix"},
+		{"lowercase q", "https://www.wikidata.org/wiki/q12345"},
+		{"just Q", "https://www.wikidata.org/wiki/Q"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := &ArtistMetadata{
+				URLs: map[string]string{"wikidata": tc.url},
+			}
+			ExtractProviderIDsFromURLs(meta)
+			if meta.WikidataID != "" {
+				t.Errorf("URL %q produced WikidataID=%q, want empty (invalid QID must be rejected)",
+					tc.url, meta.WikidataID)
+			}
+		})
+	}
+}
+
+// TestExtractProviderIDsFromURLs_AcceptsValidQID verifies that the Wikidata
+// URL parser still accepts well-formed Q-item identifiers after the
+// validation tightening.
+func TestExtractProviderIDsFromURLs_AcceptsValidQID(t *testing.T) {
+	meta := &ArtistMetadata{
+		URLs: map[string]string{"wikidata": "https://www.wikidata.org/wiki/Q175044"},
+	}
+	ExtractProviderIDsFromURLs(meta)
+	if meta.WikidataID != "Q175044" {
+		t.Errorf("WikidataID = %q, want Q175044", meta.WikidataID)
 	}
 }

--- a/internal/provider/wikidata/wikidata.go
+++ b/internal/provider/wikidata/wikidata.go
@@ -8,11 +8,22 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/provider"
 )
+
+// qidPattern matches a Wikidata Q-item identifier ("Q" followed by at least
+// one digit). It is used to distinguish QIDs from MusicBrainz UUIDs when a
+// caller passes either form to GetArtist.
+var qidPattern = regexp.MustCompile(`^Q\d+$`)
+
+// isQID returns true if s matches the Wikidata Q-item identifier format.
+func isQID(s string) bool {
+	return qidPattern.MatchString(s)
+}
 
 const (
 	defaultEndpoint        = "https://query.wikidata.org/sparql"
@@ -62,14 +73,26 @@ func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSe
 	return nil, nil
 }
 
-// GetArtist fetches metadata for an artist from Wikidata by their MusicBrainz ID.
-// When the caller has set metadata language preferences in the context, the SPARQL
-// query uses those preferences in wikibase:label so that entity labels (artist name,
-// country name, genre name) are returned in the user's preferred language.
-func (a *Adapter) GetArtist(ctx context.Context, mbid string) (*provider.ArtistMetadata, error) {
-	// Validate MBID format before interpolating into SPARQL query to prevent injection.
-	if !provider.IsUUID(mbid) {
-		return nil, &provider.ErrNotFound{Provider: provider.NameWikidata, ID: mbid}
+// GetArtist fetches metadata for an artist from Wikidata.
+// The id argument may be either a MusicBrainz UUID (in which case the SPARQL
+// query filters on P434) or a Wikidata Q-item identifier (in which case the
+// query looks up the entity directly). Any other input is rejected as
+// ErrNotFound without a network call. This matters because a Wikidata entity
+// may not have its P434 (MusicBrainz artist ID) property populated even when
+// MusicBrainz advertises the reverse URL relation; MB's URL is then the only
+// reliable discovery path and it carries a QID rather than an MBID.
+//
+// When the caller has set metadata language preferences in the context, the
+// SPARQL query uses those preferences in wikibase:label so that entity labels
+// (artist name, country name, genre name) are returned in the user's preferred
+// language.
+func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
+	// Validate the input as either a UUID or a QID before interpolating into
+	// the SPARQL query. This guards against injection regardless of which
+	// branch buildArtistQuery takes below.
+	isUUID := provider.IsUUID(id)
+	if !isUUID && !isQID(id) {
+		return nil, &provider.ErrNotFound{Provider: provider.NameWikidata, ID: id}
 	}
 
 	if err := a.limiter.Wait(ctx, provider.NameWikidata); err != nil {
@@ -80,17 +103,23 @@ func (a *Adapter) GetArtist(ctx context.Context, mbid string) (*provider.ArtistM
 	}
 
 	langPrefs := provider.MetadataLanguages(ctx)
-	query := buildArtistQuery(mbid, langPrefs)
+	query := buildArtistQuery(id, langPrefs)
 	bindings, err := a.executeSPARQL(ctx, query)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(bindings) == 0 {
-		return nil, &provider.ErrNotFound{Provider: provider.NameWikidata, ID: mbid}
+		return nil, &provider.ErrNotFound{Provider: provider.NameWikidata, ID: id}
 	}
 
-	return mapArtist(mbid, bindings), nil
+	// Only pass a UUID through to mapArtist as the MBID; QID callers have no
+	// MBID to record on the returned metadata.
+	mbidForMap := ""
+	if isUUID {
+		mbidForMap = id
+	}
+	return mapArtist(mbidForMap, bindings), nil
 }
 
 // GetImages fetches artist images from Wikimedia Commons via Wikidata properties
@@ -255,15 +284,42 @@ func (a *Adapter) executeSPARQL(ctx context.Context, query string) ([]SPARQLBind
 	return sparqlResp.Results.Bindings, nil
 }
 
-// buildArtistQuery constructs the SPARQL query for an artist identified by MBID.
-// langPrefs is the user's ordered metadata language preference list (BCP 47 tags).
-// The wikibase:label SERVICE is told to try each language in the preference order,
-// falling back through parent subtags and ultimately to English when no match exists.
-// For example, preferences ["ja", "en-GB"] become "ja,en-gb,en": "en-GB" is kept
-// as-is, its base "en" is expanded inline, and the trailing "en" fallback is not
-// duplicated. The Wikidata label service resolves by trying each entry left to right.
-func buildArtistQuery(mbid string, langPrefs []string) string {
+// buildArtistQuery constructs the SPARQL query for an artist identified by
+// either a MusicBrainz UUID or a Wikidata Q-item identifier.
+//
+//   - When id is a UUID, the query filters entities whose P434 property
+//     (MusicBrainz artist ID) equals the given string. This is the historical
+//     path and works when the Wikidata entity has been cross-linked to MB.
+//   - When id is a QID (e.g. "Q175044"), the query binds ?item directly to
+//     wd:<QID>. This is required when P434 is absent on the Wikidata entity
+//     but MusicBrainz still advertises the wikidata URL relation, because
+//     the P434-based filter would return zero bindings in that case.
+//
+// The caller is expected to have already validated id as either a UUID or a
+// QID; any other input is interpolated verbatim.
+//
+// langPrefs is the user's ordered metadata language preference list (BCP 47
+// tags). The wikibase:label SERVICE is told to try each language in the
+// preference order, falling back through parent subtags and ultimately to
+// English when no match exists. For example, preferences ["ja", "en-GB"]
+// become "ja,en-gb,en": "en-GB" is kept as-is, its base "en" is expanded
+// inline, and the trailing "en" fallback is not duplicated. The Wikidata
+// label service resolves by trying each entry left to right.
+func buildArtistQuery(id string, langPrefs []string) string {
 	lang := wikidataLangParam(langPrefs)
+	// QID path: bind ?item directly to the entity.
+	if isQID(id) {
+		return fmt.Sprintf(`
+SELECT ?item ?itemLabel ?inception ?dissolved ?countryLabel ?genreLabel WHERE {
+  BIND(wd:%s AS ?item)
+  OPTIONAL { ?item wdt:P571 ?inception . }
+  OPTIONAL { ?item wdt:P576 ?dissolved . }
+  OPTIONAL { ?item wdt:P495 ?country . }
+  OPTIONAL { ?item wdt:P136 ?genre . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "%s" . }
+}`, id, lang)
+	}
+	// MBID path: filter on P434.
 	return fmt.Sprintf(`
 SELECT ?item ?itemLabel ?inception ?dissolved ?countryLabel ?genreLabel WHERE {
   ?item wdt:P434 "%s" .
@@ -272,7 +328,7 @@ SELECT ?item ?itemLabel ?inception ?dissolved ?countryLabel ?genreLabel WHERE {
   OPTIONAL { ?item wdt:P495 ?country . }
   OPTIONAL { ?item wdt:P136 ?genre . }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "%s" . }
-}`, mbid, lang)
+}`, id, lang)
 }
 
 // wikidataLangParam builds the comma-separated language string for the

--- a/internal/provider/wikidata/wikidata_test.go
+++ b/internal/provider/wikidata/wikidata_test.go
@@ -349,6 +349,110 @@ func TestGetArtistInvalidMBID(t *testing.T) {
 	}
 }
 
+// TestGetArtist_AcceptsQID verifies that a Wikidata QID (e.g. "Q175044") is
+// accepted by GetArtist and that the SPARQL query sent to the server uses
+// the direct-entity BIND form (wd:Q175044) rather than the P434-based filter.
+// This path is required for artists whose Wikidata entity lacks a P434
+// cross-link to MusicBrainz: a P434 query would return zero bindings.
+func TestGetArtist_AcceptsQID(t *testing.T) {
+	artistData := loadFixture(t, "artist_radiohead.json")
+	queryCh := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/sparql-results+json")
+		queryCh <- r.URL.Query().Get("query")
+		_, _ = w.Write(artistData)
+	}))
+	defer srv.Close()
+
+	limiter := provider.NewRateLimiterMap()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	a := NewWithEndpoint(limiter, logger, srv.URL)
+
+	meta, err := a.GetArtist(context.Background(), "Q175044")
+	if err != nil {
+		t.Fatalf("GetArtist(QID): %v", err)
+	}
+
+	captured := <-queryCh
+	// Direct-entity form must be present.
+	if !strings.Contains(captured, "BIND(wd:Q175044 AS ?item)") {
+		t.Errorf("expected SPARQL to bind wd:Q175044 directly; query:\n%s", captured)
+	}
+	// The P434-based filter must not appear on the QID path.
+	if strings.Contains(captured, "wdt:P434") {
+		t.Errorf("did not expect wdt:P434 in SPARQL for QID path; query:\n%s", captured)
+	}
+
+	// MusicBrainzID on the returned metadata must be empty when the caller
+	// supplied a QID rather than a UUID; there is no MBID to record.
+	if meta.MusicBrainzID != "" {
+		t.Errorf("MusicBrainzID = %q, want empty when input is a QID", meta.MusicBrainzID)
+	}
+}
+
+// TestGetArtist_AcceptsMBID_PreservesExistingPath verifies that a UUID input
+// still routes through the P434-based SPARQL query and that the returned
+// metadata carries the MBID as before, so QID support does not regress the
+// existing MBID lookup path.
+func TestGetArtist_AcceptsMBID_PreservesExistingPath(t *testing.T) {
+	artistData := loadFixture(t, "artist_radiohead.json")
+	queryCh := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/sparql-results+json")
+		queryCh <- r.URL.Query().Get("query")
+		_, _ = w.Write(artistData)
+	}))
+	defer srv.Close()
+
+	limiter := provider.NewRateLimiterMap()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	a := NewWithEndpoint(limiter, logger, srv.URL)
+
+	mbid := "a74b1b7f-71a5-4011-9441-d0b5e4122711"
+	meta, err := a.GetArtist(context.Background(), mbid)
+	if err != nil {
+		t.Fatalf("GetArtist(MBID): %v", err)
+	}
+
+	captured := <-queryCh
+	// P434-based filter is the historical path for UUID inputs.
+	if !strings.Contains(captured, "wdt:P434") {
+		t.Errorf("expected wdt:P434 in SPARQL for MBID path; query:\n%s", captured)
+	}
+	// BIND form must not appear on the MBID path.
+	if strings.Contains(captured, "BIND(wd:") {
+		t.Errorf("did not expect BIND(wd:...) in SPARQL for MBID path; query:\n%s", captured)
+	}
+
+	if meta.MusicBrainzID != mbid {
+		t.Errorf("MusicBrainzID = %q, want %q", meta.MusicBrainzID, mbid)
+	}
+}
+
+// TestIsQID covers the Q-item identifier matcher used by GetArtist to route
+// between the direct-entity and P434-based SPARQL paths.
+func TestIsQID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"Q44190", true},
+		{"Q1", true},
+		{"Q175044", true},
+		{"q175044", false}, // lowercase q is not valid
+		{"Q", false},       // needs at least one digit
+		{"Q12abc", false},  // digits only after Q
+		{"QQ1", false},
+		{"a74b1b7f-71a5-4011-9441-d0b5e4122711", false}, // UUID, not QID
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isQID(tt.input); got != tt.want {
+			t.Errorf("isQID(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestGetImagesInvalidMBID(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/internal/scraper/executor.go
+++ b/internal/scraper/executor.go
@@ -126,21 +126,46 @@ func (e *Executor) ScrapeAll(ctx context.Context, mbid, name, scope string, prov
 		}
 	}
 
-	// Apply mergeable fields only from providers that were actually selected.
-	// Also populate AttemptedProviders for providers that responded without
-	// error, so callers can update per-provider fetch timestamps. Errored
-	// providers are excluded to avoid hiding outages behind misleading
-	// "attempted" markers.
+	// Populate AttemptedProviders for providers that responded without error,
+	// so callers can update per-provider fetch timestamps. Errored providers
+	// are excluded to avoid hiding outages behind misleading "attempted"
+	// markers.
+	//
+	// Mergeable data falls into two buckets:
+	//   1. Provider IDs, URL relations, and aliases: orthogonal to field
+	//      selection. A provider that loses every field may still be the
+	//      only source of the artist's Wikidata/Deezer/Spotify ID or a
+	//      relation URL. These must merge for every successful provider so
+	//      downstream persistence records them.
+	//   2. Name/SortName and classification fields (Type, Gender,
+	//      Disambiguation, YearsActive): selection-gated to respect the
+	//      priority-wins semantics the scraper config defines.
+	//
+	// Collapsing both into one gate was the #1158 root cause: Wikidata
+	// returned Q175044 but lost every field to MusicBrainz, so nothing was
+	// merged from its result and the QID was dropped before persistence.
 	for provName, pr := range cache {
 		if pr.err != nil {
 			continue
 		}
 		result.AttemptedProviders = append(result.AttemptedProviders, provName)
-		if !selectedProviders[provName] || pr.meta == nil {
+		if pr.meta == nil {
+			continue
+		}
+		applyProviderIDsAndURLs(result, pr.meta)
+		if !selectedProviders[provName] {
 			continue
 		}
 		applyMergeableFields(result, pr.meta, provName)
 	}
+	// Final pass: backfill provider IDs from URL relations on the aggregated
+	// result. MusicBrainz publishes URL relations (deezer, wikidata, spotify,
+	// discogs, allmusic) whose last path segment is the provider's native ID;
+	// we can persist those even when the corresponding provider adapter was
+	// never invoked (e.g. the user has not enabled Deezer as a scraper). The
+	// non-scraper orchestrator performs the same sweep in FetchMetadata; the
+	// scraper path needs to match it so persistence sees the same IDs.
+	provider.ExtractProviderIDsFromURLs(result.Metadata)
 	// Post-merge normalization: clear gender for non-individual types regardless
 	// of provider iteration order (Go map iteration is non-deterministic).
 	if result.Metadata.Type != "" && !artist.IsIndividualType(result.Metadata.Type) {
@@ -489,9 +514,13 @@ func applyFieldValue(field FieldName, pr *providerResult, result *provider.Fetch
 	return false
 }
 
-// applyMergeableFields copies non-field-specific data (IDs, URLs, aliases) from
-// a provider result into the merged FetchResult.
-func applyMergeableFields(result *provider.FetchResult, meta *provider.ArtistMetadata, source provider.ProviderName) {
+// applyProviderIDsAndURLs merges provider identifiers, URL relations, and
+// aliases from a provider result into the merged FetchResult. These three
+// buckets are orthogonal to per-field selection and must merge for every
+// provider that succeeded (regardless of whether the provider "won" any
+// field), so that downstream persistence sees every ID the query chain
+// discovered. See #1158.
+func applyProviderIDsAndURLs(result *provider.FetchResult, meta *provider.ArtistMetadata) {
 	if meta.MusicBrainzID != "" && result.Metadata.MusicBrainzID == "" {
 		result.Metadata.MusicBrainzID = meta.MusicBrainzID
 	}
@@ -510,6 +539,24 @@ func applyMergeableFields(result *provider.FetchResult, meta *provider.ArtistMet
 	if meta.SpotifyID != "" && result.Metadata.SpotifyID == "" {
 		result.Metadata.SpotifyID = meta.SpotifyID
 	}
+	for k, v := range meta.URLs {
+		if _, exists := result.Metadata.URLs[k]; !exists {
+			result.Metadata.URLs[k] = v
+		}
+	}
+	for _, alias := range meta.Aliases {
+		if !containsString(result.Metadata.Aliases, alias) {
+			result.Metadata.Aliases = append(result.Metadata.Aliases, alias)
+		}
+	}
+}
+
+// applyMergeableFields copies classification fields (Name, SortName, Type,
+// Gender, Disambiguation, YearsActive) from a selected provider's result
+// into the merged FetchResult. Callers must gate this on the scraper-config
+// selection, because these fields follow priority-wins semantics; IDs and
+// URLs belong in applyProviderIDsAndURLs, which is called unconditionally.
+func applyMergeableFields(result *provider.FetchResult, meta *provider.ArtistMetadata, source provider.ProviderName) {
 	// MusicBrainz is authoritative for artist names (it owns the MBID), so
 	// its Name/SortName always win. This is especially important when
 	// language-aware name promotion selects a localized alias. Other
@@ -540,21 +587,6 @@ func applyMergeableFields(result *provider.FetchResult, meta *provider.ArtistMet
 	if meta.YearsActive != "" && result.Metadata.YearsActive == "" {
 		result.Metadata.YearsActive = meta.YearsActive
 	}
-
-	// Merge URLs
-	for k, v := range meta.URLs {
-		if _, exists := result.Metadata.URLs[k]; !exists {
-			result.Metadata.URLs[k] = v
-		}
-	}
-
-	// Merge aliases (deduplicated)
-	for _, alias := range meta.Aliases {
-		if !containsString(result.Metadata.Aliases, alias) {
-			result.Metadata.Aliases = append(result.Metadata.Aliases, alias)
-		}
-	}
-
 }
 
 func fieldToImageType(field FieldName) provider.ImageType {

--- a/internal/scraper/executor_test.go
+++ b/internal/scraper/executor_test.go
@@ -681,3 +681,119 @@ func TestApplyFieldValueDetailFieldsEmpty(t *testing.T) {
 		})
 	}
 }
+
+// TestApplyProviderIDsAndURLs_MergesIDsURLsAliases verifies the post-#1158
+// split: applyProviderIDsAndURLs always merges provider IDs, URL relations,
+// and aliases into the aggregated result, with first-write-wins semantics
+// on IDs so a later provider never clobbers a higher-priority provider's ID.
+func TestApplyProviderIDsAndURLs_MergesIDsURLsAliases(t *testing.T) {
+	result := &provider.FetchResult{
+		Metadata: &provider.ArtistMetadata{
+			URLs: make(map[string]string),
+		},
+	}
+	meta := &provider.ArtistMetadata{
+		MusicBrainzID: "mbid-123",
+		AudioDBID:     "adb-123",
+		DiscogsID:     "disc-123",
+		WikidataID:    "Q175044",
+		DeezerID:      "5269",
+		SpotifyID:     "spotify-id",
+		URLs: map[string]string{
+			"wikidata": "https://www.wikidata.org/wiki/Q175044",
+			"deezer":   "https://www.deezer.com/artist/5269",
+		},
+		Aliases: []string{"12 Stones", "Twelve Stones"},
+	}
+
+	applyProviderIDsAndURLs(result, meta)
+
+	if result.Metadata.WikidataID != "Q175044" {
+		t.Errorf("WikidataID = %q, want Q175044", result.Metadata.WikidataID)
+	}
+	if result.Metadata.DeezerID != "5269" {
+		t.Errorf("DeezerID = %q, want 5269", result.Metadata.DeezerID)
+	}
+	if result.Metadata.SpotifyID != "spotify-id" {
+		t.Errorf("SpotifyID = %q, want spotify-id", result.Metadata.SpotifyID)
+	}
+	if len(result.Metadata.URLs) != 2 {
+		t.Errorf("URLs len = %d, want 2", len(result.Metadata.URLs))
+	}
+	if len(result.Metadata.Aliases) != 2 {
+		t.Errorf("Aliases len = %d, want 2", len(result.Metadata.Aliases))
+	}
+}
+
+// TestApplyProviderIDsAndURLs_FirstWriteWins verifies first-write-wins so a
+// lower-priority provider cannot clobber a higher-priority provider's IDs.
+func TestApplyProviderIDsAndURLs_FirstWriteWins(t *testing.T) {
+	result := &provider.FetchResult{
+		Metadata: &provider.ArtistMetadata{
+			WikidataID: "Q-existing",
+			URLs:       make(map[string]string),
+		},
+	}
+	loserMeta := &provider.ArtistMetadata{
+		WikidataID: "Q-new",
+	}
+
+	applyProviderIDsAndURLs(result, loserMeta)
+
+	if result.Metadata.WikidataID != "Q-existing" {
+		t.Errorf("WikidataID = %q, want Q-existing (first write wins)", result.Metadata.WikidataID)
+	}
+}
+
+// TestApplyProviderIDsAndURLs_DoesNotMergeClassification verifies the split
+// keeps classification fields (Name, Type, Gender, etc.) out of the always-
+// merged bucket; those are applyMergeableFields's responsibility and must
+// be gated on provider selection.
+func TestApplyProviderIDsAndURLs_DoesNotMergeClassification(t *testing.T) {
+	result := &provider.FetchResult{
+		Metadata: &provider.ArtistMetadata{
+			URLs: make(map[string]string),
+		},
+	}
+	meta := &provider.ArtistMetadata{
+		Name:           "Should Not Merge",
+		SortName:       "Should Not Merge",
+		Type:           "Group",
+		Gender:         "Female",
+		Disambiguation: "Should Not Merge",
+		YearsActive:    "1999-present",
+	}
+
+	applyProviderIDsAndURLs(result, meta)
+
+	if result.Metadata.Name != "" || result.Metadata.Type != "" ||
+		result.Metadata.Gender != "" || result.Metadata.Disambiguation != "" ||
+		result.Metadata.YearsActive != "" || result.Metadata.SortName != "" {
+		t.Errorf("applyProviderIDsAndURLs leaked classification fields: %+v", result.Metadata)
+	}
+}
+
+// TestApplyMergeableFields_DoesNotTouchIDs verifies that after the #1158
+// split, the selection-gated applyMergeableFields no longer handles provider
+// IDs. Those are now exclusively applyProviderIDsAndURLs's job, which runs
+// unconditionally.
+func TestApplyMergeableFields_DoesNotTouchIDs(t *testing.T) {
+	result := &provider.FetchResult{
+		Metadata: &provider.ArtistMetadata{
+			URLs: make(map[string]string),
+		},
+	}
+	meta := &provider.ArtistMetadata{
+		MusicBrainzID: "mbid-should-not-merge",
+		WikidataID:    "Q-should-not-merge",
+		DeezerID:      "should-not-merge",
+	}
+
+	applyMergeableFields(result, meta, provider.NameAudioDB)
+
+	if result.Metadata.MusicBrainzID != "" ||
+		result.Metadata.WikidataID != "" ||
+		result.Metadata.DeezerID != "" {
+		t.Errorf("applyMergeableFields leaked provider IDs: %+v", result.Metadata)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1158. Provider IDs (WikidataID, DeezerID, SpotifyID) were not being persisted end-to-end for artists where the source provider lost every text field to a higher-priority adapter. The fix lives in two layers:

1. **Capture IDs at discovery time, not selection time.** The scraper executor was gating `applyMergeableFields` on whether the provider won any field. A provider that lost every field (e.g. Wikidata losing everything to MusicBrainz) had its returned IDs, URL relations, and aliases dropped before persistence. Split the function into `applyProviderIDsAndURLs` (always called) and a thinner `applyMergeableFields` (still selection-gated for Name/Type/Gender/Disambiguation/YearsActive).
2. **Sweep URL-derived IDs on the aggregated result.** The non-scraper orchestrator path at `internal/provider/orchestrator.go:210` already did this. The scraper path now matches it: one `ExtractProviderIDsFromURLs(result.Metadata)` call after the merge loop captures Deezer / Spotify / Wikidata / Discogs / AllMusic IDs from MusicBrainz URL relations even when the corresponding adapter is not configured in the scraper.

The earlier commit's contributions (MB-URL → `providerIDs[NameWikidata]` propagation in `EnrichProviderIDs`, and a QID-accepting `Wikidata.GetArtist` that switches to direct-entity SPARQL) remain -- they're a meaningful optimization when MB has the Wikidata URL relation, and they unblock Wikidata entities whose P434 property is absent. They just weren't sufficient to fix the headline bug on their own, because they populate `providerIDs` (orchestrator-local map) rather than `a.WikidataID` (the persistence source of truth).

Also addresses the CodeRabbit review finding on the earlier commit: `ExtractProviderIDsFromURLs` now requires Wikidata last-path segments to match `^Q[0-9]+$` before accepting them, so malformed URLs like `/wiki/Qabc` or `/wiki/Special:Random` cannot propagate a bogus QID into `providerIDs`.

## Mechanical improvements for future refreshes

- **Wikidata**: once the QID is persisted (first refresh), `a.ProviderIDMap()` feeds it to the orchestrator on every subsequent refresh. `GetArtist` then uses `BIND(wd:Q175044 AS ?item)` directly instead of filtering on P434. For entities where P434 is absent on Wikidata (the original #1158 scenario), this is the only path that returns data -- before this PR, those artists silently got no Wikidata metadata.
- **Deezer / Spotify**: if these are enabled as scraper providers later, their adapters now receive the numeric native ID on first refresh instead of trying and failing with an MBID they do not understand.
- **Ongoing capture**: new URL relations MusicBrainz adds over time get picked up automatically -- no extra network traffic, just persistence of data that was already in the response.

## Scope note on the split

`applyMergeableFields` used to merge IDs, URLs, aliases, Name/SortName, Type, Gender, Disambiguation, and YearsActive in one call. After the split:

- `applyProviderIDsAndURLs(result, meta)` -- always called. Merges the six provider IDs, URL relations, and aliases with first-write-wins semantics.
- `applyMergeableFields(result, meta, source)` -- selection-gated. Merges the classification bucket only (Name, SortName, Type, Gender, Disambiguation, YearsActive). MusicBrainz-authoritative Name/SortName logic is unchanged.

This keeps the priority-wins semantics for classification fields while fixing the ID-capture regression.

## Test plan

Automated (all passing):

- [x] `go test -race ./internal/scraper/...` -- 4 new tests for the split (`TestApplyProviderIDsAndURLs_MergesIDsURLsAliases`, `TestApplyProviderIDsAndURLs_FirstWriteWins`, `TestApplyProviderIDsAndURLs_DoesNotMergeClassification`, `TestApplyMergeableFields_DoesNotTouchIDs`).
- [x] `go test -race ./internal/provider/...` -- 2 new tests for QID validation (`TestExtractProviderIDsFromURLs_RejectsInvalidQID` with Qabc / Q12a34 / q123 / Q:suffix / bare Q all rejected, `TestExtractProviderIDsFromURLs_AcceptsValidQID`).
- [x] `go test -race ./internal/provider/wikidata/...` -- agent's original QID-accepting tests (`TestGetArtist_AcceptsQID`, `TestGetArtist_AcceptsMBID_PreservesExistingPath`, `TestIsQID`).
- [x] `bash scripts/pre-push-gate.sh` -- PASS. Patch coverage 100% on the newly added executable lines.

Manual UAT (native build against local library):

- [x] Refresh `12 Stones` (MBID `6f81a7dc-be31-4498-ae95-6d994ffec614`). DB query `SELECT provider, provider_id FROM artist_provider_ids WHERE artist_id='3979f4f7-3f40-400d-a8ea-ebe0b885e308'` shows `wikidata=Q175044`, `deezer=5269`, `spotify=0DrXhci3WAyo0WJv1RBOG6` (previously the wikidata row had empty `provider_id` with `fetched_at` set, and no deezer/spotify rows existed at all).
- [x] Providers tab UI renders the populated IDs end-to-end.
- [x] No regressions on AudioDB / Discogs rows (already-working providers still persist).
- [x] Server log `/tmp/stillwater.log` shows no new errors during refresh.

## Files changed

| File | Change |
|---|---|
| `internal/provider/orchestrator.go` | Export `ExtractProviderIDsFromURLs`; propagate `WikidataID` from MB URLs in `EnrichProviderIDs`; add `wikidataQIDRe` validation regex |
| `internal/provider/orchestrator_test.go` | `TestEnrichProviderIDs_*` suite + `TestExtractProviderIDsFromURLs_{Rejects,Accepts}ValidQID` |
| `internal/provider/wikidata/wikidata.go` | `GetArtist` accepts UUID or QID; switches SPARQL shape accordingly |
| `internal/provider/wikidata/wikidata_test.go` | QID / UUID routing tests + `isQID` regex tests |
| `internal/scraper/executor.go` | Split `applyMergeableFields` into ID/URL bucket (always called) + classification bucket (selection-gated); final URL-extract sweep on aggregated result |
| `internal/scraper/executor_test.go` | 4 tests covering the split invariants |

Closes #1158


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Wikidata identifiers as first-class metadata lookup options, enabling direct artist queries using Wikidata Q-items.
  * Enhanced provider ID enrichment with stricter validation and extraction of Wikidata identifiers from URL relations.

* **Bug Fixes**
  * Improved metadata aggregation to extract and preserve provider IDs from all successful data sources, not just selected providers.

* **Tests**
  * Added comprehensive test coverage for Wikidata identifier validation, routing, and metadata merging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->