### PR TITLE
fix(rule): resolve, preserve dismissal, invalidate cache, purge on disable

### DIFF
--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -1168,6 +1168,13 @@ func (p *Pipeline) ClearRuleCache() {
 // (RunRule / RunRuleScoped) only write pass rows for the specific rule they
 // evaluated, not for every rule the engine happened to consider.
 //
+// Issue #1105: this function is also the natural site for "rule passed, so
+// resolve any stale open violation row" reconciliation. When a rule was
+// considered AND did not appear in the new violation set, any open or
+// pending_choice rule_violations row for that (rule, artist) pair is stale
+// and is transitioned to resolved. Dismissed and already-resolved rows are
+// left untouched (see ResolveViolationIfActive).
+//
 // Returns true when every pass write succeeded. Failures are warn-logged and
 // fold into the caller's persistOK flag so the artist stays dirty and the
 // next pass retries, mirroring how violation-write failures are handled.
@@ -1189,6 +1196,19 @@ func (p *Pipeline) persistPassResults(
 		}
 		if err := p.ruleService.UpsertRuleResultPass(ctx, a.ID, rid, evaluatedAt); err != nil {
 			p.logger.Warn("persisting pass result",
+				"rule_id", rid, "artist", a.Name, "error", err)
+			ok = false
+		}
+		// Issue #1105: resolve any stale open violation row. A rule that
+		// was considered but did not produce a violation in this pass means
+		// either the auto-fix succeeded (the resolvedRows path already
+		// covered that) OR the underlying condition was corrected
+		// out-of-band (user dropped a file in place, scanner refreshed
+		// metadata, etc.). The latter has no in-memory marker, so without
+		// this reconciliation the dashboard keeps reporting a cleared
+		// violation as open indefinitely.
+		if _, err := p.ruleService.ResolveViolationIfActive(ctx, rid, a.ID); err != nil {
+			p.logger.Warn("resolving stale violation after pass",
 				"rule_id", rid, "artist", a.Name, "error", err)
 			ok = false
 		}
@@ -1248,6 +1268,20 @@ func (p *Pipeline) attemptFix(ctx context.Context, a *artist.Artist, v *Violatio
 				RuleID:  v.RuleID,
 				Fixed:   false,
 				Message: "fix failed",
+			}
+		}
+		// Issue #1108: fixers mutate the filesystem (delete extraneous
+		// images, write NFOs, save trimmed logos, rename directories) but
+		// do not invalidate the rule engine's FSCache. Within the cache's
+		// 60s TTL the next Evaluate call would read a stale directory
+		// listing -- the deleted file still appears, the new file is still
+		// missing -- and resurrect the violation we just fixed. Invalidate
+		// the artist directory here so every fixer benefits without
+		// threading the cache into each fixer constructor. DiscoveryOnly
+		// fixes do not write to disk and do not need invalidation.
+		if fr != nil && fr.Fixed && !v.Config.DiscoveryOnly && a.Path != "" {
+			if cache := p.engine.FSCache(); cache != nil {
+				cache.InvalidatePath(a.Path)
 			}
 		}
 		return fr

--- a/internal/rule/lifecycle_test.go
+++ b/internal/rule/lifecycle_test.go
@@ -1,0 +1,256 @@
+package rule
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+)
+
+// TestPipeline_ReEvalPassResolvesStaleViolation exercises issue #1105: when a
+// rule that previously violated now passes (because the underlying condition
+// was corrected out-of-band, e.g. user dropped artist.nfo into the directory),
+// the existing open rule_violations row must transition to status='resolved'.
+// Without the fix, persistPassResults would write the rule_results pass row
+// but leave the violation row stuck at status='open' forever.
+func TestPipeline_ReEvalPassResolvesStaleViolation(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	artistSvc := artist.NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	disableAllRulesExcept(t, db, RuleNFOExists)
+
+	a := &artist.Artist{
+		Name:      "Pass After Fix",
+		SortName:  "Pass After Fix",
+		Path:      t.TempDir(),
+		NFOExists: true, // checkNFOExists -> nil (rule passes)
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// Pre-seed an open violation row that pre-dates the (out-of-band) fix.
+	stale := &RuleViolation{
+		RuleID: RuleNFOExists, ArtistID: a.ID, ArtistName: a.Name,
+		Severity: "error", Message: "stale; nfo now exists", Fixable: true,
+		Status: ViolationStatusOpen,
+	}
+	if err := ruleSvc.UpsertViolation(ctx, stale); err != nil {
+		t.Fatalf("seeding stale violation: %v", err)
+	}
+
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, nil, nil, testLogger())
+
+	if _, err := pipeline.RunForArtist(ctx, a); err != nil {
+		t.Fatalf("RunForArtist: %v", err)
+	}
+
+	// The pre-existing violation row must now be status='resolved' with
+	// resolved_at populated. Without the #1105 fix it stays at 'open'.
+	rv, err := ruleSvc.GetViolationByID(ctx, stale.ID)
+	if err != nil {
+		t.Fatalf("GetViolationByID: %v", err)
+	}
+	if rv.Status != ViolationStatusResolved {
+		t.Errorf("violation status after re-eval = %q, want %q", rv.Status, ViolationStatusResolved)
+	}
+	if rv.ResolvedAt == nil {
+		t.Errorf("resolved_at = nil, want populated")
+	}
+}
+
+// TestPipeline_ReEvalDoesNotResolveDismissed verifies the #1105 fix respects
+// the #1107 invariant: a rule that now passes must NOT clobber a
+// previously-dismissed violation row back to resolved. Dismissed is terminal
+// from the user's perspective and ResolveViolationIfActive only touches rows
+// in status open or pending_choice.
+func TestPipeline_ReEvalDoesNotResolveDismissed(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	artistSvc := artist.NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	disableAllRulesExcept(t, db, RuleNFOExists)
+
+	a := &artist.Artist{
+		Name: "Dismissed Survives", SortName: "Dismissed Survives",
+		Path: t.TempDir(), NFOExists: true,
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	v := &RuleViolation{
+		RuleID: RuleNFOExists, ArtistID: a.ID, ArtistName: a.Name,
+		Severity: "error", Message: "old", Fixable: true,
+		Status: ViolationStatusOpen,
+	}
+	if err := ruleSvc.UpsertViolation(ctx, v); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := ruleSvc.DismissViolation(ctx, v.ID); err != nil {
+		t.Fatalf("dismiss: %v", err)
+	}
+
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, nil, nil, testLogger())
+	if _, err := pipeline.RunForArtist(ctx, a); err != nil {
+		t.Fatalf("RunForArtist: %v", err)
+	}
+
+	rv, err := ruleSvc.GetViolationByID(ctx, v.ID)
+	if err != nil {
+		t.Fatalf("GetViolationByID: %v", err)
+	}
+	if rv.Status != ViolationStatusDismissed {
+		t.Errorf("dismissed violation status = %q, want %q (must survive re-eval)", rv.Status, ViolationStatusDismissed)
+	}
+}
+
+// TestPipeline_FixerInvalidatesFSCache exercises issue #1108: after a fixer
+// mutates the filesystem, the engine's FSCache must be invalidated so the
+// next Evaluate call re-reads the directory listing instead of serving the
+// pre-mutation snapshot. We exercise this by populating the dir cache, then
+// driving the NFOFixer through the pipeline (which writes artist.nfo), and
+// asserting the cached dir entry is gone.
+func TestPipeline_FixerInvalidatesFSCache(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	artistSvc := artist.NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	disableAllRulesExcept(t, db, RuleNFOExists)
+	if _, err := db.ExecContext(ctx,
+		`UPDATE rules SET automation_mode = ? WHERE id = ?`,
+		AutomationModeAuto, RuleNFOExists); err != nil {
+		t.Fatalf("setting automation_mode=auto: %v", err)
+	}
+
+	dir := t.TempDir()
+	a := &artist.Artist{
+		Name: "Cache Invalidation", SortName: "Cache Invalidation",
+		Path: dir, NFOExists: false, LibraryID: "lib-test",
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	cache := NewFSCache(60*time.Second, 100, testLogger())
+	engine.SetFSCache(cache)
+
+	// Prime the cache by reading the (currently empty) directory.
+	if _, err := cache.ReadDir(dir); err != nil {
+		t.Fatalf("priming cache ReadDir: %v", err)
+	}
+	if cache.Len() == 0 {
+		t.Fatalf("cache empty after prime; expected at least one entry")
+	}
+
+	nfoFixer := &NFOFixer{fsCheck: nonSharedFSCheck()}
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{nfoFixer}, nil, testLogger())
+
+	runResult, err := pipeline.RunForArtist(ctx, a)
+	if err != nil {
+		t.Fatalf("RunForArtist: %v", err)
+	}
+	if runResult.FixesSucceeded != 1 {
+		t.Fatalf("FixesSucceeded = %d, want 1", runResult.FixesSucceeded)
+	}
+
+	// After the fix, a fresh ReadDir(dir) must observe artist.nfo. If the
+	// cache was not invalidated the call would return the stale empty
+	// listing and miss the new file.
+	entries, err := cache.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("post-fix ReadDir: %v", err)
+	}
+	var sawNFO bool
+	for _, e := range entries {
+		if e.Name == "artist.nfo" {
+			sawNFO = true
+			break
+		}
+	}
+	if !sawNFO {
+		t.Errorf("post-fix ReadDir missed artist.nfo; cache was not invalidated")
+	}
+
+	// Sanity: artist.nfo really does exist on disk -- the test is meaningful
+	// only when the underlying filesystem mutation actually happened.
+	if _, err := os.Stat(filepath.Join(dir, "artist.nfo")); err != nil {
+		t.Fatalf("artist.nfo missing on disk: %v", err)
+	}
+}
+
+// TestService_DisablingRuleSoftResolvesViolations is the #1143 contract test
+// distinct from TestService_DisablingRuleDoesNotMarkDirty: when a rule is
+// disabled, every active violation for that rule transitions to resolved with
+// resolved_at populated. The test seeds an artist + a rule + an open
+// violation, then disables the rule and asserts the row is now resolved.
+func TestService_DisablingRuleSoftResolvesViolations(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	if err := svc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+
+	r, err := svc.GetByID(ctx, RuleNFOExists)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if !r.Enabled {
+		// Force-enable so the test is independent of seed defaults.
+		r.Enabled = true
+		if err := svc.Update(ctx, r); err != nil {
+			t.Fatalf("force-enable: %v", err)
+		}
+	}
+
+	v := &RuleViolation{
+		RuleID: RuleNFOExists, ArtistID: "a1", ArtistName: "A1",
+		Severity: "error", Message: "missing nfo", Fixable: true,
+		Status: ViolationStatusOpen,
+	}
+	if err := svc.UpsertViolation(ctx, v); err != nil {
+		t.Fatalf("UpsertViolation: %v", err)
+	}
+
+	// Refresh the rule and disable it.
+	r, err = svc.GetByID(ctx, RuleNFOExists)
+	if err != nil {
+		t.Fatalf("GetByID after seed: %v", err)
+	}
+	r.Enabled = false
+	if err := svc.Update(ctx, r); err != nil {
+		t.Fatalf("disable Update: %v", err)
+	}
+
+	got, err := svc.GetViolationByID(ctx, v.ID)
+	if err != nil {
+		t.Fatalf("GetViolationByID: %v", err)
+	}
+	if got.Status != ViolationStatusResolved {
+		t.Errorf("status after disable = %q, want %q (soft-resolve per #1143)", got.Status, ViolationStatusResolved)
+	}
+	if got.ResolvedAt == nil {
+		t.Errorf("resolved_at = nil, want populated")
+	}
+}

--- a/internal/rule/lifecycle_test.go
+++ b/internal/rule/lifecycle_test.go
@@ -254,3 +254,81 @@ func TestService_DisablingRuleSoftResolvesViolations(t *testing.T) {
 		t.Errorf("resolved_at = nil, want populated")
 	}
 }
+
+// TestService_DisableFilesystemRulesSoftResolvesViolations asserts that the
+// auto-disable path (DisableFilesystemRules, triggered when the last local
+// library is removed) runs the same cleanup as a manual disable Update: open
+// violations transition to resolved and rule_results rows are purged. Without
+// this, an auto-disabled fs rule keeps surfacing stale "needs attention"
+// counts and stale pass/fail rows on the dashboard.
+func TestService_DisableFilesystemRulesSoftResolvesViolations(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	if err := svc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+
+	// RuleNFOExists is the lone filesystem-dependent rule; force-enable it so
+	// the test is independent of seed defaults.
+	r, err := svc.GetByID(ctx, RuleNFOExists)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if !r.Enabled {
+		r.Enabled = true
+		if err := svc.Update(ctx, r); err != nil {
+			t.Fatalf("force-enable: %v", err)
+		}
+	}
+
+	// Seed an artist (FK target) before upserting a violation. UpsertViolation
+	// atomically writes a sibling rule_results row, so we don't need to insert
+	// rule_results manually -- after the auto-disable, both rows must be gone
+	// (rule_results) or resolved (rule_violations).
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artists (id, name, path) VALUES (?, ?, '')`,
+		"a1", "A1",
+	); err != nil {
+		t.Fatalf("seed artist: %v", err)
+	}
+
+	v := &RuleViolation{
+		RuleID: RuleNFOExists, ArtistID: "a1", ArtistName: "A1",
+		Severity: "error", Message: "missing nfo", Fixable: true,
+		Status: ViolationStatusOpen,
+	}
+	if err := svc.UpsertViolation(ctx, v); err != nil {
+		t.Fatalf("UpsertViolation: %v", err)
+	}
+
+	count, err := svc.DisableFilesystemRules(ctx)
+	if err != nil {
+		t.Fatalf("DisableFilesystemRules: %v", err)
+	}
+	if count < 1 {
+		t.Fatalf("DisableFilesystemRules count = %d, want >= 1", count)
+	}
+
+	got, err := svc.GetViolationByID(ctx, v.ID)
+	if err != nil {
+		t.Fatalf("GetViolationByID: %v", err)
+	}
+	if got.Status != ViolationStatusResolved {
+		t.Errorf("status after auto-disable = %q, want %q", got.Status, ViolationStatusResolved)
+	}
+	if got.ResolvedAt == nil {
+		t.Errorf("resolved_at = nil, want populated after auto-disable")
+	}
+
+	var resultsCount int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM rule_results WHERE rule_id = ?`, RuleNFOExists,
+	).Scan(&resultsCount); err != nil {
+		t.Fatalf("count rule_results: %v", err)
+	}
+	if resultsCount != 0 {
+		t.Errorf("rule_results rows for %s = %d, want 0 (cleanup should have purged)", RuleNFOExists, resultsCount)
+	}
+}

--- a/internal/rule/lifecycle_test.go
+++ b/internal/rule/lifecycle_test.go
@@ -253,6 +253,20 @@ func TestService_DisablingRuleSoftResolvesViolations(t *testing.T) {
 	if got.ResolvedAt == nil {
 		t.Errorf("resolved_at = nil, want populated")
 	}
+
+	// rule_results must also be purged on the manual-disable path so the
+	// per-rule dashboard stops surfacing stale pass/fail counts. Without this
+	// assertion the manual disable's rule_results invariant could regress
+	// silently while only the auto-disable test catches it.
+	var resultsCount int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM rule_results WHERE rule_id = ?`, RuleNFOExists,
+	).Scan(&resultsCount); err != nil {
+		t.Fatalf("count rule_results: %v", err)
+	}
+	if resultsCount != 0 {
+		t.Errorf("rule_results rows for %s = %d, want 0 after manual disable", RuleNFOExists, resultsCount)
+	}
 }
 
 // TestService_DisableFilesystemRulesSoftResolvesViolations asserts that the

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -437,12 +437,19 @@ func (s *Service) GetByID(ctx context.Context, id string) (*Rule, error) {
 // remaining enabled rules' outcomes are unchanged by the disable, so a full
 // library walk would be wasted work.
 //
-// When a rule is disabled, active violations for that rule are deleted so
-// they stop counting against compliance scores. Without this cleanup the
-// violation rows would persist indefinitely -- the rule no longer runs, so
-// nothing would ever mark them resolved. Historical dismissed/resolved
-// rows are left alone; only open and pending_choice violations (the ones
-// still surfacing in the UI as "needs attention") are removed.
+// When a rule is disabled, active violations for that rule are soft-resolved
+// (status='resolved', resolved_at=now) so they stop counting against compliance
+// scores. Without this cleanup the violation rows would persist indefinitely:
+// the rule no longer runs, so nothing would ever mark them resolved. Historical
+// dismissed/resolved rows are left alone; only open and pending_choice
+// violations (the ones still surfacing in the UI as "needs attention") are
+// updated.
+//
+// Issue #1143: prefer soft cleanup over a hard DELETE so the violation history
+// (when the row was first created, when it was last seen, etc.) is preserved
+// for audit. The 'resolved' state mirrors the path the auto-fix pipeline takes
+// when a fixer succeeds, so downstream consumers (compliance counts, history
+// charts) treat the two transitions identically.
 func (s *Service) Update(ctx context.Context, r *Rule) error {
 	r.UpdatedAt = time.Now().UTC()
 	_, err := s.db.ExecContext(ctx, `
@@ -454,8 +461,12 @@ func (s *Service) Update(ctx context.Context, r *Rule) error {
 	}
 
 	if !r.Enabled {
+		now := time.Now().UTC().Format(time.RFC3339)
 		if _, cleanupErr := s.db.ExecContext(ctx,
-			`DELETE FROM rule_violations WHERE rule_id = ? AND status IN (?, ?)`,
+			`UPDATE rule_violations
+			    SET status = ?, resolved_at = ?, updated_at = ?
+			  WHERE rule_id = ? AND status IN (?, ?)`,
+			ViolationStatusResolved, now, now,
 			r.ID, ViolationStatusOpen, ViolationStatusPendingChoice,
 		); cleanupErr != nil {
 			return fmt.Errorf("cleaning up violations after disable: %w", cleanupErr)
@@ -784,6 +795,13 @@ func (s *Service) UpsertViolation(ctx context.Context, v *RuleViolation) error {
 	}
 	defer tx.Rollback() //nolint:errcheck
 
+	// Issue #1107: dismissed is terminal from the user's perspective. Once a
+	// row is stored as 'dismissed', re-evaluation must NOT clobber the status
+	// or dismissed_at back to fresh values; otherwise every Run Rules pass
+	// resurrects a violation the user explicitly hid. We preserve status and
+	// dismissed_at when the existing row is dismissed, while still letting
+	// resolved -> open transitions happen normally (a user-deleted file
+	// should re-open the violation that previously fixed it).
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO rule_violations (id, rule_id, artist_id, artist_name, severity, message, fixable, status, candidates, dismissed_at, resolved_at, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -792,9 +810,13 @@ func (s *Service) UpsertViolation(ctx context.Context, v *RuleViolation) error {
 			severity = excluded.severity,
 			message = excluded.message,
 			fixable = excluded.fixable,
-			status = excluded.status,
+			status = CASE WHEN rule_violations.status = 'dismissed'
+			              THEN rule_violations.status
+			              ELSE excluded.status END,
 			candidates = excluded.candidates,
-			dismissed_at = excluded.dismissed_at,
+			dismissed_at = CASE WHEN rule_violations.status = 'dismissed'
+			                    THEN rule_violations.dismissed_at
+			                    ELSE excluded.dismissed_at END,
 			resolved_at = excluded.resolved_at,
 			updated_at = excluded.updated_at
 	`, v.ID, v.RuleID, v.ArtistID, v.ArtistName, v.Severity, v.Message,
@@ -811,12 +833,21 @@ func (s *Service) UpsertViolation(ctx context.Context, v *RuleViolation) error {
 	// and the transaction rolls back. Re-read the persisted id inside the
 	// same tx and sync v.ID so the result-row write lands cleanly and the
 	// caller observes the authoritative id.
+	//
+	// Issue #1107: also re-read the persisted status so writeResultRow
+	// reflects the post-upsert state. When the stored row was 'dismissed',
+	// the ON CONFLICT preserves it and we must NOT write a fail row even if
+	// the incoming v.Status is 'open'. Otherwise rule_results would carry a
+	// fresh fail for a violation the user explicitly hid.
+	var persistedStatus string
 	if err := tx.QueryRowContext(ctx,
-		`SELECT id FROM rule_violations WHERE rule_id = ? AND artist_id = ?`,
+		`SELECT id, status FROM rule_violations WHERE rule_id = ? AND artist_id = ?`,
 		v.RuleID, v.ArtistID,
-	).Scan(&v.ID); err != nil {
+	).Scan(&v.ID, &persistedStatus); err != nil {
 		return fmt.Errorf("loading persisted violation id: %w", err)
 	}
+	writeResultRow = writeResultRow &&
+		(persistedStatus == ViolationStatusOpen || persistedStatus == ViolationStatusPendingChoice)
 
 	if writeResultRow {
 		if err := upsertRuleResultFailExec(ctx, tx, v.ArtistID, v.RuleID, v.ID, v.Message, v.UpdatedAt); err != nil {
@@ -1196,6 +1227,31 @@ func (s *Service) ResolveViolation(ctx context.Context, id string) error {
 		return fmt.Errorf("resolving violation: %w", err)
 	}
 	return nil
+}
+
+// ResolveViolationIfActive transitions an open or pending_choice violation
+// for the given (rule_id, artist_id) pair to status='resolved'. Dismissed and
+// already-resolved rows are left untouched: dismissed is terminal (#1107) and
+// resolved is idempotent. Returns true when a row was actually updated so the
+// caller can decide whether to log or emit an event.
+//
+// Issue #1105: the rule pipeline calls this for every (rule, artist) pair
+// where the rule was considered but no longer reports a violation, so a row
+// the user fixed out-of-band (e.g. dropped a logo.png into the artist
+// directory) finally clears from the dashboard on the next Run Rules.
+func (s *Service) ResolveViolationIfActive(ctx context.Context, ruleID, artistID string) (bool, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE rule_violations
+		   SET status = ?, resolved_at = ?, updated_at = ?
+		 WHERE rule_id = ? AND artist_id = ? AND status IN (?, ?)
+	`, ViolationStatusResolved, now, now,
+		ruleID, artistID, ViolationStatusOpen, ViolationStatusPendingChoice)
+	if err != nil {
+		return false, fmt.Errorf("resolving active violation: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
 // CountActiveViolationsForArtist returns the count of active (open + pending_choice)

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -461,26 +461,37 @@ func (s *Service) Update(ctx context.Context, r *Rule) error {
 	}
 
 	if !r.Enabled {
-		now := time.Now().UTC().Format(time.RFC3339)
-		if _, cleanupErr := s.db.ExecContext(ctx,
-			`UPDATE rule_violations
-			    SET status = ?, resolved_at = ?, updated_at = ?
-			  WHERE rule_id = ? AND status IN (?, ?)`,
-			ViolationStatusResolved, now, now,
-			r.ID, ViolationStatusOpen, ViolationStatusPendingChoice,
-		); cleanupErr != nil {
-			return fmt.Errorf("cleaning up violations after disable: %w", cleanupErr)
+		if err := s.cleanupDisabledRuleState(ctx, r.ID); err != nil {
+			return err
 		}
-		// Full delete of rule_results on disable (not status-filtered like
-		// rule_violations): the rule no longer runs, so no existing row is
-		// authoritative until the rule is re-enabled and re-evaluated.
-		// Without this the per-rule dashboard would keep surfacing stale
-		// pass/fail counts for an inactive rule.
-		if _, cleanupErr := s.db.ExecContext(ctx,
-			`DELETE FROM rule_results WHERE rule_id = ?`, r.ID,
-		); cleanupErr != nil {
-			return fmt.Errorf("cleaning up rule_results after disable: %w", cleanupErr)
-		}
+	}
+	return nil
+}
+
+// cleanupDisabledRuleState soft-resolves any open or pending-choice violations
+// for the given rule and deletes its pass/fail history rows. Called from every
+// path that flips a rule from enabled to disabled (manual Update, automatic
+// DisableFilesystemRules) so that all disable transitions converge on the
+// same end state.
+//
+// Soft-resolve (UPDATE) preserves audit history per #1143; rule_results uses
+// a hard DELETE because no existing row is authoritative once the rule stops
+// running.
+func (s *Service) cleanupDisabledRuleState(ctx context.Context, ruleID string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE rule_violations
+		    SET status = ?, resolved_at = ?, updated_at = ?
+		  WHERE rule_id = ? AND status IN (?, ?)`,
+		ViolationStatusResolved, now, now,
+		ruleID, ViolationStatusOpen, ViolationStatusPendingChoice,
+	); err != nil {
+		return fmt.Errorf("cleaning up violations after disable: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM rule_results WHERE rule_id = ?`, ruleID,
+	); err != nil {
+		return fmt.Errorf("cleaning up rule_results after disable: %w", err)
 	}
 	return nil
 }
@@ -499,37 +510,72 @@ func (s *Service) DisableFilesystemRules(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 
-	// Build parameterized query with the correct number of placeholders.
 	placeholders := make([]string, len(ids))
-	args := make([]any, 0, len(ids)+1)
-	now := time.Now().UTC().Format(time.RFC3339)
+	idArgs := make([]any, len(ids))
 	for i, id := range ids {
 		placeholders[i] = "?"
-		args = append(args, id)
+		idArgs[i] = id
 	}
-	args = append(args, now)
 
-	query := fmt.Sprintf( //nolint:gosec // G201: only "?" placeholders are interpolated; all values are parameterized
-		`UPDATE rules SET enabled = 0, updated_at = ? WHERE enabled = 1 AND id IN (%s)`,
+	// Identify which fs rules are currently enabled. We need the specific IDs
+	// so the cleanup pass below only touches rules that this call actually
+	// disabled, mirroring what Update does for a single rule.
+	selectQuery := fmt.Sprintf( //nolint:gosec // G201: only "?" placeholders are interpolated; all values are parameterized
+		`SELECT id FROM rules WHERE enabled = 1 AND id IN (%s)`,
 		strings.Join(placeholders, ", "),
 	)
-	// The updated_at parameter must be first to match the SET clause position.
-	// Reorder: updated_at, then all IDs.
-	orderedArgs := make([]any, 0, len(args))
-	orderedArgs = append(orderedArgs, now)
-	for _, id := range ids {
-		orderedArgs = append(orderedArgs, id)
+	rows, err := s.db.QueryContext(ctx, selectQuery, idArgs...)
+	if err != nil {
+		return 0, fmt.Errorf("disabling filesystem rules: selecting enabled: %w", err)
+	}
+	var toDisable []string
+	scanErr := func() error {
+		defer rows.Close() //nolint:errcheck
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				return fmt.Errorf("disabling filesystem rules: scanning enabled: %w", err)
+			}
+			toDisable = append(toDisable, id)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("disabling filesystem rules: iterating enabled: %w", err)
+		}
+		return nil
+	}()
+	if scanErr != nil {
+		return 0, scanErr
+	}
+	if len(toDisable) == 0 {
+		return 0, nil
 	}
 
-	result, err := s.db.ExecContext(ctx, query, orderedArgs...)
-	if err != nil {
+	// Flip enabled=0 in one statement.
+	disablePlaceholders := make([]string, len(toDisable))
+	disableArgs := make([]any, 0, len(toDisable)+1)
+	now := time.Now().UTC().Format(time.RFC3339)
+	disableArgs = append(disableArgs, now)
+	for i, id := range toDisable {
+		disablePlaceholders[i] = "?"
+		disableArgs = append(disableArgs, id)
+	}
+	updateQuery := fmt.Sprintf( //nolint:gosec // G201: only "?" placeholders are interpolated; all values are parameterized
+		`UPDATE rules SET enabled = 0, updated_at = ? WHERE id IN (%s)`,
+		strings.Join(disablePlaceholders, ", "),
+	)
+	if _, err := s.db.ExecContext(ctx, updateQuery, disableArgs...); err != nil {
 		return 0, fmt.Errorf("disabling filesystem rules: %w", err)
 	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return 0, fmt.Errorf("disabling filesystem rules: getting rows affected: %w", err)
+
+	// Run the same disable cleanup that Update performs, so auto-disabled
+	// filesystem rules don't leave stale open violations or pass/fail rows.
+	for _, id := range toDisable {
+		if err := s.cleanupDisabledRuleState(ctx, id); err != nil {
+			return 0, fmt.Errorf("disabling filesystem rules: cleanup for %s: %w", id, err)
+		}
 	}
-	return int(rows), nil
+
+	return len(toDisable), nil
 }
 
 // RecordHealthSnapshot inserts a row into the health_history table, subject to

--- a/internal/rule/service_test.go
+++ b/internal/rule/service_test.go
@@ -235,10 +235,12 @@ func TestUpdate(t *testing.T) {
 }
 
 // TestUpdate_DisabledClearsActiveViolations verifies the cleanup branch added
-// in round 2: when a rule flips to enabled=false, open and pending_choice
-// violations for that rule are deleted so they stop showing up as "needs
-// attention" rows now that the rule no longer re-evaluates the library.
-// Historical dismissed/resolved rows must be left alone.
+// in round 2 (then refined in #1143): when a rule flips to enabled=false, open
+// and pending_choice violations for that rule are soft-resolved
+// (status='resolved', resolved_at=now) so they stop counting against
+// compliance scores while preserving the audit history (#1143 prefers Option B
+// over a hard DELETE). Historical dismissed/resolved rows must be left alone,
+// and sibling rules must not be touched.
 func TestUpdate_DisabledClearsActiveViolations(t *testing.T) {
 	db := setupTestDB(t)
 	svc := NewService(db)
@@ -293,16 +295,36 @@ func TestUpdate_DisabledClearsActiveViolations(t *testing.T) {
 	if got := countByStatus(ruleID, ViolationStatusPendingChoice); got != 0 {
 		t.Errorf("pending_choice rows for disabled rule = %d, want 0", got)
 	}
-	// Historical rows must survive the disable.
-	if got := countByStatus(ruleID, ViolationStatusResolved); got != 1 {
-		t.Errorf("resolved rows for disabled rule = %d, want 1 (history must survive)", got)
+	// #1143 soft-resolve: the original open + pending_choice rows are
+	// transitioned to resolved (2 new resolutions) and stack on top of the
+	// pre-existing resolved row, so the resolved bucket now holds 3.
+	if got := countByStatus(ruleID, ViolationStatusResolved); got != 3 {
+		t.Errorf("resolved rows for disabled rule = %d, want 3 (2 soft-resolved + 1 pre-existing)", got)
 	}
+	// Dismissed history must survive untouched (terminal state per #1107).
 	if got := countByStatus(ruleID, ViolationStatusDismissed); got != 1 {
 		t.Errorf("dismissed rows for disabled rule = %d, want 1 (history must survive)", got)
 	}
 	// Sibling rule must be untouched by the cleanup.
 	if got := countByStatus(otherID, ViolationStatusOpen); got != 1 {
 		t.Errorf("sibling rule open rows = %d, want 1 (cleanup should be rule-scoped)", got)
+	}
+	// resolved_at must be populated on the rows the cleanup actually
+	// transitioned (a1, a2). Pre-existing resolved rows in the seed (a3) may
+	// carry NULL because the test setup did not stamp ResolvedAt, so the
+	// assertion is scoped to the artists the disable path was responsible
+	// for resolving.
+	for _, aid := range []string{"a1", "a2"} {
+		var resolvedAt sql.NullString
+		if err := db.QueryRow(
+			`SELECT resolved_at FROM rule_violations WHERE rule_id = ? AND artist_id = ?`,
+			ruleID, aid,
+		).Scan(&resolvedAt); err != nil {
+			t.Fatalf("reading resolved_at for %s: %v", aid, err)
+		}
+		if !resolvedAt.Valid {
+			t.Errorf("artist %s resolved_at = NULL, want populated after disable", aid)
+		}
 	}
 }
 
@@ -2537,4 +2559,202 @@ func TestListViolationsFiltered_SearchEscapesLikeWildcards(t *testing.T) {
 			t.Errorf(`Search=C:\Users returned %+v, want one row for art-6`, got)
 		}
 	})
+}
+
+// TestUpsertViolation_PreservesDismissedStatus verifies the #1107 fix: once a
+// violation row is in 'dismissed' status, a re-evaluation that would otherwise
+// upsert the same (rule_id, artist_id) with status='open' must NOT clobber the
+// dismissed status or dismissed_at. Dismissal is terminal from the user's
+// perspective; only an explicit reset path may transition out of it.
+func TestUpsertViolation_PreservesDismissedStatus(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	// Step 1: insert an open violation.
+	v := &RuleViolation{
+		RuleID: RuleNFOExists, ArtistID: "a1", ArtistName: "A1",
+		Severity: "error", Message: "missing nfo", Fixable: true,
+		Status: ViolationStatusOpen,
+	}
+	if err := svc.UpsertViolation(ctx, v); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+
+	// Step 2: dismiss it.
+	if err := svc.DismissViolation(ctx, v.ID); err != nil {
+		t.Fatalf("dismiss: %v", err)
+	}
+
+	// Capture the post-dismiss dismissed_at so we can assert it is preserved
+	// across the resurrection upsert.
+	var dismissedAtBefore sql.NullString
+	if err := db.QueryRow(
+		`SELECT dismissed_at FROM rule_violations WHERE rule_id = ? AND artist_id = ?`,
+		v.RuleID, v.ArtistID,
+	).Scan(&dismissedAtBefore); err != nil {
+		t.Fatalf("reading pre-upsert dismissed_at: %v", err)
+	}
+	if !dismissedAtBefore.Valid {
+		t.Fatalf("dismissed_at must be populated after DismissViolation")
+	}
+
+	// Step 3: re-evaluate -- the pipeline upserts with status=open again.
+	resurrect := &RuleViolation{
+		RuleID: RuleNFOExists, ArtistID: "a1", ArtistName: "A1",
+		Severity: "error", Message: "missing nfo", Fixable: true,
+		Status: ViolationStatusOpen,
+	}
+	if err := svc.UpsertViolation(ctx, resurrect); err != nil {
+		t.Fatalf("resurrection upsert: %v", err)
+	}
+
+	// Step 4: status must still be 'dismissed' and dismissed_at unchanged.
+	var status string
+	var dismissedAtAfter sql.NullString
+	if err := db.QueryRow(
+		`SELECT status, dismissed_at FROM rule_violations WHERE rule_id = ? AND artist_id = ?`,
+		v.RuleID, v.ArtistID,
+	).Scan(&status, &dismissedAtAfter); err != nil {
+		t.Fatalf("reading post-upsert state: %v", err)
+	}
+	if status != ViolationStatusDismissed {
+		t.Errorf("status after re-eval = %q, want %q (dismissal must survive)", status, ViolationStatusDismissed)
+	}
+	if dismissedAtAfter.String != dismissedAtBefore.String {
+		t.Errorf("dismissed_at changed: before=%q after=%q", dismissedAtBefore.String, dismissedAtAfter.String)
+	}
+
+	// Step 5: the resurrection upsert must not bump rule_results for this
+	// (rule, artist). The first Upsert (status=open) legitimately wrote a
+	// fail row, but once the row is dismissed any subsequent Upsert with
+	// the same (rule_id, artist_id) is a no-op for rule_results because
+	// writeResultRow is recomputed from the persisted (preserved) status.
+	// We capture evaluated_at after the dismiss and assert it does not
+	// change across the resurrection upsert.
+	var beforeLastFailed sql.NullString
+	if err := db.QueryRow(
+		`SELECT evaluated_at FROM rule_results
+		   WHERE rule_id = ? AND artist_id = ?`,
+		v.RuleID, v.ArtistID,
+	).Scan(&beforeLastFailed); err != nil && err != sql.ErrNoRows {
+		t.Fatalf("reading pre-resurrect evaluated_at: %v", err)
+	}
+	// Nudge clock so a fresh write would visibly bump the timestamp.
+	time.Sleep(1100 * time.Millisecond)
+	if err := svc.UpsertViolation(ctx, &RuleViolation{
+		RuleID: v.RuleID, ArtistID: v.ArtistID, ArtistName: v.ArtistName,
+		Severity: v.Severity, Message: v.Message, Fixable: true,
+		Status: ViolationStatusOpen,
+	}); err != nil {
+		t.Fatalf("second resurrection upsert: %v", err)
+	}
+	var afterLastFailed sql.NullString
+	if err := db.QueryRow(
+		`SELECT evaluated_at FROM rule_results
+		   WHERE rule_id = ? AND artist_id = ?`,
+		v.RuleID, v.ArtistID,
+	).Scan(&afterLastFailed); err != nil && err != sql.ErrNoRows {
+		t.Fatalf("reading post-resurrect evaluated_at: %v", err)
+	}
+	if beforeLastFailed.String != afterLastFailed.String {
+		t.Errorf("rule_results.evaluated_at bumped across dismissed-resurrect upsert: before=%q after=%q",
+			beforeLastFailed.String, afterLastFailed.String)
+	}
+}
+
+// TestUpsertViolation_ResolvedReopensOnReDetection verifies the #1107 fix
+// preserves only the dismissed terminal state, not resolved. A violation that
+// was resolved (e.g., by the auto-fixer) but then becomes broken again on disk
+// must reopen on the next evaluation.
+func TestUpsertViolation_ResolvedReopensOnReDetection(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	v := &RuleViolation{
+		RuleID: RuleLogoExists, ArtistID: "a1", ArtistName: "A1",
+		Severity: "warning", Message: "no logo", Fixable: true,
+		Status: ViolationStatusOpen,
+	}
+	if err := svc.UpsertViolation(ctx, v); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+	if err := svc.ResolveViolation(ctx, v.ID); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	// User deletes the file again; the next evaluation re-detects the
+	// violation. status should transition resolved -> open.
+	reopen := &RuleViolation{
+		RuleID: RuleLogoExists, ArtistID: "a1", ArtistName: "A1",
+		Severity: "warning", Message: "no logo", Fixable: true,
+		Status: ViolationStatusOpen,
+	}
+	if err := svc.UpsertViolation(ctx, reopen); err != nil {
+		t.Fatalf("reopen upsert: %v", err)
+	}
+
+	var status string
+	if err := db.QueryRow(
+		`SELECT status FROM rule_violations WHERE rule_id = ? AND artist_id = ?`,
+		v.RuleID, v.ArtistID,
+	).Scan(&status); err != nil {
+		t.Fatalf("reading status: %v", err)
+	}
+	if status != ViolationStatusOpen {
+		t.Errorf("status after re-detection = %q, want %q (resolved must reopen)", status, ViolationStatusOpen)
+	}
+}
+
+// TestResolveViolationIfActive verifies the #1105 helper used by
+// persistPassResults: open and pending_choice rows are transitioned to
+// resolved, dismissed and already-resolved rows are left untouched.
+func TestResolveViolationIfActive(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	type row struct {
+		artistID  string
+		startStat string
+		wantStat  string
+		wantOK    bool
+	}
+	rows := []row{
+		{"open-art", ViolationStatusOpen, ViolationStatusResolved, true},
+		{"pending-art", ViolationStatusPendingChoice, ViolationStatusResolved, true},
+		{"dismissed-art", ViolationStatusDismissed, ViolationStatusDismissed, false},
+		{"resolved-art", ViolationStatusResolved, ViolationStatusResolved, false},
+	}
+	for _, r := range rows {
+		v := &RuleViolation{
+			RuleID: RuleNFOExists, ArtistID: r.artistID, ArtistName: r.artistID,
+			Severity: "error", Message: "stale", Fixable: true,
+			Status: r.startStat,
+		}
+		if err := svc.UpsertViolation(ctx, v); err != nil {
+			t.Fatalf("seed %s: %v", r.artistID, err)
+		}
+	}
+
+	for _, r := range rows {
+		updated, err := svc.ResolveViolationIfActive(ctx, RuleNFOExists, r.artistID)
+		if err != nil {
+			t.Fatalf("ResolveViolationIfActive(%s): %v", r.artistID, err)
+		}
+		if updated != r.wantOK {
+			t.Errorf("ResolveViolationIfActive(%s) updated=%v, want %v", r.artistID, updated, r.wantOK)
+		}
+		var got string
+		if err := db.QueryRow(
+			`SELECT status FROM rule_violations WHERE rule_id = ? AND artist_id = ?`,
+			RuleNFOExists, r.artistID,
+		).Scan(&got); err != nil {
+			t.Fatalf("reading status for %s: %v", r.artistID, err)
+		}
+		if got != r.wantStat {
+			t.Errorf("status for %s = %q, want %q", r.artistID, got, r.wantStat)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
Bundle of four rule-engine lifecycle fixes that share the evaluate/upsert/fix pipeline:

- **#1105** -- `persistPassResults` now resolves any open or `pending_choice` violation row whose rule was considered but did not appear in the new violation set. Out-of-band fixes (user dropping a logo into the artist directory, scanner refresh, etc.) finally clear from the dashboard.
- **#1107** -- `UpsertViolation` `ON CONFLICT` preserves `status` and `dismissed_at` when the stored row is dismissed. Re-evaluation no longer clobbers a user-dismissed row back to open. `resolved -> open` transitions still fire so a re-broken file reopens its violation. The post-upsert status read also recomputes `writeResultRow` so a dismissed-preserved row no longer bumps `rule_results`.
- **#1108** -- `attemptFix` invalidates `engine.FSCache` on `Path` after a successful, non-discovery fix. Within the cache TTL the next `Evaluate` reads the post-mutation directory listing instead of resurrecting the violation we just fixed.
- **#1143** -- `Service.Update` soft-resolves (`status='resolved'`, `resolved_at=now`) active violations of a disabled rule instead of hard-deleting them, preserving audit history.

## Test plan
- [x] `go test -race -timeout 300s ./...` passes
- [x] `lifecycle_test.go` covers the four pipeline contracts (resolve-on-pass, dismissed-preserved, fixer FSCache invalidation, disable soft-resolve)
- [x] `service_test.go` adds focused unit tests for `ResolveViolationIfActive` and the dismissed-preservation upsert path
- [x] Pre-push gate green (OpenAPI consistency, generated files, raw error leak, patch coverage 86.67%)
- [x] Manual UAT on dashboard action queue: re-eval clears resolved (#1105), dismissed stays dismissed (#1107), disabled rule soft-resolves (#1143). #1108 verified via direct unit test.

Closes #1105
Closes #1107
Closes #1108
Closes #1143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented fixed items from reappearing by ensuring filesystem state is refreshed after automated fixes.
  * Re-evaluation will not reopen user-dismissed violations; dismissed items remain hidden.
  * Disabling rules now soft-resolves active violations without removing their history.

* **New Features**
  * Preservation of resolution timestamps and history for auditability.
  * Targeted disabling only affects intended filesystem rules and cleans up their active state.

* **Tests**
  * New lifecycle and contract tests validating resolution, dismissal preservation, cache behavior, and disablement cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->