### PR TITLE
ci(scorecard): update SARIF upload action to v4

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        uses: github/codeql-action/upload-sarif@256d634097be96e792d6764f9edaefc4320557b1 # v4
         with:
           sarif_file: scorecard-results.sarif


### PR DESCRIPTION
## Summary
- update the Scorecard workflow SARIF upload step to github/codeql-action v4
- keep the existing Scorecard schedule, push trigger, and permissions unchanged

## Why
This removes the Node.js 20 / CodeQL v3 deprecation warnings from the manual Scorecard run without changing the workflow security posture.

## Test Plan
- Reviewed the one-line workflow diff
- Verified the repository pre-commit hooks passed during commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code scanning workflow configuration to use a newer version of the scanning action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->