### PR TITLE
ci(scorecard): add manual trigger

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,6 +5,7 @@ on:
     - cron: '30 1 * * 1'
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary
- add a manual trigger to the Scorecard workflow so it can be run from GitHub Actions

## Why
This does not change the workflow permissions or behavior beyond enabling a manual run path. It keeps the existing scheduled and push triggers intact.

## Test Plan
- Reviewed the one-line workflow diff
- Verified the repository pre-commit hooks passed during commit