### PR TITLE
fix(scanner): dedupe Emby artists on import (#1004)

### DIFF
--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -544,6 +544,101 @@ func (r *Router) handleLibraryOpStatus(w http.ResponseWriter, req *http.Request)
 	writeJSON(w, http.StatusOK, snapshot)
 }
 
+// findExistingArtistForImport locates an existing artist that an inbound
+// platform item (Emby/Jellyfin) should attach to, looking first inside the
+// connection library and then across the user's manual filesystem libraries.
+//
+// Issue #1004: when a connection (e.g. Emby) is added against a library that
+// already has artists imported via filesystem scan, the previous behavior
+// scoped dedupe to the connection library only. That caused two visible rows
+// per artist: the original filesystem artist (no platform mapping) and a new
+// connection-library artist (with the mapping). Wave 2A's UNIQUE index on
+// (connection_id, platform_artist_id) further means the backfill to the
+// filesystem row would be silently dropped, leaving the duplicate permanent.
+//
+// The fix is to consult manual libraries when the connection-scoped dedupe
+// misses, so the import attaches the platform mapping directly to the
+// existing filesystem artist instead of creating a parallel row.
+//
+// Returns (existing, skip):
+//   - existing != nil  -- caller should attach platform mapping and not create
+//   - existing == nil, skip == false -- caller should create a new artist
+//   - skip == true     -- a lookup error or MBID conflict was logged; caller
+//     must increment Skipped and move to the next item
+func (r *Router) findExistingArtistForImport(
+	ctx context.Context,
+	mbid, name string,
+	lib *library.Library,
+	manualLibs []library.Library,
+	platform string,
+	result *populateResult,
+) (existing *artist.Artist, skip bool) {
+	// 1. In-library dedupe: re-imports must find the same row created on a
+	// previous run.
+	if mbid != "" {
+		a, err := r.artistService.GetByMBIDAndLibrary(ctx, mbid, lib.ID)
+		if err != nil {
+			r.logger.Warn("dedup lookup by mbid", "mbid", mbid, "platform", platform, "error", err)
+			result.Skipped++
+			return nil, true
+		}
+		existing = a
+	}
+	if existing == nil {
+		nameMatch, err := r.artistService.GetByNameAndLibrary(ctx, name, lib.ID)
+		if err != nil {
+			r.logger.Warn("dedup lookup by name", "name", name, "platform", platform, "error", err)
+			result.Skipped++
+			return nil, true
+		}
+		if nameMatch != nil {
+			if mbid != "" && nameMatch.MusicBrainzID != "" && nameMatch.MusicBrainzID != mbid {
+				// Name collision with conflicting MBIDs: two different
+				// artists share a name. Skip to avoid wrong association.
+				r.logger.Warn("mbid conflict during name dedup, skipping",
+					"name", name, "platform", platform,
+					"platform_mbid", mbid, "existing_mbid", nameMatch.MusicBrainzID)
+				result.Skipped++
+				return nil, true
+			}
+			existing = nameMatch
+		}
+	}
+	if existing != nil {
+		return existing, false
+	}
+
+	// 2. Cross-library dedupe (issue #1004): when the connection library is
+	// freshly added against an existing filesystem library, the artist rows
+	// live under the manual library. Match by MBID first, then case-insensitive
+	// name, scoped to each manual library. If multiple manual libraries hold a
+	// candidate the first match wins (FindByMBIDOrName already prefers MBID).
+	for _, ml := range manualLibs {
+		fsArtist, err := r.artistService.FindByMBIDOrName(ctx, mbid, name, ml.ID)
+		if err != nil {
+			r.logger.Warn("cross-library dedup lookup",
+				"name", name, "manual_library", ml.ID, "platform", platform, "error", err)
+			// Best-effort: a single failing library should not abort the
+			// whole import. Skip just this manual library and try the next.
+			continue
+		}
+		if fsArtist == nil {
+			continue
+		}
+		if mbid != "" && fsArtist.MusicBrainzID != "" && fsArtist.MusicBrainzID != mbid {
+			// Same name but conflicting MBID: do not associate.
+			r.logger.Warn("cross-library mbid conflict, skipping",
+				"name", name, "platform", platform,
+				"platform_mbid", mbid, "existing_mbid", fsArtist.MusicBrainzID)
+			result.Skipped++
+			return nil, true
+		}
+		return fsArtist, false
+	}
+
+	return nil, false
+}
+
 func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, lib *library.Library, result *populateResult) error {
 	manualLibs := r.manualLibraries(ctx)
 	startIndex := 0
@@ -558,35 +653,9 @@ func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, l
 			result.Total++
 			mbid := item.ProviderIDs.MusicBrainzArtist
 
-			var existing *artist.Artist
-			if mbid != "" {
-				var lookupErr error
-				existing, lookupErr = r.artistService.GetByMBIDAndLibrary(ctx, mbid, lib.ID)
-				if lookupErr != nil {
-					r.logger.Warn("dedup lookup by mbid", "mbid", mbid, "error", lookupErr)
-					result.Skipped++
-					continue
-				}
-			}
-			if existing == nil {
-				nameMatch, lookupErr := r.artistService.GetByNameAndLibrary(ctx, item.Name, lib.ID)
-				if lookupErr != nil {
-					r.logger.Warn("dedup lookup by name", "name", item.Name, "error", lookupErr)
-					result.Skipped++
-					continue
-				}
-				if nameMatch != nil {
-					if mbid != "" && nameMatch.MusicBrainzID != "" && nameMatch.MusicBrainzID != mbid {
-						// Name matches but MBIDs conflict -- different artists
-						// with the same name. Skip to avoid wrong association.
-						r.logger.Warn("mbid conflict during name dedup, skipping",
-							"name", item.Name, "platform_mbid", mbid,
-							"existing_mbid", nameMatch.MusicBrainzID)
-						result.Skipped++
-						continue
-					}
-					existing = nameMatch
-				}
+			existing, skip := r.findExistingArtistForImport(ctx, mbid, item.Name, lib, manualLibs, "emby", result)
+			if skip {
+				continue
 			}
 
 			if existing != nil {
@@ -662,35 +731,9 @@ func (r *Router) populateFromJellyfinCtx(ctx context.Context, client *jellyfin.C
 			result.Total++
 			mbid := item.ProviderIDs.MusicBrainzArtist
 
-			var existing *artist.Artist
-			if mbid != "" {
-				var lookupErr error
-				existing, lookupErr = r.artistService.GetByMBIDAndLibrary(ctx, mbid, lib.ID)
-				if lookupErr != nil {
-					r.logger.Warn("dedup lookup by mbid", "mbid", mbid, "error", lookupErr)
-					result.Skipped++
-					continue
-				}
-			}
-			if existing == nil {
-				nameMatch, lookupErr := r.artistService.GetByNameAndLibrary(ctx, item.Name, lib.ID)
-				if lookupErr != nil {
-					r.logger.Warn("dedup lookup by name", "name", item.Name, "error", lookupErr)
-					result.Skipped++
-					continue
-				}
-				if nameMatch != nil {
-					if mbid != "" && nameMatch.MusicBrainzID != "" && nameMatch.MusicBrainzID != mbid {
-						// Name matches but MBIDs conflict -- different artists
-						// with the same name. Skip to avoid wrong association.
-						r.logger.Warn("mbid conflict during name dedup, skipping",
-							"name", item.Name, "platform_mbid", mbid,
-							"existing_mbid", nameMatch.MusicBrainzID)
-						result.Skipped++
-						continue
-					}
-					existing = nameMatch
-				}
+			existing, skip := r.findExistingArtistForImport(ctx, mbid, item.Name, lib, manualLibs, "jellyfin", result)
+			if skip {
+				continue
 			}
 
 			if existing != nil {

--- a/internal/api/handlers_connection_library_test.go
+++ b/internal/api/handlers_connection_library_test.go
@@ -2292,7 +2292,20 @@ func TestScanFromEmby_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 	}
 }
 
-func TestPopulateFromEmby_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
+// TestPopulateFromEmby_AttachesPlatformIDToFilesystemArtist verifies that
+// when a connection library is freshly populated against a filesystem library
+// already holding the artist (matched by MBID), the platform ID is attached
+// to the existing filesystem artist rather than creating a duplicate
+// connection-library row.
+//
+// Issue #1004: previously the import created a parallel artist row in the
+// connection library, leaving the user with two visible entries (one local,
+// one platform-only). With the cross-library dedup added in
+// findExistingArtistForImport, the import now reuses the filesystem artist.
+// Wave 2A's UNIQUE index on (connection_id, platform_artist_id) makes this
+// behavior load-bearing: creating the duplicate row and then trying to
+// backfill the mapping silently dropped the filesystem mapping.
+func TestPopulateFromEmby_AttachesPlatformIDToFilesystemArtist(t *testing.T) {
 	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
@@ -2358,7 +2371,6 @@ func TestPopulateFromEmby_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 		t.Fatalf("creating emby library: %v", err)
 	}
 
-	// Populate -- this creates a NEW emby-library artist.
 	client := emby.NewWithHTTPClient(embySrv.URL, "key", "", embySrv.Client(),
 		slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
 	var result populateResult
@@ -2366,31 +2378,143 @@ func TestPopulateFromEmby_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 		t.Fatalf("populateFromEmbyCtx: %v", err)
 	}
 
-	if result.Created != 1 {
-		t.Fatalf("created = %d, want 1", result.Created)
+	// No new artist row should be created; the existing filesystem artist
+	// is reused via cross-library dedup.
+	if result.Created != 0 {
+		t.Errorf("created = %d, want 0 (should reuse filesystem artist)", result.Created)
+	}
+	if result.Skipped != 1 {
+		t.Errorf("skipped = %d, want 1", result.Skipped)
 	}
 
-	// The emby-library artist should have a platform ID (existing behavior).
+	// No emby-library artist row should exist for Radiohead.
 	embyArtist, err := router.artistService.GetByNameAndLibrary(ctx, "Radiohead", embyLib.ID)
-	if err != nil || embyArtist == nil {
+	if err != nil {
 		t.Fatalf("looking up emby artist: %v", err)
 	}
-	embyPlatformID, err := router.artistService.GetPlatformID(ctx, embyArtist.ID, "conn-emby-1")
-	if err != nil {
-		t.Fatalf("GetPlatformID (emby): %v", err)
-	}
-	if embyPlatformID != "emby-radiohead-001" {
-		t.Errorf("emby artist platform ID = %q, want %q", embyPlatformID, "emby-radiohead-001")
+	if embyArtist != nil {
+		t.Errorf("emby-library artist created (id=%q); expected import to reuse filesystem artist", embyArtist.ID)
 	}
 
-	// Issue #1076: only the connection-library artist holds the mapping;
-	// the filesystem artist no longer gets a duplicate.
+	// The filesystem artist should now hold the Emby platform mapping.
 	fsPlatformID, err := router.artistService.GetPlatformID(ctx, fsArtist.ID, "conn-emby-1")
 	if err != nil {
 		t.Fatalf("GetPlatformID (fs): %v", err)
 	}
-	if fsPlatformID != "" {
-		t.Errorf("filesystem artist platform ID = %q, want empty (UNIQUE index forbids duplicate mapping)", fsPlatformID)
+	if fsPlatformID != "emby-radiohead-001" {
+		t.Errorf("filesystem artist platform ID = %q, want %q", fsPlatformID, "emby-radiohead-001")
+	}
+}
+
+// TestPopulateFromEmby_ReimportIsIdempotent verifies that re-running the
+// Emby import after a filesystem artist has already had its Emby mapping
+// attached does not create a duplicate row and does not raise a UNIQUE
+// constraint error from the (connection_id, platform_artist_id) index.
+//
+// Issue #1004 acceptance: re-running an Emby import on a library with
+// existing artist mappings must not create duplicates or fail.
+func TestPopulateFromEmby_ReimportIsIdempotent(t *testing.T) {
+	var hits atomic.Int32
+	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"Items":[{
+				"Name":"Radiohead",
+				"SortName":"Radiohead",
+				"Id":"emby-radiohead-001",
+				"Path":"",
+				"Overview":"",
+				"Genres":[],
+				"Tags":[],
+				"PremiereDate":"",
+				"EndDate":"",
+				"ProviderIds":{"MusicBrainzArtist":"mbid-radiohead"},
+				"ImageTags":{}
+			}],
+			"TotalRecordCount":1
+		}`))
+	}))
+	defer embySrv.Close()
+
+	router := testRouterForLibraryOps(t)
+	ctx := context.Background()
+	addTestConnection(t, router, "conn-emby-1", "Emby Server", "emby")
+
+	musicDir := t.TempDir()
+	manualLib := &library.Library{
+		Name: "Filesystem", Path: musicDir,
+		Type: library.TypeRegular, Source: library.SourceManual,
+	}
+	if err := router.libraryService.Create(ctx, manualLib); err != nil {
+		t.Fatalf("creating manual library: %v", err)
+	}
+	rhDir := filepath.Join(musicDir, "Radiohead")
+	if err := os.MkdirAll(rhDir, 0o755); err != nil {
+		t.Fatalf("creating dir: %v", err)
+	}
+	fsArtist := &artist.Artist{
+		Name: "Radiohead", SortName: "Radiohead",
+		MusicBrainzID: "mbid-radiohead",
+		LibraryID:     manualLib.ID, Path: rhDir,
+	}
+	if err := router.artistService.Create(ctx, fsArtist); err != nil {
+		t.Fatalf("creating fs artist: %v", err)
+	}
+
+	embyLib := &library.Library{
+		Name: "Emby Music", Type: library.TypeRegular,
+		Source: library.SourceEmby, ConnectionID: "conn-emby-1",
+		ExternalID: "emby-lib-1",
+	}
+	if err := router.libraryService.Create(ctx, embyLib); err != nil {
+		t.Fatalf("creating emby library: %v", err)
+	}
+
+	client := emby.NewWithHTTPClient(embySrv.URL, "key", "", embySrv.Client(),
+		slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	// First import: cross-library dedup should attach the mapping to fsArtist.
+	var first populateResult
+	if err := router.populateFromEmbyCtx(ctx, client, embyLib, &first); err != nil {
+		t.Fatalf("first populate: %v", err)
+	}
+	if first.Created != 0 {
+		t.Errorf("first created = %d, want 0", first.Created)
+	}
+
+	// Second import: should be a no-op against the same filesystem artist,
+	// must not create a duplicate, must not raise a UNIQUE-constraint error.
+	var second populateResult
+	if err := router.populateFromEmbyCtx(ctx, client, embyLib, &second); err != nil {
+		t.Fatalf("second populate: %v", err)
+	}
+	if second.Created != 0 {
+		t.Errorf("second created = %d, want 0", second.Created)
+	}
+
+	// Verify only one Radiohead artist exists across all libraries.
+	listed, _, err := router.artistService.List(ctx, artist.ListParams{Page: 1, PageSize: 100, Sort: "name"})
+	if err != nil {
+		t.Fatalf("listing artists: %v", err)
+	}
+	count := 0
+	for _, a := range listed {
+		if strings.EqualFold(a.Name, "Radiohead") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("Radiohead row count = %d, want 1", count)
+	}
+
+	// Verify the platform mapping is present and points to the fs artist.
+	pid, err := router.artistService.GetPlatformID(ctx, fsArtist.ID, "conn-emby-1")
+	if err != nil {
+		t.Fatalf("GetPlatformID: %v", err)
+	}
+	if pid != "emby-radiohead-001" {
+		t.Errorf("platform id = %q, want emby-radiohead-001", pid)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1004. Adding an Emby (or Jellyfin) connection against a library that already held filesystem-imported artists produced two visible rows per artist:

- the original manual-library row (no platform mapping), and
- a fresh connection-library row carrying the Emby mapping.

Wave 2A (PR #1211, merged in 5f3e829) added a `UNIQUE` index on `artist_platform_ids(connection_id, platform_artist_id)`, which made the duplicate permanent: the post-create backfill onto the filesystem row was silently rejected with `ErrPlatformIDClaimedByAnotherArtist`.

## Change

Extracted `findExistingArtistForImport` (in `internal/api/handlers_connection_library.go`), shared by `populateFromEmbyCtx` and `populateFromJellyfinCtx`:

1. Existing in-library MBID/name dedup remains so re-imports stay idempotent.
2. When the connection-library lookup misses, the helper now scans manual (filesystem) libraries via `FindByMBIDOrName` and reuses that artist, attaching the Emby/Jellyfin platform mapping to the existing filesystem row instead of creating a duplicate.
3. The same MBID-conflict guard is applied across libraries: name match with a different MBID is skipped rather than wrongly associated.

### Note on Jellyfin scope

The Emby and Jellyfin populate paths held verbatim-identical dedup logic. Per the task brief, when shared logic exists it should be extracted; both paths now call the common helper. Behavioral change is identical for Jellyfin (which has the same latent duplicate bug).

## Dependency

Builds on PR #1211 (Wave 2A) which introduced the `UNIQUE` index this fix protects against. Branched from main at 5f3e829.

## Verification

- `go test -race ./...` (full suite, 300s) -- pass
- `bash scripts/pre-push-gate.sh` -- pass (tests, OpenAPI, generated files, raw-error leak, breaking changes, patch coverage)
- `make lint` -- 0 issues
- `make fmt` -- clean

### Scripted UAT (in-test)

`TestPopulateFromEmby_ReimportIsIdempotent` (new) reproduces the issue scenario in code:

1. Create a manual library with a filesystem artist (Radiohead, MBID).
2. Create an Emby library, run `populateFromEmbyCtx` against a stub Emby server that returns the same artist.
3. Run `populateFromEmbyCtx` a second time.

Asserts:
- `result.Created == 0` on both runs (no duplicate row created),
- only one Radiohead row exists across all libraries,
- the filesystem artist holds the Emby platform mapping,
- no `UNIQUE` constraint error is raised.

`TestPopulateFromEmby_AttachesPlatformIDToFilesystemArtist` (replaces the previous test that codified the broken behavior) covers the first-import case directly.

## Test plan

- [x] `go test -race ./...` passes
- [x] `bash scripts/pre-push-gate.sh` passes
- [x] `make lint` passes
- [x] `make fmt` clean
- [x] New regression test covers the issue's reproduction steps

Closes #1004

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved artist deduplication logic when importing from streaming platforms, preventing duplicate artist entries across libraries
* Enhanced re-import handling to ensure repeated imports of the same artist don't create unwanted duplicates or constraint conflicts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->