### PR TITLE
fix(release): drop stuttering "Nightly" prefix from nightly release title and header

### DIFF
--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -108,9 +108,9 @@ release:
   # Nightly builds are always prereleases and never "latest".
   prerelease: true
   make_latest: false
-  name_template: "Nightly {{ .Tag }}"
+  name_template: "{{ .Tag }}"
   header: |
-    ## Stillwater Nightly {{ .Tag }}
+    ## Stillwater {{ .Tag }}
 
     > Automated nightly build from `main`. Intended for the updater's
     > `nightly` channel and early testers. No stability guarantees.


### PR DESCRIPTION
## Summary

- Nightly GoReleaser config prepended `Nightly ` to both the release name template and the body header. With the `nightly-YYYYMMDD` tag scheme, that rendered as "Nightly nightly-20260423" on the release page and `## Stillwater Nightly nightly-20260423` in the body, stuttering "nightly".
- The tag itself already self-identifies the build as a nightly, so dropping the redundant prefix yields `nightly-20260423` as the title and `## Stillwater nightly-20260423` as the heading.
- Config-only change; two lines in `.goreleaser.nightly.yml`. No Go code touched, no behavior change to the updater's `nightly` channel (it resolves by tag, not by release name).

## Test plan

- [x] `goreleaser check --config .goreleaser.nightly.yml` -- config still valid (the failure output is pre-existing `archives.format` deprecations, unrelated to this change).
- [ ] Next scheduled nightly (or a manual `workflow_dispatch` of `release-nightly.yml` on main after merge) produces a release titled exactly `nightly-YYYYMMDD` with header `## Stillwater nightly-YYYYMMDD`.
- [ ] Updater `nightly` channel still resolves the latest nightly release (unaffected, but worth a sanity check on the first post-merge nightly).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly release naming and header format to remove redundant prefixes, streamlining release metadata presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->