### PR TITLE
fix(release): publish Scorecard-recognized cosign bundle assets

### DIFF
--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -14,7 +14,7 @@ version: 2
 #   - docker_signs: no Docker artifacts produced here.
 #
 # Keeps cosign keyless signing of the checksums blob to match stable pipeline
-# behavior (checksums.txt.sig.bundle accompanies every release).
+# behavior (checksums.txt.sigstore.json accompanies every release).
 
 before:
   hooks:
@@ -60,7 +60,7 @@ archives:
 # `id-token: write` on the calling workflow.
 signs:
   - cmd: cosign
-    signature: "${artifact}.sig.bundle"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
       - --new-bundle-format

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,7 +91,7 @@ docker_manifests:
 
 signs:
   - cmd: cosign
-    signature: "${artifact}.sig.bundle"
+    signature: "${artifact}.sigstore.json"
     args:
       - sign-blob
       - --new-bundle-format


### PR DESCRIPTION
## Summary
- rename GoReleaser cosign checksum bundle assets from `.sig.bundle` to `.sigstore.json`
- keep the existing cosign keyless signing command and checksum-only signing scope unchanged
- update the nightly release config comment to match the new asset suffix

## Rationale
OpenSSF Scorecard v5.3.0 detects signed release assets by filename suffix and recognizes `.sigstore.json`, but not `.sig.bundle`. Sigstore/cosign documents `.sigstore.json` bundle filenames for blob signing and verification, so this changes Scorecard compatibility without weakening verification semantics.

## Test Plan
- `go test -count=1 -coverprofile=/tmp/stillwater-scorecard-signature-cover.out ./...`
- `git diff --check`
- `goreleaser check --config .goreleaser.yml` *(fails on existing deprecated archives/docker config fields; config is reported valid)*
- `goreleaser check --config .goreleaser.nightly.yml` *(fails on existing deprecated archives config fields; config is reported valid)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release signing configuration to use `.sigstore.json` format for signature artifacts instead of `.sig.bundle`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->