### PR TITLE
refactor(jellyfin): extract shared full-item POST helper

### DIFF
--- a/internal/connection/jellyfin/push.go
+++ b/internal/connection/jellyfin/push.go
@@ -90,38 +90,10 @@ func (c *Client) PushMetadata(ctx context.Context, platformArtistID string, data
 		existing["EndDate"] = ""
 	}
 
-	// Strip read-only fields that Jellyfin rejects in a POST.
-	for _, key := range jellyfinReadOnlyFields {
-		delete(existing, key)
+	if err := c.postFullItem(ctx, platformArtistID, existing, "push"); err != nil {
+		return err
 	}
 
-	payload, err := json.Marshal(existing)
-	if err != nil {
-		return fmt.Errorf("marshaling push body: %w", err)
-	}
-
-	path := fmt.Sprintf("/Items/%s", url.PathEscape(platformArtistID))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, connection.BuildRequestURL(c.BaseURL, path), bytes.NewReader(payload))
-	if err != nil {
-		return fmt.Errorf("creating push request: %w", err)
-	}
-	c.AuthFunc(req)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.HTTPClient.Do(req) //nolint:gosec // URL constructed from trusted base + artist ID
-	if err != nil {
-		return fmt.Errorf("executing push request: %w", err)
-	}
-	defer resp.Body.Close() //nolint:errcheck
-
-	if resp.StatusCode >= 300 {
-		const maxErrBody = 1 << 20 // 1 MB
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("push failed with status %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	_, _ = io.Copy(io.Discard, resp.Body)
 	c.Logger.Debug("metadata pushed to jellyfin", "artist_id", platformArtistID)
 	return nil
 }
@@ -146,33 +118,53 @@ func (c *Client) UpdateArtistLocks(ctx context.Context, platformArtistID string,
 		c.Logger.Debug("jellyfin: per-field locks ignored (not supported at item level)",
 			"artist_id", platformArtistID, "field_count", len(lockedFields))
 	}
+
+	return c.postFullItem(ctx, platformArtistID, existing, "lock update")
+}
+
+// postFullItem strips read-only fields from item, marshals it, and POSTs the
+// full body to /Items/{platformArtistID}. Jellyfin's POST /Items/{id} requires
+// a complete item body (not a delta), so both PushMetadata and
+// UpdateArtistLocks share this request/response cycle. The op label appears in
+// error messages so callers can distinguish failures (e.g. "push failed with
+// status 500", "lock update failed with status 500") without each call site
+// re-implementing the request boilerplate.
+func (c *Client) postFullItem(ctx context.Context, platformArtistID string, item map[string]any, op string) error {
+	// Strip read-only fields that Jellyfin rejects in a POST. Done here (not
+	// at each call site) so a future addition to jellyfinReadOnlyFields cannot
+	// silently slip through one path while protecting the other.
 	for _, key := range jellyfinReadOnlyFields {
-		delete(existing, key)
+		delete(item, key)
 	}
 
-	body, err := json.Marshal(existing)
+	payload, err := json.Marshal(item)
 	if err != nil {
-		return fmt.Errorf("encoding lock update body: %w", err)
+		return fmt.Errorf("marshaling %s body: %w", op, err)
 	}
+
 	path := fmt.Sprintf("/Items/%s", url.PathEscape(platformArtistID))
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, connection.BuildRequestURL(c.BaseURL, path), bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, connection.BuildRequestURL(c.BaseURL, path), bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Errorf("creating lock update request: %w", err)
+		return fmt.Errorf("creating %s request: %w", op, err)
 	}
 	c.AuthFunc(req)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.HTTPClient.Do(req) //nolint:gosec // URL constructed from trusted base + artist ID
 	if err != nil {
-		return fmt.Errorf("executing lock update: %w", err)
+		return fmt.Errorf("executing %s request: %w", op, err)
 	}
 	defer resp.Body.Close() //nolint:errcheck
+
 	if resp.StatusCode >= 300 {
+		// Cap the error body at 1 MB so a misbehaving peer that returns a
+		// huge HTML error page cannot blow up the caller's logger.
 		const maxErrBody = 1 << 20
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("lock update failed with status %d: %s", resp.StatusCode, string(respBody))
+		return fmt.Errorf("%s failed with status %d: %s", op, resp.StatusCode, string(respBody))
 	}
+
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
 }

--- a/internal/connection/jellyfin/push.go
+++ b/internal/connection/jellyfin/push.go
@@ -133,11 +133,19 @@ func (c *Client) postFullItem(ctx context.Context, platformArtistID string, item
 	// Strip read-only fields that Jellyfin rejects in a POST. Done here (not
 	// at each call site) so a future addition to jellyfinReadOnlyFields cannot
 	// silently slip through one path while protecting the other.
+	//
+	// Operate on a shallow copy so callers that retain `item` after this call
+	// (for example to log it on error or pass it to a retry) see their
+	// original map unchanged.
+	cleanItem := make(map[string]any, len(item))
+	for k, v := range item {
+		cleanItem[k] = v
+	}
 	for _, key := range jellyfinReadOnlyFields {
-		delete(item, key)
+		delete(cleanItem, key)
 	}
 
-	payload, err := json.Marshal(item)
+	payload, err := json.Marshal(cleanItem)
 	if err != nil {
 		return fmt.Errorf("marshaling %s body: %w", op, err)
 	}


### PR DESCRIPTION
## Summary
- Extract shared full-item POST helper used by `PushMetadata` and `UpdateArtistLocks` in `internal/connection/jellyfin/push.go`
- New private `c.postFullItem(ctx, platformArtistID, item, op)` centralizes read-only-field stripping, JSON marshalling, request construction, auth, content-type, response drain, and the bounded 1MB error-body handling that both call sites previously duplicated
- The `op` label parameter preserves the existing per-call-site error message prefixes (`"push failed with status 500"`, `"lock update failed with status 500"`) so existing test assertions and any external log scraping continue to work
- Read-only-field stripping moved into the helper so a future addition to `jellyfinReadOnlyFields` cannot silently slip through one path while protecting the other

## Test plan
- [x] `make fmt && make lint` (0 issues)
- [x] `go test -race ./internal/connection/jellyfin/...` (all pass, including `TestPushMetadata_ServerError` which asserts the exact `"push failed with status 500"` text)
- [x] `bash scripts/pre-push-gate.sh` (all hard checks passed; "no Go source changes in scope" patch coverage is informational)
- [x] Self-review for behaviour preservation, error-path parity, silent failures, leftover duplication

Closes #1091

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate request handling and standardized error formatting for server updates to improve maintainability.

* **Chores**
  * Internal improvements to payload preparation and response handling; no changes to user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->