### PR TITLE
fix(ci): bump github/codeql-action SHA pin to v4.35.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
         run: templ generate
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@256d634097be96e792d6764f9edaefc4320557b1 # v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: go
 
@@ -51,6 +51,6 @@ jobs:
             -o stillwater ./cmd/stillwater
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@256d634097be96e792d6764f9edaefc4320557b1 # v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: /language:go

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -82,7 +82,7 @@ jobs:
           severity: CRITICAL,HIGH,MEDIUM
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@256d634097be96e792d6764f9edaefc4320557b1 # v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         if: always()
         with:
           sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Summary
- Bump `github/codeql-action` SHA pin from `256d6340` (was tagged v4) to `95e58e9a` (v4.35.2) across all three uses.
- Fixes broken CodeQL analysis and Trivy SARIF upload that started failing with the current GitHub-hosted runner image.

## Files
- `.github/workflows/codeql.yml` -- init + analyze actions
- `.github/workflows/security.yml` -- upload-sarif action

## Test plan
- [x] actionlint clean on both files
- [ ] CI green on this PR (CodeQL + Trivy upload should pass)

Per CLAUDE.md CI/CD section: GitHub Actions stay pinned to commit SHAs with the version tag as inline comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CodeQL action versions in CI/CD workflows to the latest v4.35.2 release for enhanced code analysis and security scanning capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->