### PR TITLE
fix(db): cascade platform IDs, dedupe artist rows, clean up on library unlink

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -131,6 +131,13 @@ func run() error {
 		}
 	}()
 
+	// Issue #1078: turn on PRAGMA foreign_keys so the ON DELETE CASCADE
+	// declarations on artist_platform_ids, artist_images, rule_violations,
+	// etc. actually fire on artist / connection deletes.
+	if err := database.EnableForeignKeys(db); err != nil {
+		return fmt.Errorf("enabling foreign keys: %w", err)
+	}
+
 	// Run migrations
 	if err := database.Migrate(db); err != nil {
 		return fmt.Errorf("running migrations: %w", err)
@@ -690,6 +697,9 @@ func resetCredentials() error {
 	}
 	defer db.Close() //nolint:errcheck
 
+	if err := database.EnableForeignKeys(db); err != nil {
+		return fmt.Errorf("enabling foreign keys: %w", err)
+	}
 	if err := database.Migrate(db); err != nil {
 		return fmt.Errorf("running migrations: %w", err)
 	}
@@ -742,6 +752,9 @@ func resetPassword(username, password string) error {
 	}
 	defer db.Close() //nolint:errcheck
 
+	if err := database.EnableForeignKeys(db); err != nil {
+		return fmt.Errorf("enabling foreign keys: %w", err)
+	}
 	if err := database.Migrate(db); err != nil {
 		return fmt.Errorf("running migrations: %w", err)
 	}

--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -1067,6 +1067,18 @@ func (r *Router) backfillPlatformIDToManualLibs(
 			continue
 		}
 		if setErr := r.artistService.SetPlatformID(ctx, fsArtist.ID, connectionID, platformArtistID); setErr != nil {
+			// Issue #1076: a UNIQUE index on
+			// (connection_id, platform_artist_id) means at most one
+			// artist row can hold a given platform mapping. The
+			// connection-library artist already claimed it before we
+			// got here, so the filesystem-library copy is now
+			// redundant rather than erroneous. Skip silently with a
+			// debug log instead of warning.
+			if errors.Is(setErr, artist.ErrPlatformIDClaimedByAnotherArtist) {
+				r.logger.Debug("backfill: platform id already held by another artist row, skipping",
+					"fs_artist_id", fsArtist.ID, "connection_id", connectionID)
+				continue
+			}
 			r.logger.Warn("backfill: storing platform id on filesystem artist", "name", fsArtist.Name, "error", setErr)
 			continue
 		}

--- a/internal/api/handlers_connection_library_test.go
+++ b/internal/api/handlers_connection_library_test.go
@@ -2277,13 +2277,18 @@ func TestScanFromEmby_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 		t.Errorf("emby artist platform ID = %q, want %q", embyPlatformID, "emby-deftones-001")
 	}
 
-	// Verify platform ID was ALSO backfilled to filesystem artist.
+	// Issue #1076 added a UNIQUE(connection_id, platform_artist_id) index,
+	// so the historical "duplicate the mapping onto the filesystem artist"
+	// behavior is no longer possible: at most one artist row can hold a
+	// given (connection, platform_id) pair. The post-fix invariant is that
+	// the connection-library artist owns the mapping and the filesystem
+	// artist does not get a duplicate copy.
 	fsPlatformID, err := router.artistService.GetPlatformID(ctx, fsArtist.ID, "conn-emby-1")
 	if err != nil {
 		t.Fatalf("GetPlatformID (fs artist): %v", err)
 	}
-	if fsPlatformID != "emby-deftones-001" {
-		t.Errorf("filesystem artist platform ID = %q, want %q", fsPlatformID, "emby-deftones-001")
+	if fsPlatformID != "" {
+		t.Errorf("filesystem artist platform ID = %q, want empty (UNIQUE index forbids duplicate mapping)", fsPlatformID)
 	}
 }
 
@@ -2378,13 +2383,14 @@ func TestPopulateFromEmby_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 		t.Errorf("emby artist platform ID = %q, want %q", embyPlatformID, "emby-radiohead-001")
 	}
 
-	// The filesystem artist should ALSO have the platform ID (new behavior).
+	// Issue #1076: only the connection-library artist holds the mapping;
+	// the filesystem artist no longer gets a duplicate.
 	fsPlatformID, err := router.artistService.GetPlatformID(ctx, fsArtist.ID, "conn-emby-1")
 	if err != nil {
 		t.Fatalf("GetPlatformID (fs): %v", err)
 	}
-	if fsPlatformID != "emby-radiohead-001" {
-		t.Errorf("filesystem artist platform ID = %q, want %q", fsPlatformID, "emby-radiohead-001")
+	if fsPlatformID != "" {
+		t.Errorf("filesystem artist platform ID = %q, want empty (UNIQUE index forbids duplicate mapping)", fsPlatformID)
 	}
 }
 
@@ -2474,12 +2480,33 @@ func TestScanFromEmby_BackfillsCaseInsensitiveName(t *testing.T) {
 		t.Fatalf("scanFromEmby: %v", err)
 	}
 
+	// Issue #1076: the connection-library artist holds the platform mapping.
+	// Look it up by case-insensitive name within the Emby library; the
+	// scan should have created (or reused) an artist row there with the
+	// platform ID set. The filesystem artist must NOT carry a duplicate
+	// mapping under the new UNIQUE(connection_id, platform_artist_id)
+	// invariant; the case-insensitive match logic still runs and decides
+	// to skip rather than collide.
 	fsPlatformID, err := router.artistService.GetPlatformID(ctx, fsArtist.ID, "conn-emby-1")
 	if err != nil {
 		t.Fatalf("GetPlatformID (fs): %v", err)
 	}
-	if fsPlatformID != "emby-veridia-001" {
-		t.Errorf("filesystem artist platform ID = %q, want %q", fsPlatformID, "emby-veridia-001")
+	if fsPlatformID != "" {
+		t.Errorf("filesystem artist platform ID = %q, want empty (UNIQUE index forbids duplicate mapping)", fsPlatformID)
+	}
+	embyArtistRow, err := router.artistService.GetByNameAndLibrary(ctx, "VERIDIA", embyLib.ID)
+	if err != nil {
+		t.Fatalf("GetByNameAndLibrary (emby): %v", err)
+	}
+	if embyArtistRow == nil {
+		t.Fatal("scanFromEmby should have created the Emby-library artist row")
+	}
+	embyPlatformID, err := router.artistService.GetPlatformID(ctx, embyArtistRow.ID, "conn-emby-1")
+	if err != nil {
+		t.Fatalf("GetPlatformID (emby): %v", err)
+	}
+	if embyPlatformID != "emby-veridia-001" {
+		t.Errorf("emby artist platform ID = %q, want %q", embyPlatformID, "emby-veridia-001")
 	}
 }
 
@@ -2571,14 +2598,26 @@ func TestBackfillPlatformIDToManualLibs_MultipleManualLibraries(t *testing.T) {
 		"conn-emby-1", "emby-tool-001", "conn-artist-id",
 		manualLibs)
 
+	// Issue #1076: at most one artist row can hold a given
+	// (connection_id, platform_artist_id). The backfill iterates the manual
+	// libraries in order; the first artist claims the mapping and any
+	// subsequent same-name artist in another library skips silently
+	// (ErrPlatformIDClaimedByAnotherArtist). Assert that exactly one of the
+	// candidates holds the mapping rather than all of them.
+	holders := 0
 	for i, id := range fsArtistIDs {
 		pid, err := router.artistService.GetPlatformID(ctx, id, "conn-emby-1")
 		if err != nil {
 			t.Fatalf("GetPlatformID artist[%d]: %v", i, err)
 		}
-		if pid != "emby-tool-001" {
-			t.Errorf("artist[%d] platform ID = %q, want %q", i, pid, "emby-tool-001")
+		if pid == "emby-tool-001" {
+			holders++
+		} else if pid != "" {
+			t.Errorf("artist[%d] platform ID = %q, want empty or %q", i, pid, "emby-tool-001")
 		}
+	}
+	if holders != 1 {
+		t.Errorf("holders of platform id = %d, want exactly 1", holders)
 	}
 }
 
@@ -2717,12 +2756,21 @@ func TestScanFromJellyfin_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 		t.Fatalf("scanFromJellyfin: %v", err)
 	}
 
+	// Issue #1076: only the connection-library artist (jfArtist) holds the
+	// mapping; the filesystem artist no longer gets a duplicate.
 	fsPlatformID, err := router.artistService.GetPlatformID(ctx, fsArtist.ID, "conn-jf-1")
 	if err != nil {
 		t.Fatalf("GetPlatformID (fs): %v", err)
 	}
-	if fsPlatformID != "jf-bjork-001" {
-		t.Errorf("filesystem artist platform ID = %q, want %q", fsPlatformID, "jf-bjork-001")
+	if fsPlatformID != "" {
+		t.Errorf("filesystem artist platform ID = %q, want empty (UNIQUE index forbids duplicate mapping)", fsPlatformID)
+	}
+	jfPlatformID, err := router.artistService.GetPlatformID(ctx, jfArtist.ID, "conn-jf-1")
+	if err != nil {
+		t.Fatalf("GetPlatformID (jf): %v", err)
+	}
+	if jfPlatformID != "jf-bjork-001" {
+		t.Errorf("jellyfin artist platform ID = %q, want %q", jfPlatformID, "jf-bjork-001")
 	}
 }
 
@@ -2796,11 +2844,20 @@ func TestScanFromLidarr_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 		t.Fatalf("scanFromLidarr: %v", err)
 	}
 
+	// Issue #1076: only the connection-library artist (lidarrArtist) holds
+	// the mapping; the filesystem artist no longer gets a duplicate.
 	fsPlatformID, err := router.artistService.GetPlatformID(ctx, fsArtist.ID, "conn-lidarr-1")
 	if err != nil {
 		t.Fatalf("GetPlatformID (fs): %v", err)
 	}
-	if fsPlatformID != "42" {
-		t.Errorf("filesystem artist platform ID = %q, want %q", fsPlatformID, "42")
+	if fsPlatformID != "" {
+		t.Errorf("filesystem artist platform ID = %q, want empty (UNIQUE index forbids duplicate mapping)", fsPlatformID)
+	}
+	lidarrPlatformID, err := router.artistService.GetPlatformID(ctx, lidarrArtist.ID, "conn-lidarr-1")
+	if err != nil {
+		t.Fatalf("GetPlatformID (lidarr): %v", err)
+	}
+	if lidarrPlatformID != "42" {
+		t.Errorf("lidarr artist platform ID = %q, want %q", lidarrPlatformID, "42")
 	}
 }

--- a/internal/artist/platform_ids.go
+++ b/internal/artist/platform_ids.go
@@ -8,6 +8,14 @@ import (
 // ErrPlatformIDNotFound is returned when a platform ID mapping does not exist.
 var ErrPlatformIDNotFound = errors.New("platform id not found")
 
+// ErrPlatformIDClaimedByAnotherArtist is returned by SetPlatformID when the
+// requested (connection_id, platform_artist_id) pair is already held by a
+// different artist. Issue #1076 added a UNIQUE index on that pair so a
+// platform item can only ever be claimed by a single Stillwater artist.
+// Callers that prefer to no-op rather than fail (for example, the manual-
+// library backfill helper) should match on this sentinel via errors.Is.
+var ErrPlatformIDClaimedByAnotherArtist = errors.New("platform id already claimed by another artist")
+
 // PlatformID maps a Stillwater artist to their ID on a specific platform connection.
 type PlatformID struct {
 	ArtistID         string    `json:"artist_id"`

--- a/internal/artist/service_test.go
+++ b/internal/artist/service_test.go
@@ -633,7 +633,7 @@ func TestLibraryID_RoundTrip(t *testing.T) {
 
 	// Create a library to reference
 	_, err := db.ExecContext(ctx, `
-		INSERT INTO libraries (id, name, path, type, created_at, updated_at)
+		INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at)
 		VALUES ('lib-1', 'Test Library', '/music/test', 'regular', datetime('now'), datetime('now'))
 	`)
 	if err != nil {
@@ -693,8 +693,8 @@ func TestGetByNameAndLibrary(t *testing.T) {
 
 	// Create two libraries
 	for _, q := range []string{
-		`INSERT INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-x', 'Library X', '/music/x', 'regular', datetime('now'), datetime('now'))`,
-		`INSERT INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-y', 'Library Y', '/music/y', 'regular', datetime('now'), datetime('now'))`,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-x', 'Library X', '/music/x', 'regular', datetime('now'), datetime('now'))`,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-y', 'Library Y', '/music/y', 'regular', datetime('now'), datetime('now'))`,
 	} {
 		if _, err := db.ExecContext(ctx, q); err != nil {
 			t.Fatalf("creating library: %v", err)
@@ -742,8 +742,8 @@ func TestGetByMBIDAndLibrary(t *testing.T) {
 
 	// Create two libraries
 	for _, q := range []string{
-		`INSERT INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-m', 'Library M', '/music/m', 'regular', datetime('now'), datetime('now'))`,
-		`INSERT INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-n', 'Library N', '/music/n', 'regular', datetime('now'), datetime('now'))`,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-m', 'Library M', '/music/m', 'regular', datetime('now'), datetime('now'))`,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-n', 'Library N', '/music/n', 'regular', datetime('now'), datetime('now'))`,
 	} {
 		if _, err := db.ExecContext(ctx, q); err != nil {
 			t.Fatalf("creating library: %v", err)
@@ -970,8 +970,8 @@ func TestList_LibraryIDFilter(t *testing.T) {
 
 	// Create two libraries
 	for _, q := range []string{
-		`INSERT INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-a', 'Library A', '/music/a', 'regular', datetime('now'), datetime('now'))`,
-		`INSERT INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-b', 'Library B', '/music/b', 'regular', datetime('now'), datetime('now'))`,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-a', 'Library A', '/music/a', 'regular', datetime('now'), datetime('now'))`,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-b', 'Library B', '/music/b', 'regular', datetime('now'), datetime('now'))`,
 	} {
 		if _, err := db.ExecContext(ctx, q); err != nil {
 			t.Fatalf("creating library: %v", err)
@@ -1024,7 +1024,7 @@ func TestFindByMBIDOrName_ByMBID(t *testing.T) {
 	ctx := context.Background()
 
 	if _, err := db.ExecContext(ctx,
-		`INSERT INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
 	); err != nil {
 		t.Fatalf("creating library: %v", err)
 	}
@@ -1058,7 +1058,7 @@ func TestFindByMBIDOrName_ByNameCaseInsensitive(t *testing.T) {
 	ctx := context.Background()
 
 	if _, err := db.ExecContext(ctx,
-		`INSERT INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
 	); err != nil {
 		t.Fatalf("creating library: %v", err)
 	}
@@ -1088,7 +1088,7 @@ func TestFindByMBIDOrName_MBIDPreferredOverName(t *testing.T) {
 	ctx := context.Background()
 
 	if _, err := db.ExecContext(ctx,
-		`INSERT INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
 	); err != nil {
 		t.Fatalf("creating library: %v", err)
 	}
@@ -1129,7 +1129,7 @@ func TestFindByMBIDOrName_NotFound(t *testing.T) {
 	ctx := context.Background()
 
 	if _, err := db.ExecContext(ctx,
-		`INSERT INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
 	); err != nil {
 		t.Fatalf("creating library: %v", err)
 	}
@@ -1149,8 +1149,8 @@ func TestFindByMBIDOrName_RespectsLibraryScope(t *testing.T) {
 	ctx := context.Background()
 
 	for _, q := range []string{
-		`INSERT INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
-		`INSERT INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-emby', 'Emby', '/music/emby', 'regular', datetime('now'), datetime('now'))`,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-emby', 'Emby', '/music/emby', 'regular', datetime('now'), datetime('now'))`,
 	} {
 		if _, err := db.ExecContext(ctx, q); err != nil {
 			t.Fatalf("creating library: %v", err)
@@ -1186,7 +1186,7 @@ func TestMigration018_OrphanCleanupAndBackfill(t *testing.T) {
 		{"lib-emby", "Emby", "emby"},
 	} {
 		_, err := db.ExecContext(ctx,
-			`INSERT INTO libraries (id, name, path, type, source, created_at, updated_at) VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+			`INSERT OR IGNORE INTO libraries (id, name, path, type, source, created_at, updated_at) VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
 			lib.id, lib.name, "/music", "regular", lib.source)
 		if err != nil {
 			t.Fatalf("creating library %s: %v", lib.id, err)
@@ -1222,12 +1222,21 @@ func TestMigration018_OrphanCleanupAndBackfill(t *testing.T) {
 	}
 
 	// Create an orphaned platform ID row referencing a deleted connection.
+	// Issue #1078 turned foreign key enforcement actually on, so we disable
+	// the pragma briefly to mimic the legacy state this test was written
+	// to clean up.
+	if _, err := db.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+		t.Fatalf("disabling fks: %v", err)
+	}
 	_, err = db.ExecContext(ctx,
 		`INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id, created_at, updated_at)
 		VALUES (?, ?, ?, datetime('now'), datetime('now'))`,
 		embyArtist.ID, "deleted-conn", "orphan-platform-id")
 	if err != nil {
 		t.Fatalf("inserting orphan row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
+		t.Fatalf("re-enabling fks: %v", err)
 	}
 
 	// Run the migration SQL manually.
@@ -1265,13 +1274,20 @@ func TestMigration018_OrphanCleanupAndBackfill(t *testing.T) {
 		t.Errorf("orphan count = %d, want 0", orphanCount)
 	}
 
-	// Verify platform ID was backfilled to filesystem artist.
-	fsPlatformID, err := svc.GetPlatformID(ctx, fsArtist.ID, "conn-1")
-	if err != nil {
-		t.Fatalf("GetPlatformID (fs): %v", err)
+	// Issue #1076 added a UNIQUE(connection_id, platform_artist_id) index, so
+	// the INSERT OR IGNORE backfill above is now a no-op when the same
+	// platform id is already held by another artist (the emby artist in this
+	// case). The post-fix invariant is that exactly one artist row holds a
+	// given (connection_id, platform_artist_id) pair, not both. Dedup on
+	// startup is covered by ensureArtistPlatformIDsUnique tests in the
+	// database package; here we just assert the constraint was enforced.
+	var holders int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_platform_ids WHERE connection_id = 'conn-1' AND platform_artist_id = 'emby-deftones-001'`).Scan(&holders); err != nil {
+		t.Fatalf("counting platform id holders: %v", err)
 	}
-	if fsPlatformID != "emby-deftones-001" {
-		t.Errorf("fs platform ID = %q, want %q", fsPlatformID, "emby-deftones-001")
+	if holders != 1 {
+		t.Errorf("platform id holders = %d, want 1 (UNIQUE constraint should prevent duplicates)", holders)
 	}
 }
 

--- a/internal/artist/sqlite_platform.go
+++ b/internal/artist/sqlite_platform.go
@@ -21,7 +21,29 @@ func newSQLitePlatformIDRepo(db *sql.DB) *sqlitePlatformIDRepo {
 func (r *sqlitePlatformIDRepo) Set(ctx context.Context, artistID, connectionID, platformArtistID string) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 
-	_, err := r.db.ExecContext(ctx, `
+	// Issue #1076: a UNIQUE index on (connection_id, platform_artist_id)
+	// prevents two artist rows from claiming the same platform item.
+	// SQLite supports only one ON CONFLICT clause per INSERT, and the
+	// existing one targets (artist_id, connection_id) for upsert. Detect
+	// the cross-artist collision explicitly and return a typed sentinel so
+	// the manual-library backfill (and any other best-effort caller) can
+	// distinguish "already claimed by someone else, skip" from a real
+	// database error.
+	var existingArtistID string
+	err := r.db.QueryRowContext(ctx, `
+		SELECT artist_id FROM artist_platform_ids
+		WHERE connection_id = ? AND platform_artist_id = ?
+	`, connectionID, platformArtistID).Scan(&existingArtistID)
+	switch {
+	case err == sql.ErrNoRows:
+		// No collision; fall through to upsert.
+	case err != nil:
+		return fmt.Errorf("checking existing platform id holder: %w", err)
+	case existingArtistID != artistID:
+		return ErrPlatformIDClaimedByAnotherArtist
+	}
+
+	_, err = r.db.ExecContext(ctx, `
 		INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?)
 		ON CONFLICT (artist_id, connection_id)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -18,7 +18,22 @@ func Open(dbPath string) (*sql.DB, error) {
 		return nil, fmt.Errorf("creating database directory: %w", err)
 	}
 
-	db, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=ON")
+	// modernc.org/sqlite reads PRAGMAs from the DSN via _pragma=NAME(VALUE)
+	// query parameters. The legacy _foreign_keys=ON / _journal_mode=WAL
+	// shorthand used by mattn/go-sqlite3 is silently ignored here. Use the
+	// modernc form so the PRAGMAs actually apply on every connection.
+	//
+	// Foreign key enforcement is intentionally NOT set here. Issue #1078
+	// established that PRAGMA foreign_keys must be on for the ON DELETE
+	// CASCADE declarations to fire, but turning it on by default broke a
+	// large body of existing test fixtures that rely on insert-without-
+	// parent shortcuts. EnableForeignKeys is the explicit opt-in that
+	// production main calls; tests that need cascade semantics call it
+	// (or a local PRAGMA) themselves.
+	db, err := sql.Open(
+		"sqlite",
+		dbPath+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)",
+	)
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
@@ -28,8 +43,31 @@ func Open(dbPath string) (*sql.DB, error) {
 		return nil, fmt.Errorf("pinging database: %w", err)
 	}
 
-	// Single writer connection for SQLite
+	// Single writer connection for SQLite.
 	db.SetMaxOpenConns(1)
 
 	return db, nil
+}
+
+// EnableForeignKeys turns on PRAGMA foreign_keys for the connection pool and
+// verifies that the pragma took effect. Issue #1078: modernc.org/sqlite does
+// not respect the legacy _foreign_keys=ON DSN shorthand, so the only reliable
+// way to get FK CASCADE enforcement is to issue PRAGMA explicitly. Production
+// startup calls this immediately after Open so artist deletes actually
+// cascade through artist_platform_ids, artist_images, rule_violations, and
+// the other child tables. Tests that exercise cascade behavior call this
+// (or run a local PRAGMA) explicitly.
+func EnableForeignKeys(db *sql.DB) error {
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, "PRAGMA foreign_keys = ON"); err != nil {
+		return fmt.Errorf("enabling foreign keys: %w", err)
+	}
+	var fkOn int
+	if err := db.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&fkOn); err != nil {
+		return fmt.Errorf("checking foreign_keys pragma: %w", err)
+	}
+	if fkOn != 1 {
+		return fmt.Errorf("foreign_keys pragma not enabled (got %d); FK CASCADE will not fire", fkOn)
+	}
+	return nil
 }

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -47,6 +47,33 @@ func Migrate(db *sql.DB) error {
 		return fmt.Errorf("ensuring connection columns: %w", err)
 	}
 
+	// Issue #1078: legacy code paths (or sessions without
+	// PRAGMA foreign_keys=ON) left orphan rows in artist_platform_ids whose
+	// artist_id or connection_id no longer exist. Sweep them at startup so the
+	// invariant the FK declarations imply actually holds. Idempotent.
+	if err := cleanupOrphanArtistPlatformIDs(db); err != nil {
+		return fmt.Errorf("cleaning orphan artist_platform_ids: %w", err)
+	}
+
+	// Issue #1076: dedupe duplicate artist rows mapping to the same
+	// (connection_id, platform_artist_id) pair before enforcing the unique
+	// index. Goose only ever runs 001 once per DB, so the index added in
+	// 001_initial_schema.sql does not appear on databases that already
+	// recorded 001 as applied; create it idempotently here too.
+	if err := ensureArtistPlatformIDsUnique(db); err != nil {
+		return fmt.Errorf("ensuring artist_platform_ids unique constraint: %w", err)
+	}
+
+	// Issue #1078 follow-on: rule_results.violation_id FK is ON DELETE SET
+	// NULL, so every rule_violations DELETE scans rule_results without an
+	// index. Now that foreign key enforcement is actually on, that scan
+	// shows up in the query-plan regression test. Create the index
+	// idempotently for databases that already recorded 001 as applied.
+	if _, err := db.ExecContext(context.Background(),
+		`CREATE INDEX IF NOT EXISTS idx_rule_results_violation_id ON rule_results(violation_id)`); err != nil {
+		return fmt.Errorf("ensuring rule_results.violation_id index: %w", err)
+	}
+
 	// Issue #699: seed rule_results rows for every open / pending_choice
 	// violation already in the database. Without this, pre-existing
 	// violations would have a missing first_failed_at until the next
@@ -112,6 +139,145 @@ func ensureConnectionColumns(db *sql.DB) error {
 		return err
 	}
 	return ensureColumn(db, "connections", "pre_stillwater_config_json", "TEXT NOT NULL DEFAULT ''")
+}
+
+// cleanupOrphanArtistPlatformIDs removes rows from artist_platform_ids whose
+// artist_id or connection_id no longer reference an existing row. Such rows
+// should be impossible given the ON DELETE CASCADE foreign keys, but issue
+// #1078 caught real orphans in the wild -- presumably from a delete path that
+// ran without PRAGMA foreign_keys=ON, or from raw SQL bypassing the
+// repository. Running this on every startup is idempotent and cheap.
+func cleanupOrphanArtistPlatformIDs(db *sql.DB) error {
+	ctx := context.Background()
+	res, err := db.ExecContext(ctx, `
+		DELETE FROM artist_platform_ids
+		WHERE artist_id NOT IN (SELECT id FROM artists)
+		   OR connection_id NOT IN (SELECT id FROM connections)
+	`)
+	if err != nil {
+		return fmt.Errorf("deleting orphan artist_platform_ids: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		slog.Default().With("component", "database").Info(
+			"removed orphan artist_platform_ids rows",
+			"count", n,
+		)
+	}
+	return nil
+}
+
+// ensureArtistPlatformIDsUnique collapses duplicate artist rows that map to
+// the same (connection_id, platform_artist_id) pair, then creates the
+// UNIQUE index that prevents future duplicates. Issue #1076 documented this
+// scenario: scanner and import paths could each create an artist row for the
+// same on-disk directory after renames or re-scans, race to claim the same
+// Emby/Jellyfin item, and produce inconsistent server-side lock state.
+//
+// Dedup strategy: group by (connection_id, platform_artist_id), keep the
+// artist row with the most recent updated_at, and reassign the surviving
+// platform-id row to that artist. The losing artist rows are deleted, which
+// cascades to their platform_ids, images, violations, and rule_results.
+//
+// The index is created LAST so a partial dedup never hits a unique-constraint
+// violation that aborts the whole startup. Re-running this on a clean DB is
+// a no-op: the GROUP BY HAVING COUNT > 1 returns no rows, and the index
+// already exists from 001_initial_schema.sql.
+// dupPlatformKey is one (connection_id, platform_artist_id) pair that has
+// more than one artist row mapped to it. Used by the dedup helper.
+type dupPlatformKey struct {
+	connID, platformID string
+}
+
+// collectDuplicatePlatformKeys returns the set of (connection_id,
+// platform_artist_id) pairs that currently have more than one artist row
+// mapped to them. Split out so the rows.Close() can use defer (sqlclosecheck).
+func collectDuplicatePlatformKeys(ctx context.Context, db *sql.DB) ([]dupPlatformKey, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT connection_id, platform_artist_id
+		FROM artist_platform_ids
+		GROUP BY connection_id, platform_artist_id
+		HAVING COUNT(*) > 1
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("scanning duplicate artist_platform_ids: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var dupes []dupPlatformKey
+	for rows.Next() {
+		var d dupPlatformKey
+		if err := rows.Scan(&d.connID, &d.platformID); err != nil {
+			return nil, fmt.Errorf("scanning duplicate row: %w", err)
+		}
+		dupes = append(dupes, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating duplicate rows: %w", err)
+	}
+	return dupes, nil
+}
+
+func ensureArtistPlatformIDsUnique(db *sql.DB) error {
+	ctx := context.Background()
+	logger := slog.Default().With("component", "database")
+
+	// Find all (connection_id, platform_artist_id) tuples with more than one
+	// artist row. For each, pick the keeper artist (most recent updated_at)
+	// and delete the rest. The CASCADE FKs clean up children automatically.
+	dupes, err := collectDuplicatePlatformKeys(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	for _, d := range dupes {
+		// Keep the artist with the latest updated_at; tie-break on artist id
+		// so the choice is deterministic across runs.
+		var keeperID string
+		err := db.QueryRowContext(ctx, `
+			SELECT a.id
+			FROM artists a
+			JOIN artist_platform_ids ap ON ap.artist_id = a.id
+			WHERE ap.connection_id = ? AND ap.platform_artist_id = ?
+			ORDER BY a.updated_at DESC, a.id ASC
+			LIMIT 1
+		`, d.connID, d.platformID).Scan(&keeperID)
+		if err != nil {
+			return fmt.Errorf("picking keeper for (%s, %s): %w", d.connID, d.platformID, err)
+		}
+
+		// Delete losing artist rows. CASCADE removes their child rows
+		// (artist_platform_ids, artist_images, rule_violations, etc.).
+		res, err := db.ExecContext(ctx, `
+			DELETE FROM artists
+			WHERE id IN (
+				SELECT a.id
+				FROM artists a
+				JOIN artist_platform_ids ap ON ap.artist_id = a.id
+				WHERE ap.connection_id = ? AND ap.platform_artist_id = ? AND a.id != ?
+			)
+		`, d.connID, d.platformID, keeperID)
+		if err != nil {
+			return fmt.Errorf("deleting duplicate artists for (%s, %s): %w", d.connID, d.platformID, err)
+		}
+		n, _ := res.RowsAffected()
+		logger.Info(
+			"collapsed duplicate artist rows mapping to the same platform id",
+			"connection_id", d.connID,
+			"platform_artist_id", d.platformID,
+			"keeper_artist_id", keeperID,
+			"deleted_count", n,
+		)
+	}
+
+	// Create the unique index. CREATE UNIQUE INDEX IF NOT EXISTS is a no-op
+	// if the index already exists (clean DBs running 001 today).
+	if _, err := db.ExecContext(ctx, `
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_artist_platform_ids_unique
+		ON artist_platform_ids(connection_id, platform_artist_id)
+	`); err != nil {
+		return fmt.Errorf("creating unique index on artist_platform_ids: %w", err)
+	}
+	return nil
 }
 
 // ensureColumn adds a column to a table if it does not already exist.

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -166,17 +166,22 @@ func cleanupOrphanArtistPlatformIDs(db *sql.DB) error {
 	return nil
 }
 
-// ensureArtistPlatformIDsUnique collapses duplicate artist rows that map to
-// the same (connection_id, platform_artist_id) pair, then creates the
-// UNIQUE index that prevents future duplicates. Issue #1076 documented this
-// scenario: scanner and import paths could each create an artist row for the
-// same on-disk directory after renames or re-scans, race to claim the same
-// Emby/Jellyfin item, and produce inconsistent server-side lock state.
+// ensureArtistPlatformIDsUnique collapses duplicate platform mapping rows
+// that share the same (connection_id, platform_artist_id) pair, then creates
+// the UNIQUE index that prevents future duplicates. Issue #1076 documented
+// the scenario: scanner and import paths could each create a mapping row for
+// the same Emby/Jellyfin item, race to claim the platform id, and produce
+// inconsistent server-side lock state.
 //
-// Dedup strategy: group by (connection_id, platform_artist_id), keep the
-// artist row with the most recent updated_at, and reassign the surviving
-// platform-id row to that artist. The losing artist rows are deleted, which
-// cascades to their platform_ids, images, violations, and rule_results.
+// Dedup strategy: group by (connection_id, platform_artist_id), pick the
+// keeper artist by most recent updated_at, and delete only the losing
+// artist_platform_ids rows. The losing artist rows themselves are left
+// intact: legacy duplicates are not always true duplicate artists (a
+// connection-library artist and a filesystem/manual artist could
+// temporarily share a mapping), so cascade-deleting an artist row would
+// silently remove its images, rule state, and library association.
+// Whoever needs to reconcile the surviving artist rows can do so with
+// real visibility, after this helper has resolved the unique-key conflict.
 //
 // The index is created LAST so a partial dedup never hits a unique-constraint
 // violation that aborts the whole startup. Re-running this on a clean DB is
@@ -245,27 +250,25 @@ func ensureArtistPlatformIDsUnique(db *sql.DB) error {
 			return fmt.Errorf("picking keeper for (%s, %s): %w", d.connID, d.platformID, err)
 		}
 
-		// Delete losing artist rows. CASCADE removes their child rows
-		// (artist_platform_ids, artist_images, rule_violations, etc.).
+		// Delete only the conflicting mapping rows. The losing artist rows
+		// remain in place; collapsing the mapping is enough to satisfy the
+		// new unique index, and we avoid the silent data loss that whole-
+		// artist deletion would cause when legacy duplicates turn out to
+		// be distinct artists that briefly shared a platform id.
 		res, err := db.ExecContext(ctx, `
-			DELETE FROM artists
-			WHERE id IN (
-				SELECT a.id
-				FROM artists a
-				JOIN artist_platform_ids ap ON ap.artist_id = a.id
-				WHERE ap.connection_id = ? AND ap.platform_artist_id = ? AND a.id != ?
-			)
+			DELETE FROM artist_platform_ids
+			WHERE connection_id = ? AND platform_artist_id = ? AND artist_id != ?
 		`, d.connID, d.platformID, keeperID)
 		if err != nil {
-			return fmt.Errorf("deleting duplicate artists for (%s, %s): %w", d.connID, d.platformID, err)
+			return fmt.Errorf("deleting duplicate platform mappings for (%s, %s): %w", d.connID, d.platformID, err)
 		}
 		n, _ := res.RowsAffected()
 		logger.Info(
-			"collapsed duplicate artist rows mapping to the same platform id",
+			"collapsed duplicate platform mapping rows",
 			"connection_id", d.connID,
 			"platform_artist_id", d.platformID,
 			"keeper_artist_id", keeperID,
-			"deleted_count", n,
+			"deleted_mappings", n,
 		)
 	}
 

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -146,15 +146,27 @@ func TestEnsureArtistPlatformIDsUnique_DedupesExisting(t *testing.T) {
 		t.Fatalf("ensureArtistPlatformIDsUnique: %v", err)
 	}
 
-	// Only the keeper artist remains; the loser was deleted, cascading its
-	// platform_id row away.
+	// Both artist rows remain. The dedup helper resolves the unique-key
+	// conflict by deleting only the losing platform mapping; legacy
+	// duplicates are not always true duplicate artists, so we never erase
+	// an artist row out from under its images, rule state, or library
+	// association during a startup repair.
 	var n int
 	if err := db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM artists WHERE id IN ('a-old', 'a-new')`).Scan(&n); err != nil {
 		t.Fatalf("count artists: %v", err)
 	}
+	if n != 2 {
+		t.Errorf("artist count = %d, want 2 (both artists must remain after dedup)", n)
+	}
+
+	// Exactly one mapping row survives, and it points to the keeper.
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_platform_ids WHERE connection_id = 'c-1' AND platform_artist_id = 'shared'`).Scan(&n); err != nil {
+		t.Fatalf("count mappings: %v", err)
+	}
 	if n != 1 {
-		t.Errorf("artist count = %d, want 1 (loser should be deleted)", n)
+		t.Errorf("mapping count = %d, want 1 (loser mapping should be deleted)", n)
 	}
 
 	var keeper string
@@ -164,6 +176,18 @@ func TestEnsureArtistPlatformIDsUnique_DedupesExisting(t *testing.T) {
 	}
 	if keeper != "a-new" {
 		t.Errorf("keeper = %q, want a-new", keeper)
+	}
+
+	// The losing artist's other associations are untouched. The keeper now
+	// owns the mapping; the loser stays in artists with whatever other
+	// state it had.
+	var loserName string
+	if err := db.QueryRowContext(ctx,
+		`SELECT name FROM artists WHERE id = 'a-old'`).Scan(&loserName); err != nil {
+		t.Errorf("losing artist row was unexpectedly removed: %v", err)
+	}
+	if loserName != "Old" {
+		t.Errorf("losing artist name = %q, want Old", loserName)
 	}
 
 	// Index is back; a duplicate insert is now rejected.

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -1,0 +1,234 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// openMigratedDB opens an in-memory SQLite database, runs the 001 migration
+// + runtime helpers, and turns on PRAGMA foreign_keys so cascade behavior is
+// actually exercised. Production main calls EnableForeignKeys for the same
+// reason; tests in this file replicate that path because their assertions
+// depend on FK CASCADE / FK rejection actually firing.
+func openMigratedDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("opening db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if err := EnableForeignKeys(db); err != nil {
+		t.Fatalf("enabling foreign keys: %v", err)
+	}
+	return db
+}
+
+func seedConnection(t *testing.T, db *sql.DB, id string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
+		VALUES (?, 'Conn', 'emby', 'http://t', 'k', 1, 'ok', datetime('now'), datetime('now'))
+	`, id)
+	if err != nil {
+		t.Fatalf("seeding connection: %v", err)
+	}
+}
+
+func seedArtist(t *testing.T, db *sql.DB, id, name string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+	`, id, name, name, "/music/"+name)
+	if err != nil {
+		t.Fatalf("seeding artist %s: %v", id, err)
+	}
+}
+
+// TestArtistPlatformIDsCascadeOnArtistDelete verifies that deleting an artist
+// row removes its artist_platform_ids row via ON DELETE CASCADE. This is the
+// regression test called for in issue #1078.
+func TestArtistPlatformIDsCascadeOnArtistDelete(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	seedConnection(t, db, "conn-cascade")
+	seedArtist(t, db, "a-1", "ArtistOne")
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id)
+		VALUES ('a-1', 'conn-cascade', 'platform-1')
+	`); err != nil {
+		t.Fatalf("inserting platform id: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `DELETE FROM artists WHERE id = 'a-1'`); err != nil {
+		t.Fatalf("deleting artist: %v", err)
+	}
+
+	var n int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_platform_ids WHERE artist_id = 'a-1'`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("artist_platform_ids count = %d, want 0 (CASCADE should have removed it)", n)
+	}
+}
+
+// TestArtistPlatformIDsUniqueConstraint covers issue #1076: inserting two
+// rows with the same (connection_id, platform_artist_id) must be rejected
+// by the UNIQUE index, regardless of artist_id.
+func TestArtistPlatformIDsUniqueConstraint(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	seedConnection(t, db, "c-1")
+	seedArtist(t, db, "a-1", "First")
+	seedArtist(t, db, "a-2", "Second")
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id)
+		VALUES ('a-1', 'c-1', 'shared')
+	`); err != nil {
+		t.Fatalf("first insert: %v", err)
+	}
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id)
+		VALUES ('a-2', 'c-1', 'shared')
+	`)
+	if err == nil {
+		t.Fatal("expected unique constraint violation on duplicate (connection_id, platform_artist_id)")
+	}
+}
+
+// TestEnsureArtistPlatformIDsUnique_DedupesExisting covers the runtime
+// dedupe helper. It inserts a duplicate state on a DB without the index,
+// then asserts the helper collapses the duplicates and creates the index.
+//
+// The setup must bypass the index that Migrate already created in the
+// openMigratedDB helper; we drop it, insert the duplicates, and re-run the
+// helper to simulate "legacy database with pre-existing duplicates".
+func TestEnsureArtistPlatformIDsUnique_DedupesExisting(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `DROP INDEX IF EXISTS idx_artist_platform_ids_unique`); err != nil {
+		t.Fatalf("dropping unique index: %v", err)
+	}
+
+	seedConnection(t, db, "c-1")
+	seedArtist(t, db, "a-old", "Old")
+	seedArtist(t, db, "a-new", "New")
+	// Newer updated_at on a-new makes it the keeper; tie-break is artist id.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE artists SET updated_at = '2025-01-01T00:00:00Z' WHERE id = 'a-old'`); err != nil {
+		t.Fatalf("updating a-old: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`UPDATE artists SET updated_at = '2026-01-01T00:00:00Z' WHERE id = 'a-new'`); err != nil {
+		t.Fatalf("updating a-new: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id)
+		VALUES ('a-old', 'c-1', 'shared'), ('a-new', 'c-1', 'shared')
+	`); err != nil {
+		t.Fatalf("inserting duplicates: %v", err)
+	}
+
+	if err := ensureArtistPlatformIDsUnique(db); err != nil {
+		t.Fatalf("ensureArtistPlatformIDsUnique: %v", err)
+	}
+
+	// Only the keeper artist remains; the loser was deleted, cascading its
+	// platform_id row away.
+	var n int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artists WHERE id IN ('a-old', 'a-new')`).Scan(&n); err != nil {
+		t.Fatalf("count artists: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("artist count = %d, want 1 (loser should be deleted)", n)
+	}
+
+	var keeper string
+	if err := db.QueryRowContext(ctx,
+		`SELECT artist_id FROM artist_platform_ids WHERE connection_id = 'c-1' AND platform_artist_id = 'shared'`).Scan(&keeper); err != nil {
+		t.Fatalf("querying keeper: %v", err)
+	}
+	if keeper != "a-new" {
+		t.Errorf("keeper = %q, want a-new", keeper)
+	}
+
+	// Index is back; a duplicate insert is now rejected.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		VALUES ('a-third', 'Third', 'Third', '/m/Third', datetime('now'), datetime('now'))
+	`); err != nil {
+		t.Fatalf("inserting a-third: %v", err)
+	}
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id)
+		VALUES ('a-third', 'c-1', 'shared')
+	`)
+	if err == nil {
+		t.Error("expected unique constraint violation after dedup helper ran")
+	}
+}
+
+// TestCleanupOrphanArtistPlatformIDs covers the safety net for issue #1078.
+// Insert a row with foreign keys disabled (mimicking the suspected legacy
+// path), then run the cleanup and assert the orphan is gone.
+func TestCleanupOrphanArtistPlatformIDs(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	seedConnection(t, db, "c-1")
+	seedArtist(t, db, "a-1", "Real")
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id)
+		VALUES ('a-1', 'c-1', 'p-1')
+	`); err != nil {
+		t.Fatalf("inserting good row: %v", err)
+	}
+
+	// Insert an orphan by temporarily disabling foreign key enforcement.
+	if _, err := db.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
+		t.Fatalf("disabling fks: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id)
+		VALUES ('does-not-exist', 'c-1', 'p-orphan')
+	`); err != nil {
+		t.Fatalf("inserting orphan: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `PRAGMA foreign_keys = ON`); err != nil {
+		t.Fatalf("re-enabling fks: %v", err)
+	}
+
+	if err := cleanupOrphanArtistPlatformIDs(db); err != nil {
+		t.Fatalf("cleanupOrphanArtistPlatformIDs: %v", err)
+	}
+
+	var n int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_platform_ids WHERE platform_artist_id = 'p-orphan'`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("orphan count = %d, want 0", n)
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_platform_ids WHERE platform_artist_id = 'p-1'`).Scan(&n); err != nil {
+		t.Fatalf("count good row: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("good row count = %d, want 1", n)
+	}
+}

--- a/internal/database/migrations/001_initial_schema.sql
+++ b/internal/database/migrations/001_initial_schema.sql
@@ -255,6 +255,16 @@ CREATE TABLE IF NOT EXISTS artist_platform_ids (
 CREATE INDEX idx_artist_platform_ids_connection
     ON artist_platform_ids(connection_id);
 
+-- Issue #1076: prevent duplicate artist rows from racing to claim the same
+-- platform mapping. Different scanner / import paths previously created a
+-- new artist row for the same on-disk directory after renames or re-scans
+-- and mapped it to an already-claimed (connection_id, platform_artist_id)
+-- pair. The runtime ensureArtistPlatformIDsUnique helper collapses any
+-- existing duplicates on startup before this index is enforced for legacy
+-- databases that already recorded 001 as applied.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_artist_platform_ids_unique
+    ON artist_platform_ids(connection_id, platform_artist_id);
+
 CREATE TABLE IF NOT EXISTS artist_aliases (
     id TEXT PRIMARY KEY,
     artist_id TEXT NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
@@ -381,6 +391,12 @@ CREATE INDEX idx_rule_results_rule_id      ON rule_results(rule_id);
 CREATE INDEX idx_rule_results_artist_id    ON rule_results(artist_id);
 CREATE INDEX idx_rule_results_passed       ON rule_results(passed);
 CREATE INDEX idx_rule_results_evaluated_at ON rule_results(evaluated_at);
+-- Required for the ON DELETE SET NULL cascade on the rule_violations FK.
+-- Without this index, every rule_violations DELETE scans rule_results to
+-- find rows whose violation_id matches, which the query-plan regression
+-- test (cleanup_old_violations) flags as a performance regression now
+-- that foreign key enforcement is actually on (issue #1078).
+CREATE INDEX IF NOT EXISTS idx_rule_results_violation_id ON rule_results(violation_id);
 
 -- =============================================================================
 -- Health tracking

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -244,7 +244,14 @@ func (s *Service) CountArtists(ctx context.Context, libraryID string) (int, erro
 }
 
 // DeleteWithArtists removes a library and all artists belonging to it in a
-// single transaction. Band members are cleaned up by ON DELETE CASCADE.
+// single transaction. Child rows (artist_platform_ids, artist_images,
+// artist_aliases, band_members, rule_violations, rule_results, nfo_snapshots,
+// metadata_changes, mb_snapshots, artist_provider_ids) are removed via
+// ON DELETE CASCADE. Issue #1072 also calls for pruning artists that came in
+// from the library's connection but were never assigned a library_id (so a
+// straight WHERE library_id = ? misses them). Those are detected via
+// artist_platform_ids whose connection_id matches the library's connection
+// AND whose artist no longer has any library_id.
 func (s *Service) DeleteWithArtists(ctx context.Context, id string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -252,9 +259,42 @@ func (s *Service) DeleteWithArtists(ctx context.Context, id string) error {
 	}
 	defer tx.Rollback() //nolint:errcheck
 
+	// Look up the library's connection_id so we can prune artists that came
+	// in from this connection but have no library_id assigned. This matches
+	// the issue #1072 expectation that "Delete artists" actually removes
+	// every artist sourced from the unlinked library, including ones whose
+	// library_id was lost in an earlier code path.
+	var connectionID sql.NullString
+	if err := tx.QueryRowContext(ctx,
+		`SELECT connection_id FROM libraries WHERE id = ?`, id).Scan(&connectionID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("library not found: %s", id)
+		}
+		return fmt.Errorf("looking up library connection: %w", err)
+	}
+
 	if _, err := tx.ExecContext(ctx,
 		`DELETE FROM artists WHERE library_id = ?`, id); err != nil {
 		return fmt.Errorf("deleting library artists: %w", err)
+	}
+
+	// Prune artists that have no library_id and whose only remaining
+	// platform mapping is for this library's connection. These are the
+	// "orphaned references" called out in the bug report. Skip when the
+	// library was not connected to a platform (manual library).
+	if connectionID.Valid && connectionID.String != "" {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM artists
+			WHERE library_id IS NULL
+			  AND id IN (
+			    SELECT artist_id FROM artist_platform_ids WHERE connection_id = ?
+			  )
+			  AND id NOT IN (
+			    SELECT artist_id FROM artist_platform_ids WHERE connection_id != ?
+			  )
+		`, connectionID.String, connectionID.String); err != nil {
+			return fmt.Errorf("pruning orphaned connection artists: %w", err)
+		}
 	}
 
 	result, err := tx.ExecContext(ctx, `DELETE FROM libraries WHERE id = ?`, id)

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -282,18 +282,33 @@ func (s *Service) DeleteWithArtists(ctx context.Context, id string) error {
 	// platform mapping is for this library's connection. These are the
 	// "orphaned references" called out in the bug report. Skip when the
 	// library was not connected to a platform (manual library).
+	//
+	// IMPORTANT: only run the prune when this is the LAST library on the
+	// connection. With sibling libraries still attached, an artist with
+	// library_id IS NULL might legitimately belong to one of those siblings
+	// (e.g. a prior code path lost its library_id but the artist is still
+	// being managed via the connection). Deleting blindly here would erase
+	// data that another linked library still references.
 	if connectionID.Valid && connectionID.String != "" {
-		if _, err := tx.ExecContext(ctx, `
-			DELETE FROM artists
-			WHERE library_id IS NULL
-			  AND id IN (
-			    SELECT artist_id FROM artist_platform_ids WHERE connection_id = ?
-			  )
-			  AND id NOT IN (
-			    SELECT artist_id FROM artist_platform_ids WHERE connection_id != ?
-			  )
-		`, connectionID.String, connectionID.String); err != nil {
-			return fmt.Errorf("pruning orphaned connection artists: %w", err)
+		var siblingLibraries int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM libraries WHERE connection_id = ? AND id != ?`,
+			connectionID.String, id).Scan(&siblingLibraries); err != nil {
+			return fmt.Errorf("counting sibling libraries on connection: %w", err)
+		}
+		if siblingLibraries == 0 {
+			if _, err := tx.ExecContext(ctx, `
+				DELETE FROM artists
+				WHERE library_id IS NULL
+				  AND id IN (
+				    SELECT artist_id FROM artist_platform_ids WHERE connection_id = ?
+				  )
+				  AND id NOT IN (
+				    SELECT artist_id FROM artist_platform_ids WHERE connection_id != ?
+				  )
+			`, connectionID.String, connectionID.String); err != nil {
+				return fmt.Errorf("pruning orphaned connection artists: %w", err)
+			}
 		}
 	}
 

--- a/internal/library/service_test.go
+++ b/internal/library/service_test.go
@@ -1026,3 +1026,82 @@ func TestDeleteWithArtists_PrunesOrphanedConnectionArtists(t *testing.T) {
 		t.Errorf("multi jelly mapping count = %d, want 1 (connection still exists)", jellyMaps)
 	}
 }
+
+// TestDeleteWithArtists_PrunePreservesSiblingLibraryArtists guards the
+// CodeRabbit-flagged regression on PR #1211: when a connection has more
+// than one library, unlinking one of them must NOT prune artists that
+// are missing library_id but still belong to the connection. Those
+// artists may legitimately belong to a sibling library on the same
+// connection. The prune fallback is only safe when this is the LAST
+// library on the connection.
+func TestDeleteWithArtists_PrunePreservesSiblingLibraryArtists(t *testing.T) {
+	db := setupTestDB(t)
+	if err := database.EnableForeignKeys(db); err != nil {
+		t.Fatalf("enabling foreign keys: %v", err)
+	}
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedConnection(t, db, "conn-emby", "emby")
+
+	// Two libraries on the same connection.
+	musicDir := t.TempDir()
+	classicalDir := t.TempDir()
+	music := &Library{Name: "Music", Path: musicDir, Type: TypeRegular, ConnectionID: "conn-emby", ExternalID: "emby-music", Source: SourceEmby}
+	classical := &Library{Name: "Classical", Path: classicalDir, Type: TypeClassical, ConnectionID: "conn-emby", ExternalID: "emby-classical", Source: SourceEmby}
+	if err := svc.Create(ctx, music); err != nil {
+		t.Fatalf("Create music library: %v", err)
+	}
+	if err := svc.Create(ctx, classical); err != nil {
+		t.Fatalf("Create classical library: %v", err)
+	}
+
+	// Artist directly attached to the library being deleted.
+	seedArtist(t, db, "art-music", "MusicArtist", music.ID)
+	seedPlatformID(t, db, "art-music", "conn-emby", "emby-music-1")
+
+	// Artist with NULL library_id but a connection mapping. With only
+	// the music library on this connection, the old prune would delete
+	// this row. With the classical library still attached, the new
+	// guard must preserve it.
+	seedArtist(t, db, "art-sibling-orphan", "SiblingOrphan", "")
+	seedPlatformID(t, db, "art-sibling-orphan", "conn-emby", "emby-orphan-1")
+
+	if err := svc.DeleteWithArtists(ctx, music.ID); err != nil {
+		t.Fatalf("DeleteWithArtists: %v", err)
+	}
+
+	// The directly-attached artist is gone.
+	var attached int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artists WHERE id = 'art-music'`).Scan(&attached); err != nil {
+		t.Fatalf("counting attached artist: %v", err)
+	}
+	if attached != 0 {
+		t.Errorf("attached artist count = %d, want 0", attached)
+	}
+
+	// The sibling-library orphan is preserved because the classical
+	// library still hangs off the connection.
+	var orphan int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artists WHERE id = 'art-sibling-orphan'`).Scan(&orphan); err != nil {
+		t.Fatalf("counting sibling orphan: %v", err)
+	}
+	if orphan != 1 {
+		t.Errorf("sibling orphan count = %d, want 1 (must be preserved while sibling libraries exist)", orphan)
+	}
+
+	// Now delete the last library on the connection. Without siblings
+	// remaining, the prune is safe and the orphan must finally go.
+	if err := svc.DeleteWithArtists(ctx, classical.ID); err != nil {
+		t.Fatalf("DeleteWithArtists last library: %v", err)
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artists WHERE id = 'art-sibling-orphan'`).Scan(&orphan); err != nil {
+		t.Fatalf("counting sibling orphan after last delete: %v", err)
+	}
+	if orphan != 0 {
+		t.Errorf("sibling orphan count after last library delete = %d, want 0 (prune fires when last library is gone)", orphan)
+	}
+}

--- a/internal/library/service_test.go
+++ b/internal/library/service_test.go
@@ -857,3 +857,172 @@ func TestHasLocalLibrary(t *testing.T) {
 		t.Error("expected HasLocalLibrary = false after deleting the local library")
 	}
 }
+
+// seedConnection inserts a connection row so libraries can reference it.
+// Used by the issue #1072 / #1078 / #1076 cascade and dedup tests below.
+func seedConnection(t *testing.T, db *sql.DB, id, connType string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'http://test', 'k', 1, 'ok', datetime('now'), datetime('now'))
+	`, id, "Conn-"+id, connType)
+	if err != nil {
+		t.Fatalf("seeding connection: %v", err)
+	}
+}
+
+// seedArtist inserts an artist row with the given library_id (may be empty).
+func seedArtist(t *testing.T, db *sql.DB, id, name, libraryID string) {
+	t.Helper()
+	var libArg any
+	if libraryID == "" {
+		libArg = nil
+	} else {
+		libArg = libraryID
+	}
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO artists (id, name, sort_name, path, library_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+	`, id, name, name, "/music/"+name, libArg)
+	if err != nil {
+		t.Fatalf("seeding artist %s: %v", id, err)
+	}
+}
+
+// seedPlatformID inserts a row in artist_platform_ids. Used for cascade /
+// orphan tests where we deliberately bypass the repository to set up state.
+func seedPlatformID(t *testing.T, db *sql.DB, artistID, connID, platformID string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id, created_at, updated_at)
+		VALUES (?, ?, ?, datetime('now'), datetime('now'))
+	`, artistID, connID, platformID)
+	if err != nil {
+		t.Fatalf("seeding platform id: %v", err)
+	}
+}
+
+// TestDeleteWithArtists_CascadesPlatformIDs covers issue #1078: deleting an
+// artist row must remove its artist_platform_ids row via ON DELETE CASCADE.
+// Regression guard for the orphan rows that were observed in production.
+func TestDeleteWithArtists_CascadesPlatformIDs(t *testing.T) {
+	db := setupTestDB(t)
+	if err := database.EnableForeignKeys(db); err != nil {
+		t.Fatalf("enabling foreign keys: %v", err)
+	}
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedConnection(t, db, "conn-emby", "emby")
+	dir := t.TempDir()
+	lib := &Library{Name: "Emby Lib", Path: dir, Type: TypeRegular, ConnectionID: "conn-emby", ExternalID: "emby-1", Source: SourceEmby}
+	if err := svc.Create(ctx, lib); err != nil {
+		t.Fatalf("Create library: %v", err)
+	}
+	seedArtist(t, db, "art-1", "Deftones", lib.ID)
+	seedPlatformID(t, db, "art-1", "conn-emby", "emby-deftones-001")
+
+	// Sanity: row exists.
+	var pre int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_platform_ids WHERE artist_id = 'art-1'`).Scan(&pre); err != nil {
+		t.Fatalf("preflight count: %v", err)
+	}
+	if pre != 1 {
+		t.Fatalf("preflight platform id count = %d, want 1", pre)
+	}
+
+	if err := svc.DeleteWithArtists(ctx, lib.ID); err != nil {
+		t.Fatalf("DeleteWithArtists: %v", err)
+	}
+
+	var post int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_platform_ids WHERE artist_id = 'art-1'`).Scan(&post); err != nil {
+		t.Fatalf("post count: %v", err)
+	}
+	if post != 0 {
+		t.Errorf("artist_platform_ids row count = %d, want 0 (cascade should have removed it)", post)
+	}
+
+	var artistCount int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artists WHERE id = 'art-1'`).Scan(&artistCount); err != nil {
+		t.Fatalf("artist count: %v", err)
+	}
+	if artistCount != 0 {
+		t.Errorf("artist row count = %d, want 0", artistCount)
+	}
+}
+
+// TestDeleteWithArtists_PrunesOrphanedConnectionArtists covers issue #1072:
+// when a connected library is unlinked with deleteArtists=true, artists that
+// came from the same connection but have a NULL library_id (because some
+// earlier code path lost the assignment) should also be pruned.
+func TestDeleteWithArtists_PrunesOrphanedConnectionArtists(t *testing.T) {
+	db := setupTestDB(t)
+	if err := database.EnableForeignKeys(db); err != nil {
+		t.Fatalf("enabling foreign keys: %v", err)
+	}
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedConnection(t, db, "conn-jelly", "jellyfin")
+
+	// Library tied to the connection.
+	dir := t.TempDir()
+	lib := &Library{Name: "Jelly Lib", Path: dir, Type: TypeRegular, ConnectionID: "conn-jelly", ExternalID: "j-1", Source: SourceJellyfin}
+	if err := svc.Create(ctx, lib); err != nil {
+		t.Fatalf("Create library: %v", err)
+	}
+
+	// Artist properly attached to the library.
+	seedArtist(t, db, "art-attached", "Attached", lib.ID)
+	seedPlatformID(t, db, "art-attached", "conn-jelly", "jp-1")
+
+	// Artist sourced from the same connection but missing library_id.
+	seedArtist(t, db, "art-orphan", "Orphan", "")
+	seedPlatformID(t, db, "art-orphan", "conn-jelly", "jp-2")
+
+	// Artist with mappings to two connections (this connection plus another).
+	// Must NOT be pruned: it still has a non-null mapping after the unlink.
+	seedConnection(t, db, "conn-other", "emby")
+	seedArtist(t, db, "art-multi", "Multi", "")
+	seedPlatformID(t, db, "art-multi", "conn-jelly", "jp-3")
+	seedPlatformID(t, db, "art-multi", "conn-other", "ep-3")
+
+	if err := svc.DeleteWithArtists(ctx, lib.ID); err != nil {
+		t.Fatalf("DeleteWithArtists: %v", err)
+	}
+
+	check := func(id string, wantPresent bool) {
+		t.Helper()
+		var n int
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM artists WHERE id = ?`, id).Scan(&n); err != nil {
+			t.Fatalf("counting artist %s: %v", id, err)
+		}
+		got := n > 0
+		if got != wantPresent {
+			t.Errorf("artist %s present = %v, want %v", id, got, wantPresent)
+		}
+	}
+	check("art-attached", false)
+	check("art-orphan", false)
+	check("art-multi", true)
+
+	// Multi's mapping for the deleted connection must be gone (FK cascade
+	// from connection only fires on connection delete; here we only deleted
+	// the library, but the artist row survival check above covers the user
+	// expectation). The mapping for "conn-jelly" remains because we kept
+	// the connection alive in this test; real connection-delete is tested
+	// elsewhere.
+	var jellyMaps int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_platform_ids WHERE artist_id = 'art-multi' AND connection_id = 'conn-jelly'`).Scan(&jellyMaps); err != nil {
+		t.Fatalf("counting multi jelly mappings: %v", err)
+	}
+	if jellyMaps != 1 {
+		t.Errorf("multi jelly mapping count = %d, want 1 (connection still exists)", jellyMaps)
+	}
+}


### PR DESCRIPTION
## Summary
Bundle of three intertwined data-integrity fixes:

- **#1078** -- enforce `ON DELETE CASCADE` on `artist_platform_ids` and add `idx_rule_results_violation_id` so the `rule_violations` DELETE path does not regress on FK lookup. Foreign key enforcement is now actually on at runtime; the cascade fires correctly when artists are deleted.
- **#1076** -- add `UNIQUE INDEX (connection_id, platform_artist_id)` on `artist_platform_ids` to prevent duplicate artist rows from racing to claim the same platform mapping. Runtime `ensureArtistPlatformIDsUnique` helper collapses pre-existing duplicates on startup for legacy databases that already recorded migration 001 as applied (Goose cannot detect in-place 001 edits).
- **#1072** -- library unlink with the "Delete artists" toggle now cascades through `artist_platform_ids` and prunes orphaned artists per the toggle. Toggle-OFF removes the platform mapping while keeping the artists.

#1076 acceptance criterion 3 ("Scanner no longer creates shadow artist rows for already-mapped items") is intentionally deferred -- that work is part of W3.A (#1004) which addresses the same scanner path for cross-connection deduplication.

## Schema drift note
This PR edits `internal/database/migrations/001_initial_schema.sql` IN PLACE. Goose cannot detect in-place edits to 001, so Docker UAT and any cross-branch testing must use a fresh DB. The runtime `ensureArtistPlatformIDsUnique` helper plus `CREATE INDEX IF NOT EXISTS` calls in `migrate.go` provide drift-resistant application of the new constraints on existing databases.

## Test plan
- [x] `go test -race -timeout 300s ./...` passes
- [x] `migrate_test.go` exercises the runtime dedupe helper for legacy DBs
- [x] `service_test.go` (artist + library) covers CASCADE delete, unique-constraint rejection, unlink-with-toggle (both modes)
- [x] `handlers_connection_library_test.go` covers the API surface for unlink-with-toggle
- [x] Pre-push gate green (OpenAPI consistency, generated files, raw error leak, patch coverage)
- [x] **Manual UAT:** Live DB had `idx_artist_platform_ids_unique` and `idx_rule_results_violation_id` applied at startup via the runtime helper. Unlinked Jellyfin library: 295 artists deleted, 295 mappings cascaded in lockstep, no new orphan rows. Re-added Jellyfin: counts returned exactly to pre-unlink state (600 Emby + 295 Jellyfin = 895 mappings, 1501 artists, 0 duplicates, 0 orphans).

Closes #1072
Closes #1076
Closes #1078

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate platform-ID mapping behavior and made backfill skip already-claimed mappings.
  * Removed orphaned artist-platform rows during migrations.
  * Improved library deletion to prune only appropriate artists when unlinking a library.

* **Database Integrity**
  * Enforced SQLite foreign-key checks at startup and before migrations.
  * Added uniqueness on platform mappings and startup dedupe/cleanup steps.

* **Tests**
  * Added regression tests covering cascade deletes, uniqueness, dedupe, and orphan cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->