### PR TITLE
chore(release): add SLSA build provenance attestations (#1209)

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -185,7 +185,10 @@ jobs:
           set -euo pipefail
           out="stillwater_${TAG}_provenance.intoto.jsonl"
           cp "$BUNDLE" "$out"
-          gh release upload "$TAG" "$out"
+          # --clobber: idempotent on workflow retry (e.g. workflow_dispatch
+          # rerun on the same nightly tag). gh deletes the existing asset
+          # before re-uploading.
+          gh release upload "$TAG" "$out" --clobber
 
       # Retention: keep the 14 most recent nightly releases (and their tags);
       # delete everything older. Only touches `nightly-*` refs; non-nightly

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -33,9 +33,10 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # create tags and GitHub Releases
-      packages: write   # parity with stable; harmless if unused
-      id-token: write   # cosign keyless signing of checksums
+      contents: write       # create tags and GitHub Releases
+      packages: write       # parity with stable; harmless if unused
+      id-token: write       # cosign keyless signing of checksums
+      attestations: write   # SLSA build provenance via actions/attest-build-provenance
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -160,6 +161,31 @@ jobs:
           args: release --clean --config .goreleaser.nightly.yml --skip=validate
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # SLSA v1 build provenance for nightly artifacts. Mirrors the stable
+      # release pipeline (.github/workflows/release.yml) so OpenSSF Scorecard's
+      # Signed-Releases provenance sub-check is satisfied for both channels.
+      - name: Generate build provenance attestation
+        id: attest
+        if: steps.guard.outputs.skip != 'true'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            dist/stillwater_*_checksums.txt
+            dist/stillwater_*.tar.gz
+            dist/stillwater_*.zip
+
+      - name: Attach provenance to release
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          out="stillwater_${TAG}_provenance.intoto.jsonl"
+          cp "$BUNDLE" "$out"
+          gh release upload "$TAG" "$out"
 
       # Retention: keep the 14 most recent nightly releases (and their tags);
       # delete everything older. Only touches `nightly-*` refs; non-nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -70,6 +71,33 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_PREVIOUS_TAG: ${{ steps.prev.outputs.prev }}
+
+      # Generate a SLSA v1 build-provenance attestation covering every release
+      # artifact (checksums file + per-arch archives). The action signs the
+      # bundle via the same Sigstore keyless flow cosign already uses, so this
+      # reuses the existing OIDC trust setup. A single bundle covers all
+      # subjects (in-toto v1 supports multi-subject statements); we attach it
+      # to the GitHub Release as *.intoto.jsonl so OpenSSF Scorecard's
+      # Signed-Releases check recognizes it as provenance.
+      - name: Generate build provenance attestation
+        id: attest
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            dist/stillwater_*_checksums.txt
+            dist/stillwater_*.tar.gz
+            dist/stillwater_*.zip
+
+      - name: Attach provenance to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          out="stillwater_${TAG#v}_provenance.intoto.jsonl"
+          cp "$BUNDLE" "$out"
+          gh release upload "$TAG" "$out"
 
       - name: Mark stable release as latest
         if: "!contains(github.ref_name, '-rc') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-alpha')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,10 @@ jobs:
           set -euo pipefail
           out="stillwater_${TAG#v}_provenance.intoto.jsonl"
           cp "$BUNDLE" "$out"
-          gh release upload "$TAG" "$out"
+          # --clobber: idempotent on workflow retry. gh deletes the existing
+          # asset before re-uploading, so a failed retry leaves the release
+          # without provenance until the next successful run.
+          gh release upload "$TAG" "$out" --clobber
 
       - name: Mark stable release as latest
         if: "!contains(github.ref_name, '-rc') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-alpha')"

--- a/.typos.toml
+++ b/.typos.toml
@@ -12,3 +12,11 @@ extend-exclude = [
 [default.extend-identifiers]
 # Go variable names that are not typos
 fpr = "fpr"  # FieldProviderResult in internal/provider/orchestrator.go
+
+[default.extend-words]
+# Project / standard names that look like typos.
+# in-toto (https://in-toto.io) is the SLSA attestation format; ".intoto.jsonl"
+# is the canonical file suffix that OpenSSF Scorecard's Signed-Releases check
+# recognizes. Without this allowlist, typos rewrites it to ".into.jsonl" and
+# silently breaks Scorecard provenance detection.
+intoto = "intoto"


### PR DESCRIPTION
## Summary
- Add `actions/attest-build-provenance@v4.1.0` step to both `release.yml` and `release-nightly.yml` after the GoReleaser run
- Generate one SLSA v1 in-toto multi-subject attestation covering every release artifact (`*_checksums.txt`, `*.tar.gz`, `*.zip`) and attach it as `stillwater_<version>_provenance.intoto.jsonl` on the GitHub Release
- Add `attestations: write` permission to both jobs
- Allowlist `intoto` in `.typos.toml` to stop the typos pre-commit hook from silently rewriting `.intoto.jsonl` to `.into.jsonl`

Closes #1209.

## Rationale
OpenSSF Scorecard treats signing and provenance as separate sub-checks. Cosign blob signing (#1023, #1167, #1202) proves *who* signed the bytes; build provenance proves *which workflow run on which commit* produced them. Scorecard was warning "does not have provenance" on every release. The `.intoto.jsonl` suffix is the filename Scorecard's release scanner recognizes for SLSA attestations.

Reuses the existing Sigstore keyless OIDC trust setup -- no new secrets. Single multi-subject bundle (matches the `slsa-framework/slsa-github-generator` shape) instead of one attestation per artifact, to keep the release page tidy.

Backfilling provenance on already-published releases (v0.9.5, v0.9.6, rc tags) is intentionally out of scope: provenance is only meaningful when generated by the original build run.

## Test plan
- [ ] actionlint clean on both workflows (verified locally)
- [ ] Cut a `v*-rc.*` test tag and confirm the release has a `*_provenance.intoto.jsonl` asset
- [ ] `gh attestation verify <artifact> --repo sydlexius/stillwater` passes against any artifact in that release
- [ ] Next Scorecard run no longer warns "does not have provenance" for that tag
- [ ] Same flow runs cleanly on the next nightly cron

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release artifacts now include SLSA v1 provenance attestations attached as additional release assets for regular releases and nightly builds.
  * Attestation files are produced per release/tag and uploaded alongside other artifacts with idempotent retries to ensure reliable publishing.
  * Added a tooling allowlist entry for "intoto" to prevent automatic typo corrections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->