### PR TITLE
fix(ci): correct codeql-action SHA pin in scorecard.yml

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@256d634097be96e792d6764f9edaefc4320557b1 # v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           sarif_file: scorecard-results.sarif


### PR DESCRIPTION
## Summary
- Follow-up to #1205, which missed the `upload-sarif` step in `.github/workflows/scorecard.yml` despite the PR body claiming "all three uses".
- The stale SHA `256d6340` does not exist in `github/codeql-action`, so scorecard.dev's sigstore-based publisher rejects the run with `imposter commit: ... does not belong to github/codeql-action/upload-sarif` (HTTP 400) and the Scorecard workflow fails.
- Pin to the same `v4.35.2` SHA (`95e58e9a`) already used by `codeql.yml` and `security.yml`.

## Test plan
- [x] actionlint clean
- [ ] Scorecard workflow re-runs green on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)