### PR TITLE
fix(provider): honor configured priority on refresh (#1030)

### DIFF
--- a/internal/scraper/executor.go
+++ b/internal/scraper/executor.go
@@ -42,6 +42,14 @@ func NewExecutor(service *Service, registry *provider.Registry, settings *provid
 // ScrapeAll scrapes all enabled fields using the scraper configuration for the
 // given scope. It returns a merged FetchResult compatible with the
 // provider.Orchestrator output.
+//
+// Per-field provider ordering is sourced from the UI-configured priority list
+// (provider.priority.<field> settings, exposed by SettingsService.GetPriorities)
+// rather than the scraper config's hardcoded primary + fallback chain. This
+// keeps the refresh path consistent with what the user sees and edits in
+// Settings > Providers (#1030). The scraper config still controls which fields
+// are enabled and supplies a backup fallback list for any provider absent from
+// the priority settings.
 func (e *Executor) ScrapeAll(ctx context.Context, mbid, name, scope string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error) {
 	// Ensure providerIDs is writable so EnrichProviderIDs can populate it
 	// with IDs extracted from earlier providers' URL results.
@@ -57,6 +65,15 @@ func (e *Executor) ScrapeAll(ctx context.Context, mbid, name, scope string, prov
 	available, err := e.providerSettings.AvailableProviderNames(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("loading available providers: %w", err)
+	}
+
+	priorities, err := e.providerSettings.GetPriorities(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading provider priorities: %w", err)
+	}
+	priorityByField := make(map[FieldName][]provider.ProviderName, len(priorities))
+	for _, pri := range priorities {
+		priorityByField[FieldName(pri.Field)] = pri.EnabledProviders()
 	}
 
 	result := &provider.FetchResult{
@@ -80,7 +97,13 @@ func (e *Executor) ScrapeAll(ctx context.Context, mbid, name, scope string, prov
 			continue
 		}
 
-		fr := e.scrapeField(ctx, mbid, name, field, *chain, available, providerIDs, cache, &mu, result)
+		// Build the effective ordered provider list for this field by combining
+		// the user-configured priority list (authoritative) with any providers
+		// from the scraper config's fallback chain that are not yet listed.
+		// The first entry in the resulting list becomes the effective primary.
+		effField, effChain := effectiveFieldOrdering(field, *chain, priorityByField[field.Field])
+
+		fr := e.scrapeField(ctx, mbid, name, effField, effChain, available, providerIDs, cache, &mu, result)
 		if fr.Err != nil {
 			result.Errors = append(result.Errors,
 				fmt.Sprintf("%s: %s", fr.Field, fr.Err.Error()))
@@ -611,4 +634,53 @@ func containsString(slice []string, s string) bool {
 		}
 	}
 	return false
+}
+
+// effectiveFieldOrdering merges the UI-configured priority list for a field
+// with the scraper config's primary + fallback chain to produce the final
+// ordered provider list to query. The priority list is authoritative for
+// ordering: its first enabled provider becomes the effective primary, and any
+// providers from the scraper config (primary + fallback chain) that are not
+// already covered are appended so newly registered providers are not silently
+// dropped.
+//
+// When the priority list is empty (e.g. no setting persisted and no defaults
+// for a custom field), the original scraper-config primary and chain are
+// returned unchanged so behavior matches the pre-#1030 path.
+func effectiveFieldOrdering(field FieldConfig, chain FallbackChain, priority []provider.ProviderName) (FieldConfig, FallbackChain) {
+	if len(priority) == 0 {
+		return field, chain
+	}
+
+	// Build the effective ordered list: priority entries first, then any
+	// scraper-config entries (primary + chain) that are not already present.
+	seen := make(map[provider.ProviderName]bool, len(priority)+len(chain.Providers)+1)
+	ordered := make([]provider.ProviderName, 0, len(priority)+len(chain.Providers)+1)
+	for _, p := range priority {
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		ordered = append(ordered, p)
+	}
+	if field.Primary != "" && !seen[field.Primary] {
+		seen[field.Primary] = true
+		ordered = append(ordered, field.Primary)
+	}
+	for _, p := range chain.Providers {
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		ordered = append(ordered, p)
+	}
+
+	effField := field
+	effField.Primary = ordered[0]
+
+	effChain := FallbackChain{
+		Category:  chain.Category,
+		Providers: ordered,
+	}
+	return effField, effChain
 }

--- a/internal/scraper/executor.go
+++ b/internal/scraper/executor.go
@@ -71,6 +71,14 @@ func (e *Executor) ScrapeAll(ctx context.Context, mbid, name, scope string, prov
 	if err != nil {
 		return nil, fmt.Errorf("loading provider priorities: %w", err)
 	}
+	// priorityByField records the enabled provider list for every field
+	// that has a priority configured. The map's presence (not just
+	// emptiness) carries meaning: a field absent from the map has no
+	// configuration and falls back to the scraper-config chain, while a
+	// field present with an empty slice means the user explicitly
+	// disabled every provider for that field and the field should be
+	// skipped entirely. Collapsing the two cases would silently
+	// re-enable disabled providers via the chain fallback.
 	priorityByField := make(map[FieldName][]provider.ProviderName, len(priorities))
 	for _, pri := range priorities {
 		priorityByField[FieldName(pri.Field)] = pri.EnabledProviders()
@@ -101,7 +109,16 @@ func (e *Executor) ScrapeAll(ctx context.Context, mbid, name, scope string, prov
 		// the user-configured priority list (authoritative) with any providers
 		// from the scraper config's fallback chain that are not yet listed.
 		// The first entry in the resulting list becomes the effective primary.
-		effField, effChain := effectiveFieldOrdering(field, *chain, priorityByField[field.Field])
+		//
+		// hasPriority distinguishes "no priority configured" (fall back to
+		// scraper-config chain) from "priority configured but every
+		// provider disabled" (skip the field entirely so disabled
+		// providers cannot leak back in via the chain).
+		priority, hasPriority := priorityByField[field.Field]
+		if hasPriority && len(priority) == 0 {
+			continue
+		}
+		effField, effChain := effectiveFieldOrdering(field, *chain, priority, hasPriority)
 
 		fr := e.scrapeField(ctx, mbid, name, effField, effChain, available, providerIDs, cache, &mu, result)
 		if fr.Err != nil {
@@ -644,11 +661,14 @@ func containsString(slice []string, s string) bool {
 // already covered are appended so newly registered providers are not silently
 // dropped.
 //
-// When the priority list is empty (e.g. no setting persisted and no defaults
-// for a custom field), the original scraper-config primary and chain are
-// returned unchanged so behavior matches the pre-#1030 path.
-func effectiveFieldOrdering(field FieldConfig, chain FallbackChain, priority []provider.ProviderName) (FieldConfig, FallbackChain) {
-	if len(priority) == 0 {
+// When the field has no priority configured at all (hasPriority=false), the
+// original scraper-config primary and chain are returned unchanged so
+// behavior matches the pre-#1030 path. The "configured but empty" case
+// (hasPriority=true, len(priority)==0) must be handled by the caller -- it
+// means "all providers disabled" and the field should be skipped, never
+// passed to this function.
+func effectiveFieldOrdering(field FieldConfig, chain FallbackChain, priority []provider.ProviderName, hasPriority bool) (FieldConfig, FallbackChain) {
+	if !hasPriority {
 		return field, chain
 	}
 

--- a/internal/scraper/executor_test.go
+++ b/internal/scraper/executor_test.go
@@ -885,21 +885,25 @@ func TestExecutorPriorityFallbackPreservesUnlistedProviders(t *testing.T) {
 			return nil, &provider.ErrNotFound{Provider: provider.NameMusicBrainz, ID: id}
 		},
 	})
+	// Wikidata is intentionally chosen here: the default genres priority
+	// chain (DefaultPriorities()) is [MusicBrainz, LastFM, AudioDB,
+	// Discogs, Spotify, Wikipedia], so Wikidata is NOT auto-appended by
+	// GetPriorities' default-reconciliation. That makes it a true "only
+	// in the FallbackChain, never in the priority list" provider, which
+	// is the exact scenario this test is meant to exercise.
 	registry.Register(&mockProvider{
-		name:    provider.NameAudioDB,
+		name:    provider.NameWikidata,
 		authReq: false,
 		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
-			recordCall(provider.NameAudioDB)
+			recordCall(provider.NameWikidata)
 			return &provider.ArtistMetadata{Genres: []string{"jazz"}}, nil
 		},
 	})
 
 	ctx := context.Background()
-	if err := settings.SetAPIKey(ctx, provider.NameAudioDB, "adb-key"); err != nil {
-		t.Fatalf("SetAPIKey audiodb: %v", err)
-	}
 
-	// Priority list contains only MusicBrainz; AudioDB is only in the chain.
+	// Priority list contains only MusicBrainz; Wikidata is only in the
+	// scraper-config fallback chain.
 	if err := settings.SetPriority(ctx, "genres", []provider.ProviderName{provider.NameMusicBrainz}); err != nil {
 		t.Fatalf("SetPriority: %v", err)
 	}
@@ -910,7 +914,7 @@ func TestExecutorPriorityFallbackPreservesUnlistedProviders(t *testing.T) {
 			{Field: FieldGenres, Primary: provider.NameMusicBrainz, Enabled: true, Category: CategoryMetadata},
 		},
 		FallbackChains: []FallbackChain{
-			{Category: CategoryMetadata, Providers: []provider.ProviderName{provider.NameMusicBrainz, provider.NameAudioDB}},
+			{Category: CategoryMetadata, Providers: []provider.ProviderName{provider.NameMusicBrainz, provider.NameWikidata}},
 		},
 	}
 	if err := svc.SaveConfig(ctx, ScopeGlobal, cfg, nil); err != nil {
@@ -924,13 +928,104 @@ func TestExecutorPriorityFallbackPreservesUnlistedProviders(t *testing.T) {
 	}
 
 	if len(result.Metadata.Genres) == 0 || result.Metadata.Genres[0] != "jazz" {
-		t.Errorf("expected genres from AudioDB chain fallback, got %v", result.Metadata.Genres)
+		t.Errorf("expected genres from Wikidata chain fallback, got %v", result.Metadata.Genres)
 	}
 
 	callMu.Lock()
 	defer callMu.Unlock()
-	if len(callOrder) < 2 || callOrder[0] != provider.NameMusicBrainz || callOrder[1] != provider.NameAudioDB {
-		t.Errorf("expected call order [MusicBrainz, AudioDB], got %v", callOrder)
+	if len(callOrder) < 2 || callOrder[0] != provider.NameMusicBrainz || callOrder[1] != provider.NameWikidata {
+		t.Errorf("expected call order [MusicBrainz, Wikidata], got %v", callOrder)
+	}
+}
+
+// TestExecutorPriorityFallback_AllDisabledSkipsField verifies the
+// configured-empty branch: when a field has a priority configured but every
+// provider is in the Disabled set, the field must be skipped entirely. The
+// regression this guards against is the prior code path falling back to the
+// scraper-config chain on len(priority)==0, which silently re-enabled the
+// providers the user had just disabled.
+func TestExecutorPriorityFallback_AllDisabledSkipsField(t *testing.T) {
+	registry, settings, svc, logger := setupExecutorTest(t)
+
+	var callOrder []provider.ProviderName
+	var callMu sync.Mutex
+	recordCall := func(name provider.ProviderName) {
+		callMu.Lock()
+		defer callMu.Unlock()
+		callOrder = append(callOrder, name)
+	}
+
+	// Both providers must exist as registered mocks so the executor can
+	// reach the chain-walking code path. If either were missing it would
+	// short-circuit elsewhere and the test would not actually exercise
+	// the configured-empty branch we care about.
+	registry.Register(&mockProvider{
+		name:    provider.NameMusicBrainz,
+		authReq: false,
+		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+			recordCall(provider.NameMusicBrainz)
+			return &provider.ArtistMetadata{Genres: []string{"should-not-appear"}}, nil
+		},
+	})
+	registry.Register(&mockProvider{
+		name:    provider.NameAudioDB,
+		authReq: false,
+		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+			recordCall(provider.NameAudioDB)
+			return &provider.ArtistMetadata{Genres: []string{"should-not-appear"}}, nil
+		},
+	})
+
+	ctx := context.Background()
+
+	// Configure the genres priority and then disable every provider in
+	// it. After the default-reconciliation in GetPriorities, the list
+	// is [MusicBrainz, LastFM, AudioDB, Discogs, Spotify, Wikipedia];
+	// disabling all of those leaves EnabledProviders() empty for
+	// "genres". The executor must treat this as "skip the field," NOT
+	// "fall back to the scraper-config chain."
+	if err := settings.SetPriority(ctx, "genres", []provider.ProviderName{provider.NameMusicBrainz}); err != nil {
+		t.Fatalf("SetPriority: %v", err)
+	}
+	allGenresDefaults := []provider.ProviderName{
+		provider.NameMusicBrainz, provider.NameLastFM, provider.NameAudioDB,
+		provider.NameDiscogs, provider.NameSpotify, provider.NameWikipedia,
+	}
+	if err := settings.SetDisabledProviders(ctx, "genres", allGenresDefaults); err != nil {
+		t.Fatalf("SetDisabledProviders: %v", err)
+	}
+
+	cfg := &ScraperConfig{
+		Scope: ScopeGlobal,
+		Fields: []FieldConfig{
+			{Field: FieldGenres, Primary: provider.NameMusicBrainz, Enabled: true, Category: CategoryMetadata},
+		},
+		FallbackChains: []FallbackChain{
+			// Chain still mentions MusicBrainz + AudioDB. The bug being
+			// guarded against would route through this chain when
+			// EnabledProviders() returned empty, calling both providers
+			// and merging their results.
+			{Category: CategoryMetadata, Providers: []provider.ProviderName{provider.NameMusicBrainz, provider.NameAudioDB}},
+		},
+	}
+	if err := svc.SaveConfig(ctx, ScopeGlobal, cfg, nil); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	exec := NewExecutor(svc, registry, settings, logger)
+	result, err := exec.ScrapeAll(ctx, "mbid-x", "Test Artist", ScopeGlobal, nil)
+	if err != nil {
+		t.Fatalf("ScrapeAll: %v", err)
+	}
+
+	if len(result.Metadata.Genres) != 0 {
+		t.Errorf("expected no genres when every provider for the field is disabled, got %v", result.Metadata.Genres)
+	}
+
+	callMu.Lock()
+	defer callMu.Unlock()
+	if len(callOrder) != 0 {
+		t.Errorf("expected zero provider calls for fully-disabled field, got %v", callOrder)
 	}
 }
 

--- a/internal/scraper/executor_test.go
+++ b/internal/scraper/executor_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/encryption"
@@ -777,6 +779,161 @@ func TestApplyProviderIDsAndURLs_DoesNotMergeClassification(t *testing.T) {
 // split, the selection-gated applyMergeableFields no longer handles provider
 // IDs. Those are now exclusively applyProviderIDsAndURLs's job, which runs
 // unconditionally.
+// TestExecutorHonorsConfiguredPriority verifies the #1030 fix: the scraper
+// executor must consult the UI-configured provider.priority.<field> settings
+// (exposed by SettingsService.GetPriorities) when deciding which provider to
+// query first for a field, instead of using the hardcoded ScraperConfig.Primary
+// value. The setup configures Last.fm as the scraper-config primary for
+// biography but overrides priority to put AudioDB first; the test asserts
+// AudioDB was called first AND its biography won.
+func TestExecutorHonorsConfiguredPriority(t *testing.T) {
+	registry, settings, svc, logger := setupExecutorTest(t)
+
+	// Track call order so we can prove AudioDB was queried first.
+	var callOrder []provider.ProviderName
+	var callMu sync.Mutex
+	recordCall := func(name provider.ProviderName) {
+		callMu.Lock()
+		defer callMu.Unlock()
+		callOrder = append(callOrder, name)
+	}
+
+	registry.Register(&mockProvider{
+		name:    provider.NameAudioDB,
+		authReq: false,
+		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+			recordCall(provider.NameAudioDB)
+			return &provider.ArtistMetadata{Biography: "AudioDB-sourced biography text long enough to clear the IsJunkBiography minimum length filter."}, nil
+		},
+	})
+	registry.Register(&mockProvider{
+		name:    provider.NameLastFM,
+		authReq: true,
+		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+			recordCall(provider.NameLastFM)
+			return &provider.ArtistMetadata{Biography: "Last.fm-sourced biography text long enough to clear the IsJunkBiography minimum length filter."}, nil
+		},
+	})
+
+	ctx := context.Background()
+	// Stash a Last.fm API key so AvailableProviderNames includes it.
+	if err := settings.SetAPIKey(ctx, provider.NameLastFM, "lfm-key"); err != nil {
+		t.Fatalf("SetAPIKey lastfm: %v", err)
+	}
+	if err := settings.SetAPIKey(ctx, provider.NameAudioDB, "adb-key"); err != nil {
+		t.Fatalf("SetAPIKey audiodb: %v", err)
+	}
+
+	// Scraper config: Last.fm is the primary for biography (mirrors the
+	// hardcoded DefaultConfig() value the bug report calls out).
+	cfg := &ScraperConfig{
+		Scope: ScopeGlobal,
+		Fields: []FieldConfig{
+			{Field: FieldBiography, Primary: provider.NameLastFM, Enabled: true, Category: CategoryMetadata},
+		},
+		FallbackChains: []FallbackChain{
+			{Category: CategoryMetadata, Providers: []provider.ProviderName{provider.NameLastFM, provider.NameAudioDB}},
+		},
+	}
+	if err := svc.SaveConfig(ctx, ScopeGlobal, cfg, nil); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	// User reorders biography priority: AudioDB first, then Last.fm.
+	if err := settings.SetPriority(ctx, "biography", []provider.ProviderName{provider.NameAudioDB, provider.NameLastFM}); err != nil {
+		t.Fatalf("SetPriority: %v", err)
+	}
+
+	exec := NewExecutor(svc, registry, settings, logger)
+	result, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
+	if err != nil {
+		t.Fatalf("ScrapeAll: %v", err)
+	}
+
+	if result.Metadata.Biography == "" || !strings.HasPrefix(result.Metadata.Biography, "AudioDB-sourced") {
+		t.Errorf("expected biography from AudioDB (configured first in priority), got %q",
+			result.Metadata.Biography)
+	}
+
+	callMu.Lock()
+	defer callMu.Unlock()
+	if len(callOrder) == 0 || callOrder[0] != provider.NameAudioDB {
+		t.Errorf("expected AudioDB to be called first, got call order %v", callOrder)
+	}
+}
+
+// TestExecutorPriorityFallbackPreservesUnlistedProviders verifies that when a
+// provider is present in the scraper-config fallback chain but absent from the
+// user's priority list, it is still appended to the effective ordering so
+// newly registered providers are not silently skipped.
+func TestExecutorPriorityFallbackPreservesUnlistedProviders(t *testing.T) {
+	registry, settings, svc, logger := setupExecutorTest(t)
+
+	var callOrder []provider.ProviderName
+	var callMu sync.Mutex
+	recordCall := func(name provider.ProviderName) {
+		callMu.Lock()
+		defer callMu.Unlock()
+		callOrder = append(callOrder, name)
+	}
+
+	registry.Register(&mockProvider{
+		name:    provider.NameMusicBrainz,
+		authReq: false,
+		getArtFn: func(_ context.Context, id string) (*provider.ArtistMetadata, error) {
+			recordCall(provider.NameMusicBrainz)
+			return nil, &provider.ErrNotFound{Provider: provider.NameMusicBrainz, ID: id}
+		},
+	})
+	registry.Register(&mockProvider{
+		name:    provider.NameAudioDB,
+		authReq: false,
+		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+			recordCall(provider.NameAudioDB)
+			return &provider.ArtistMetadata{Genres: []string{"jazz"}}, nil
+		},
+	})
+
+	ctx := context.Background()
+	if err := settings.SetAPIKey(ctx, provider.NameAudioDB, "adb-key"); err != nil {
+		t.Fatalf("SetAPIKey audiodb: %v", err)
+	}
+
+	// Priority list contains only MusicBrainz; AudioDB is only in the chain.
+	if err := settings.SetPriority(ctx, "genres", []provider.ProviderName{provider.NameMusicBrainz}); err != nil {
+		t.Fatalf("SetPriority: %v", err)
+	}
+
+	cfg := &ScraperConfig{
+		Scope: ScopeGlobal,
+		Fields: []FieldConfig{
+			{Field: FieldGenres, Primary: provider.NameMusicBrainz, Enabled: true, Category: CategoryMetadata},
+		},
+		FallbackChains: []FallbackChain{
+			{Category: CategoryMetadata, Providers: []provider.ProviderName{provider.NameMusicBrainz, provider.NameAudioDB}},
+		},
+	}
+	if err := svc.SaveConfig(ctx, ScopeGlobal, cfg, nil); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	exec := NewExecutor(svc, registry, settings, logger)
+	result, err := exec.ScrapeAll(ctx, "mbid-x", "Test Artist", ScopeGlobal, nil)
+	if err != nil {
+		t.Fatalf("ScrapeAll: %v", err)
+	}
+
+	if len(result.Metadata.Genres) == 0 || result.Metadata.Genres[0] != "jazz" {
+		t.Errorf("expected genres from AudioDB chain fallback, got %v", result.Metadata.Genres)
+	}
+
+	callMu.Lock()
+	defer callMu.Unlock()
+	if len(callOrder) < 2 || callOrder[0] != provider.NameMusicBrainz || callOrder[1] != provider.NameAudioDB {
+		t.Errorf("expected call order [MusicBrainz, AudioDB], got %v", callOrder)
+	}
+}
+
 func TestApplyMergeableFields_DoesNotTouchIDs(t *testing.T) {
 	result := &provider.FetchResult{
 		Metadata: &provider.ArtistMetadata{

--- a/web/templates/settings.templ
+++ b/web/templates/settings.templ
@@ -4613,7 +4613,7 @@ templ PriorityChipRow(pri provider.FieldPriority, keys []provider.ProviderKeySta
 templ priorityChipRowInner(pri provider.FieldPriority, available []provider.ProviderName) {
 	<div id={ "priority-row-" + pri.Field } class="rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3">
 		<div class="flex items-center gap-3 mb-2">
-			<span class="text-sm font-medium capitalize w-24 shrink-0">{ pri.Field }</span>
+			<span class="text-sm font-medium w-24 shrink-0">{ t(ctx, "field." + pri.Field) }</span>
 			<span class="text-xs text-gray-400 dark:text-gray-500">{ t(ctx, "settings.priorities.instructions") }</span>
 		</div>
 		<div class="flex flex-wrap gap-2" data-sortable-field={ pri.Field }>

--- a/web/templates/settings_templ.go
+++ b/web/templates/settings_templ.go
@@ -7859,14 +7859,14 @@ func priorityChipRowInner(pri provider.FieldPriority, available []provider.Provi
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 629, "\" class=\"rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3\"><div class=\"flex items-center gap-3 mb-2\"><span class=\"text-sm font-medium capitalize w-24 shrink-0\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 629, "\" class=\"rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3\"><div class=\"flex items-center gap-3 mb-2\"><span class=\"text-sm font-medium w-24 shrink-0\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var419 string
-		templ_7745c5c3_Var419, templ_7745c5c3_Err = templ.JoinStringErrs(pri.Field)
+		templ_7745c5c3_Var419, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "field."+pri.Field))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings.templ`, Line: 4616, Col: 73}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings.templ`, Line: 4616, Col: 81}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var419))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

The scraper executor (the active code path during artist refresh) ignored the user-configured provider priority list (`provider.priority.<field>` settings, edited via Settings > Providers) and used the hardcoded `ScraperConfig.Primary` + fallback chain instead. PR #880 fixed the orchestrator path, but `cmd/stillwater/main.go` calls `orchestrator.SetExecutor(scraperExecutor)`, which routes every refresh through the executor exclusively.

This change loads the priority list once per `ScrapeAll` via `SettingsService.GetPriorities` and merges it with the scraper config's primary + chain to build the effective per-field ordering. The user's priority list wins; any provider not listed in priorities (newly registered, or scraper-only) is appended at the end so coverage is not silently dropped. When no priority is configured for a field, the original scraper chain is preserved unchanged.

## Tests

Two new unit tests in `internal/scraper/executor_test.go`:
- `TestExecutorHonorsConfiguredPriority` -- configures Last.fm as the scraper-config primary for biography, overrides priority to put AudioDB first, asserts AudioDB was called first AND its biography won.
- `TestExecutorPriorityFallbackPreservesUnlistedProviders` -- proves a provider listed only in the scraper config's fallback chain (and absent from the priority list) is still reachable.

## Verification

- `go test -race ./...` -- pass (full suite)
- `bash scripts/pre-push-gate.sh` -- pass
- `make lint` -- 0 issues
- `make fmt` -- clean

## UAT note

The unit tests deterministically prove the configured top provider is queried first via call-order tracking, which is the verifiable behavior the issue asks for. A live UAT against Settings > Providers + an artist refresh would observe the same ordering in `Sources` / debug logs.

Closes #1030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider execution order now respects user-configured UI priorities per field; unprioritized providers remain available as fallbacks.
  * If a field’s priority list is explicitly set empty in settings, that field is skipped (no provider calls, no data).

* **Tests**
  * Added tests covering priority-driven ordering, inclusion of fallback providers, and the configured-empty skip behavior.

* **Documentation**
  * Settings UI now shows localized labels for provider-priority fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->