### PR TITLE
chore(release): v0.9.6

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // These variables are set at build time via -ldflags.
 var (
-	Version = "0.9.6-rc.2"
+	Version = "0.9.6"
 	Commit  = "unknown"
 	Date    = "unknown"
 )


### PR DESCRIPTION
Bumps the dev-fallback `Version` constant in `internal/version/version.go` from `0.9.6-rc.2` to `0.9.6` so `go run ./cmd/stillwater` without ldflags reports the correct version on `main`.

This PR is the main-branch companion to the already-pushed signed tag `v0.9.6` (object SHA `a54797f7`, commit `1828472`). The release workflow is producing artifacts from the tagged commit; landing this commit on main via squash is purely for history hygiene, matching the historical v0.9.5 and v0.9.6-rc.2 flow.

See the GitHub Release at v0.9.6 for the full user-facing changelog.

## Test plan

- [x] `bash scripts/pre-push-gate.sh` PASS
- [x] Local `grype dir:.` -- no vulnerabilities found
- [x] M36 milestone shows 0 open issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped from 0.9.6-rc.2 (release candidate) to 0.9.6 (stable release).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->