### PR TITLE
fix: artists are M:N with libraries via artist_libraries (#1004)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,7 @@ ignore:
   # All extracted helper functions (resetPasswordDB, getDBIntSetting, etc.) are
   # tested separately in cmd/stillwater/main_test.go.
   - "cmd/stillwater/main.go"
+  # One-shot debugging / UAT helper scripts. Not part of the production
+  # binary; scripts/pre-push-gate.sh excludes the same directory from
+  # patch coverage so this keeps gate and codecov aligned.
+  - "scripts/**"

--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -546,7 +546,7 @@ func (r *Router) handleLibraryOpStatus(w http.ResponseWriter, req *http.Request)
 
 // dedupeForImport finds an existing artist that an inbound platform item
 // (Emby / Jellyfin / Lidarr) should attach to, scanning across ALL
-// libraries (issue #1004). Returns:
+// libraries. Returns:
 //   - (existing, false): caller attaches platform mapping + library
 //     membership and skips creation
 //   - (nil, false): caller creates a new artist row
@@ -618,7 +618,7 @@ func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, l
 				if setErr := r.artistService.SetPlatformID(ctx, existing.ID, lib.ConnectionID, item.ID); setErr != nil {
 					r.logger.Warn("storing emby platform id", "name", existing.Name, "error", setErr)
 				}
-				// Issue #1004: record that this Emby library now also
+				// record that this Emby library now also
 				// observes the existing artist (filesystem-imported or
 				// Jellyfin-imported, etc.). Idempotent.
 				if memErr := r.artistService.AddLibraryMembership(ctx, existing.ID, lib.ID, "emby"); memErr != nil {
@@ -658,7 +658,7 @@ func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, l
 			if setErr := r.artistService.SetPlatformID(ctx, a.ID, lib.ConnectionID, item.ID); setErr != nil {
 				r.logger.Warn("storing emby platform id", "name", a.Name, "error", setErr)
 			}
-			// Issue #1004: record initial library membership for the
+			// record initial library membership for the
 			// freshly-created artist.
 			if memErr := r.artistService.AddLibraryMembership(ctx, a.ID, lib.ID, "emby"); memErr != nil {
 				r.logger.Warn("adding emby library membership for new artist", "name", a.Name, "error", memErr)
@@ -707,7 +707,7 @@ func (r *Router) populateFromJellyfinCtx(ctx context.Context, client *jellyfin.C
 				if setErr := r.artistService.SetPlatformID(ctx, existing.ID, lib.ConnectionID, item.ID); setErr != nil {
 					r.logger.Warn("storing jellyfin platform id", "name", existing.Name, "error", setErr)
 				}
-				// Issue #1004: record that this Jellyfin library now also
+				// record that this Jellyfin library now also
 				// observes the existing artist. Idempotent.
 				if memErr := r.artistService.AddLibraryMembership(ctx, existing.ID, lib.ID, "jellyfin"); memErr != nil {
 					r.logger.Warn("adding jellyfin library membership", "name", existing.Name, "error", memErr)
@@ -746,7 +746,7 @@ func (r *Router) populateFromJellyfinCtx(ctx context.Context, client *jellyfin.C
 			if setErr := r.artistService.SetPlatformID(ctx, a.ID, lib.ConnectionID, item.ID); setErr != nil {
 				r.logger.Warn("storing jellyfin platform id", "name", a.Name, "error", setErr)
 			}
-			// Issue #1004: record initial library membership for the
+			// record initial library membership for the
 			// freshly-created artist.
 			if memErr := r.artistService.AddLibraryMembership(ctx, a.ID, lib.ID, "jellyfin"); memErr != nil {
 				r.logger.Warn("adding jellyfin library membership for new artist", "name", a.Name, "error", memErr)
@@ -775,38 +775,22 @@ func (r *Router) populateFromLidarrCtx(ctx context.Context, client *lidarr.Clien
 		result.Total++
 		mbid := la.ForeignArtistID
 
-		if mbid != "" {
-			existing, lookupErr := r.artistService.GetByMBIDAndLibrary(ctx, mbid, lib.ID)
-			if lookupErr != nil {
-				r.logger.Warn("dedup lookup by mbid", "mbid", mbid, "error", lookupErr)
-				result.Skipped++
-				continue
+		existing, skip := r.dedupeForImport(ctx, mbid, la.ArtistName, "lidarr", result)
+		if skip {
+			continue
+		}
+
+		if existing != nil {
+			if setErr := r.artistService.SetPlatformID(ctx, existing.ID, lib.ConnectionID, fmt.Sprintf("%d", la.ID)); setErr != nil {
+				r.logger.Warn("storing lidarr platform id", "name", existing.Name, "error", setErr)
 			}
-			if existing != nil {
-				// Store the platform-to-Stillwater artist ID mapping.
-				if setErr := r.artistService.SetPlatformID(ctx, existing.ID, lib.ConnectionID, fmt.Sprintf("%d", la.ID)); setErr != nil {
-					r.logger.Warn("storing lidarr platform id", "name", existing.Name, "error", setErr)
-				}
-				r.backfillPlatformIDToManualLibs(ctx, mbid, la.ArtistName, lib.ConnectionID, fmt.Sprintf("%d", la.ID), existing.ID, manualLibs)
-				result.Skipped++
-				continue
+			// record this Lidarr library's membership.
+			if memErr := r.artistService.AddLibraryMembership(ctx, existing.ID, lib.ID, "lidarr"); memErr != nil {
+				r.logger.Warn("adding lidarr library membership", "name", existing.Name, "error", memErr)
 			}
-		} else {
-			existing, lookupErr := r.artistService.GetByNameAndLibrary(ctx, la.ArtistName, lib.ID)
-			if lookupErr != nil {
-				r.logger.Warn("dedup lookup by name", "name", la.ArtistName, "error", lookupErr)
-				result.Skipped++
-				continue
-			}
-			if existing != nil {
-				// Store the platform-to-Stillwater artist ID mapping.
-				if setErr := r.artistService.SetPlatformID(ctx, existing.ID, lib.ConnectionID, fmt.Sprintf("%d", la.ID)); setErr != nil {
-					r.logger.Warn("storing lidarr platform id", "name", existing.Name, "error", setErr)
-				}
-				r.backfillPlatformIDToManualLibs(ctx, mbid, la.ArtistName, lib.ConnectionID, fmt.Sprintf("%d", la.ID), existing.ID, manualLibs)
-				result.Skipped++
-				continue
-			}
+			r.backfillPlatformIDToManualLibs(ctx, mbid, la.ArtistName, lib.ConnectionID, fmt.Sprintf("%d", la.ID), existing.ID, manualLibs)
+			result.Skipped++
+			continue
 		}
 
 		a := &artist.Artist{
@@ -822,9 +806,12 @@ func (r *Router) populateFromLidarrCtx(ctx context.Context, client *lidarr.Clien
 		}
 		result.Created++
 
-		// Store the platform-to-Stillwater artist ID mapping.
 		if setErr := r.artistService.SetPlatformID(ctx, a.ID, lib.ConnectionID, fmt.Sprintf("%d", la.ID)); setErr != nil {
 			r.logger.Warn("storing lidarr platform id", "name", a.Name, "error", setErr)
+		}
+		// record initial library membership.
+		if memErr := r.artistService.AddLibraryMembership(ctx, a.ID, lib.ID, "lidarr"); memErr != nil {
+			r.logger.Warn("adding lidarr library membership for new artist", "name", a.Name, "error", memErr)
 		}
 		r.backfillPlatformIDToManualLibs(ctx, mbid, la.ArtistName, lib.ConnectionID, fmt.Sprintf("%d", la.ID), a.ID, manualLibs)
 	}
@@ -1079,7 +1066,7 @@ func (r *Router) backfillPlatformIDToManualLibs(
 			continue
 		}
 		if setErr := r.artistService.SetPlatformID(ctx, fsArtist.ID, connectionID, platformArtistID); setErr != nil {
-			// Issue #1076: a UNIQUE index on
+			// a UNIQUE index on
 			// (connection_id, platform_artist_id) means at most one
 			// artist row can hold a given platform mapping. The
 			// connection-library artist already claimed it before we

--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -1056,34 +1056,39 @@ func (r *Router) backfillPlatformIDToManualLibs(
 	mbid, name, connectionID, platformArtistID, connArtistID string,
 	manualLibs []library.Library,
 ) {
-	for _, ml := range manualLibs {
-		fsArtist, err := r.artistService.FindByMBIDOrName(ctx, mbid, name, ml.ID)
-		if err != nil {
-			r.logger.Warn("backfill: finding filesystem artist", "name", name, "library", ml.ID, "error", err)
-			continue
-		}
-		if fsArtist == nil || fsArtist.ID == connArtistID {
-			continue
-		}
-		if setErr := r.artistService.SetPlatformID(ctx, fsArtist.ID, connectionID, platformArtistID); setErr != nil {
-			// a UNIQUE index on
-			// (connection_id, platform_artist_id) means at most one
-			// artist row can hold a given platform mapping. The
-			// connection-library artist already claimed it before we
-			// got here, so the filesystem-library copy is now
-			// redundant rather than erroneous. Skip silently with a
-			// debug log instead of warning.
-			if errors.Is(setErr, artist.ErrPlatformIDClaimedByAnotherArtist) {
-				r.logger.Debug("backfill: platform id already held by another artist row, skipping",
-					"fs_artist_id", fsArtist.ID, "connection_id", connectionID)
-				continue
-			}
-			r.logger.Warn("backfill: storing platform id on filesystem artist", "name", fsArtist.Name, "error", setErr)
-			continue
-		}
-		r.logger.Debug("backfill: platform id propagated to filesystem artist",
-			"name", fsArtist.Name, "fs_artist_id", fsArtist.ID, "connection_id", connectionID)
+	// In the M:N model an artist row is shared across libraries, so the
+	// per-library loop is vestigial; one unscoped lookup resolves the row
+	// that any of the manual libraries would observe. The manualLibs
+	// parameter is retained as a presence guard: skip entirely when the
+	// caller has no manual libraries configured.
+	if len(manualLibs) == 0 {
+		return
 	}
+	fsArtist, err := r.artistService.FindByMBIDOrNameUnscoped(ctx, mbid, name)
+	if err != nil {
+		r.logger.Warn("backfill: finding filesystem artist", "name", name, "error", err)
+		return
+	}
+	if fsArtist == nil || fsArtist.ID == connArtistID {
+		return
+	}
+	if setErr := r.artistService.SetPlatformID(ctx, fsArtist.ID, connectionID, platformArtistID); setErr != nil {
+		// a UNIQUE index on (connection_id, platform_artist_id) means at
+		// most one artist row can hold a given platform mapping. The
+		// connection-library artist already claimed it before we got
+		// here, so the filesystem-library copy is now redundant rather
+		// than erroneous. Skip silently with a debug log instead of
+		// warning.
+		if errors.Is(setErr, artist.ErrPlatformIDClaimedByAnotherArtist) {
+			r.logger.Debug("backfill: platform id already held by another artist row, skipping",
+				"fs_artist_id", fsArtist.ID, "connection_id", connectionID)
+			return
+		}
+		r.logger.Warn("backfill: storing platform id on filesystem artist", "name", fsArtist.Name, "error", setErr)
+		return
+	}
+	r.logger.Debug("backfill: platform id propagated to filesystem artist",
+		"name", fsArtist.Name, "fs_artist_id", fsArtist.ID, "connection_id", connectionID)
 }
 
 // manualLibraries returns all libraries with source "manual". Used by scan

--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -544,6 +544,49 @@ func (r *Router) handleLibraryOpStatus(w http.ResponseWriter, req *http.Request)
 	writeJSON(w, http.StatusOK, snapshot)
 }
 
+// dedupeForImport finds an existing artist that an inbound platform item
+// (Emby / Jellyfin / Lidarr) should attach to, scanning across ALL
+// libraries (issue #1004). Returns:
+//   - (existing, false): caller attaches platform mapping + library
+//     membership and skips creation
+//   - (nil, false): caller creates a new artist row
+//   - (nil, true): a lookup error or MBID conflict was logged; caller
+//     must increment Skipped and move to the next item
+//
+// Replaces the previous per-library-scoped GetByMBIDAndLibrary +
+// GetByNameAndLibrary lookups, which produced duplicate artist rows when
+// the same real-world artist was imported from multiple libraries (the
+// classic Emby + Jellyfin against the same /music topology).
+func (r *Router) dedupeForImport(
+	ctx context.Context,
+	mbid, name, source string,
+	result *populateResult,
+) (*artist.Artist, bool) {
+	if mbid == "" && name == "" {
+		return nil, false
+	}
+	a, err := r.artistService.FindByMBIDOrNameUnscoped(ctx, mbid, name)
+	if err != nil {
+		r.logger.Warn("dedup lookup",
+			"mbid", mbid, "name", name, "platform", source, "error", err)
+		result.Skipped++
+		return nil, true
+	}
+	if a == nil {
+		return nil, false
+	}
+	if mbid != "" && a.MusicBrainzID != "" && a.MusicBrainzID != mbid {
+		// Name collision with conflicting MBIDs: two different artists
+		// share a name. Skip to avoid wrong association.
+		r.logger.Warn("mbid conflict during dedup, skipping",
+			"name", name, "platform", source,
+			"platform_mbid", mbid, "existing_mbid", a.MusicBrainzID)
+		result.Skipped++
+		return nil, true
+	}
+	return a, false
+}
+
 func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, lib *library.Library, result *populateResult) error {
 	manualLibs := r.manualLibraries(ctx)
 	startIndex := 0
@@ -558,35 +601,9 @@ func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, l
 			result.Total++
 			mbid := item.ProviderIDs.MusicBrainzArtist
 
-			var existing *artist.Artist
-			if mbid != "" {
-				var lookupErr error
-				existing, lookupErr = r.artistService.GetByMBIDAndLibrary(ctx, mbid, lib.ID)
-				if lookupErr != nil {
-					r.logger.Warn("dedup lookup by mbid", "mbid", mbid, "error", lookupErr)
-					result.Skipped++
-					continue
-				}
-			}
-			if existing == nil {
-				nameMatch, lookupErr := r.artistService.GetByNameAndLibrary(ctx, item.Name, lib.ID)
-				if lookupErr != nil {
-					r.logger.Warn("dedup lookup by name", "name", item.Name, "error", lookupErr)
-					result.Skipped++
-					continue
-				}
-				if nameMatch != nil {
-					if mbid != "" && nameMatch.MusicBrainzID != "" && nameMatch.MusicBrainzID != mbid {
-						// Name matches but MBIDs conflict -- different artists
-						// with the same name. Skip to avoid wrong association.
-						r.logger.Warn("mbid conflict during name dedup, skipping",
-							"name", item.Name, "platform_mbid", mbid,
-							"existing_mbid", nameMatch.MusicBrainzID)
-						result.Skipped++
-						continue
-					}
-					existing = nameMatch
-				}
+			existing, skip := r.dedupeForImport(ctx, mbid, item.Name, "emby", result)
+			if skip {
+				continue
 			}
 
 			if existing != nil {
@@ -600,6 +617,12 @@ func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, l
 				// Store the platform-to-Stillwater artist ID mapping.
 				if setErr := r.artistService.SetPlatformID(ctx, existing.ID, lib.ConnectionID, item.ID); setErr != nil {
 					r.logger.Warn("storing emby platform id", "name", existing.Name, "error", setErr)
+				}
+				// Issue #1004: record that this Emby library now also
+				// observes the existing artist (filesystem-imported or
+				// Jellyfin-imported, etc.). Idempotent.
+				if memErr := r.artistService.AddLibraryMembership(ctx, existing.ID, lib.ID, "emby"); memErr != nil {
+					r.logger.Warn("adding emby library membership", "name", existing.Name, "error", memErr)
 				}
 				r.backfillPlatformIDToManualLibs(ctx, mbid, item.Name, lib.ConnectionID, item.ID, existing.ID, manualLibs)
 				// Download any missing images.
@@ -635,6 +658,11 @@ func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, l
 			if setErr := r.artistService.SetPlatformID(ctx, a.ID, lib.ConnectionID, item.ID); setErr != nil {
 				r.logger.Warn("storing emby platform id", "name", a.Name, "error", setErr)
 			}
+			// Issue #1004: record initial library membership for the
+			// freshly-created artist.
+			if memErr := r.artistService.AddLibraryMembership(ctx, a.ID, lib.ID, "emby"); memErr != nil {
+				r.logger.Warn("adding emby library membership for new artist", "name", a.Name, "error", memErr)
+			}
 			r.backfillPlatformIDToManualLibs(ctx, mbid, item.Name, lib.ConnectionID, item.ID, a.ID, manualLibs)
 
 			r.downloadPlatformImages(ctx, client, item.ID, item.ImageTags, item.BackdropImageTags, a, "emby", result)
@@ -662,35 +690,9 @@ func (r *Router) populateFromJellyfinCtx(ctx context.Context, client *jellyfin.C
 			result.Total++
 			mbid := item.ProviderIDs.MusicBrainzArtist
 
-			var existing *artist.Artist
-			if mbid != "" {
-				var lookupErr error
-				existing, lookupErr = r.artistService.GetByMBIDAndLibrary(ctx, mbid, lib.ID)
-				if lookupErr != nil {
-					r.logger.Warn("dedup lookup by mbid", "mbid", mbid, "error", lookupErr)
-					result.Skipped++
-					continue
-				}
-			}
-			if existing == nil {
-				nameMatch, lookupErr := r.artistService.GetByNameAndLibrary(ctx, item.Name, lib.ID)
-				if lookupErr != nil {
-					r.logger.Warn("dedup lookup by name", "name", item.Name, "error", lookupErr)
-					result.Skipped++
-					continue
-				}
-				if nameMatch != nil {
-					if mbid != "" && nameMatch.MusicBrainzID != "" && nameMatch.MusicBrainzID != mbid {
-						// Name matches but MBIDs conflict -- different artists
-						// with the same name. Skip to avoid wrong association.
-						r.logger.Warn("mbid conflict during name dedup, skipping",
-							"name", item.Name, "platform_mbid", mbid,
-							"existing_mbid", nameMatch.MusicBrainzID)
-						result.Skipped++
-						continue
-					}
-					existing = nameMatch
-				}
+			existing, skip := r.dedupeForImport(ctx, mbid, item.Name, "jellyfin", result)
+			if skip {
+				continue
 			}
 
 			if existing != nil {
@@ -704,6 +706,11 @@ func (r *Router) populateFromJellyfinCtx(ctx context.Context, client *jellyfin.C
 				// Store the platform-to-Stillwater artist ID mapping.
 				if setErr := r.artistService.SetPlatformID(ctx, existing.ID, lib.ConnectionID, item.ID); setErr != nil {
 					r.logger.Warn("storing jellyfin platform id", "name", existing.Name, "error", setErr)
+				}
+				// Issue #1004: record that this Jellyfin library now also
+				// observes the existing artist. Idempotent.
+				if memErr := r.artistService.AddLibraryMembership(ctx, existing.ID, lib.ID, "jellyfin"); memErr != nil {
+					r.logger.Warn("adding jellyfin library membership", "name", existing.Name, "error", memErr)
 				}
 				r.backfillPlatformIDToManualLibs(ctx, mbid, item.Name, lib.ConnectionID, item.ID, existing.ID, manualLibs)
 				// Download any missing images.
@@ -738,6 +745,11 @@ func (r *Router) populateFromJellyfinCtx(ctx context.Context, client *jellyfin.C
 			// Store the platform-to-Stillwater artist ID mapping.
 			if setErr := r.artistService.SetPlatformID(ctx, a.ID, lib.ConnectionID, item.ID); setErr != nil {
 				r.logger.Warn("storing jellyfin platform id", "name", a.Name, "error", setErr)
+			}
+			// Issue #1004: record initial library membership for the
+			// freshly-created artist.
+			if memErr := r.artistService.AddLibraryMembership(ctx, a.ID, lib.ID, "jellyfin"); memErr != nil {
+				r.logger.Warn("adding jellyfin library membership for new artist", "name", a.Name, "error", memErr)
 			}
 			r.backfillPlatformIDToManualLibs(ctx, mbid, item.Name, lib.ConnectionID, item.ID, a.ID, manualLibs)
 

--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -655,13 +655,10 @@ func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, l
 			result.Created++
 
 			// Store the platform-to-Stillwater artist ID mapping.
+			// Initial artist_libraries membership is recorded by
+			// artist.Service.Create via AddDerivingSource.
 			if setErr := r.artistService.SetPlatformID(ctx, a.ID, lib.ConnectionID, item.ID); setErr != nil {
 				r.logger.Warn("storing emby platform id", "name", a.Name, "error", setErr)
-			}
-			// record initial library membership for the
-			// freshly-created artist.
-			if memErr := r.artistService.AddLibraryMembership(ctx, a.ID, lib.ID, "emby"); memErr != nil {
-				r.logger.Warn("adding emby library membership for new artist", "name", a.Name, "error", memErr)
 			}
 			r.backfillPlatformIDToManualLibs(ctx, mbid, item.Name, lib.ConnectionID, item.ID, a.ID, manualLibs)
 
@@ -743,13 +740,10 @@ func (r *Router) populateFromJellyfinCtx(ctx context.Context, client *jellyfin.C
 			result.Created++
 
 			// Store the platform-to-Stillwater artist ID mapping.
+			// Initial artist_libraries membership is recorded by
+			// artist.Service.Create via AddDerivingSource.
 			if setErr := r.artistService.SetPlatformID(ctx, a.ID, lib.ConnectionID, item.ID); setErr != nil {
 				r.logger.Warn("storing jellyfin platform id", "name", a.Name, "error", setErr)
-			}
-			// record initial library membership for the
-			// freshly-created artist.
-			if memErr := r.artistService.AddLibraryMembership(ctx, a.ID, lib.ID, "jellyfin"); memErr != nil {
-				r.logger.Warn("adding jellyfin library membership for new artist", "name", a.Name, "error", memErr)
 			}
 			r.backfillPlatformIDToManualLibs(ctx, mbid, item.Name, lib.ConnectionID, item.ID, a.ID, manualLibs)
 
@@ -806,12 +800,10 @@ func (r *Router) populateFromLidarrCtx(ctx context.Context, client *lidarr.Clien
 		}
 		result.Created++
 
+		// Initial artist_libraries membership is recorded by
+		// artist.Service.Create via AddDerivingSource.
 		if setErr := r.artistService.SetPlatformID(ctx, a.ID, lib.ConnectionID, fmt.Sprintf("%d", la.ID)); setErr != nil {
 			r.logger.Warn("storing lidarr platform id", "name", a.Name, "error", setErr)
-		}
-		// record initial library membership.
-		if memErr := r.artistService.AddLibraryMembership(ctx, a.ID, lib.ID, "lidarr"); memErr != nil {
-			r.logger.Warn("adding lidarr library membership for new artist", "name", a.Name, "error", memErr)
 		}
 		r.backfillPlatformIDToManualLibs(ctx, mbid, la.ArtistName, lib.ConnectionID, fmt.Sprintf("%d", la.ID), a.ID, manualLibs)
 	}

--- a/internal/api/handlers_connection_library_test.go
+++ b/internal/api/handlers_connection_library_test.go
@@ -2358,7 +2358,10 @@ func TestPopulateFromEmby_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 		t.Fatalf("creating emby library: %v", err)
 	}
 
-	// Populate -- this creates a NEW emby-library artist.
+	// Issue #1004: Emby populate must NOT create a duplicate row when the
+	// inbound artist matches an existing filesystem artist by MBID. The
+	// existing artist gets the Emby platform mapping + an Emby library
+	// membership, and result.Created stays at 0.
 	client := emby.NewWithHTTPClient(embySrv.URL, "key", "", embySrv.Client(),
 		slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
 	var result populateResult
@@ -2366,31 +2369,31 @@ func TestPopulateFromEmby_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 		t.Fatalf("populateFromEmbyCtx: %v", err)
 	}
 
-	if result.Created != 1 {
-		t.Fatalf("created = %d, want 1", result.Created)
+	if result.Created != 0 {
+		t.Fatalf("created = %d, want 0 (existing filesystem artist must absorb the import)", result.Created)
 	}
 
-	// The emby-library artist should have a platform ID (existing behavior).
-	embyArtist, err := router.artistService.GetByNameAndLibrary(ctx, "Radiohead", embyLib.ID)
-	if err != nil || embyArtist == nil {
-		t.Fatalf("looking up emby artist: %v", err)
-	}
-	embyPlatformID, err := router.artistService.GetPlatformID(ctx, embyArtist.ID, "conn-emby-1")
-	if err != nil {
-		t.Fatalf("GetPlatformID (emby): %v", err)
-	}
-	if embyPlatformID != "emby-radiohead-001" {
-		t.Errorf("emby artist platform ID = %q, want %q", embyPlatformID, "emby-radiohead-001")
-	}
-
-	// Issue #1076: only the connection-library artist holds the mapping;
-	// the filesystem artist no longer gets a duplicate.
+	// Filesystem artist now holds the Emby platform mapping.
 	fsPlatformID, err := router.artistService.GetPlatformID(ctx, fsArtist.ID, "conn-emby-1")
 	if err != nil {
 		t.Fatalf("GetPlatformID (fs): %v", err)
 	}
-	if fsPlatformID != "" {
-		t.Errorf("filesystem artist platform ID = %q, want empty (UNIQUE index forbids duplicate mapping)", fsPlatformID)
+	if fsPlatformID != "emby-radiohead-001" {
+		t.Errorf("filesystem artist platform ID = %q, want %q (mapping must attach to canonical row)",
+			fsPlatformID, "emby-radiohead-001")
+	}
+
+	// No second Radiohead row was created.
+	memberships, err := router.artistService.LibrariesForArtist(ctx, fsArtist.ID)
+	if err != nil {
+		t.Fatalf("LibrariesForArtist: %v", err)
+	}
+	gotLibs := map[string]string{}
+	for _, m := range memberships {
+		gotLibs[m.LibraryID] = m.Source
+	}
+	if got := gotLibs[embyLib.ID]; got != "emby" {
+		t.Errorf("emby membership source = %q, want emby (memberships=%+v)", got, memberships)
 	}
 }
 
@@ -2859,5 +2862,135 @@ func TestScanFromLidarr_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 	}
 	if lidarrPlatformID != "42" {
 		t.Errorf("lidarr artist platform ID = %q, want %q", lidarrPlatformID, "42")
+	}
+}
+
+// TestPopulate_EmbyAndJellyfin_CollapsesIntoOneArtist is the issue #1004
+// killer integration test. With M:N artist_libraries (no per-library scope
+// on dedupe), populating both Emby and Jellyfin against the same on-disk
+// artist must produce ONE artist row carrying both platform mappings and
+// both library memberships, not two parallel rows.
+//
+// Topology under test: no filesystem library (the canonical pre-fix bug
+// scenario). Emby populates first and creates the artist; Jellyfin
+// populates second and absorbs into the existing row.
+func TestPopulate_EmbyAndJellyfin_CollapsesIntoOneArtist(t *testing.T) {
+	const mbid = "mbid-12-stones"
+
+	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"Items":[{
+				"Name":"12 Stones","SortName":"12 Stones",
+				"Id":"emby-12-stones",
+				"Path":"","Overview":"American rock band.",
+				"Genres":["Rock"],"Tags":[],
+				"PremiereDate":"","EndDate":"",
+				"ProviderIds":{"MusicBrainzArtist":"` + mbid + `"},
+				"ImageTags":{}
+			}],
+			"TotalRecordCount":1
+		}`))
+	}))
+	defer embySrv.Close()
+
+	jfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"Items":[{
+				"Name":"12 Stones","SortName":"12 Stones",
+				"Id":"jelly-12-stones",
+				"Path":"/music/12 Stones","Overview":"American rock band.",
+				"Genres":["Rock"],"Tags":[],
+				"PremiereDate":"","EndDate":"",
+				"ProviderIds":{"MusicBrainzArtist":"` + mbid + `"},
+				"ImageTags":{}
+			}],
+			"TotalRecordCount":1
+		}`))
+	}))
+	defer jfSrv.Close()
+
+	router := testRouterForLibraryOps(t)
+	ctx := context.Background()
+
+	addTestConnection(t, router, "conn-emby", "Emby", "emby")
+	addTestConnection(t, router, "conn-jelly", "Jellyfin", "jellyfin")
+
+	embyLib := &library.Library{
+		Name: "Emby Music", Type: library.TypeRegular,
+		Source: library.SourceEmby, ConnectionID: "conn-emby", ExternalID: "emby-lib",
+	}
+	if err := router.libraryService.Create(ctx, embyLib); err != nil {
+		t.Fatalf("create emby library: %v", err)
+	}
+	jfLib := &library.Library{
+		Name: "Jellyfin Music", Type: library.TypeRegular,
+		Source: library.SourceJellyfin, ConnectionID: "conn-jelly", ExternalID: "jelly-lib",
+	}
+	if err := router.libraryService.Create(ctx, jfLib); err != nil {
+		t.Fatalf("create jellyfin library: %v", err)
+	}
+
+	embyClient := emby.NewWithHTTPClient(embySrv.URL, "key", "", embySrv.Client(),
+		slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+	jfClient := jellyfin.NewWithHTTPClient(jfSrv.URL, "key", "", jfSrv.Client(),
+		slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	// Emby populates first: creates the canonical artist row.
+	var rEmby populateResult
+	if err := router.populateFromEmbyCtx(ctx, embyClient, embyLib, &rEmby); err != nil {
+		t.Fatalf("emby populate: %v", err)
+	}
+	if rEmby.Created != 1 {
+		t.Errorf("emby created = %d, want 1", rEmby.Created)
+	}
+
+	// Jellyfin populates second: must absorb into the same artist row, not
+	// create a duplicate.
+	var rJF populateResult
+	if err := router.populateFromJellyfinCtx(ctx, jfClient, jfLib, &rJF); err != nil {
+		t.Fatalf("jellyfin populate: %v", err)
+	}
+	if rJF.Created != 0 {
+		t.Errorf("jellyfin created = %d, want 0 (must dedupe to existing artist)", rJF.Created)
+	}
+
+	// Exactly one 12 Stones row exists end-to-end.
+	a, err := router.artistService.GetByMBID(ctx, mbid)
+	if err != nil || a == nil {
+		t.Fatalf("GetByMBID after both populates: a=%v err=%v", a, err)
+	}
+
+	// Both platform mappings live on the canonical row.
+	embyPID, err := router.artistService.GetPlatformID(ctx, a.ID, "conn-emby")
+	if err != nil {
+		t.Fatalf("GetPlatformID emby: %v", err)
+	}
+	if embyPID != "emby-12-stones" {
+		t.Errorf("emby platform id = %q, want emby-12-stones", embyPID)
+	}
+	jfPID, err := router.artistService.GetPlatformID(ctx, a.ID, "conn-jelly")
+	if err != nil {
+		t.Fatalf("GetPlatformID jellyfin: %v", err)
+	}
+	if jfPID != "jelly-12-stones" {
+		t.Errorf("jellyfin platform id = %q, want jelly-12-stones", jfPID)
+	}
+
+	// Both library memberships live on the canonical row.
+	memberships, err := router.artistService.LibrariesForArtist(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("LibrariesForArtist: %v", err)
+	}
+	gotSources := map[string]string{}
+	for _, m := range memberships {
+		gotSources[m.LibraryID] = m.Source
+	}
+	if gotSources[embyLib.ID] != "emby" {
+		t.Errorf("emby membership source = %q, want emby", gotSources[embyLib.ID])
+	}
+	if gotSources[jfLib.ID] != "jellyfin" {
+		t.Errorf("jellyfin membership source = %q, want jellyfin", gotSources[jfLib.ID])
 	}
 }

--- a/internal/artist/platform_ids.go
+++ b/internal/artist/platform_ids.go
@@ -32,4 +32,10 @@ type PlatformPresence struct {
 	HasEmby     bool `json:"has_emby"`
 	HasJellyfin bool `json:"has_jellyfin"`
 	HasLidarr   bool `json:"has_lidarr"`
+	// HasFilesystem records membership in at least one filesystem-source
+	// library (a libraries row whose connection_id is NULL). Replaces the
+	// pre-#1004 path-presence heuristic in the artist list row, which
+	// gave false positives for Emby/Jellyfin-only artists that happen to
+	// carry an on-disk path written by the connection populate.
+	HasFilesystem bool `json:"has_filesystem"`
 }

--- a/internal/artist/platform_ids.go
+++ b/internal/artist/platform_ids.go
@@ -10,7 +10,7 @@ var ErrPlatformIDNotFound = errors.New("platform id not found")
 
 // ErrPlatformIDClaimedByAnotherArtist is returned by SetPlatformID when the
 // requested (connection_id, platform_artist_id) pair is already held by a
-// different artist. Issue #1076 added a UNIQUE index on that pair so a
+// different artist. A new a UNIQUE index on that pair so a
 // platform item can only ever be claimed by a single Stillwater artist.
 // Callers that prefer to no-op rather than fail (for example, the manual-
 // library backfill helper) should match on this sentinel via errors.Is.
@@ -34,7 +34,7 @@ type PlatformPresence struct {
 	HasLidarr   bool `json:"has_lidarr"`
 	// HasFilesystem records membership in at least one filesystem-source
 	// library (a libraries row whose connection_id is NULL). Replaces the
-	// pre-#1004 path-presence heuristic in the artist list row, which
+	// legacy path-presence heuristic in the artist list row, which
 	// gave false positives for Emby/Jellyfin-only artists that happen to
 	// carry an on-disk path written by the connection populate.
 	HasFilesystem bool `json:"has_filesystem"`

--- a/internal/artist/platform_ids_test.go
+++ b/internal/artist/platform_ids_test.go
@@ -2,6 +2,7 @@ package artist
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 
@@ -288,6 +289,46 @@ func addMembership(t *testing.T, svc *Service, artistID, libraryID, source strin
 	}
 }
 
+// setupPlatformPresenceTestWithDB is a sibling of setupPlatformPresenceTest
+// that also returns the underlying *sql.DB. Several legacy-fallback tests
+// need to insert rows (e.g. artists with only artists.library_id and no
+// artist_libraries membership) that Service.Create cannot produce.
+func setupPlatformPresenceTestWithDB(t *testing.T) (*Service, *sql.DB) {
+	t.Helper()
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	ctx := context.Background()
+	for _, q := range []string{
+		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
+			VALUES ('conn-1', 'Test Emby', 'emby', 'http://emby:8096', 'enc-key', 1, 'ok', datetime('now'), datetime('now'))`,
+		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
+			VALUES ('conn-2', 'Test Jellyfin', 'jellyfin', 'http://jf:8096', 'enc-key', 1, 'ok', datetime('now'), datetime('now'))`,
+		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
+			VALUES ('conn-3', 'Test Lidarr', 'lidarr', 'http://lidarr:8686', 'enc-key', 1, 'ok', datetime('now'), datetime('now'))`,
+		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
+			VALUES ('lib-emby', 'lib-emby', '/music', 'regular', 'import', 'conn-1', datetime('now'), datetime('now'))`,
+		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
+			VALUES ('lib-jelly', 'lib-jelly', '/music', 'regular', 'import', 'conn-2', datetime('now'), datetime('now'))`,
+		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
+			VALUES ('lib-lidarr', 'lib-lidarr', '/music', 'regular', 'import', 'conn-3', datetime('now'), datetime('now'))`,
+		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
+			VALUES ('lib-fs', 'lib-fs', '/music', 'regular', 'manual', NULL, datetime('now'), datetime('now'))`,
+	} {
+		if _, err := db.ExecContext(ctx, q); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return NewService(db), db
+}
+
 func TestGetPlatformPresenceForArtists(t *testing.T) {
 	svc := setupPlatformPresenceTest(t)
 	ctx := context.Background()
@@ -428,5 +469,88 @@ func TestGetPlatformPresenceForArtists_AllPlatforms(t *testing.T) {
 	}
 	if !p.HasLidarr {
 		t.Error("expected HasLidarr=true")
+	}
+}
+
+// TestGetPlatformPresenceForArtists_LegacyLibraryIDFallback exercises the
+// hybrid OR-fallback added for the M:N transition. An artist row that
+// still carries only the legacy artists.library_id column (no
+// artist_libraries membership) must still surface its presence; the
+// fallback branch goes away once the column drop in #1214 lands.
+func TestGetPlatformPresenceForArtists_LegacyLibraryIDFallback(t *testing.T) {
+	svc, db := setupPlatformPresenceTestWithDB(t)
+	ctx := context.Background()
+
+	// Create an artist directly via SQL so artist.Service.Create does
+	// not auto-populate artist_libraries. The artists.library_id column
+	// is the only thing pointing at lib-emby for this row.
+	_ = svc
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artists (id, name, sort_name, library_id, path, created_at, updated_at)
+		VALUES ('a-legacy-emby', 'Legacy Emby', 'Legacy Emby', 'lib-emby',
+			'/music/legacy', datetime('now'), datetime('now'))
+	`); err != nil {
+		t.Fatalf("seeding legacy artist: %v", err)
+	}
+
+	// Same shape but pointing at a filesystem (NULL connection_id) library.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artists (id, name, sort_name, library_id, path, created_at, updated_at)
+		VALUES ('a-legacy-fs', 'Legacy FS', 'Legacy FS', 'lib-fs',
+			'/music/legacy-fs', datetime('now'), datetime('now'))
+	`); err != nil {
+		t.Fatalf("seeding legacy fs artist: %v", err)
+	}
+
+	result, err := svc.GetPlatformPresenceForArtists(ctx,
+		[]string{"a-legacy-emby", "a-legacy-fs"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pe := result["a-legacy-emby"]
+	if !pe.HasEmby {
+		t.Error("legacy emby artist: expected HasEmby=true via library_id fallback")
+	}
+	if pe.HasFilesystem {
+		t.Error("legacy emby artist: expected HasFilesystem=false")
+	}
+
+	pf := result["a-legacy-fs"]
+	if !pf.HasFilesystem {
+		t.Error("legacy fs artist: expected HasFilesystem=true via library_id fallback")
+	}
+	if pf.HasEmby || pf.HasJellyfin || pf.HasLidarr {
+		t.Errorf("legacy fs artist: expected platform flags all false, got %+v", pf)
+	}
+}
+
+// TestGetPlatformPresenceForArtists_MembershipAndLegacyDeDuplicate verifies
+// that an artist with BOTH an artist_libraries row AND a legacy
+// artists.library_id pointing at the same library is reported once per
+// presence kind (the UNION + GROUP-equivalent semantics dedupe).
+func TestGetPlatformPresenceForArtists_MembershipAndLegacyDeDuplicate(t *testing.T) {
+	svc, db := setupPlatformPresenceTestWithDB(t)
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artists (id, name, sort_name, library_id, path, created_at, updated_at)
+		VALUES ('a-both', 'BothPaths', 'BothPaths', 'lib-emby',
+			'/music/both', datetime('now'), datetime('now'))
+	`); err != nil {
+		t.Fatalf("seeding artist: %v", err)
+	}
+	addMembership(t, svc, "a-both", "lib-emby", "emby")
+
+	result, err := svc.GetPlatformPresenceForArtists(ctx, []string{"a-both"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := result["a-both"]
+	if !p.HasEmby {
+		t.Error("expected HasEmby=true")
+	}
+	if p.HasFilesystem || p.HasJellyfin || p.HasLidarr {
+		t.Errorf("expected only HasEmby, got %+v", p)
 	}
 }

--- a/internal/artist/platform_ids_test.go
+++ b/internal/artist/platform_ids_test.go
@@ -265,6 +265,10 @@ func setupPlatformPresenceTest(t *testing.T) *Service {
 			VALUES ('lib-jelly', 'lib-jelly', '/music', 'regular', 'import', 'conn-2', datetime('now'), datetime('now'))`,
 		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
 			VALUES ('lib-lidarr', 'lib-lidarr', '/music', 'regular', 'import', 'conn-3', datetime('now'), datetime('now'))`,
+		// connection_id NULL marks a manual filesystem library; presence
+		// derived from artist_libraries treats this as HasFilesystem.
+		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
+			VALUES ('lib-fs', 'lib-fs', '/music', 'regular', 'manual', NULL, datetime('now'), datetime('now'))`,
 	} {
 		if _, err := db.ExecContext(ctx, q); err != nil {
 			t.Fatal(err)
@@ -291,6 +295,7 @@ func TestGetPlatformPresenceForArtists(t *testing.T) {
 	a1 := createTestArtist(t, svc, "Radiohead")
 	a2 := createTestArtist(t, svc, "Bjork")
 	a3 := createTestArtist(t, svc, "Portishead")
+	a4 := createTestArtist(t, svc, "Aphex Twin")
 
 	// a1: Emby + Jellyfin (presence requires both the
 	// platform mapping AND the library membership; helper seeds both).
@@ -311,12 +316,16 @@ func TestGetPlatformPresenceForArtists(t *testing.T) {
 
 	// a3: no platform IDs and no memberships (should be absent from result)
 
-	result, err := svc.GetPlatformPresenceForArtists(ctx, []string{a1.ID, a2.ID, a3.ID})
+	// a4: filesystem-only (NULL connection_id library). No platform mapping;
+	// presence comes purely from the membership row.
+	addMembership(t, svc, a4.ID, "lib-fs", "filesystem")
+
+	result, err := svc.GetPlatformPresenceForArtists(ctx, []string{a1.ID, a2.ID, a3.ID, a4.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// a1 should have Emby and Jellyfin
+	// a1 should have Emby and Jellyfin (no filesystem membership).
 	p1 := result[a1.ID]
 	if !p1.HasEmby {
 		t.Error("a1: expected HasEmby=true")
@@ -327,8 +336,11 @@ func TestGetPlatformPresenceForArtists(t *testing.T) {
 	if p1.HasLidarr {
 		t.Error("a1: expected HasLidarr=false")
 	}
+	if p1.HasFilesystem {
+		t.Error("a1: expected HasFilesystem=false")
+	}
 
-	// a2 should have Lidarr only
+	// a2 should have Lidarr only (no filesystem membership).
 	p2 := result[a2.ID]
 	if p2.HasEmby {
 		t.Error("a2: expected HasEmby=false")
@@ -339,10 +351,24 @@ func TestGetPlatformPresenceForArtists(t *testing.T) {
 	if !p2.HasLidarr {
 		t.Error("a2: expected HasLidarr=true")
 	}
+	if p2.HasFilesystem {
+		t.Error("a2: expected HasFilesystem=false")
+	}
 
 	// a3 should not be in the map
 	if _, ok := result[a3.ID]; ok {
 		t.Error("a3: expected to be absent from result map")
+	}
+
+	// a4 has only a filesystem (NULL connection_id) membership; assert
+	// HasFilesystem=true and every platform flag false.
+	p4 := result[a4.ID]
+	if !p4.HasFilesystem {
+		t.Error("a4: expected HasFilesystem=true")
+	}
+	if p4.HasEmby || p4.HasJellyfin || p4.HasLidarr {
+		t.Errorf("a4: expected platform flags all false, got emby=%v jellyfin=%v lidarr=%v",
+			p4.HasEmby, p4.HasJellyfin, p4.HasLidarr)
 	}
 }
 

--- a/internal/artist/platform_ids_test.go
+++ b/internal/artist/platform_ids_test.go
@@ -484,7 +484,6 @@ func TestGetPlatformPresenceForArtists_LegacyLibraryIDFallback(t *testing.T) {
 	// Create an artist directly via SQL so artist.Service.Create does
 	// not auto-populate artist_libraries. The artists.library_id column
 	// is the only thing pointing at lib-emby for this row.
-	_ = svc
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO artists (id, name, sort_name, library_id, path, created_at, updated_at)
 		VALUES ('a-legacy-emby', 'Legacy Emby', 'Legacy Emby', 'lib-emby',

--- a/internal/artist/platform_ids_test.go
+++ b/internal/artist/platform_ids_test.go
@@ -254,6 +254,17 @@ func setupPlatformPresenceTest(t *testing.T) *Service {
 			VALUES ('conn-2', 'Test Jellyfin', 'jellyfin', 'http://jf:8096', 'enc-key', 1, 'ok', datetime('now'), datetime('now'))`,
 		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
 			VALUES ('conn-3', 'Test Lidarr', 'lidarr', 'http://lidarr:8686', 'enc-key', 1, 'ok', datetime('now'), datetime('now'))`,
+		// presence is derived from artist_libraries, so the
+		// fixture creates one library per connection. Tests using this
+		// setup add membership rows pointing at these library IDs to
+		// signal presence (in addition to the artist_platform_ids row,
+		// which carries the actual platform identifier).
+		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
+			VALUES ('lib-emby', 'lib-emby', '/music', 'regular', 'import', 'conn-1', datetime('now'), datetime('now'))`,
+		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
+			VALUES ('lib-jelly', 'lib-jelly', '/music', 'regular', 'import', 'conn-2', datetime('now'), datetime('now'))`,
+		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
+			VALUES ('lib-lidarr', 'lib-lidarr', '/music', 'regular', 'import', 'conn-3', datetime('now'), datetime('now'))`,
 	} {
 		if _, err := db.ExecContext(ctx, q); err != nil {
 			t.Fatal(err)
@@ -261,6 +272,16 @@ func setupPlatformPresenceTest(t *testing.T) *Service {
 	}
 
 	return NewService(db)
+}
+
+// addMembership inserts an artist_libraries row for a presence test. Issue
+// #1004: presence is now derived from these rows, not from the platform
+// mapping, so tests asserting Has* must seed both.
+func addMembership(t *testing.T, svc *Service, artistID, libraryID, source string) {
+	t.Helper()
+	if err := svc.AddLibraryMembership(context.Background(), artistID, libraryID, source); err != nil {
+		t.Fatalf("AddLibraryMembership(%s, %s, %s): %v", artistID, libraryID, source, err)
+	}
 }
 
 func TestGetPlatformPresenceForArtists(t *testing.T) {
@@ -271,20 +292,24 @@ func TestGetPlatformPresenceForArtists(t *testing.T) {
 	a2 := createTestArtist(t, svc, "Bjork")
 	a3 := createTestArtist(t, svc, "Portishead")
 
-	// a1: Emby + Jellyfin
+	// a1: Emby + Jellyfin (presence requires both the
+	// platform mapping AND the library membership; helper seeds both).
 	if err := svc.SetPlatformID(ctx, a1.ID, "conn-1", "emby-111"); err != nil {
 		t.Fatal(err)
 	}
+	addMembership(t, svc, a1.ID, "lib-emby", "emby")
 	if err := svc.SetPlatformID(ctx, a1.ID, "conn-2", "jf-111"); err != nil {
 		t.Fatal(err)
 	}
+	addMembership(t, svc, a1.ID, "lib-jelly", "jellyfin")
 
 	// a2: Lidarr only
 	if err := svc.SetPlatformID(ctx, a2.ID, "conn-3", "lidarr-222"); err != nil {
 		t.Fatal(err)
 	}
+	addMembership(t, svc, a2.ID, "lib-lidarr", "lidarr")
 
-	// a3: no platform IDs (should be absent from result)
+	// a3: no platform IDs and no memberships (should be absent from result)
 
 	result, err := svc.GetPlatformPresenceForArtists(ctx, []string{a1.ID, a2.ID, a3.ID})
 	if err != nil {
@@ -353,10 +378,15 @@ func TestGetPlatformPresenceForArtists_AllPlatforms(t *testing.T) {
 
 	a := createTestArtist(t, svc, "Radiohead")
 
-	// Artist with all three platform types
+	// Artist with all three platform types. presence flows
+	// from artist_libraries memberships, not the platform mappings; seed
+	// both to assert presence.
 	svc.SetPlatformID(ctx, a.ID, "conn-1", "emby-111")
+	addMembership(t, svc, a.ID, "lib-emby", "emby")
 	svc.SetPlatformID(ctx, a.ID, "conn-2", "jf-111")
+	addMembership(t, svc, a.ID, "lib-jelly", "jellyfin")
 	svc.SetPlatformID(ctx, a.ID, "conn-3", "lidarr-111")
+	addMembership(t, svc, a.ID, "lib-lidarr", "lidarr")
 
 	result, err := svc.GetPlatformPresenceForArtists(ctx, []string{a.ID})
 	if err != nil {

--- a/internal/artist/platform_ids_test.go
+++ b/internal/artist/platform_ids_test.go
@@ -245,6 +245,12 @@ func setupPlatformPresenceTest(t *testing.T) *Service {
 	if err := database.Migrate(db); err != nil {
 		t.Fatal(err)
 	}
+	// Mirror production: enforce foreign keys so orphan
+	// artist_libraries / artist_platform_ids writes fail loudly in tests
+	// rather than silently passing.
+	if err := database.EnableForeignKeys(db); err != nil {
+		t.Fatal(err)
+	}
 	t.Cleanup(func() { db.Close() })
 
 	ctx := context.Background()
@@ -300,6 +306,10 @@ func setupPlatformPresenceTestWithDB(t *testing.T) (*Service, *sql.DB) {
 		t.Fatal(err)
 	}
 	if err := database.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	// See setupPlatformPresenceTest: mirror production FK enforcement.
+	if err := database.EnableForeignKeys(db); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { db.Close() })

--- a/internal/artist/repository.go
+++ b/internal/artist/repository.go
@@ -12,18 +12,18 @@ type Repository interface {
 	GetByMBID(ctx context.Context, mbid string) (*Artist, error)
 
 	// GetByName looks up an artist by case-insensitive exact name match
-	// without any library scope. Issue #1004: connection populates use this
+	// without any library scope. connection populates use this
 	// to dedupe across all libraries (the legacy GetByNameAndLibrary scoped
 	// to one library and missed cross-library duplicates).
 	GetByName(ctx context.Context, name string) (*Artist, error)
 
 	// FindByMBIDOrNameUnscoped performs unscoped MBID-then-name lookup,
-	// matching the dedupe priority used by connection populates. Issue #1004
-	// replacement for the library-scoped FindByMBIDOrName.
+	// matching the dedupe priority used by connection populates. Replaces
+	// the library-scoped FindByMBIDOrName.
 	FindByMBIDOrNameUnscoped(ctx context.Context, mbid, name string) (*Artist, error)
 
 	// Deprecated: use GetByMBID. The library-scoped variant remains while
-	// legacy populate paths are migrated; remove with #1004 cleanup.
+	// legacy populate paths are migrated; remove with the M:N cleanup.
 	GetByMBIDAndLibrary(ctx context.Context, mbid, libraryID string) (*Artist, error)
 	// Deprecated: use GetByName. See GetByMBIDAndLibrary above.
 	GetByNameAndLibrary(ctx context.Context, name, libraryID string) (*Artist, error)

--- a/internal/artist/repository.go
+++ b/internal/artist/repository.go
@@ -10,8 +10,24 @@ type Repository interface {
 	Create(ctx context.Context, a *Artist) error
 	GetByID(ctx context.Context, id string) (*Artist, error)
 	GetByMBID(ctx context.Context, mbid string) (*Artist, error)
+
+	// GetByName looks up an artist by case-insensitive exact name match
+	// without any library scope. Issue #1004: connection populates use this
+	// to dedupe across all libraries (the legacy GetByNameAndLibrary scoped
+	// to one library and missed cross-library duplicates).
+	GetByName(ctx context.Context, name string) (*Artist, error)
+
+	// FindByMBIDOrNameUnscoped performs unscoped MBID-then-name lookup,
+	// matching the dedupe priority used by connection populates. Issue #1004
+	// replacement for the library-scoped FindByMBIDOrName.
+	FindByMBIDOrNameUnscoped(ctx context.Context, mbid, name string) (*Artist, error)
+
+	// Deprecated: use GetByMBID. The library-scoped variant remains while
+	// legacy populate paths are migrated; remove with #1004 cleanup.
 	GetByMBIDAndLibrary(ctx context.Context, mbid, libraryID string) (*Artist, error)
+	// Deprecated: use GetByName. See GetByMBIDAndLibrary above.
 	GetByNameAndLibrary(ctx context.Context, name, libraryID string) (*Artist, error)
+	// Deprecated: use FindByMBIDOrNameUnscoped. See GetByMBIDAndLibrary above.
 	FindByMBIDOrName(ctx context.Context, mbid, name, libraryID string) (*Artist, error)
 	GetByPath(ctx context.Context, path string) (*Artist, error)
 	List(ctx context.Context, params ListParams) ([]Artist, int, error)

--- a/internal/artist/repository.go
+++ b/internal/artist/repository.go
@@ -206,8 +206,11 @@ type PlatformIDRepository interface {
 	// DeleteByArtistID removes all platform ID mappings for the given artist.
 	DeleteByArtistID(ctx context.Context, artistID string) error
 
-	// GetPresenceForArtists returns per-artist platform presence (Emby, Jellyfin,
-	// Lidarr) by joining artist_platform_ids with connections to determine
-	// connection type. Artists with no platform IDs are omitted from the result.
+	// GetPresenceForArtists returns per-artist platform presence (filesystem,
+	// Emby, Jellyfin, Lidarr) derived from artist_libraries memberships joined
+	// with libraries: a NULL library.connection_id maps to HasFilesystem; a
+	// non-NULL connection_id maps to HasEmby/HasJellyfin/HasLidarr based on the
+	// connection type. Artists with no membership rows are omitted from the
+	// result map; the caller treats a missing entry as no presence.
 	GetPresenceForArtists(ctx context.Context, artistIDs []string) (map[string]PlatformPresence, error)
 }

--- a/internal/artist/scan.go
+++ b/internal/artist/scan.go
@@ -201,8 +201,18 @@ func buildWhereClause(params ListParams) (string, []any) {
 	}
 
 	if params.LibraryID != "" {
-		conditions = append(conditions, "library_id = ?")
-		args = append(args, params.LibraryID)
+		// Match either via the M:N membership table or the legacy
+		// library_id column, so artists created before the membership
+		// rollout still appear in per-library queries until phase 7
+		// drops the column.
+		conditions = append(conditions, `(
+			EXISTS (
+				SELECT 1 FROM artist_libraries al
+				WHERE al.artist_id = artists.id AND al.library_id = ?
+			)
+			OR artists.library_id = ?
+		)`)
+		args = append(args, params.LibraryID, params.LibraryID)
 	}
 
 	switch params.Filter {
@@ -335,16 +345,37 @@ func buildWhereClause(params ListParams) (string, []any) {
 	}
 	if len(libIncludes) > 0 {
 		ph := strings.Repeat("?,", len(libIncludes))
-		conditions = append(conditions, "library_id IN ("+ph[:len(ph)-1]+")")
+		// Union semantics: match if the artist has membership in ANY of
+		// the included libraries OR the legacy column points at one.
+		// Drop the legacy branch in the column-removal phase.
+		conditions = append(conditions, `(
+			EXISTS (
+				SELECT 1 FROM artist_libraries al
+				WHERE al.artist_id = artists.id
+				  AND al.library_id IN (`+ph[:len(ph)-1]+`)
+			)
+			OR artists.library_id IN (`+ph[:len(ph)-1]+`)
+		)`)
+		for _, id := range libIncludes {
+			args = append(args, id)
+		}
 		for _, id := range libIncludes {
 			args = append(args, id)
 		}
 	}
 	if len(libExcludes) > 0 {
 		ph := strings.Repeat("?,", len(libExcludes))
-		// Use IS NULL OR NOT IN so artists with no library assignment are not
-		// silently dropped when excluding a specific library (NULL NOT IN (...) = NULL).
-		conditions = append(conditions, "(library_id IS NULL OR library_id NOT IN ("+ph[:len(ph)-1]+"))")
+		// Drop artists with membership OR legacy pointer in any excluded
+		// library. Artists with neither pass through (nothing to exclude),
+		// matching the prior "IS NULL OR NOT IN" semantic.
+		conditions = append(conditions, `NOT EXISTS (
+			SELECT 1 FROM artist_libraries al
+			WHERE al.artist_id = artists.id
+			  AND al.library_id IN (`+ph[:len(ph)-1]+`)
+		) AND (artists.library_id IS NULL OR artists.library_id NOT IN (`+ph[:len(ph)-1]+`))`)
+		for _, id := range libExcludes {
+			args = append(args, id)
+		}
 		for _, id := range libExcludes {
 			args = append(args, id)
 		}

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -449,10 +449,12 @@ func (s *Service) CountLibrariesForArtist(ctx context.Context, artistID string) 
 	return s.memberships.CountForArtist(ctx, artistID)
 }
 
-// Deprecated: use FindByMBIDOrNameUnscoped after the rollout.
 // FindByMBIDOrName finds an artist by MBID first, then falls back to
 // case-insensitive name match, both scoped to the given library.
 // Returns nil, nil when no match is found.
+//
+// Deprecated: use FindByMBIDOrNameUnscoped. Removed alongside the
+// artists.library_id column when the legacy scoped repo surface goes.
 func (s *Service) FindByMBIDOrName(ctx context.Context, mbid, name, libraryID string) (*Artist, error) {
 	a, err := s.artists.FindByMBIDOrName(ctx, mbid, name, libraryID)
 	if err != nil || a == nil {

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -195,6 +195,15 @@ func NewDefaultRepos(db *sql.DB) (
 // Create inserts a new artist and persists its provider IDs and image metadata.
 // If normalized data persistence fails, the artist row is deleted as a
 // best-effort rollback (CASCADE handles child tables).
+//
+// When a.LibraryID is set, an artist_libraries membership is inserted
+// alongside the artist row so the artist appears in per-library queries.
+// The source is derived from the target library: a connection-backed
+// library uses the connection type (emby / jellyfin / lidarr); otherwise
+// the artist is recorded as filesystem-sourced. Membership insert is
+// best-effort; FK failures (e.g., the library does not exist in tests
+// that bypass the libraries table) are ignored so the artist row still
+// lands.
 func (s *Service) Create(ctx context.Context, a *Artist) error {
 	if err := s.artists.Create(ctx, a); err != nil {
 		return err
@@ -203,7 +212,22 @@ func (s *Service) Create(ctx context.Context, a *Artist) error {
 		_ = s.artists.Delete(ctx, a.ID) // best-effort rollback
 		return err
 	}
+	s.recordInitialMembershipBestEffort(ctx, a)
 	return nil
+}
+
+// recordInitialMembershipBestEffort inserts an artist_libraries row
+// derived from a.LibraryID. The membership repo deduces the source from
+// the target library (filesystem when no connection, otherwise the
+// connection's type) and quietly skips when the library does not exist.
+func (s *Service) recordInitialMembershipBestEffort(ctx context.Context, a *Artist) {
+	if s.memberships == nil || a.LibraryID == "" {
+		return
+	}
+	if err := s.memberships.AddDerivingSource(ctx, a.ID, a.LibraryID); err != nil {
+		slog.Warn("recording initial library membership",
+			"artist_id", a.ID, "library_id", a.LibraryID, "error", err)
+	}
 }
 
 // GetHealthStats returns aggregate health metrics for non-excluded artists.

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -83,6 +83,7 @@ type Service struct {
 	completeness CompletenessRepository
 	history      *HistoryService
 	mbSnapshots  MBSnapshotRepository
+	memberships  MembershipRepository
 }
 
 // SetHistoryService attaches a HistoryService to the artist Service so that
@@ -132,7 +133,16 @@ func NewService(db *sql.DB) *Service {
 		platformIDs:  newSQLitePlatformIDRepo(db),
 		completeness: newSQLiteCompletenessRepo(db),
 		mbSnapshots:  newSQLiteMBSnapshotRepo(db),
+		memberships:  newSQLiteMembershipRepo(db),
 	}
+}
+
+// SetMembershipRepository attaches a MembershipRepository to the artist
+// Service for the issue #1004 M:N artist-libraries surface. Setter form
+// matches SetMBSnapshotRepository so existing NewServiceWithRepos callers
+// (and their test fakes) keep working without a signature break.
+func (s *Service) SetMembershipRepository(repo MembershipRepository) {
+	s.memberships = repo
 }
 
 // NewServiceWithRepos creates an artist service using the provided repository
@@ -343,6 +353,79 @@ func (s *Service) GetByMBIDAndLibrary(ctx context.Context, mbid, libraryID strin
 	return a, nil
 }
 
+// GetByName retrieves an artist by case-insensitive exact name match,
+// without library scope. Issue #1004 replacement for GetByNameAndLibrary.
+// Returns nil, nil when no match is found.
+func (s *Service) GetByName(ctx context.Context, name string) (*Artist, error) {
+	a, err := s.artists.GetByName(ctx, name)
+	if err != nil || a == nil {
+		return a, err
+	}
+	if err := s.hydrateProviderIDs(ctx, a); err != nil {
+		return nil, err
+	}
+	if err := s.hydrateImages(ctx, a); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// FindByMBIDOrNameUnscoped tries MBID first, then case-insensitive name,
+// without library scope. Issue #1004 replacement for FindByMBIDOrName,
+// used by connection populate paths to dedupe across all libraries.
+// Returns nil, nil when no match is found.
+func (s *Service) FindByMBIDOrNameUnscoped(ctx context.Context, mbid, name string) (*Artist, error) {
+	a, err := s.artists.FindByMBIDOrNameUnscoped(ctx, mbid, name)
+	if err != nil || a == nil {
+		return a, err
+	}
+	if err := s.hydrateProviderIDs(ctx, a); err != nil {
+		return nil, err
+	}
+	if err := s.hydrateImages(ctx, a); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// AddLibraryMembership records that an artist is observed by the given
+// library. Idempotent. Issue #1004.
+func (s *Service) AddLibraryMembership(ctx context.Context, artistID, libraryID, source string) error {
+	if s.memberships == nil {
+		return nil
+	}
+	return s.memberships.Add(ctx, artistID, libraryID, source)
+}
+
+// RemoveLibraryMembership removes a single (artist, library) pair from the
+// membership table. Issue #1004.
+func (s *Service) RemoveLibraryMembership(ctx context.Context, artistID, libraryID string) error {
+	if s.memberships == nil {
+		return nil
+	}
+	return s.memberships.Remove(ctx, artistID, libraryID)
+}
+
+// LibrariesForArtist returns every library this artist is currently a
+// member of. Issue #1004.
+func (s *Service) LibrariesForArtist(ctx context.Context, artistID string) ([]LibraryMembership, error) {
+	if s.memberships == nil {
+		return nil, nil
+	}
+	return s.memberships.ListForArtist(ctx, artistID)
+}
+
+// CountLibrariesForArtist returns the number of libraries this artist is
+// currently a member of. Used by the unlink path to decide whether to
+// prune the artist after a library detachment. Issue #1004.
+func (s *Service) CountLibrariesForArtist(ctx context.Context, artistID string) (int, error) {
+	if s.memberships == nil {
+		return 0, nil
+	}
+	return s.memberships.CountForArtist(ctx, artistID)
+}
+
+// Deprecated: use FindByMBIDOrNameUnscoped after the issue #1004 rollout.
 // FindByMBIDOrName finds an artist by MBID first, then falls back to
 // case-insensitive name match, both scoped to the given library.
 // Returns nil, nil when no match is found.

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -138,7 +138,7 @@ func NewService(db *sql.DB) *Service {
 }
 
 // SetMembershipRepository attaches a MembershipRepository to the artist
-// Service for the issue #1004 M:N artist-libraries surface. Setter form
+// Service for the M:N artist-libraries surface. Setter form
 // matches SetMBSnapshotRepository so existing NewServiceWithRepos callers
 // (and their test fakes) keep working without a signature break.
 func (s *Service) SetMembershipRepository(repo MembershipRepository) {
@@ -227,7 +227,7 @@ func (s *Service) ListUnevaluatedIDs(ctx context.Context) ([]string, error) {
 
 // MarkDirty stamps dirty_since for one artist. The rule pipeline picks up
 // artists whose dirty_since is newer than rules_evaluated_at on the next
-// "Run Rules" invocation. See issue #698.
+// "Run Rules" invocation.
 func (s *Service) MarkDirty(ctx context.Context, id string, ts time.Time) error {
 	return s.artists.MarkDirty(ctx, id, ts)
 }
@@ -354,7 +354,7 @@ func (s *Service) GetByMBIDAndLibrary(ctx context.Context, mbid, libraryID strin
 }
 
 // GetByName retrieves an artist by case-insensitive exact name match,
-// without library scope. Issue #1004 replacement for GetByNameAndLibrary.
+// without library scope. replacement for GetByNameAndLibrary.
 // Returns nil, nil when no match is found.
 func (s *Service) GetByName(ctx context.Context, name string) (*Artist, error) {
 	a, err := s.artists.GetByName(ctx, name)
@@ -371,7 +371,7 @@ func (s *Service) GetByName(ctx context.Context, name string) (*Artist, error) {
 }
 
 // FindByMBIDOrNameUnscoped tries MBID first, then case-insensitive name,
-// without library scope. Issue #1004 replacement for FindByMBIDOrName,
+// without library scope. replacement for FindByMBIDOrName,
 // used by connection populate paths to dedupe across all libraries.
 // Returns nil, nil when no match is found.
 func (s *Service) FindByMBIDOrNameUnscoped(ctx context.Context, mbid, name string) (*Artist, error) {
@@ -389,7 +389,7 @@ func (s *Service) FindByMBIDOrNameUnscoped(ctx context.Context, mbid, name strin
 }
 
 // AddLibraryMembership records that an artist is observed by the given
-// library. Idempotent. Issue #1004.
+// library. Idempotent
 func (s *Service) AddLibraryMembership(ctx context.Context, artistID, libraryID, source string) error {
 	if s.memberships == nil {
 		return nil
@@ -398,7 +398,7 @@ func (s *Service) AddLibraryMembership(ctx context.Context, artistID, libraryID,
 }
 
 // RemoveLibraryMembership removes a single (artist, library) pair from the
-// membership table. Issue #1004.
+// membership table
 func (s *Service) RemoveLibraryMembership(ctx context.Context, artistID, libraryID string) error {
 	if s.memberships == nil {
 		return nil
@@ -407,7 +407,7 @@ func (s *Service) RemoveLibraryMembership(ctx context.Context, artistID, library
 }
 
 // LibrariesForArtist returns every library this artist is currently a
-// member of. Issue #1004.
+// member of
 func (s *Service) LibrariesForArtist(ctx context.Context, artistID string) ([]LibraryMembership, error) {
 	if s.memberships == nil {
 		return nil, nil
@@ -417,7 +417,7 @@ func (s *Service) LibrariesForArtist(ctx context.Context, artistID string) ([]Li
 
 // CountLibrariesForArtist returns the number of libraries this artist is
 // currently a member of. Used by the unlink path to decide whether to
-// prune the artist after a library detachment. Issue #1004.
+// prune the artist after a library detachment
 func (s *Service) CountLibrariesForArtist(ctx context.Context, artistID string) (int, error) {
 	if s.memberships == nil {
 		return 0, nil
@@ -425,7 +425,7 @@ func (s *Service) CountLibrariesForArtist(ctx context.Context, artistID string) 
 	return s.memberships.CountForArtist(ctx, artistID)
 }
 
-// Deprecated: use FindByMBIDOrNameUnscoped after the issue #1004 rollout.
+// Deprecated: use FindByMBIDOrNameUnscoped after the rollout.
 // FindByMBIDOrName finds an artist by MBID first, then falls back to
 // case-insensitive name match, both scoped to the given library.
 // Returns nil, nil when no match is found.
@@ -753,8 +753,8 @@ func applyProviderFieldToArtist(a *Artist, providerName, value string) {
 
 // ValidateFieldUpdate returns a non-nil error when the field value is
 // invalid. Validation rules:
-//   - "name" must not be empty or whitespace-only.
-//   - "musicbrainz_id" must be a valid UUID (or empty, which clears the ID).
+// - "name" must not be empty or whitespace-only.
+// - "musicbrainz_id" must be a valid UUID (or empty, which clears the ID).
 //
 // All other fields are accepted as-is (free-form text).
 func ValidateFieldUpdate(field, value string) error {

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -200,10 +200,15 @@ func NewDefaultRepos(db *sql.DB) (
 // alongside the artist row so the artist appears in per-library queries.
 // The source is derived from the target library: a connection-backed
 // library uses the connection type (emby / jellyfin / lidarr); otherwise
-// the artist is recorded as filesystem-sourced. Membership insert is
-// best-effort; FK failures (e.g., the library does not exist in tests
-// that bypass the libraries table) are ignored so the artist row still
-// lands.
+// the artist is recorded as filesystem-sourced.
+//
+// AddDerivingSource silently no-ops when the target library does not
+// exist (its SELECT-driven INSERT yields zero rows in that case), so any
+// error returned here is a real DB-level failure (locked, FK violation
+// on the artist row, etc.) and is treated as fatal. Memberships are
+// load-bearing under M:N -- an artist row without a corresponding
+// membership disappears from per-library views -- so we roll the
+// artist back rather than leaving a half-created record.
 func (s *Service) Create(ctx context.Context, a *Artist) error {
 	if err := s.artists.Create(ctx, a); err != nil {
 		return err
@@ -212,22 +217,22 @@ func (s *Service) Create(ctx context.Context, a *Artist) error {
 		_ = s.artists.Delete(ctx, a.ID) // best-effort rollback
 		return err
 	}
-	s.recordInitialMembershipBestEffort(ctx, a)
+	if err := s.recordInitialMembership(ctx, a); err != nil {
+		_ = s.artists.Delete(ctx, a.ID) // keep create atomic for required data
+		return fmt.Errorf("recording initial library membership: %w", err)
+	}
 	return nil
 }
 
-// recordInitialMembershipBestEffort inserts an artist_libraries row
-// derived from a.LibraryID. The membership repo deduces the source from
-// the target library (filesystem when no connection, otherwise the
-// connection's type) and quietly skips when the library does not exist.
-func (s *Service) recordInitialMembershipBestEffort(ctx context.Context, a *Artist) {
+// recordInitialMembership inserts an artist_libraries row derived from
+// a.LibraryID. The membership repo deduces the source from the target
+// library (filesystem when no connection, otherwise the connection's
+// type) and is a no-op when the library does not exist.
+func (s *Service) recordInitialMembership(ctx context.Context, a *Artist) error {
 	if s.memberships == nil || a.LibraryID == "" {
-		return
+		return nil
 	}
-	if err := s.memberships.AddDerivingSource(ctx, a.ID, a.LibraryID); err != nil {
-		slog.Warn("recording initial library membership",
-			"artist_id", a.ID, "library_id", a.LibraryID, "error", err)
-	}
+	return s.memberships.AddDerivingSource(ctx, a.ID, a.LibraryID)
 }
 
 // GetHealthStats returns aggregate health metrics for non-excluded artists.

--- a/internal/artist/service_mn_test.go
+++ b/internal/artist/service_mn_test.go
@@ -117,6 +117,45 @@ func TestFindByMBIDOrNameUnscoped_CrossesLibraries(t *testing.T) {
 	}
 }
 
+// MBID precedence: when an artist with a matching MBID exists alongside a
+// different artist sharing the same name, the MBID match must win.
+// Without this guarantee a regression that fell back to case-insensitive
+// name lookup before MBID would still pass the happy-path tests.
+func TestFindByMBIDOrNameUnscoped_MBIDPrecedence(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedLibForMNTests(t, ctx, db, "lib-fs", "manual")
+	seedLibForMNTests(t, ctx, db, "lib-emby", "emby")
+
+	mbid := "11111111-2222-3333-4444-555555555555"
+
+	aMBID := testArtist("TieName", "/music/emby/TieName")
+	aMBID.MusicBrainzID = mbid
+	aMBID.LibraryID = "lib-emby"
+	if err := svc.Create(ctx, aMBID); err != nil {
+		t.Fatalf("Create aMBID: %v", err)
+	}
+
+	aName := testArtist("TieName", "/music/fs/TieName")
+	aName.LibraryID = "lib-fs"
+	if err := svc.Create(ctx, aName); err != nil {
+		t.Fatalf("Create aName: %v", err)
+	}
+
+	got, err := svc.FindByMBIDOrNameUnscoped(ctx, mbid, "TieName")
+	if err != nil {
+		t.Fatalf("FindByMBIDOrNameUnscoped: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected artist, got nil")
+	}
+	if got.ID != aMBID.ID {
+		t.Errorf("ID = %q, want %q (MBID match must win over name match)", got.ID, aMBID.ID)
+	}
+}
+
 func TestGetByName_CaseInsensitive(t *testing.T) {
 	db := setupTestDB(t)
 	svc := NewService(db)

--- a/internal/artist/service_mn_test.go
+++ b/internal/artist/service_mn_test.go
@@ -1,0 +1,262 @@
+package artist
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// seedLibForMNTests inserts a single library row used as a home for
+// helper-created artists below. Each test that needs more libraries seeds
+// them inline.
+func seedLibForMNTests(t *testing.T, ctx context.Context, db *sql.DB, id string, source string) {
+	t.Helper()
+	_, err := db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, source, created_at, updated_at)
+		 VALUES (?, ?, '/music', 'regular', ?, datetime('now'), datetime('now'))`,
+		id, id, source)
+	if err != nil {
+		t.Fatalf("seed library %s: %v", id, err)
+	}
+}
+
+func TestFindByMBIDOrNameUnscoped_ByMBID(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedLibForMNTests(t, ctx, db, "lib-fs", "manual")
+	seedLibForMNTests(t, ctx, db, "lib-emby", "emby")
+
+	mbid := "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
+	a := testArtist("Nirvana", "/music/Nirvana")
+	a.MusicBrainzID = mbid
+	a.LibraryID = "lib-emby"
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Unscoped lookup should find the artist regardless of which library
+	// the caller has in mind. This is the populate-path dedupe contract.
+	got, err := svc.FindByMBIDOrNameUnscoped(ctx, mbid, "Nirvana")
+	if err != nil {
+		t.Fatalf("FindByMBIDOrNameUnscoped: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected artist, got nil")
+	}
+	if got.ID != a.ID {
+		t.Errorf("ID = %q, want %q", got.ID, a.ID)
+	}
+}
+
+func TestFindByMBIDOrNameUnscoped_ByNameCaseInsensitive(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedLibForMNTests(t, ctx, db, "lib-fs", "manual")
+
+	a := testArtist("Veridia", "/music/Veridia")
+	a.LibraryID = "lib-fs"
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.FindByMBIDOrNameUnscoped(ctx, "", "VERIDIA")
+	if err != nil {
+		t.Fatalf("FindByMBIDOrNameUnscoped: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected artist, got nil")
+	}
+	if got.ID != a.ID {
+		t.Errorf("ID = %q, want %q", got.ID, a.ID)
+	}
+}
+
+func TestFindByMBIDOrNameUnscoped_NotFound(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	got, err := svc.FindByMBIDOrNameUnscoped(ctx, "no-such-mbid", "No Such Artist")
+	if err != nil {
+		t.Fatalf("FindByMBIDOrNameUnscoped: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestFindByMBIDOrNameUnscoped_CrossesLibraries(t *testing.T) {
+	// The unscoped variant exists specifically to find an artist regardless
+	// of library context. Seed an artist on one library and look it up
+	// without a library scope.
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedLibForMNTests(t, ctx, db, "lib-fs", "manual")
+	seedLibForMNTests(t, ctx, db, "lib-emby", "emby")
+
+	mbid := "ffffffff-ffff-ffff-ffff-ffffffffffff"
+	a := testArtist("Muse", "/music/emby/Muse")
+	a.MusicBrainzID = mbid
+	a.LibraryID = "lib-emby"
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.FindByMBIDOrNameUnscoped(ctx, mbid, "Muse")
+	if err != nil {
+		t.Fatalf("FindByMBIDOrNameUnscoped: %v", err)
+	}
+	if got == nil || got.ID != a.ID {
+		t.Errorf("got %+v, want id=%s", got, a.ID)
+	}
+}
+
+func TestGetByName_CaseInsensitive(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedLibForMNTests(t, ctx, db, "lib-fs", "manual")
+
+	a := testArtist("Portishead", "/music/Portishead")
+	a.LibraryID = "lib-fs"
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.GetByName(ctx, "PORTISHEAD")
+	if err != nil {
+		t.Fatalf("GetByName: %v", err)
+	}
+	if got == nil || got.ID != a.ID {
+		t.Errorf("got %+v, want id=%s", got, a.ID)
+	}
+}
+
+func TestGetByName_NotFound(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	got, err := svc.GetByName(ctx, "Nobody Is Here")
+	if err != nil {
+		t.Fatalf("GetByName: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+// TestMembershipServicePassthroughs covers the four membership Service
+// methods (Add / Remove / List / Count) end-to-end through the service shell
+// rather than against the repo directly. These methods are thin wrappers
+// today but constitute the public M:N surface, so a test that exercises them
+// via the Service guards against a future refactor that would silently break
+// the wrapper layer.
+func TestMembershipServicePassthroughs(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedLibForMNTests(t, ctx, db, "lib-fs", "manual")
+	seedLibForMNTests(t, ctx, db, "lib-emby", "emby")
+
+	a := testArtist("Bjork", "/music/Bjork")
+	a.LibraryID = "lib-fs"
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Service.Create auto-derives the initial filesystem membership; baseline
+	// count after creation should be 1.
+	if got, err := svc.CountLibrariesForArtist(ctx, a.ID); err != nil {
+		t.Fatalf("CountLibrariesForArtist baseline: %v", err)
+	} else if got != 1 {
+		t.Errorf("baseline count = %d, want 1", got)
+	}
+
+	if err := svc.AddLibraryMembership(ctx, a.ID, "lib-emby", "emby"); err != nil {
+		t.Fatalf("AddLibraryMembership: %v", err)
+	}
+
+	// Idempotent on duplicate add.
+	if err := svc.AddLibraryMembership(ctx, a.ID, "lib-emby", "emby"); err != nil {
+		t.Fatalf("AddLibraryMembership (duplicate): %v", err)
+	}
+
+	libs, err := svc.LibrariesForArtist(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("LibrariesForArtist: %v", err)
+	}
+	if len(libs) != 2 {
+		t.Fatalf("LibrariesForArtist returned %d rows, want 2", len(libs))
+	}
+	bySource := map[string]string{}
+	for _, m := range libs {
+		bySource[m.Source] = m.LibraryID
+	}
+	if bySource["filesystem"] != "lib-fs" {
+		t.Errorf("filesystem -> %q, want lib-fs", bySource["filesystem"])
+	}
+	if bySource["emby"] != "lib-emby" {
+		t.Errorf("emby -> %q, want lib-emby", bySource["emby"])
+	}
+
+	if got, err := svc.CountLibrariesForArtist(ctx, a.ID); err != nil {
+		t.Fatalf("CountLibrariesForArtist post-add: %v", err)
+	} else if got != 2 {
+		t.Errorf("post-add count = %d, want 2", got)
+	}
+
+	if err := svc.RemoveLibraryMembership(ctx, a.ID, "lib-emby"); err != nil {
+		t.Fatalf("RemoveLibraryMembership: %v", err)
+	}
+
+	// Removing again is a no-op, not an error.
+	if err := svc.RemoveLibraryMembership(ctx, a.ID, "lib-emby"); err != nil {
+		t.Fatalf("RemoveLibraryMembership (no-op): %v", err)
+	}
+
+	if got, err := svc.CountLibrariesForArtist(ctx, a.ID); err != nil {
+		t.Fatalf("CountLibrariesForArtist post-remove: %v", err)
+	} else if got != 1 {
+		t.Errorf("post-remove count = %d, want 1", got)
+	}
+}
+
+// TestMembershipMethods_NoMembershipRepo covers the nil-repo guard on the
+// Service: when membership repo wiring is absent, the methods return zero
+// values without erroring, so callers never need to gate on availability.
+func TestMembershipMethods_NoMembershipRepo(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	svc.memberships = nil
+	ctx := context.Background()
+
+	if err := svc.AddLibraryMembership(ctx, "any", "any", "filesystem"); err != nil {
+		t.Errorf("AddLibraryMembership returned err with nil repo: %v", err)
+	}
+	if err := svc.RemoveLibraryMembership(ctx, "any", "any"); err != nil {
+		t.Errorf("RemoveLibraryMembership returned err with nil repo: %v", err)
+	}
+	libs, err := svc.LibrariesForArtist(ctx, "any")
+	if err != nil {
+		t.Errorf("LibrariesForArtist returned err with nil repo: %v", err)
+	}
+	if libs != nil {
+		t.Errorf("LibrariesForArtist with nil repo returned %v, want nil", libs)
+	}
+	got, err := svc.CountLibrariesForArtist(ctx, "any")
+	if err != nil {
+		t.Errorf("CountLibrariesForArtist returned err with nil repo: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("CountLibrariesForArtist with nil repo = %d, want 0", got)
+	}
+}

--- a/internal/artist/service_test.go
+++ b/internal/artist/service_test.go
@@ -3,11 +3,37 @@ package artist
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/database"
 )
+
+// failingMembershipRepo wraps a real MembershipRepository but returns a
+// fixed error from AddDerivingSource. Used to exercise the Create
+// rollback path when the membership write fails for non-recoverable
+// reasons (locked DB, FK violation, etc.).
+type failingMembershipRepo struct {
+	inner MembershipRepository
+	err   error
+}
+
+func (f *failingMembershipRepo) Add(ctx context.Context, artistID, libraryID, source string) error {
+	return f.inner.Add(ctx, artistID, libraryID, source)
+}
+func (f *failingMembershipRepo) Remove(ctx context.Context, artistID, libraryID string) error {
+	return f.inner.Remove(ctx, artistID, libraryID)
+}
+func (f *failingMembershipRepo) ListForArtist(ctx context.Context, artistID string) ([]LibraryMembership, error) {
+	return f.inner.ListForArtist(ctx, artistID)
+}
+func (f *failingMembershipRepo) CountForArtist(ctx context.Context, artistID string) (int, error) {
+	return f.inner.CountForArtist(ctx, artistID)
+}
+func (f *failingMembershipRepo) AddDerivingSource(ctx context.Context, artistID, libraryID string) error {
+	return f.err
+}
 
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
@@ -83,6 +109,57 @@ func TestCreateAndGetByID(t *testing.T) {
 	}
 	if got.CreatedAt.IsZero() {
 		t.Error("expected CreatedAt to be set")
+	}
+}
+
+// TestCreate_MembershipWriteFailureRollsBack verifies that an unexpected
+// failure from the membership repository during Create rolls the artist
+// row back instead of leaving a half-created record. Under M:N,
+// memberships are load-bearing: an artist row with no membership is
+// invisible to per-library views, so the artist is rolled back rather
+// than persisted in a partial state.
+func TestCreate_MembershipWriteFailureRollsBack(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	// Need a library row to give Create a real LibraryID target. Without
+	// one, recordInitialMembership early-returns and never calls the
+	// failing AddDerivingSource path.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)
+		VALUES ('lib-fs', 'lib-fs', '/music', 'regular', 'filesystem',
+			datetime('now'), datetime('now'))
+	`); err != nil {
+		t.Fatalf("seeding library: %v", err)
+	}
+
+	// Inject a failing membership repo. Reuse the real one for the other
+	// methods so any incidental reads still work.
+	wantErr := errors.New("simulated membership write failure")
+	svc.SetMembershipRepository(&failingMembershipRepo{
+		inner: newSQLiteMembershipRepo(db),
+		err:   wantErr,
+	})
+
+	a := testArtist("Faker", "/music/Faker")
+	a.LibraryID = "lib-fs"
+	err := svc.Create(ctx, a)
+	if err == nil {
+		t.Fatal("expected Create to return error after membership write failed")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Create error = %v, want wrap of %v", err, wantErr)
+	}
+
+	// Artist row must NOT exist after rollback.
+	var n int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artists WHERE name = 'Faker'`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("artist count after rollback = %d, want 0 (membership failure must roll back the artist row)", n)
 	}
 }
 

--- a/internal/artist/sqlite_artist.go
+++ b/internal/artist/sqlite_artist.go
@@ -133,7 +133,7 @@ func (r *sqliteArtistRepo) GetByMBID(ctx context.Context, mbid string) (*Artist,
 }
 
 // GetByName performs case-insensitive exact-name lookup with no library
-// scope. Used by issue #1004 connection populate paths to dedupe across all
+// scope. Used by connection populate paths to dedupe across all
 // libraries; replaces the older GetByNameAndLibrary call site.
 func (r *sqliteArtistRepo) GetByName(ctx context.Context, name string) (*Artist, error) {
 	row := r.db.QueryRowContext(ctx,
@@ -150,7 +150,7 @@ func (r *sqliteArtistRepo) GetByName(ctx context.Context, name string) (*Artist,
 
 // FindByMBIDOrNameUnscoped tries MBID first then case-insensitive name,
 // returning the first match without any library scope. This is the dedupe
-// helper for issue #1004's unscoped populate path.
+// helper for the unscoped populate path.
 func (r *sqliteArtistRepo) FindByMBIDOrNameUnscoped(ctx context.Context, mbid, name string) (*Artist, error) {
 	if mbid != "" {
 		a, err := r.GetByMBID(ctx, mbid)
@@ -298,7 +298,7 @@ func (r *sqliteArtistRepo) Update(ctx context.Context, a *Artist) error {
 	// UPDATE: they are owned by MarkDirty/MarkRulesEvaluated and racing with
 	// concurrent event-driven dirty marks would silently lose mutations.
 	// The Artist struct still carries these fields for read-side consumers,
-	// but write-side ownership lives in the targeted helpers (#698).
+	// but write-side ownership lives in the targeted helpers.
 	_, err := r.db.ExecContext(ctx, `
 		UPDATE artists SET
 			name = ?, sort_name = ?, type = ?, gender = ?, origin = ?, disambiguation = ?,

--- a/internal/artist/sqlite_artist.go
+++ b/internal/artist/sqlite_artist.go
@@ -132,6 +132,41 @@ func (r *sqliteArtistRepo) GetByMBID(ctx context.Context, mbid string) (*Artist,
 	return a, nil
 }
 
+// GetByName performs case-insensitive exact-name lookup with no library
+// scope. Used by issue #1004 connection populate paths to dedupe across all
+// libraries; replaces the older GetByNameAndLibrary call site.
+func (r *sqliteArtistRepo) GetByName(ctx context.Context, name string) (*Artist, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT `+artistColumns+` FROM artists WHERE LOWER(name) = LOWER(?) LIMIT 1`, name)
+	a, err := scanArtist(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting artist by name: %w", err)
+	}
+	return a, nil
+}
+
+// FindByMBIDOrNameUnscoped tries MBID first then case-insensitive name,
+// returning the first match without any library scope. This is the dedupe
+// helper for issue #1004's unscoped populate path.
+func (r *sqliteArtistRepo) FindByMBIDOrNameUnscoped(ctx context.Context, mbid, name string) (*Artist, error) {
+	if mbid != "" {
+		a, err := r.GetByMBID(ctx, mbid)
+		if err != nil {
+			return nil, fmt.Errorf("finding by mbid (unscoped): %w", err)
+		}
+		if a != nil {
+			return a, nil
+		}
+	}
+	if name == "" {
+		return nil, nil
+	}
+	return r.GetByName(ctx, name)
+}
+
 func (r *sqliteArtistRepo) GetByMBIDAndLibrary(ctx context.Context, mbid, libraryID string) (*Artist, error) {
 	row := r.db.QueryRowContext(ctx,
 		`SELECT `+artistColumns+` FROM artists

--- a/internal/artist/sqlite_completeness.go
+++ b/internal/artist/sqlite_completeness.go
@@ -25,7 +25,6 @@ SELECT
     a.id,
     a.name,
     a.type,
-    COALESCE(a.library_id, '')  AS library_id,
     a.biography,
     a.genres,
     a.styles,
@@ -63,8 +62,14 @@ WHERE a.is_excluded = 0`
 	var args []any
 
 	if libraryID != "" {
-		query = baseQuery + " AND a.library_id = ?"
-		args = []any{libraryID}
+		query = baseQuery + ` AND (
+			EXISTS (
+				SELECT 1 FROM artist_libraries al
+				WHERE al.artist_id = a.id AND al.library_id = ?
+			)
+			OR a.library_id = ?
+		)`
+		args = []any{libraryID, libraryID}
 	} else {
 		query = baseQuery
 	}
@@ -81,7 +86,7 @@ WHERE a.is_excluded = 0`
 		var nfoInt, hasMBIDInt, hasThumbInt, hasFanartInt, hasLogoInt, hasBannerInt int
 
 		if err := rows.Scan(
-			&cr.ID, &cr.Name, &cr.Type, &cr.LibraryID,
+			&cr.ID, &cr.Name, &cr.Type,
 			&cr.Biography, &cr.Genres, &cr.Styles, &cr.Moods, &cr.YearsActive,
 			&cr.Born, &cr.Formed, &cr.Died, &cr.Disbanded,
 			&nfoInt, &hasMBIDInt,
@@ -90,6 +95,10 @@ WHERE a.is_excluded = 0`
 			return nil, fmt.Errorf("scanning completeness row: %w", err)
 		}
 
+		// LibraryID is the filter scope when set. Unfiltered queries leave
+		// it empty because an artist can hold memberships in many libraries
+		// and there is no canonical "the" library to report.
+		cr.LibraryID = libraryID
 		cr.NFOExists = nfoInt == 1
 		cr.HasMBID = hasMBIDInt == 1
 		cr.HasThumb = hasThumbInt == 1
@@ -114,18 +123,24 @@ func (r *sqliteCompletenessRepo) GetLowestCompleteness(ctx context.Context, libr
 	}
 
 	const baseQuery = `
-SELECT id, name, COALESCE(library_id, '') AS library_id, health_score
-FROM artists
-WHERE is_excluded = 0`
+SELECT a.id, a.name, a.health_score
+FROM artists a
+WHERE a.is_excluded = 0`
 
 	var query string
 	var args []any
 
 	if libraryID != "" {
-		query = baseQuery + " AND library_id = ? ORDER BY health_score ASC LIMIT ?"
-		args = []any{libraryID, limit}
+		query = baseQuery + ` AND (
+			EXISTS (
+				SELECT 1 FROM artist_libraries al
+				WHERE al.artist_id = a.id AND al.library_id = ?
+			)
+			OR a.library_id = ?
+		) ORDER BY a.health_score ASC LIMIT ?`
+		args = []any{libraryID, libraryID, limit}
 	} else {
-		query = baseQuery + " ORDER BY health_score ASC LIMIT ?"
+		query = baseQuery + " ORDER BY a.health_score ASC LIMIT ?"
 		args = []any{limit}
 	}
 
@@ -138,9 +153,11 @@ WHERE is_excluded = 0`
 	var results []LowestCompletenessArtist
 	for rows.Next() {
 		var a LowestCompletenessArtist
-		if err := rows.Scan(&a.ID, &a.Name, &a.LibraryID, &a.HealthScore); err != nil {
+		if err := rows.Scan(&a.ID, &a.Name, &a.HealthScore); err != nil {
 			return nil, fmt.Errorf("scanning lowest completeness row: %w", err)
 		}
+		// LibraryID reflects the filter scope; empty when unfiltered.
+		a.LibraryID = libraryID
 		results = append(results, a)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/artist/sqlite_health_stats.go
+++ b/internal/artist/sqlite_health_stats.go
@@ -87,8 +87,14 @@ WHERE a.is_excluded = 0`
 	var args []any
 
 	if libraryID != "" {
-		query = baseQuery + " AND a.library_id = ?"
-		args = []any{libraryID}
+		query = baseQuery + ` AND (
+			EXISTS (
+				SELECT 1 FROM artist_libraries al
+				WHERE al.artist_id = a.id AND al.library_id = ?
+			)
+			OR a.library_id = ?
+		)`
+		args = []any{libraryID, libraryID}
 	} else {
 		query = baseQuery
 	}

--- a/internal/artist/sqlite_image.go
+++ b/internal/artist/sqlite_image.go
@@ -274,9 +274,16 @@ func (r *sqliteImageRepo) NewestWriteTimesByArtist(ctx context.Context, libraryI
 		SELECT a.id, MAX(ai.last_written_at)
 		FROM artist_images ai
 		JOIN artists a ON ai.artist_id = a.id
-		WHERE a.library_id = ? AND ai.last_written_at != ''
+		WHERE (
+			EXISTS (
+				SELECT 1 FROM artist_libraries al
+				WHERE al.artist_id = a.id AND al.library_id = ?
+			)
+			OR a.library_id = ?
+		)
+		AND ai.last_written_at != ''
 		GROUP BY a.id`,
-		libraryID,
+		libraryID, libraryID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("querying newest write times by artist for library %s: %w", libraryID, err)

--- a/internal/artist/sqlite_membership.go
+++ b/internal/artist/sqlite_membership.go
@@ -39,6 +39,12 @@ type MembershipRepository interface {
 	// to. Used by the unlink path to decide whether to prune the artist
 	// (zero remaining memberships AND zero platform mappings -> prune).
 	CountForArtist(ctx context.Context, artistID string) (int, error)
+
+	// AddDerivingSource inserts a membership row whose source is derived
+	// from the target library's connection (or 'filesystem' when the
+	// library has no connection). No-op when the library row does not
+	// exist; idempotent when the membership already exists.
+	AddDerivingSource(ctx context.Context, artistID, libraryID string) error
 }
 
 type sqliteMembershipRepo struct {
@@ -108,4 +114,31 @@ func (r *sqliteMembershipRepo) CountForArtist(ctx context.Context, artistID stri
 		return 0, fmt.Errorf("counting memberships for artist %s: %w", artistID, err)
 	}
 	return n, nil
+}
+
+func (r *sqliteMembershipRepo) AddDerivingSource(ctx context.Context, artistID, libraryID string) error {
+	// SELECT-driven INSERT: when the libraries row does not exist the
+	// SELECT yields zero rows and the INSERT is a no-op, so callers do
+	// not have to pre-check for FK validity. Source is computed from the
+	// connection type when one is present; manual filesystem libraries
+	// fall through to 'filesystem'. INSERT OR IGNORE preserves the
+	// original added_at on repeat calls.
+	_, err := r.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO artist_libraries (artist_id, library_id, source, added_at)
+		SELECT ?, l.id,
+			CASE
+				WHEN c.type = 'emby'     THEN 'emby'
+				WHEN c.type = 'jellyfin' THEN 'jellyfin'
+				WHEN c.type = 'lidarr'   THEN 'lidarr'
+				ELSE 'filesystem'
+			END,
+			datetime('now')
+		FROM libraries l
+		LEFT JOIN connections c ON c.id = l.connection_id
+		WHERE l.id = ?
+	`, artistID, libraryID)
+	if err != nil {
+		return fmt.Errorf("inserting derived membership: %w", err)
+	}
+	return nil
 }

--- a/internal/artist/sqlite_membership.go
+++ b/internal/artist/sqlite_membership.go
@@ -8,7 +8,7 @@ import (
 
 // LibraryMembership records that an artist is observed by a particular
 // library. An artist can have many memberships across filesystem and
-// connection libraries. Issue #1004.
+// connection libraries
 type LibraryMembership struct {
 	ArtistID  string `json:"artist_id"`
 	LibraryID string `json:"library_id"`

--- a/internal/artist/sqlite_membership.go
+++ b/internal/artist/sqlite_membership.go
@@ -1,0 +1,111 @@
+package artist
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// LibraryMembership records that an artist is observed by a particular
+// library. An artist can have many memberships across filesystem and
+// connection libraries. Issue #1004.
+type LibraryMembership struct {
+	ArtistID  string `json:"artist_id"`
+	LibraryID string `json:"library_id"`
+	// Source is the discovery channel: 'filesystem', 'emby', 'jellyfin',
+	// or 'manual'. Tracked for debugging and future UI affordances.
+	Source  string `json:"source"`
+	AddedAt string `json:"added_at"`
+}
+
+// MembershipRepository manages the M:N relationship between artists and
+// libraries via the artist_libraries join table. The Repository interface
+// provides legacy library_id-scoped lookups during the multi-phase rollout;
+// MembershipRepository is the new authoritative surface.
+type MembershipRepository interface {
+	// Add inserts (or upserts on conflict) a membership row. Idempotent: a
+	// repeat Add with the same (artistID, libraryID) is a no-op (the source
+	// and added_at of the existing row are preserved).
+	Add(ctx context.Context, artistID, libraryID, source string) error
+
+	// Remove deletes a membership row. No-op if the membership does not
+	// exist; returns nil error in that case.
+	Remove(ctx context.Context, artistID, libraryID string) error
+
+	// ListForArtist returns every library membership the artist holds.
+	ListForArtist(ctx context.Context, artistID string) ([]LibraryMembership, error)
+
+	// CountForArtist returns the number of libraries this artist belongs
+	// to. Used by the unlink path to decide whether to prune the artist
+	// (zero remaining memberships AND zero platform mappings -> prune).
+	CountForArtist(ctx context.Context, artistID string) (int, error)
+}
+
+type sqliteMembershipRepo struct {
+	db *sql.DB
+}
+
+func newSQLiteMembershipRepo(db *sql.DB) *sqliteMembershipRepo {
+	return &sqliteMembershipRepo{db: db}
+}
+
+func (r *sqliteMembershipRepo) Add(ctx context.Context, artistID, libraryID, source string) error {
+	// INSERT OR IGNORE preserves the original added_at on idempotent re-adds,
+	// which is the right semantic: "this artist was first seen in this
+	// library at <original time>" should not move forward on every populate.
+	_, err := r.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO artist_libraries (artist_id, library_id, source, added_at)
+		VALUES (?, ?, ?, datetime('now'))
+	`, artistID, libraryID, source)
+	if err != nil {
+		return fmt.Errorf("adding artist library membership: %w", err)
+	}
+	return nil
+}
+
+func (r *sqliteMembershipRepo) Remove(ctx context.Context, artistID, libraryID string) error {
+	_, err := r.db.ExecContext(ctx,
+		`DELETE FROM artist_libraries WHERE artist_id = ? AND library_id = ?`,
+		artistID, libraryID)
+	if err != nil {
+		return fmt.Errorf("removing artist library membership: %w", err)
+	}
+	return nil
+}
+
+func (r *sqliteMembershipRepo) ListForArtist(ctx context.Context, artistID string) ([]LibraryMembership, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT artist_id, library_id, source, added_at
+		FROM artist_libraries
+		WHERE artist_id = ?
+		ORDER BY added_at, library_id
+	`, artistID)
+	if err != nil {
+		return nil, fmt.Errorf("listing memberships for artist %s: %w", artistID, err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var out []LibraryMembership
+	for rows.Next() {
+		var m LibraryMembership
+		if err := rows.Scan(&m.ArtistID, &m.LibraryID, &m.Source, &m.AddedAt); err != nil {
+			return nil, fmt.Errorf("scanning membership row: %w", err)
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating membership rows: %w", err)
+	}
+	return out, nil
+}
+
+func (r *sqliteMembershipRepo) CountForArtist(ctx context.Context, artistID string) (int, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_libraries WHERE artist_id = ?`,
+		artistID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("counting memberships for artist %s: %w", artistID, err)
+	}
+	return n, nil
+}

--- a/internal/artist/sqlite_membership_test.go
+++ b/internal/artist/sqlite_membership_test.go
@@ -190,6 +190,84 @@ func TestMembershipCascadeOnArtistDelete(t *testing.T) {
 	}
 }
 
+// TestMembershipAddDerivingSource exercises the production create path that
+// derives the membership source from the target library's connection type.
+// All three connection-backed types plus the no-connection (filesystem)
+// case are covered, and idempotency is asserted on a repeat call.
+func TestMembershipAddDerivingSource(t *testing.T) {
+	db := openTestDB(t)
+	seedMembershipFixtures(t, db) // gives us lib-fs (filesystem) + lib-emby (emby)
+	repo := newSQLiteMembershipRepo(db)
+	ctx := context.Background()
+
+	// Seed a Jellyfin connection-library and a Lidarr connection-library
+	// alongside the fixture's filesystem and Emby libraries.
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
+		VALUES ('conn-jf', 'Jellyfin', 'jellyfin', 'http://t', 'k', 1, 'ok', datetime('now'), datetime('now')),
+		       ('conn-lr', 'Lidarr',   'lidarr',   'http://t', 'k', 1, 'ok', datetime('now'), datetime('now'))
+	`)
+	if err != nil {
+		t.Fatalf("seeding extra connections: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
+		VALUES ('lib-jf', 'lib-jf', '/music', 'regular', 'import', 'conn-jf', datetime('now'), datetime('now')),
+		       ('lib-lr', 'lib-lr', '/music', 'regular', 'import', 'conn-lr', datetime('now'), datetime('now'))
+	`)
+	if err != nil {
+		t.Fatalf("seeding extra libraries: %v", err)
+	}
+
+	cases := []struct {
+		libraryID  string
+		wantSource string
+	}{
+		{"lib-fs", "filesystem"},
+		{"lib-emby", "emby"},
+		{"lib-jf", "jellyfin"},
+		{"lib-lr", "lidarr"},
+	}
+	for _, tc := range cases {
+		if err := repo.AddDerivingSource(ctx, "a-1", tc.libraryID); err != nil {
+			t.Fatalf("AddDerivingSource(%s): %v", tc.libraryID, err)
+		}
+	}
+
+	// Repeat call must be a no-op (INSERT OR IGNORE).
+	if err := repo.AddDerivingSource(ctx, "a-1", "lib-fs"); err != nil {
+		t.Fatalf("AddDerivingSource(lib-fs) idempotent: %v", err)
+	}
+
+	memberships, err := repo.ListForArtist(ctx, "a-1")
+	if err != nil {
+		t.Fatalf("ListForArtist: %v", err)
+	}
+	if len(memberships) != len(cases) {
+		t.Fatalf("memberships = %d, want %d", len(memberships), len(cases))
+	}
+
+	bySource := map[string]string{}
+	for _, m := range memberships {
+		bySource[m.Source] = m.LibraryID
+	}
+	for _, tc := range cases {
+		if got := bySource[tc.wantSource]; got != tc.libraryID {
+			t.Errorf("source %q -> library %q, want %q", tc.wantSource, got, tc.libraryID)
+		}
+	}
+
+	// Cascade still works for derived rows.
+	if _, err := db.ExecContext(ctx, `DELETE FROM artists WHERE id = 'a-1'`); err != nil {
+		t.Fatalf("delete artist: %v", err)
+	}
+	if got, err := repo.CountForArtist(ctx, "a-1"); err != nil {
+		t.Fatalf("count after cascade: %v", err)
+	} else if got != 0 {
+		t.Errorf("post-cascade count = %d, want 0", got)
+	}
+}
+
 // TestArtistGetByName verifies the unscoped name lookup is case-insensitive
 // and returns nil when no match exists.
 func TestArtistGetByName(t *testing.T) {

--- a/internal/artist/sqlite_membership_test.go
+++ b/internal/artist/sqlite_membership_test.go
@@ -12,7 +12,7 @@ import (
 // migration applied + foreign keys enabled, matching the convention used in
 // internal/database/migrate_test.go. Tests share this helper so they get the
 // same schema as production startup, including the artist_libraries table
-// added in #1004.
+// .
 func openTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	db, err := database.Open(":memory:")
@@ -75,7 +75,7 @@ func seedMembershipFixtures(t *testing.T, db *sql.DB) {
 }
 
 // TestMembershipAddIsIdempotent verifies Add inserts a row on first call
-// and is a no-op on repeat. Issue #1004.
+// and is a no-op on repeat.
 func TestMembershipAddIsIdempotent(t *testing.T) {
 	db := openTestDB(t)
 	seedMembershipFixtures(t, db)
@@ -182,7 +182,7 @@ func TestMembershipCascadeOnArtistDelete(t *testing.T) {
 }
 
 // TestArtistGetByName verifies the unscoped name lookup is case-insensitive
-// and returns nil when no match exists. Issue #1004.
+// and returns nil when no match exists.
 func TestArtistGetByName(t *testing.T) {
 	db := openTestDB(t)
 	ctx := context.Background()
@@ -218,7 +218,7 @@ func TestArtistGetByName(t *testing.T) {
 
 // TestArtistFindByMBIDOrNameUnscoped covers the dedupe priority: MBID
 // match wins when present; falls through to case-insensitive name
-// otherwise. Issue #1004.
+// otherwise.
 func TestArtistFindByMBIDOrNameUnscoped(t *testing.T) {
 	db := openTestDB(t)
 	ctx := context.Background()

--- a/internal/artist/sqlite_membership_test.go
+++ b/internal/artist/sqlite_membership_test.go
@@ -1,0 +1,278 @@
+package artist
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/database"
+)
+
+// openTestDB sets up an in-memory SQLite database with the production
+// migration applied + foreign keys enabled, matching the convention used in
+// internal/database/migrate_test.go. Tests share this helper so they get the
+// same schema as production startup, including the artist_libraries table
+// added in #1004.
+func openTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("opening db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if err := database.EnableForeignKeys(db); err != nil {
+		t.Fatalf("foreign keys: %v", err)
+	}
+	return db
+}
+
+// seedMembershipFixtures inserts the libraries and artists referenced by
+// every membership test. Returns the set of seeded library IDs for
+// convenience. The artist_libraries table is intentionally left empty so
+// each test starts with a clean membership ledger.
+func seedMembershipFixtures(t *testing.T, db *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Two libraries: one filesystem (no connection_id) and one Emby
+	// connection-library. The 'source' column on libraries is informational;
+	// the membership 'source' is provided per-call by the caller.
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)
+		VALUES ('lib-fs', 'lib-fs', '/music', 'regular', 'filesystem',
+			datetime('now'), datetime('now'))
+	`)
+	if err != nil {
+		t.Fatalf("seeding fs library: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
+		VALUES ('conn-emby', 'Emby', 'emby', 'http://t', 'k', 1, 'ok',
+			datetime('now'), datetime('now'))
+	`)
+	if err != nil {
+		t.Fatalf("seeding emby connection: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
+		VALUES ('lib-emby', 'lib-emby', '/music', 'regular', 'import', 'conn-emby',
+			datetime('now'), datetime('now'))
+	`)
+	if err != nil {
+		t.Fatalf("seeding emby library: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		VALUES ('a-1', 'TestArtist', 'TestArtist', '/music/TestArtist',
+			datetime('now'), datetime('now'))
+	`)
+	if err != nil {
+		t.Fatalf("seeding artist: %v", err)
+	}
+}
+
+// TestMembershipAddIsIdempotent verifies Add inserts a row on first call
+// and is a no-op on repeat. Issue #1004.
+func TestMembershipAddIsIdempotent(t *testing.T) {
+	db := openTestDB(t)
+	seedMembershipFixtures(t, db)
+	repo := newSQLiteMembershipRepo(db)
+	ctx := context.Background()
+
+	if err := repo.Add(ctx, "a-1", "lib-fs", "filesystem"); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	if err := repo.Add(ctx, "a-1", "lib-fs", "filesystem"); err != nil {
+		t.Fatalf("second add: %v", err)
+	}
+
+	got, err := repo.CountForArtist(ctx, "a-1")
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if got != 1 {
+		t.Errorf("count = %d, want 1 (idempotent add must not duplicate)", got)
+	}
+}
+
+// TestMembershipMultipleLibraries verifies an artist can be a member of
+// many libraries with different sources and that ListForArtist returns
+// them all.
+func TestMembershipMultipleLibraries(t *testing.T) {
+	db := openTestDB(t)
+	seedMembershipFixtures(t, db)
+	repo := newSQLiteMembershipRepo(db)
+	ctx := context.Background()
+
+	if err := repo.Add(ctx, "a-1", "lib-fs", "filesystem"); err != nil {
+		t.Fatalf("add fs: %v", err)
+	}
+	if err := repo.Add(ctx, "a-1", "lib-emby", "emby"); err != nil {
+		t.Fatalf("add emby: %v", err)
+	}
+
+	memberships, err := repo.ListForArtist(ctx, "a-1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(memberships) != 2 {
+		t.Fatalf("memberships = %d, want 2", len(memberships))
+	}
+
+	bySource := map[string]string{}
+	for _, m := range memberships {
+		bySource[m.Source] = m.LibraryID
+	}
+	if bySource["filesystem"] != "lib-fs" {
+		t.Errorf("filesystem -> %q, want lib-fs", bySource["filesystem"])
+	}
+	if bySource["emby"] != "lib-emby" {
+		t.Errorf("emby -> %q, want lib-emby", bySource["emby"])
+	}
+}
+
+// TestMembershipRemove verifies Remove deletes only the targeted pair and
+// is a no-op for nonexistent pairs.
+func TestMembershipRemove(t *testing.T) {
+	db := openTestDB(t)
+	seedMembershipFixtures(t, db)
+	repo := newSQLiteMembershipRepo(db)
+	ctx := context.Background()
+
+	_ = repo.Add(ctx, "a-1", "lib-fs", "filesystem")
+	_ = repo.Add(ctx, "a-1", "lib-emby", "emby")
+
+	if err := repo.Remove(ctx, "a-1", "lib-emby"); err != nil {
+		t.Fatalf("remove emby: %v", err)
+	}
+	got, _ := repo.CountForArtist(ctx, "a-1")
+	if got != 1 {
+		t.Errorf("after remove count = %d, want 1", got)
+	}
+
+	// Nonexistent pair: no error.
+	if err := repo.Remove(ctx, "a-1", "lib-emby"); err != nil {
+		t.Errorf("remove nonexistent: %v", err)
+	}
+}
+
+// TestMembershipCascadeOnArtistDelete verifies that deleting the parent
+// artist cascades to artist_libraries via the FK ON DELETE CASCADE.
+func TestMembershipCascadeOnArtistDelete(t *testing.T) {
+	db := openTestDB(t)
+	seedMembershipFixtures(t, db)
+	repo := newSQLiteMembershipRepo(db)
+	ctx := context.Background()
+
+	_ = repo.Add(ctx, "a-1", "lib-fs", "filesystem")
+
+	if _, err := db.ExecContext(ctx, `DELETE FROM artists WHERE id = 'a-1'`); err != nil {
+		t.Fatalf("delete artist: %v", err)
+	}
+	got, err := repo.CountForArtist(ctx, "a-1")
+	if err != nil {
+		t.Fatalf("count after cascade: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("post-cascade count = %d, want 0", got)
+	}
+}
+
+// TestArtistGetByName verifies the unscoped name lookup is case-insensitive
+// and returns nil when no match exists. Issue #1004.
+func TestArtistGetByName(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		VALUES ('a-veridia', 'VERIDIA', 'VERIDIA', '/music/VERIDIA',
+			datetime('now'), datetime('now'))
+	`)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	repo := newSQLiteArtistRepo(db)
+	a, err := repo.GetByName(ctx, "veridia")
+	if err != nil {
+		t.Fatalf("GetByName: %v", err)
+	}
+	if a == nil {
+		t.Fatal("GetByName returned nil for case-insensitive match")
+	}
+	if a.ID != "a-veridia" {
+		t.Errorf("id = %q, want a-veridia", a.ID)
+	}
+
+	none, err := repo.GetByName(ctx, "Nonexistent")
+	if err != nil {
+		t.Fatalf("GetByName miss: %v", err)
+	}
+	if none != nil {
+		t.Errorf("expected nil for unknown name, got %+v", none)
+	}
+}
+
+// TestArtistFindByMBIDOrNameUnscoped covers the dedupe priority: MBID
+// match wins when present; falls through to case-insensitive name
+// otherwise. Issue #1004.
+func TestArtistFindByMBIDOrNameUnscoped(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		VALUES ('a-byname', 'NameOnly', 'NameOnly', '/music/NameOnly',
+			datetime('now'), datetime('now'))
+	`)
+	if err != nil {
+		t.Fatalf("seed name-only: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		VALUES ('a-bymbid', 'MBIDArtist', 'MBIDArtist', '/music/MBIDArtist',
+			datetime('now'), datetime('now'))
+	`)
+	if err != nil {
+		t.Fatalf("seed mbid: %v", err)
+	}
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
+		VALUES ('a-bymbid', 'musicbrainz', 'mb-1', datetime('now'))
+	`)
+	if err != nil {
+		t.Fatalf("seed mbid provider id: %v", err)
+	}
+
+	repo := newSQLiteArtistRepo(db)
+
+	a, err := repo.FindByMBIDOrNameUnscoped(ctx, "mb-1", "")
+	if err != nil || a == nil {
+		t.Fatalf("mbid path: a=%v err=%v", a, err)
+	}
+	if a.ID != "a-bymbid" {
+		t.Errorf("mbid match id = %q, want a-bymbid", a.ID)
+	}
+
+	a, err = repo.FindByMBIDOrNameUnscoped(ctx, "", "nameonly")
+	if err != nil || a == nil {
+		t.Fatalf("name path: a=%v err=%v", a, err)
+	}
+	if a.ID != "a-byname" {
+		t.Errorf("name match id = %q, want a-byname", a.ID)
+	}
+
+	// MBID present but unmatched: must fall through to name. The MBID
+	// belongs to a different artist, so the name match returns the
+	// name-only row, not the MBID-bearing row.
+	a, err = repo.FindByMBIDOrNameUnscoped(ctx, "mb-missing", "nameonly")
+	if err != nil || a == nil {
+		t.Fatalf("fallback path: a=%v err=%v", a, err)
+	}
+	if a.ID != "a-byname" {
+		t.Errorf("fallback id = %q, want a-byname", a.ID)
+	}
+}

--- a/internal/artist/sqlite_membership_test.go
+++ b/internal/artist/sqlite_membership_test.go
@@ -142,13 +142,20 @@ func TestMembershipRemove(t *testing.T) {
 	repo := newSQLiteMembershipRepo(db)
 	ctx := context.Background()
 
-	_ = repo.Add(ctx, "a-1", "lib-fs", "filesystem")
-	_ = repo.Add(ctx, "a-1", "lib-emby", "emby")
+	if err := repo.Add(ctx, "a-1", "lib-fs", "filesystem"); err != nil {
+		t.Fatalf("add fs: %v", err)
+	}
+	if err := repo.Add(ctx, "a-1", "lib-emby", "emby"); err != nil {
+		t.Fatalf("add emby: %v", err)
+	}
 
 	if err := repo.Remove(ctx, "a-1", "lib-emby"); err != nil {
 		t.Fatalf("remove emby: %v", err)
 	}
-	got, _ := repo.CountForArtist(ctx, "a-1")
+	got, err := repo.CountForArtist(ctx, "a-1")
+	if err != nil {
+		t.Fatalf("count after remove: %v", err)
+	}
 	if got != 1 {
 		t.Errorf("after remove count = %d, want 1", got)
 	}
@@ -167,7 +174,9 @@ func TestMembershipCascadeOnArtistDelete(t *testing.T) {
 	repo := newSQLiteMembershipRepo(db)
 	ctx := context.Background()
 
-	_ = repo.Add(ctx, "a-1", "lib-fs", "filesystem")
+	if err := repo.Add(ctx, "a-1", "lib-fs", "filesystem"); err != nil {
+		t.Fatalf("add fs: %v", err)
+	}
 
 	if _, err := db.ExecContext(ctx, `DELETE FROM artists WHERE id = 'a-1'`); err != nil {
 		t.Fatalf("delete artist: %v", err)

--- a/internal/artist/sqlite_platform.go
+++ b/internal/artist/sqlite_platform.go
@@ -21,7 +21,7 @@ func newSQLitePlatformIDRepo(db *sql.DB) *sqlitePlatformIDRepo {
 func (r *sqlitePlatformIDRepo) Set(ctx context.Context, artistID, connectionID, platformArtistID string) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 
-	// Issue #1076: a UNIQUE index on (connection_id, platform_artist_id)
+	// a UNIQUE index on (connection_id, platform_artist_id)
 	// prevents two artist rows from claiming the same platform item.
 	// SQLite supports only one ON CONFLICT clause per INSERT, and the
 	// existing one targets (artist_id, connection_id) for upsert. Detect
@@ -119,10 +119,15 @@ func (r *sqlitePlatformIDRepo) DeleteByArtistID(ctx context.Context, artistID st
 }
 
 // GetPresenceForArtists returns a map of artist ID to PlatformPresence.
-// Connection-platform presence comes from joining artist_platform_ids with
-// connections; filesystem presence (issue #1004) comes from joining
-// artist_libraries with libraries WHERE connection_id IS NULL. Artists with
-// no mappings AND no memberships are omitted.
+// presence derives from artist_libraries memberships (the
+// authoritative "currently observed by" record), not from artist_platform_ids
+// (which can lag behind library state -- a library unlink leaves the
+// connection and its mappings intact). One query covers all four presence
+// flags; library.connection_id IS NULL maps to filesystem presence,
+// otherwise the connection's type maps to HasEmby/HasJellyfin/HasLidarr.
+//
+// Artists with no membership rows are omitted from the result map; the
+// caller treats a missing entry as "no presence."
 func (r *sqlitePlatformIDRepo) GetPresenceForArtists(ctx context.Context, artistIDs []string) (map[string]PlatformPresence, error) {
 	if len(artistIDs) == 0 {
 		return nil, nil
@@ -134,15 +139,18 @@ func (r *sqlitePlatformIDRepo) GetPresenceForArtists(ctx context.Context, artist
 		placeholders[i] = "?"
 		args[i] = id
 	}
-	in := strings.Join(placeholders, ",")
 
-	// Connection-platform presence. One row per (artist, connection_type).
-	platformQuery := `SELECT ap.artist_id, c.type ` + //nolint:gosec // G202: placeholders are "?" literals
-		`FROM artist_platform_ids ap ` +
-		`JOIN connections c ON c.id = ap.connection_id ` +
-		`WHERE ap.artist_id IN (` + in + `) ` +
-		`GROUP BY ap.artist_id, c.type`
-	rows, err := r.db.QueryContext(ctx, platformQuery, args...)
+	// Alias is "presence_kind" rather than "source" to avoid colliding
+	// with libraries.source in the GROUP BY (SQLite resolves the bare
+	// name to the table column, raising "ambiguous column" otherwise).
+	query := `SELECT al.artist_id, ` + //nolint:gosec // G202: placeholders are "?" literals
+		`CASE WHEN l.connection_id IS NULL THEN 'filesystem' ELSE COALESCE(c.type, '') END AS presence_kind ` +
+		`FROM artist_libraries al ` +
+		`JOIN libraries l ON l.id = al.library_id ` +
+		`LEFT JOIN connections c ON c.id = l.connection_id ` +
+		`WHERE al.artist_id IN (` + strings.Join(placeholders, ",") + `) ` +
+		`GROUP BY al.artist_id, presence_kind`
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("batch getting platform presence: %w", err)
 	}
@@ -150,12 +158,14 @@ func (r *sqlitePlatformIDRepo) GetPresenceForArtists(ctx context.Context, artist
 
 	result := make(map[string]PlatformPresence, len(artistIDs))
 	for rows.Next() {
-		var artistID, connType string
-		if err := rows.Scan(&artistID, &connType); err != nil {
+		var artistID, kind string
+		if err := rows.Scan(&artistID, &kind); err != nil {
 			return nil, fmt.Errorf("scanning platform presence row: %w", err)
 		}
 		p := result[artistID]
-		switch connType {
+		switch kind {
+		case "filesystem":
+			p.HasFilesystem = true
 		case "emby":
 			p.HasEmby = true
 		case "jellyfin":
@@ -167,35 +177,6 @@ func (r *sqlitePlatformIDRepo) GetPresenceForArtists(ctx context.Context, artist
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating platform presence rows: %w", err)
-	}
-
-	// Filesystem-library presence: any artist with at least one
-	// artist_libraries row pointing at a connection-less library is in
-	// at least one filesystem library. Issue #1004 replacement for the
-	// pre-existing path-based heuristic.
-	fsQuery := `SELECT al.artist_id ` + //nolint:gosec // G202: placeholders are "?" literals
-		`FROM artist_libraries al ` +
-		`JOIN libraries l ON l.id = al.library_id ` +
-		`WHERE al.artist_id IN (` + in + `) ` +
-		`AND l.connection_id IS NULL ` +
-		`GROUP BY al.artist_id`
-	fsRows, err := r.db.QueryContext(ctx, fsQuery, args...)
-	if err != nil {
-		return nil, fmt.Errorf("batch getting filesystem presence: %w", err)
-	}
-	defer fsRows.Close() //nolint:errcheck
-
-	for fsRows.Next() {
-		var artistID string
-		if err := fsRows.Scan(&artistID); err != nil {
-			return nil, fmt.Errorf("scanning filesystem presence row: %w", err)
-		}
-		p := result[artistID]
-		p.HasFilesystem = true
-		result[artistID] = p
-	}
-	if err := fsRows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating filesystem presence rows: %w", err)
 	}
 	return result, nil
 }

--- a/internal/artist/sqlite_platform.go
+++ b/internal/artist/sqlite_platform.go
@@ -118,9 +118,11 @@ func (r *sqlitePlatformIDRepo) DeleteByArtistID(ctx context.Context, artistID st
 	return nil
 }
 
-// GetPresenceForArtists returns a map of artist ID to PlatformPresence by
-// joining artist_platform_ids with connections to determine which platform
-// types each artist has a mapping for. Artists with no mappings are omitted.
+// GetPresenceForArtists returns a map of artist ID to PlatformPresence.
+// Connection-platform presence comes from joining artist_platform_ids with
+// connections; filesystem presence (issue #1004) comes from joining
+// artist_libraries with libraries WHERE connection_id IS NULL. Artists with
+// no mappings AND no memberships are omitted.
 func (r *sqlitePlatformIDRepo) GetPresenceForArtists(ctx context.Context, artistIDs []string) (map[string]PlatformPresence, error) {
 	if len(artistIDs) == 0 {
 		return nil, nil
@@ -132,15 +134,15 @@ func (r *sqlitePlatformIDRepo) GetPresenceForArtists(ctx context.Context, artist
 		placeholders[i] = "?"
 		args[i] = id
 	}
+	in := strings.Join(placeholders, ",")
 
-	// Return one row per (artist, connection_type) pair. GROUP BY collapses
-	// multiple connections of the same type into a single row per artist.
-	query := `SELECT ap.artist_id, c.type ` + //nolint:gosec // G202: placeholders are "?" literals
+	// Connection-platform presence. One row per (artist, connection_type).
+	platformQuery := `SELECT ap.artist_id, c.type ` + //nolint:gosec // G202: placeholders are "?" literals
 		`FROM artist_platform_ids ap ` +
 		`JOIN connections c ON c.id = ap.connection_id ` +
-		`WHERE ap.artist_id IN (` + strings.Join(placeholders, ",") + `) ` +
+		`WHERE ap.artist_id IN (` + in + `) ` +
 		`GROUP BY ap.artist_id, c.type`
-	rows, err := r.db.QueryContext(ctx, query, args...)
+	rows, err := r.db.QueryContext(ctx, platformQuery, args...)
 	if err != nil {
 		return nil, fmt.Errorf("batch getting platform presence: %w", err)
 	}
@@ -165,6 +167,35 @@ func (r *sqlitePlatformIDRepo) GetPresenceForArtists(ctx context.Context, artist
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating platform presence rows: %w", err)
+	}
+
+	// Filesystem-library presence: any artist with at least one
+	// artist_libraries row pointing at a connection-less library is in
+	// at least one filesystem library. Issue #1004 replacement for the
+	// pre-existing path-based heuristic.
+	fsQuery := `SELECT al.artist_id ` + //nolint:gosec // G202: placeholders are "?" literals
+		`FROM artist_libraries al ` +
+		`JOIN libraries l ON l.id = al.library_id ` +
+		`WHERE al.artist_id IN (` + in + `) ` +
+		`AND l.connection_id IS NULL ` +
+		`GROUP BY al.artist_id`
+	fsRows, err := r.db.QueryContext(ctx, fsQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("batch getting filesystem presence: %w", err)
+	}
+	defer fsRows.Close() //nolint:errcheck
+
+	for fsRows.Next() {
+		var artistID string
+		if err := fsRows.Scan(&artistID); err != nil {
+			return nil, fmt.Errorf("scanning filesystem presence row: %w", err)
+		}
+		p := result[artistID]
+		p.HasFilesystem = true
+		result[artistID] = p
+	}
+	if err := fsRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating filesystem presence rows: %w", err)
 	}
 	return result, nil
 }

--- a/internal/artist/sqlite_platform.go
+++ b/internal/artist/sqlite_platform.go
@@ -143,14 +143,31 @@ func (r *sqlitePlatformIDRepo) GetPresenceForArtists(ctx context.Context, artist
 	// Alias is "presence_kind" rather than "source" to avoid colliding
 	// with libraries.source in the GROUP BY (SQLite resolves the bare
 	// name to the table column, raising "ambiguous column" otherwise).
-	query := `SELECT al.artist_id, ` + //nolint:gosec // G202: placeholders are "?" literals
+	//
+	// Hybrid OR-fallback: UNION the membership-derived rows with the
+	// legacy artists.library_id projection so artists created by
+	// still-legacy writers (or older fixtures) without an
+	// artist_libraries row are still visible. The legacy branch goes
+	// away when #1214 drops the column.
+	in := strings.Join(placeholders, ",")
+	query := `SELECT artist_id, presence_kind FROM (` + //nolint:gosec // G202: placeholders are "?" literals
+		`SELECT al.artist_id AS artist_id, ` +
 		`CASE WHEN l.connection_id IS NULL THEN 'filesystem' ELSE COALESCE(c.type, '') END AS presence_kind ` +
 		`FROM artist_libraries al ` +
 		`JOIN libraries l ON l.id = al.library_id ` +
 		`LEFT JOIN connections c ON c.id = l.connection_id ` +
-		`WHERE al.artist_id IN (` + strings.Join(placeholders, ",") + `) ` +
-		`GROUP BY al.artist_id, presence_kind`
-	rows, err := r.db.QueryContext(ctx, query, args...)
+		`WHERE al.artist_id IN (` + in + `) ` +
+		`UNION ` +
+		`SELECT a.id AS artist_id, ` +
+		`CASE WHEN l.connection_id IS NULL THEN 'filesystem' ELSE COALESCE(c.type, '') END AS presence_kind ` +
+		`FROM artists a ` +
+		`JOIN libraries l ON l.id = a.library_id ` +
+		`LEFT JOIN connections c ON c.id = l.connection_id ` +
+		`WHERE a.id IN (` + in + `) ` +
+		`  AND a.library_id IS NOT NULL AND a.library_id <> ''` +
+		`)`
+	queryArgs := append(append([]any{}, args...), args...)
+	rows, err := r.db.QueryContext(ctx, query, queryArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("batch getting platform presence: %w", err)
 	}

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -85,6 +85,17 @@ func Migrate(db *sql.DB) error {
 		return fmt.Errorf("backfilling rule_results from violations: %w", err)
 	}
 
+	// Issue #1004: artists become M:N with libraries via artist_libraries.
+	// On fresh installs this only ensures the table exists (001 already has
+	// it). On pre-1004 DBs this also backfills memberships from the orphan
+	// artists.library_id column and collapses legacy duplicate artist rows
+	// (one canonical row per real-world artist, with the loser library_ids
+	// folded into artist_libraries memberships). Idempotent: on second
+	// startup the helper finds no work to do.
+	if err := ensureArtistLibrariesMembership(db); err != nil {
+		return fmt.Errorf("ensuring artist_libraries membership: %w", err)
+	}
+
 	return nil
 }
 
@@ -281,6 +292,493 @@ func ensureArtistPlatformIDsUnique(db *sql.DB) error {
 		return fmt.Errorf("creating unique index on artist_platform_ids: %w", err)
 	}
 	return nil
+}
+
+// ensureArtistLibrariesMembership ensures the artist_libraries table exists,
+// backfills memberships from the legacy artists.library_id column on pre-1004
+// DBs, and collapses any duplicate artist rows produced by the old
+// per-library-scoped scanner. Idempotent: on a fresh install or already-
+// migrated DB it is a fast no-op.
+//
+// The collapse step picks a canonical artist per duplicate group as follows:
+//  1. Group by MusicBrainz ID when present (strongest identity).
+//  2. Group by LOWER(name) for rows without an MBID, excluding any artist
+//     already claimed by an MBID group.
+//  3. Within each group, prefer the row whose library is filesystem-sourced
+//     (or whose library_id is null and so represents the canonical
+//     filesystem-only path); tie-break by oldest created_at, then artist id.
+//
+// Re-pointing FK rows to the canonical artist uses INSERT OR IGNORE for
+// composite-PK / unique-indexed tables (the canonical row's existing entry
+// wins) and UPDATE OR IGNORE for single-PK tables with secondary uniques.
+// Loser artist rows are then deleted; ON DELETE CASCADE cleans up any FK
+// rows that did not get re-pointed (i.e. duplicates that conflicted with the
+// canonical's existing data).
+func ensureArtistLibrariesMembership(db *sql.DB) error {
+	ctx := context.Background()
+	logger := slog.Default().With("component", "database")
+
+	// Step 1: idempotent table + index. 001 has these for fresh installs;
+	// pre-1004 DBs need them at startup.
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS artist_libraries (
+			artist_id  TEXT NOT NULL REFERENCES artists(id)   ON DELETE CASCADE,
+			library_id TEXT NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+			source     TEXT NOT NULL CHECK (source IN ('filesystem','emby','jellyfin','manual')),
+			added_at   TEXT NOT NULL DEFAULT (datetime('now')),
+			PRIMARY KEY (artist_id, library_id)
+		)
+	`); err != nil {
+		return fmt.Errorf("ensuring artist_libraries table: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		CREATE INDEX IF NOT EXISTS idx_artist_libraries_library
+		ON artist_libraries(library_id)
+	`); err != nil {
+		return fmt.Errorf("ensuring artist_libraries index: %w", err)
+	}
+
+	// Step 2: backfill memberships from the orphan artists.library_id column.
+	// Fresh installs skip silently because the column does not exist.
+	hasOrphan, err := columnExists(db, "artists", "library_id")
+	if err != nil {
+		return fmt.Errorf("checking artists.library_id presence: %w", err)
+	}
+	if !hasOrphan {
+		return nil
+	}
+
+	res, err := db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO artist_libraries (artist_id, library_id, source, added_at)
+		SELECT
+			a.id,
+			a.library_id,
+			CASE
+				WHEN c.type = 'emby'     THEN 'emby'
+				WHEN c.type = 'jellyfin' THEN 'jellyfin'
+				ELSE 'filesystem'
+			END,
+			a.created_at
+		FROM artists a
+		JOIN libraries l ON l.id = a.library_id
+		LEFT JOIN connections c ON c.id = l.connection_id
+		WHERE a.library_id IS NOT NULL AND a.library_id != ''
+	`)
+	if err != nil {
+		return fmt.Errorf("backfilling artist_libraries from orphan library_id: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		logger.Info("backfilled artist_libraries memberships from legacy library_id",
+			"rows", n)
+	}
+
+	// Step 3: collapse legacy duplicate artists.
+	return collapseDuplicateArtists(ctx, db, logger)
+}
+
+// collapseGroup describes a duplicate artist group: one canonical row that
+// keeps its identity, and one or more loser rows whose FK children get
+// re-pointed at the canonical before the losers are deleted.
+type collapseGroup struct {
+	canonicalID string
+	loserIDs    []string
+}
+
+// collapseDuplicateArtists finds duplicate artist groups by MBID then by
+// case-insensitive name and collapses them per the rules in
+// ensureArtistLibrariesMembership. The whole collapse runs in a single
+// transaction so a partial failure rolls back to a consistent state.
+func collapseDuplicateArtists(ctx context.Context, db *sql.DB, logger *slog.Logger) error {
+	mbidGroups, err := findDuplicateGroupsByMBID(ctx, db)
+	if err != nil {
+		return fmt.Errorf("finding mbid duplicates: %w", err)
+	}
+
+	claimed := make(map[string]bool, len(mbidGroups)*2)
+	for _, g := range mbidGroups {
+		claimed[g.canonicalID] = true
+		for _, l := range g.loserIDs {
+			claimed[l] = true
+		}
+	}
+
+	nameGroups, err := findDuplicateGroupsByName(ctx, db, claimed)
+	if err != nil {
+		return fmt.Errorf("finding name duplicates: %w", err)
+	}
+
+	allGroups := append(mbidGroups, nameGroups...)
+	if len(allGroups) == 0 {
+		return nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin collapse tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	var totalRepointed, totalRemoved int64
+	for _, g := range allGroups {
+		repointed, err := repointArtistFKs(ctx, tx, g.canonicalID, g.loserIDs)
+		if err != nil {
+			return fmt.Errorf("re-pointing canonical=%s: %w", g.canonicalID, err)
+		}
+		totalRepointed += repointed
+
+		// Carry the losers' library memberships onto the canonical artist.
+		// This catches the case where a loser had a library that the
+		// canonical did not yet know about (the typical Emby+Jellyfin
+		// duplicate scenario).
+		placeholders, args := buildInList(g.loserIDs)
+		args = append([]any{g.canonicalID}, args...)
+		//nolint:gosec // G201: placeholders is a "?,?,..." literal built by buildInList from a known-length loop
+		insertSQL := fmt.Sprintf(`
+			INSERT OR IGNORE INTO artist_libraries (artist_id, library_id, source, added_at)
+			SELECT
+				?,
+				a.library_id,
+				CASE
+					WHEN c.type = 'emby'     THEN 'emby'
+					WHEN c.type = 'jellyfin' THEN 'jellyfin'
+					ELSE 'filesystem'
+				END,
+				a.created_at
+			FROM artists a
+			JOIN libraries l ON l.id = a.library_id
+			LEFT JOIN connections c ON c.id = l.connection_id
+			WHERE a.id IN (%s)
+			  AND a.library_id IS NOT NULL AND a.library_id != ''
+		`, placeholders)
+		if _, err := tx.ExecContext(ctx, insertSQL, args...); err != nil {
+			return fmt.Errorf("inserting loser memberships under canonical=%s: %w",
+				g.canonicalID, err)
+		}
+
+		// Delete losers. ON DELETE CASCADE removes any remaining FK children
+		// (rows that conflicted on insert/update and were not re-pointed).
+		delPh, delArgs := buildInList(g.loserIDs)
+		deleteSQL := fmt.Sprintf(`DELETE FROM artists WHERE id IN (%s)`, delPh) //nolint:gosec // G201: delPh is a "?,?,..." literal
+		delRes, err := tx.ExecContext(ctx, deleteSQL, delArgs...)
+		if err != nil {
+			return fmt.Errorf("deleting losers under canonical=%s: %w",
+				g.canonicalID, err)
+		}
+		n, _ := delRes.RowsAffected()
+		totalRemoved += n
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit collapse tx: %w", err)
+	}
+
+	logger.Info("collapsed duplicate artist rows (issue #1004)",
+		"groups", len(allGroups),
+		"repointed_rows", totalRepointed,
+		"removed_artists", totalRemoved,
+	)
+	return nil
+}
+
+// pickCanonicalCTE produces the CASE expression that ranks rows within a
+// duplicate group. Lower rank wins. Filesystem-source rows rank highest:
+// either the artist has no library (legacy data) or its library is not
+// attached to a connection (manual filesystem library). Connection-backed
+// rows (Emby, Jellyfin, ...) fall back. The MusicBrainz ID lives on
+// artist_provider_ids, so we LEFT JOIN it here for the MBID grouping query.
+// The CTE is reused by both group finders so the canonical-pick rule is
+// identical.
+const pickCanonicalCTE = `
+WITH ranked AS (
+	SELECT
+		a.id,
+		COALESCE(ap.provider_id, '') AS mbid,
+		a.name,
+		a.created_at,
+		CASE
+			WHEN a.library_id IS NULL OR a.library_id = '' THEN 0
+			WHEN c.type IS NULL                         THEN 1
+			ELSE 2
+		END AS source_rank
+	FROM artists a
+	LEFT JOIN artist_provider_ids ap
+		ON ap.artist_id = a.id AND ap.provider = 'musicbrainz'
+	LEFT JOIN libraries   l ON l.id = a.library_id
+	LEFT JOIN connections c ON c.id = l.connection_id
+)
+`
+
+// findDuplicateGroupsByMBID returns one collapseGroup per MBID that has more
+// than one artist row. Within each group the canonical is the lowest
+// (source_rank, created_at, id) row.
+func findDuplicateGroupsByMBID(ctx context.Context, db *sql.DB) ([]collapseGroup, error) {
+	rows, err := db.QueryContext(ctx, pickCanonicalCTE+`
+		SELECT id, mbid, source_rank, created_at
+		FROM ranked
+		WHERE mbid != ''
+		  AND mbid IN (
+			SELECT mbid FROM ranked
+			WHERE mbid != ''
+			GROUP BY mbid HAVING COUNT(*) > 1
+		)
+		ORDER BY mbid, source_rank, created_at, id
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying mbid duplicate groups: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	groups := []collapseGroup{}
+	var current *collapseGroup
+	var currentKey string
+	for rows.Next() {
+		var id, mbid, createdAt string
+		var rank int
+		if err := rows.Scan(&id, &mbid, &rank, &createdAt); err != nil {
+			return nil, fmt.Errorf("scanning mbid duplicate row: %w", err)
+		}
+		if mbid != currentKey {
+			currentKey = mbid
+			groups = append(groups, collapseGroup{canonicalID: id})
+			current = &groups[len(groups)-1]
+			continue
+		}
+		current.loserIDs = append(current.loserIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating mbid duplicate rows: %w", err)
+	}
+	return groups, nil
+}
+
+// findDuplicateGroupsByName returns collapseGroups for case-insensitive name
+// duplicates, excluding any artist already claimed by an MBID group. This
+// catches duplicates that exist because one or both rows lack an MBID (typical
+// for filesystem-only artists that were also imported from Emby/Jellyfin).
+func findDuplicateGroupsByName(ctx context.Context, db *sql.DB, claimed map[string]bool) ([]collapseGroup, error) {
+	rows, err := db.QueryContext(ctx, pickCanonicalCTE+`
+		SELECT id, name, source_rank, created_at
+		FROM ranked
+		WHERE LOWER(name) IN (
+			SELECT LOWER(name) FROM ranked
+			GROUP BY LOWER(name) HAVING COUNT(*) > 1
+		)
+		ORDER BY LOWER(name), source_rank, created_at, id
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying name duplicate groups: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	type rawRow struct {
+		id, name string
+	}
+	byName := map[string][]rawRow{}
+	for rows.Next() {
+		var id, name, createdAt string
+		var rank int
+		if err := rows.Scan(&id, &name, &rank, &createdAt); err != nil {
+			return nil, fmt.Errorf("scanning name duplicate row: %w", err)
+		}
+		key := name
+		// LOWER for grouping; preserve original case in the row for logging.
+		// (SQLite's GROUP BY in the subquery uses LOWER, so we re-key here.)
+		// We could push LOWER(name) into the SELECT, but storing the
+		// original-case name keeps the slog line readable.
+		_ = key
+		k := lowercaseASCII(name)
+		byName[k] = append(byName[k], rawRow{id: id, name: name})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating name duplicate rows: %w", err)
+	}
+
+	groups := []collapseGroup{}
+	for _, rs := range byName {
+		// Drop rows already in an MBID group; if fewer than two remain there
+		// is no duplicate left to collapse for this name.
+		filtered := rs[:0]
+		for _, r := range rs {
+			if !claimed[r.id] {
+				filtered = append(filtered, r)
+			}
+		}
+		if len(filtered) < 2 {
+			continue
+		}
+		// First filtered row is canonical (rows already arrive sorted by
+		// source_rank, created_at, id from the ORDER BY above).
+		g := collapseGroup{canonicalID: filtered[0].id}
+		for _, r := range filtered[1:] {
+			g.loserIDs = append(g.loserIDs, r.id)
+		}
+		groups = append(groups, g)
+	}
+	return groups, nil
+}
+
+// repointArtistFKs moves every child row owned by losers to canonical, with
+// per-table conflict resolution. Returns the total number of rows actually
+// re-pointed (informational; rows that conflicted with the canonical's
+// existing data are dropped on cascade when losers are deleted).
+//
+// Tables with composite PK (artist_id, X) get INSERT OR IGNORE: the
+// canonical's existing row wins for any (canonical, X) collision; loser rows
+// for keys the canonical does not have are absorbed.
+//
+// Tables with single-id PK and a secondary UNIQUE on (artist_id, ...) get
+// UPDATE OR IGNORE: rows that would create a unique-violation when re-keyed
+// to canonical are silently dropped (canonical already has data for that
+// slot and we keep canonical's).
+//
+// Tables with single-id PK and no other uniques get a plain UPDATE.
+func repointArtistFKs(ctx context.Context, tx *sql.Tx, canonical string, losers []string) (int64, error) {
+	loserPh, loserArgs := buildInList(losers)
+	var total int64
+
+	// Composite-PK tables: INSERT OR IGNORE the loser rows under canonical.
+	// We must list columns explicitly because each table's column set differs.
+	insertOrIgnore := []struct {
+		table   string
+		columns string
+		selectX string // "X" portion of the SELECT after the canonical id
+	}{
+		{
+			"artist_provider_ids",
+			"(artist_id, provider, provider_id, fetched_at)",
+			"provider, provider_id, fetched_at",
+		},
+		{
+			"artist_platform_ids",
+			"(artist_id, connection_id, platform_artist_id, created_at, updated_at)",
+			"connection_id, platform_artist_id, created_at, updated_at",
+		},
+		{
+			"rule_results",
+			"(artist_id, rule_id, passed, violation_id, evaluated_at, violation_message, first_failed_at)",
+			"rule_id, passed, violation_id, evaluated_at, violation_message, first_failed_at",
+		},
+	}
+	for _, t := range insertOrIgnore {
+		args := append([]any{canonical}, loserArgs...)
+		stmt := fmt.Sprintf( //nolint:gosec // G201: table/columns/loserPh are hard-coded literals or static placeholder strings
+			`INSERT OR IGNORE INTO %s %s SELECT ?, %s FROM %s WHERE artist_id IN (%s)`,
+			t.table, t.columns, t.selectX, t.table, loserPh,
+		)
+		res, err := tx.ExecContext(ctx, stmt, args...)
+		if err != nil {
+			return total, fmt.Errorf("re-pointing %s: %w", t.table, err)
+		}
+		n, _ := res.RowsAffected()
+		total += n
+	}
+
+	// Single-PK tables with secondary UNIQUE: UPDATE OR IGNORE so unique-
+	// violations drop silently (canonical already covers that slot).
+	updateOrIgnore := []string{
+		"artist_images",   // UNIQUE (artist_id, image_type, slot_index)
+		"mb_snapshots",    // UNIQUE (artist_id, field)
+		"rule_violations", // UNIQUE (rule_id, artist_id)
+	}
+	for _, t := range updateOrIgnore {
+		args := append([]any{canonical}, loserArgs...)
+		stmt := fmt.Sprintf( //nolint:gosec // G201: table is a hard-coded literal
+			`UPDATE OR IGNORE %s SET artist_id = ? WHERE artist_id IN (%s)`,
+			t, loserPh,
+		)
+		res, err := tx.ExecContext(ctx, stmt, args...)
+		if err != nil {
+			return total, fmt.Errorf("re-pointing %s: %w", t, err)
+		}
+		n, _ := res.RowsAffected()
+		total += n
+	}
+
+	// Plain UPDATE: no secondary uniques, all loser rows survive.
+	plainUpdate := []string{
+		"artist_aliases",
+		"band_members",
+		"nfo_snapshots",
+		"metadata_changes",
+	}
+	for _, t := range plainUpdate {
+		args := append([]any{canonical}, loserArgs...)
+		stmt := fmt.Sprintf( //nolint:gosec // G201: table is a hard-coded literal
+			`UPDATE %s SET artist_id = ? WHERE artist_id IN (%s)`,
+			t, loserPh,
+		)
+		res, err := tx.ExecContext(ctx, stmt, args...)
+		if err != nil {
+			return total, fmt.Errorf("re-pointing %s: %w", t, err)
+		}
+		n, _ := res.RowsAffected()
+		total += n
+	}
+
+	return total, nil
+}
+
+// columnExists returns true if the named column is present on the table.
+// Used by ensureArtistLibrariesMembership to decide whether to backfill from
+// the orphan artists.library_id column (present on pre-1004 DBs only).
+func columnExists(db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.QueryContext(context.Background(),
+		fmt.Sprintf("PRAGMA table_info(%s)", table)) //nolint:gosec // G201: table is a hard-coded literal
+	if err != nil {
+		return false, fmt.Errorf("reading %s schema: %w", table, err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			ctype     string
+			notnull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
+			return false, fmt.Errorf("scanning %s schema row: %w", table, err)
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+// buildInList returns ("?,?,?", []any{ids...}) for use in WHERE x IN (...).
+// Returns an empty-string SQL literal when the input is empty so the IN
+// clause stays valid (matches nothing instead of producing a syntax error).
+func buildInList(ids []string) (string, []any) {
+	if len(ids) == 0 {
+		return "''", nil
+	}
+	placeholders := make([]byte, 0, len(ids)*2)
+	args := make([]any, 0, len(ids))
+	for i, id := range ids {
+		if i > 0 {
+			placeholders = append(placeholders, ',')
+		}
+		placeholders = append(placeholders, '?')
+		args = append(args, id)
+	}
+	return string(placeholders), args
+}
+
+// lowercaseASCII lowercases a string using ASCII semantics. Matches SQLite's
+// default LOWER() behavior for the ASCII range, which is what the duplicate
+// detection grouping uses. Non-ASCII bytes pass through unchanged in both
+// SQLite and here, so the grouping stays consistent.
+func lowercaseASCII(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'A' && c <= 'Z' {
+			b[i] = c + ('a' - 'A')
+		}
+	}
+	return string(b)
 }
 
 // ensureColumn adds a column to a table if it does not already exist.

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -438,11 +438,28 @@ func collapseDuplicateArtists(ctx context.Context, db *sql.DB, logger *slog.Logg
 		// This catches the case where a loser had a library that the
 		// canonical did not yet know about (the typical Emby+Jellyfin
 		// duplicate scenario).
-		placeholders, args := buildInList(g.loserIDs)
-		args = append([]any{g.canonicalID}, args...)
+		//
+		// Two sources are unioned: (1) any rows already materialized in
+		// artist_libraries for the losers (the M:N source of truth), and
+		// (2) the legacy artists.library_id column for losers that have
+		// not been backfilled into artist_libraries yet. Without (1) a
+		// loser with multiple memberships would only carry one of them.
+		placeholders, inArgs := buildInList(g.loserIDs)
+		args := []any{g.canonicalID}
+		args = append(args, inArgs...)
+		args = append(args, g.canonicalID)
+		args = append(args, inArgs...)
 		//nolint:gosec // G201: placeholders is a "?,?,..." literal built by buildInList from a known-length loop
 		insertSQL := fmt.Sprintf(`
 			INSERT OR IGNORE INTO artist_libraries (artist_id, library_id, source, added_at)
+			SELECT
+				?,
+				al.library_id,
+				al.source,
+				al.added_at
+			FROM artist_libraries al
+			WHERE al.artist_id IN (%s)
+			UNION ALL
 			SELECT
 				?,
 				a.library_id,
@@ -458,7 +475,7 @@ func collapseDuplicateArtists(ctx context.Context, db *sql.DB, logger *slog.Logg
 			LEFT JOIN connections c ON c.id = l.connection_id
 			WHERE a.id IN (%s)
 			 AND a.library_id IS NOT NULL AND a.library_id != ''
-		`, placeholders)
+		`, placeholders, placeholders)
 		if _, err := tx.ExecContext(ctx, insertSQL, args...); err != nil {
 			return fmt.Errorf("inserting loser memberships under canonical=%s: %w",
 				g.canonicalID, err)

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -544,13 +544,19 @@ func collapseDuplicateArtists(ctx context.Context, db *sql.DB, logger *slog.Logg
 // artist_provider_ids, so we LEFT JOIN it here for the MBID grouping query.
 // The CTE is reused by both group finders so the canonical-pick rule is
 // identical.
+//
+// created_at is normalized via datetime() because the artists table has
+// a mix of formats in the wild (SQLite "YYYY-MM-DD HH:MM:SS" written by
+// older code, RFC3339 "T"-separated strings written by newer Go callers).
+// Lexical TEXT ordering would otherwise pick the wrong winner whenever
+// the formats mix in the same duplicate group.
 const pickCanonicalCTE = `
 WITH ranked AS (
 	SELECT
 		a.id,
 		COALESCE(ap.provider_id, '') AS mbid,
 		a.name,
-		a.created_at,
+		datetime(a.created_at) AS created_at_norm,
 		CASE
 			WHEN a.library_id IS NULL OR a.library_id = '' THEN 0
 			WHEN c.type IS NULL THEN 1
@@ -569,7 +575,7 @@ WITH ranked AS (
 // (source_rank, created_at, id) row.
 func findDuplicateGroupsByMBID(ctx context.Context, db *sql.DB) ([]collapseGroup, error) {
 	rows, err := db.QueryContext(ctx, pickCanonicalCTE+`
-		SELECT id, mbid, source_rank, created_at
+		SELECT id, mbid, source_rank, created_at_norm
 		FROM ranked
 		WHERE mbid != ''
 		 AND mbid IN (
@@ -577,7 +583,7 @@ func findDuplicateGroupsByMBID(ctx context.Context, db *sql.DB) ([]collapseGroup
 			WHERE mbid != ''
 			GROUP BY mbid HAVING COUNT(*) > 1
 		)
-		ORDER BY mbid, source_rank, created_at, id
+		ORDER BY mbid, source_rank, created_at_norm, id
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("querying mbid duplicate groups: %w", err)
@@ -613,13 +619,13 @@ func findDuplicateGroupsByMBID(ctx context.Context, db *sql.DB) ([]collapseGroup
 // for filesystem-only artists that were also imported from Emby/Jellyfin).
 func findDuplicateGroupsByName(ctx context.Context, db *sql.DB, claimed map[string]bool) ([]collapseGroup, error) {
 	rows, err := db.QueryContext(ctx, pickCanonicalCTE+`
-		SELECT id, name, source_rank, created_at
+		SELECT id, name, source_rank, created_at_norm
 		FROM ranked
 		WHERE LOWER(name) IN (
 			SELECT LOWER(name) FROM ranked
 			GROUP BY LOWER(name) HAVING COUNT(*) > 1
 		)
-		ORDER BY LOWER(name), source_rank, created_at, id
+		ORDER BY LOWER(name), source_rank, created_at_norm, id
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("querying name duplicate groups: %w", err)

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -449,6 +449,7 @@ func collapseDuplicateArtists(ctx context.Context, db *sql.DB, logger *slog.Logg
 				CASE
 					WHEN c.type = 'emby' THEN 'emby'
 					WHEN c.type = 'jellyfin' THEN 'jellyfin'
+					WHEN c.type = 'lidarr' THEN 'lidarr'
 					ELSE 'filesystem'
 				END,
 				a.created_at

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -363,6 +363,7 @@ func ensureArtistLibrariesMembership(db *sql.DB) error {
 			CASE
 				WHEN c.type = 'emby' THEN 'emby'
 				WHEN c.type = 'jellyfin' THEN 'jellyfin'
+				WHEN c.type = 'lidarr' THEN 'lidarr'
 				ELSE 'filesystem'
 			END,
 			a.created_at
@@ -462,9 +463,39 @@ func collapseDuplicateArtists(ctx context.Context, db *sql.DB, logger *slog.Logg
 				g.canonicalID, err)
 		}
 
-		// Delete losers. ON DELETE CASCADE removes any remaining FK children
-		// (rows that conflicted on insert/update and were not re-pointed).
+		// Explicitly clean any FK children still owned by losers before the
+		// parent delete. The OR-IGNORE re-point steps above intentionally
+		// leave loser-side rows behind for slots the canonical already
+		// claimed; those rows would normally be reaped by ON DELETE
+		// CASCADE when the loser is deleted, but database.Migrate may run
+		// before EnableForeignKeys (e.g. some test setups), in which case
+		// the cascade does not fire and the rows survive as orphans. The
+		// explicit DELETE is correct under both pragma states.
 		delPh, delArgs := buildInList(g.loserIDs)
+		childTables := []string{
+			"artist_libraries",
+			"artist_provider_ids",
+			"artist_platform_ids",
+			"artist_images",
+			"mb_snapshots",
+			"rule_results",
+			"rule_violations",
+			"artist_aliases",
+			"band_members",
+			"nfo_snapshots",
+			"metadata_changes",
+		}
+		for _, t := range childTables {
+			childSQL := fmt.Sprintf(`DELETE FROM %s WHERE artist_id IN (%s)`, t, delPh) //nolint:gosec // G201: t is a hard-coded literal, delPh is a "?,?,..." literal
+			if _, err := tx.ExecContext(ctx, childSQL, delArgs...); err != nil {
+				return fmt.Errorf("cleaning %s for losers under canonical=%s: %w",
+					t, g.canonicalID, err)
+			}
+		}
+
+		// Delete losers. With FKs ON, ON DELETE CASCADE would also reap
+		// the children above (idempotent); with FKs OFF, the explicit
+		// cleanup above is what kept the schema consistent.
 		deleteSQL := fmt.Sprintf(`DELETE FROM artists WHERE id IN (%s)`, delPh) //nolint:gosec // G201: delPh is a "?,?,..." literal
 		delRes, err := tx.ExecContext(ctx, deleteSQL, delArgs...)
 		if err != nil {

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -636,8 +636,19 @@ func repointArtistFKs(ctx context.Context, tx *sql.Tx, canonical string, losers 
 	loserPh, loserArgs := buildInList(losers)
 	var total int64
 
-	// Composite-PK tables: INSERT OR IGNORE the loser rows under canonical.
-	// We must list columns explicitly because each table's column set differs.
+	// Composite-PK tables without secondary uniques: INSERT OR IGNORE the
+	// loser rows under canonical. (artist_id, X) PK is the only conflict
+	// surface, so canonical's existing rows win and loser's surplus rows
+	// are absorbed. We list columns explicitly because each schema differs.
+	//
+	// artist_platform_ids is intentionally NOT in this group: it carries an
+	// extra UNIQUE (connection_id, platform_artist_id) that would cause
+	// INSERT OR IGNORE to drop every loser row whose platform mapping is
+	// already claimed by the loser itself, then the cascade-delete of the
+	// loser would lose the mapping entirely. It uses UPDATE OR IGNORE
+	// below, which moves the loser's row onto canonical (preserving the
+	// platform mapping) and only drops the row if canonical already has
+	// its own mapping for the same connection.
 	insertOrIgnore := []struct {
 		table   string
 		columns string
@@ -647,11 +658,6 @@ func repointArtistFKs(ctx context.Context, tx *sql.Tx, canonical string, losers 
 			"artist_provider_ids",
 			"(artist_id, provider, provider_id, fetched_at)",
 			"provider, provider_id, fetched_at",
-		},
-		{
-			"artist_platform_ids",
-			"(artist_id, connection_id, platform_artist_id, created_at, updated_at)",
-			"connection_id, platform_artist_id, created_at, updated_at",
 		},
 		{
 			"rule_results",
@@ -673,12 +679,22 @@ func repointArtistFKs(ctx context.Context, tx *sql.Tx, canonical string, losers 
 		total += n
 	}
 
-	// Single-PK tables with secondary UNIQUE: UPDATE OR IGNORE so unique-
-	// violations drop silently (canonical already covers that slot).
+	// Tables with at least one UNIQUE constraint that includes artist_id:
+	// UPDATE OR IGNORE moves the loser row's artist_id to canonical, and
+	// silently drops the row when the move would conflict with a row
+	// canonical already owns for the same slot. Whatever loser-side rows
+	// remain after this UPDATE are removed by the cascade when the loser
+	// artist is deleted.
+	//
+	// artist_platform_ids is here (not in insertOrIgnore) because of the
+	// UNIQUE (connection_id, platform_artist_id) added by issue #1076.
+	// Moving the loser's row onto canonical preserves the platform mapping
+	// when canonical does not yet have one for the same connection.
 	updateOrIgnore := []string{
-		"artist_images",   // UNIQUE (artist_id, image_type, slot_index)
-		"mb_snapshots",    // UNIQUE (artist_id, field)
-		"rule_violations", // UNIQUE (rule_id, artist_id)
+		"artist_images",       // UNIQUE (artist_id, image_type, slot_index)
+		"mb_snapshots",        // UNIQUE (artist_id, field)
+		"rule_violations",     // UNIQUE (rule_id, artist_id)
+		"artist_platform_ids", // PK (artist_id, connection_id) + UNIQUE (connection_id, platform_artist_id)
 	}
 	for _, t := range updateOrIgnore {
 		args := append([]any{canonical}, loserArgs...)

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/pressly/goose/v3"
 )
@@ -47,7 +49,7 @@ func Migrate(db *sql.DB) error {
 		return fmt.Errorf("ensuring connection columns: %w", err)
 	}
 
-	// Issue #1078: legacy code paths (or sessions without
+	// legacy code paths (or sessions without
 	// PRAGMA foreign_keys=ON) left orphan rows in artist_platform_ids whose
 	// artist_id or connection_id no longer exist. Sweep them at startup so the
 	// invariant the FK declarations imply actually holds. Idempotent.
@@ -55,7 +57,7 @@ func Migrate(db *sql.DB) error {
 		return fmt.Errorf("cleaning orphan artist_platform_ids: %w", err)
 	}
 
-	// Issue #1076: dedupe duplicate artist rows mapping to the same
+	// dedupe duplicate artist rows mapping to the same
 	// (connection_id, platform_artist_id) pair before enforcing the unique
 	// index. Goose only ever runs 001 once per DB, so the index added in
 	// 001_initial_schema.sql does not appear on databases that already
@@ -64,7 +66,7 @@ func Migrate(db *sql.DB) error {
 		return fmt.Errorf("ensuring artist_platform_ids unique constraint: %w", err)
 	}
 
-	// Issue #1078 follow-on: rule_results.violation_id FK is ON DELETE SET
+	// rule_results.violation_id FK is ON DELETE SET
 	// NULL, so every rule_violations DELETE scans rule_results without an
 	// index. Now that foreign key enforcement is actually on, that scan
 	// shows up in the query-plan regression test. Create the index
@@ -74,7 +76,7 @@ func Migrate(db *sql.DB) error {
 		return fmt.Errorf("ensuring rule_results.violation_id index: %w", err)
 	}
 
-	// Issue #699: seed rule_results rows for every open / pending_choice
+	// seed rule_results rows for every open / pending_choice
 	// violation already in the database. Without this, pre-existing
 	// violations would have a missing first_failed_at until the next
 	// pipeline pass re-evaluated the artist, losing the "how long has
@@ -85,7 +87,7 @@ func Migrate(db *sql.DB) error {
 		return fmt.Errorf("backfilling rule_results from violations: %w", err)
 	}
 
-	// Issue #1004: artists become M:N with libraries via artist_libraries.
+	// artists become M:N with libraries via artist_libraries.
 	// On fresh installs this only ensures the table exists (001 already has
 	// it). On pre-1004 DBs this also backfills memberships from the orphan
 	// artists.library_id column and collapses legacy duplicate artist rows
@@ -155,7 +157,7 @@ func ensureConnectionColumns(db *sql.DB) error {
 // cleanupOrphanArtistPlatformIDs removes rows from artist_platform_ids whose
 // artist_id or connection_id no longer reference an existing row. Such rows
 // should be impossible given the ON DELETE CASCADE foreign keys, but issue
-// #1078 caught real orphans in the wild -- presumably from a delete path that
+// Earlier audits caught real orphans in the wild -- presumably from a delete path that
 // ran without PRAGMA foreign_keys=ON, or from raw SQL bypassing the
 // repository. Running this on every startup is idempotent and cheap.
 func cleanupOrphanArtistPlatformIDs(db *sql.DB) error {
@@ -163,7 +165,7 @@ func cleanupOrphanArtistPlatformIDs(db *sql.DB) error {
 	res, err := db.ExecContext(ctx, `
 		DELETE FROM artist_platform_ids
 		WHERE artist_id NOT IN (SELECT id FROM artists)
-		   OR connection_id NOT IN (SELECT id FROM connections)
+		 OR connection_id NOT IN (SELECT id FROM connections)
 	`)
 	if err != nil {
 		return fmt.Errorf("deleting orphan artist_platform_ids: %w", err)
@@ -179,7 +181,7 @@ func cleanupOrphanArtistPlatformIDs(db *sql.DB) error {
 
 // ensureArtistPlatformIDsUnique collapses duplicate platform mapping rows
 // that share the same (connection_id, platform_artist_id) pair, then creates
-// the UNIQUE index that prevents future duplicates. Issue #1076 documented
+// the UNIQUE index that prevents future duplicates. documented
 // the scenario: scanner and import paths could each create a mapping row for
 // the same Emby/Jellyfin item, race to claim the platform id, and produce
 // inconsistent server-side lock state.
@@ -301,12 +303,12 @@ func ensureArtistPlatformIDsUnique(db *sql.DB) error {
 // migrated DB it is a fast no-op.
 //
 // The collapse step picks a canonical artist per duplicate group as follows:
-//  1. Group by MusicBrainz ID when present (strongest identity).
-//  2. Group by LOWER(name) for rows without an MBID, excluding any artist
-//     already claimed by an MBID group.
-//  3. Within each group, prefer the row whose library is filesystem-sourced
-//     (or whose library_id is null and so represents the canonical
-//     filesystem-only path); tie-break by oldest created_at, then artist id.
+// 1. Group by MusicBrainz ID when present (strongest identity).
+// 2. Group by LOWER(name) for rows without an MBID, excluding any artist
+// already claimed by an MBID group.
+// 3. Within each group, prefer the row whose library is filesystem-sourced
+// (or whose library_id is null and so represents the canonical
+// filesystem-only path); tie-break by oldest created_at, then artist id.
 //
 // Re-pointing FK rows to the canonical artist uses INSERT OR IGNORE for
 // composite-PK / unique-indexed tables (the canonical row's existing entry
@@ -319,17 +321,22 @@ func ensureArtistLibrariesMembership(db *sql.DB) error {
 	logger := slog.Default().With("component", "database")
 
 	// Step 1: idempotent table + index. 001 has these for fresh installs;
-	// pre-1004 DBs need them at startup.
+	// pre-1004 DBs need them at startup. The CHECK constraint includes
+	// 'lidarr' (later addition); rebuildArtistLibrariesIfStaleCheck
+	// detects an old shape (no lidarr) and rewrites the table in place.
 	if _, err := db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS artist_libraries (
-			artist_id  TEXT NOT NULL REFERENCES artists(id)   ON DELETE CASCADE,
+			artist_id TEXT NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
 			library_id TEXT NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
-			source     TEXT NOT NULL CHECK (source IN ('filesystem','emby','jellyfin','manual')),
-			added_at   TEXT NOT NULL DEFAULT (datetime('now')),
+			source TEXT NOT NULL CHECK (source IN ('filesystem','emby','jellyfin','lidarr','manual')),
+			added_at TEXT NOT NULL DEFAULT (datetime('now')),
 			PRIMARY KEY (artist_id, library_id)
 		)
 	`); err != nil {
 		return fmt.Errorf("ensuring artist_libraries table: %w", err)
+	}
+	if err := rebuildArtistLibrariesIfStaleCheck(ctx, db); err != nil {
+		return fmt.Errorf("rebuilding artist_libraries with current CHECK: %w", err)
 	}
 	if _, err := db.ExecContext(ctx, `
 		CREATE INDEX IF NOT EXISTS idx_artist_libraries_library
@@ -354,7 +361,7 @@ func ensureArtistLibrariesMembership(db *sql.DB) error {
 			a.id,
 			a.library_id,
 			CASE
-				WHEN c.type = 'emby'     THEN 'emby'
+				WHEN c.type = 'emby' THEN 'emby'
 				WHEN c.type = 'jellyfin' THEN 'jellyfin'
 				ELSE 'filesystem'
 			END,
@@ -439,7 +446,7 @@ func collapseDuplicateArtists(ctx context.Context, db *sql.DB, logger *slog.Logg
 				?,
 				a.library_id,
 				CASE
-					WHEN c.type = 'emby'     THEN 'emby'
+					WHEN c.type = 'emby' THEN 'emby'
 					WHEN c.type = 'jellyfin' THEN 'jellyfin'
 					ELSE 'filesystem'
 				END,
@@ -448,7 +455,7 @@ func collapseDuplicateArtists(ctx context.Context, db *sql.DB, logger *slog.Logg
 			JOIN libraries l ON l.id = a.library_id
 			LEFT JOIN connections c ON c.id = l.connection_id
 			WHERE a.id IN (%s)
-			  AND a.library_id IS NOT NULL AND a.library_id != ''
+			 AND a.library_id IS NOT NULL AND a.library_id != ''
 		`, placeholders)
 		if _, err := tx.ExecContext(ctx, insertSQL, args...); err != nil {
 			return fmt.Errorf("inserting loser memberships under canonical=%s: %w",
@@ -472,7 +479,7 @@ func collapseDuplicateArtists(ctx context.Context, db *sql.DB, logger *slog.Logg
 		return fmt.Errorf("commit collapse tx: %w", err)
 	}
 
-	logger.Info("collapsed duplicate artist rows (issue #1004)",
+	logger.Info("collapsed duplicate artist rows",
 		"groups", len(allGroups),
 		"repointed_rows", totalRepointed,
 		"removed_artists", totalRemoved,
@@ -497,13 +504,13 @@ WITH ranked AS (
 		a.created_at,
 		CASE
 			WHEN a.library_id IS NULL OR a.library_id = '' THEN 0
-			WHEN c.type IS NULL                         THEN 1
+			WHEN c.type IS NULL THEN 1
 			ELSE 2
 		END AS source_rank
 	FROM artists a
 	LEFT JOIN artist_provider_ids ap
 		ON ap.artist_id = a.id AND ap.provider = 'musicbrainz'
-	LEFT JOIN libraries   l ON l.id = a.library_id
+	LEFT JOIN libraries l ON l.id = a.library_id
 	LEFT JOIN connections c ON c.id = l.connection_id
 )
 `
@@ -516,7 +523,7 @@ func findDuplicateGroupsByMBID(ctx context.Context, db *sql.DB) ([]collapseGroup
 		SELECT id, mbid, source_rank, created_at
 		FROM ranked
 		WHERE mbid != ''
-		  AND mbid IN (
+		 AND mbid IN (
 			SELECT mbid FROM ranked
 			WHERE mbid != ''
 			GROUP BY mbid HAVING COUNT(*) > 1
@@ -687,7 +694,7 @@ func repointArtistFKs(ctx context.Context, tx *sql.Tx, canonical string, losers 
 	// artist is deleted.
 	//
 	// artist_platform_ids is here (not in insertOrIgnore) because of the
-	// UNIQUE (connection_id, platform_artist_id) added by issue #1076.
+	// UNIQUE (connection_id, platform_artist_id) added in a prior change.
 	// Moving the loser's row onto canonical preserves the platform mapping
 	// when canonical does not yet have one for the same connection.
 	updateOrIgnore := []string{
@@ -732,6 +739,64 @@ func repointArtistFKs(ctx context.Context, tx *sql.Tx, canonical string, losers 
 	}
 
 	return total, nil
+}
+
+// rebuildArtistLibrariesIfStaleCheck detects pre-existing artist_libraries
+// tables whose CHECK constraint predates the addition of 'lidarr' as a
+// permitted source value and rewrites them in place.
+// SQLite does not support ALTER ... DROP CHECK, so we do the standard
+// rebuild dance: create a temp table with the current shape, copy data
+// across, drop the old, rename. Idempotent: when the existing CHECK
+// already matches, this is a fast no-op.
+func rebuildArtistLibrariesIfStaleCheck(ctx context.Context, db *sql.DB) error {
+	var sqlText sql.NullString
+	if err := db.QueryRowContext(ctx,
+		`SELECT sql FROM sqlite_master WHERE type='table' AND name='artist_libraries'`).Scan(&sqlText); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("reading artist_libraries CREATE: %w", err)
+	}
+	if !sqlText.Valid || strings.Contains(sqlText.String, "'lidarr'") {
+		return nil
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin rebuild tx: %w", err)
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.ExecContext(ctx, `
+		CREATE TABLE artist_libraries_new (
+			artist_id TEXT NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+			library_id TEXT NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+			source TEXT NOT NULL CHECK (source IN ('filesystem','emby','jellyfin','lidarr','manual')),
+			added_at TEXT NOT NULL DEFAULT (datetime('now')),
+			PRIMARY KEY (artist_id, library_id)
+		)
+	`); err != nil {
+		return fmt.Errorf("creating artist_libraries_new: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO artist_libraries_new (artist_id, library_id, source, added_at)
+		SELECT artist_id, library_id, source, added_at FROM artist_libraries
+	`); err != nil {
+		return fmt.Errorf("copying artist_libraries rows: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DROP TABLE artist_libraries`); err != nil {
+		return fmt.Errorf("dropping old artist_libraries: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE artist_libraries_new RENAME TO artist_libraries`); err != nil {
+		return fmt.Errorf("renaming artist_libraries_new: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit rebuild: %w", err)
+	}
+	slog.Default().With("component", "database").Info(
+		"rebuilt artist_libraries table to refresh CHECK constraint")
+	return nil
 }
 
 // columnExists returns true if the named column is present on the table.

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -640,6 +640,107 @@ func TestCollapseDuplicatesPreferMBIDOverName(t *testing.T) {
 	}
 }
 
+// TestCollapseDuplicates_FKDisabledExplicitChildCleanup covers the
+// startup ordering where collapseDuplicateArtists runs BEFORE
+// EnableForeignKeys turns SQLite FK enforcement on. The collapse code
+// has an explicit per-table DELETE that defends against FK-OFF (where
+// ON DELETE CASCADE would not fire and child rows would survive as
+// orphans pointing at the deleted loser artist).
+//
+// openMigratedDB enables FKs eagerly, so the rest of the suite can
+// rely on cascade rather than the explicit cleanup. This test
+// deliberately bypasses that helper and uses the FK-OFF startup shape
+// the production migration path actually runs under.
+func TestCollapseDuplicates_FKDisabledExplicitChildCleanup(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("opening db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if err := Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	// IMPORTANT: do NOT call EnableForeignKeys yet. We are simulating
+	// the startup window in which collapseDuplicateArtists runs, so
+	// CASCADE must not fire and the explicit child cleanup is the only
+	// thing keeping orphans from surviving.
+	ctx := context.Background()
+
+	seedLibrary(t, db, "lib-fs", "filesystem", "")
+	seedArtistWithLibrary(t, db, "a-keep", "Cher", "lib-fs", "2026-01-01T00:00:00Z")
+	seedArtistWithLibrary(t, db, "a-loser", "Cher", "lib-fs", "2026-01-02T00:00:00Z")
+
+	// Both rows share an MBID -> same group, a-keep wins on created_at.
+	for _, aid := range []string{"a-keep", "a-loser"} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
+			VALUES (?, 'musicbrainz', 'mbid-fk-test', datetime('now'))
+		`, aid); err != nil {
+			t.Fatalf("seeding mb id %s: %v", aid, err)
+		}
+	}
+
+	// Seed a dependent rule_violations row on the loser. With FK
+	// enforcement ON, deleting the loser would CASCADE this away.
+	// With FK enforcement OFF (this test), only the explicit per-table
+	// DELETE in collapseDuplicateArtists can prevent it from becoming
+	// an orphan.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO rules (id, name, category, enabled, automation_mode, created_at, updated_at)
+		VALUES ('rule-1', 'Test Rule', 'integrity', 1, 'manual',
+			datetime('now'), datetime('now'))
+	`); err != nil {
+		t.Fatalf("seeding rule: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO rule_violations (id, rule_id, artist_id, artist_name, message, created_at)
+		VALUES ('rv-1', 'rule-1', 'a-loser', 'Cher', 'test', datetime('now'))
+	`); err != nil {
+		t.Fatalf("seeding rule_violations: %v", err)
+	}
+
+	// Run the collapse path the production migrate startup uses.
+	if err := ensureArtistLibrariesMembership(db); err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+
+	// a-loser should be gone, a-keep should survive.
+	var keepN, loserN int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artists WHERE id = 'a-keep'`).Scan(&keepN); err != nil {
+		t.Fatalf("count keeper: %v", err)
+	}
+	if keepN != 1 {
+		t.Errorf("canonical artist count = %d, want 1", keepN)
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artists WHERE id = 'a-loser'`).Scan(&loserN); err != nil {
+		t.Fatalf("count loser: %v", err)
+	}
+	if loserN != 0 {
+		t.Errorf("loser count = %d, want 0", loserN)
+	}
+
+	// Critical assertion: rule_violations row pointing at a-loser must
+	// NOT survive even though FK CASCADE was disabled when the collapse
+	// ran. Without the explicit child-cleanup DELETE in
+	// collapseDuplicateArtists, this row would still be present.
+	var orphanN int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM rule_violations WHERE artist_id = 'a-loser'`).Scan(&orphanN); err != nil {
+		t.Fatalf("count orphans: %v", err)
+	}
+	if orphanN != 0 {
+		t.Errorf("orphaned rule_violations rows for a-loser = %d, want 0 (explicit child cleanup must run when FKs are off)", orphanN)
+	}
+
+	// Sanity: turning FK on after the collapse should not surface
+	// any deferred constraint violations either.
+	if err := EnableForeignKeys(db); err != nil {
+		t.Errorf("EnableForeignKeys after collapse: %v", err)
+	}
+}
+
 // TestCollapseDuplicates_CreatedAtMixedFormatsPickEarliest covers the
 // pickCanonicalCTE datetime normalization. The artists table contains
 // rows in two formats in the wild: SQLite's "YYYY-MM-DD HH:MM:SS" written

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -51,7 +51,7 @@ func seedArtist(t *testing.T, db *sql.DB, id, name string) {
 
 // TestArtistPlatformIDsCascadeOnArtistDelete verifies that deleting an artist
 // row removes its artist_platform_ids row via ON DELETE CASCADE. This is the
-// regression test called for in issue #1078.
+// regression test called for in
 func TestArtistPlatformIDsCascadeOnArtistDelete(t *testing.T) {
 	db := openMigratedDB(t)
 	ctx := context.Background()
@@ -80,7 +80,7 @@ func TestArtistPlatformIDsCascadeOnArtistDelete(t *testing.T) {
 	}
 }
 
-// TestArtistPlatformIDsUniqueConstraint covers issue #1076: inserting two
+// TestArtistPlatformIDsUniqueConstraint covers inserting two
 // rows with the same (connection_id, platform_artist_id) must be rejected
 // by the UNIQUE index, regardless of artist_id.
 func TestArtistPlatformIDsUniqueConstraint(t *testing.T) {
@@ -206,7 +206,7 @@ func TestEnsureArtistPlatformIDsUnique_DedupesExisting(t *testing.T) {
 	}
 }
 
-// TestCleanupOrphanArtistPlatformIDs covers the safety net for issue #1078.
+// TestCleanupOrphanArtistPlatformIDs covers the safety net for
 // Insert a row with foreign keys disabled (mimicking the suspected legacy
 // path), then run the cleanup and assert the orphan is gone.
 func TestCleanupOrphanArtistPlatformIDs(t *testing.T) {
@@ -304,7 +304,7 @@ func seedConnectionWithType(t *testing.T, db *sql.DB, id, connType string) {
 // TestArtistLibrariesBackfillFromOrphanColumn verifies that the migration
 // reads the legacy artists.library_id column and creates a matching
 // artist_libraries membership row, with source derived from the library's
-// connection type. Issue #1004.
+// connection type.
 func TestArtistLibrariesBackfillFromOrphanColumn(t *testing.T) {
 	db := openMigratedDB(t)
 	ctx := context.Background()
@@ -366,12 +366,10 @@ func TestArtistLibrariesBackfillFromOrphanColumn(t *testing.T) {
 
 // TestCollapseDuplicatesByMBID seeds two artist rows with the same MBID under
 // different libraries (filesystem + emby) and asserts the migration:
-//   - keeps the filesystem row as canonical
-//   - re-points the loser's artist_provider_ids and other FK rows
-//   - inserts a membership row for the loser's library under the canonical
-//   - deletes the loser artist row
-//
-// Issue #1004 architectural fix.
+// - keeps the filesystem row as canonical
+// - re-points the loser's artist_provider_ids and other FK rows
+// - inserts a membership row for the loser's library under the canonical
+// - deletes the loser artist row
 func TestCollapseDuplicatesByMBID(t *testing.T) {
 	db := openMigratedDB(t)
 	ctx := context.Background()
@@ -515,12 +513,12 @@ func TestCollapseDuplicatesByName(t *testing.T) {
 
 // TestCollapseDuplicatesPreservesPlatformMappings covers the regression
 // caught during UAT: artist_platform_ids has a secondary UNIQUE on
-// (connection_id, platform_artist_id) added in #1076. The original collapse
+// (connection_id, platform_artist_id). The original collapse
 // helper used INSERT OR IGNORE to move the loser's mapping onto canonical,
 // which the unique index rejected, and the loser cascade-delete then dropped
 // the mapping entirely. UPDATE OR IGNORE on the artist_id column moves the
 // loser row onto canonical and only drops the row when canonical already
-// has a mapping for the same connection. Issue #1004.
+// has a mapping for the same connection.
 func TestCollapseDuplicatesPreservesPlatformMappings(t *testing.T) {
 	db := openMigratedDB(t)
 	ctx := context.Background()

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -598,11 +598,16 @@ func TestCollapseDuplicatesPreferMBIDOverName(t *testing.T) {
 	seedLibrary(t, db, "lib-fs", "filesystem", "")
 	seedLibrary(t, db, "lib-emby", "import", "conn-emby")
 
-	// Two artists with same MBID -> grouped by MBID. Both happen to have
-	// names that also match a third unrelated artist; the MBID group claims
-	// them both, so the third artist must NOT be folded into a name group.
+	// Two artists with same MBID -> grouped by MBID. A third "Cher" with no
+	// MBID exists on a different library; it must NOT be folded into either
+	// group because (a) it has no MBID to match the MBID group, and (b) the
+	// name-precedence branch excludes any artist already claimed by an MBID
+	// group. Without this third row the test passes even when the
+	// `claimed` filtering in findDuplicateGroupsByName is broken.
+	seedLibrary(t, db, "lib-other", "filesystem", "")
 	seedArtistWithLibrary(t, db, "a-fs", "Cher", "lib-fs", "2026-01-01T00:00:00Z")
 	seedArtistWithLibrary(t, db, "a-emby", "Cher", "lib-emby", "2026-01-02T00:00:00Z")
+	seedArtistWithLibrary(t, db, "a-other", "Cher", "lib-other", "2026-01-03T00:00:00Z")
 	for _, aid := range []string{"a-fs", "a-emby"} {
 		if _, err := db.ExecContext(ctx, `
 			INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
@@ -616,12 +621,21 @@ func TestCollapseDuplicatesPreferMBIDOverName(t *testing.T) {
 		t.Fatalf("collapse: %v", err)
 	}
 
-	// One Cher remains (a-fs canonical).
+	// Two Chers remain: the MBID group's canonical (a-fs) and the
+	// MBID-less standalone (a-other) which name-precedence must leave alone.
 	var n int
 	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artists WHERE name = 'Cher'`).Scan(&n); err != nil {
 		t.Fatalf("count: %v", err)
 	}
-	if n != 1 {
-		t.Errorf("Cher count = %d, want 1", n)
+	if n != 2 {
+		t.Errorf("Cher count = %d, want 2 (canonical + MBID-less standalone)", n)
+	}
+	// The MBID-less Cher must survive specifically.
+	var stillThere int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artists WHERE id = 'a-other'`).Scan(&stillThere); err != nil {
+		t.Fatalf("count a-other: %v", err)
+	}
+	if stillThere != 1 {
+		t.Errorf("a-other survived = %d, want 1 (MBID-less row must not be folded into MBID group)", stillThere)
 	}
 }

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -639,3 +639,52 @@ func TestCollapseDuplicatesPreferMBIDOverName(t *testing.T) {
 		t.Errorf("a-other survived = %d, want 1 (MBID-less row must not be folded into MBID group)", stillThere)
 	}
 }
+
+// TestCollapseDuplicates_CreatedAtMixedFormatsPickEarliest covers the
+// pickCanonicalCTE datetime normalization. The artists table contains
+// rows in two formats in the wild: SQLite's "YYYY-MM-DD HH:MM:SS" written
+// by older code, and RFC3339 "YYYY-MM-DDTHH:MM:SSZ" written by newer Go
+// callers. Without `datetime()` normalization, lexical TEXT ordering
+// would treat 'T' (0x54) > ' ' (0x20), so a 2026-01-01T00:00:00Z RFC3339
+// row would sort AFTER a 2026-02-01 00:00:00 SQLite row even though it
+// is chronologically earlier. The canonical-pick rule is "lowest
+// (source_rank, created_at, id) wins", so the wrong winner could be
+// chosen on real-world DBs whose history mixes both formats.
+func TestCollapseDuplicates_CreatedAtMixedFormatsPickEarliest(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	seedLibrary(t, db, "lib-fs", "filesystem", "")
+
+	// Two filesystem rows with the same MBID, identical source_rank.
+	// Tie-breaker is created_at_norm, then id. Format mismatch:
+	//   a-rfc:    2026-01-01T00:00:00Z (RFC3339, chronologically earliest)
+	//   a-sqlite: 2026-02-01 00:00:00  (SQLite text, chronologically later)
+	// Lexically: 'T' > ' ', so without datetime() the SQLite row sorts
+	// first and would be picked as canonical -- the wrong answer.
+	seedArtistWithLibrary(t, db, "a-rfc", "TwinPeaks", "lib-fs", "2026-01-01T00:00:00Z")
+	seedArtistWithLibrary(t, db, "a-sqlite", "TwinPeaks", "lib-fs", "2026-02-01 00:00:00")
+	for _, aid := range []string{"a-rfc", "a-sqlite"} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
+			VALUES (?, 'musicbrainz', 'mbid-twinpeaks', datetime('now'))
+		`, aid); err != nil {
+			t.Fatalf("seeding mb id %s: %v", aid, err)
+		}
+	}
+
+	if err := ensureArtistLibrariesMembership(db); err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+
+	// The chronologically earliest row (a-rfc, January) must survive as
+	// canonical; the later row (a-sqlite, February) must be the loser.
+	var survivor string
+	if err := db.QueryRowContext(ctx,
+		`SELECT id FROM artists WHERE name = 'TwinPeaks'`).Scan(&survivor); err != nil {
+		t.Fatalf("query survivor: %v", err)
+	}
+	if survivor != "a-rfc" {
+		t.Errorf("canonical = %q, want a-rfc (chronologically earliest after datetime() normalization)", survivor)
+	}
+}

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -513,6 +513,82 @@ func TestCollapseDuplicatesByName(t *testing.T) {
 	}
 }
 
+// TestCollapseDuplicatesPreservesPlatformMappings covers the regression
+// caught during UAT: artist_platform_ids has a secondary UNIQUE on
+// (connection_id, platform_artist_id) added in #1076. The original collapse
+// helper used INSERT OR IGNORE to move the loser's mapping onto canonical,
+// which the unique index rejected, and the loser cascade-delete then dropped
+// the mapping entirely. UPDATE OR IGNORE on the artist_id column moves the
+// loser row onto canonical and only drops the row when canonical already
+// has a mapping for the same connection. Issue #1004.
+func TestCollapseDuplicatesPreservesPlatformMappings(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	seedConnectionWithType(t, db, "conn-emby", "emby")
+	seedConnectionWithType(t, db, "conn-jelly", "jellyfin")
+	seedLibrary(t, db, "lib-fs", "filesystem", "")
+	seedLibrary(t, db, "lib-emby", "import", "conn-emby")
+	seedLibrary(t, db, "lib-jelly", "import", "conn-jelly")
+
+	seedArtistWithLibrary(t, db, "a-fs", "12 Stones", "lib-fs", "2026-01-01T00:00:00Z")
+	seedArtistWithLibrary(t, db, "a-emby", "12 Stones", "lib-emby", "2026-01-02T00:00:00Z")
+	seedArtistWithLibrary(t, db, "a-jelly", "12 Stones", "lib-jelly", "2026-01-03T00:00:00Z")
+	for _, aid := range []string{"a-fs", "a-emby", "a-jelly"} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
+			VALUES (?, 'musicbrainz', 'mbid-12-stones', datetime('now'))
+		`, aid); err != nil {
+			t.Fatalf("seed mbid for %s: %v", aid, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id, created_at, updated_at)
+		VALUES ('a-emby', 'conn-emby', 'emby-12s-id',
+			strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+	`); err != nil {
+		t.Fatalf("seed emby mapping: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id, created_at, updated_at)
+		VALUES ('a-jelly', 'conn-jelly', 'jelly-12s-id',
+			strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+	`); err != nil {
+		t.Fatalf("seed jellyfin mapping: %v", err)
+	}
+
+	if err := ensureArtistLibrariesMembership(db); err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+
+	var n int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artists`).Scan(&n); err != nil {
+		t.Fatalf("count artists: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("artist count after collapse = %d, want 1", n)
+	}
+
+	want := map[string]string{
+		"conn-emby":  "emby-12s-id",
+		"conn-jelly": "jelly-12s-id",
+	}
+	for connID, expectPID := range want {
+		var got string
+		err := db.QueryRowContext(ctx, `
+			SELECT platform_artist_id FROM artist_platform_ids
+			WHERE artist_id = 'a-fs' AND connection_id = ?
+		`, connID).Scan(&got)
+		if err != nil {
+			t.Errorf("missing %s mapping on canonical: %v", connID, err)
+			continue
+		}
+		if got != expectPID {
+			t.Errorf("%s mapping = %q, want %q", connID, got, expectPID)
+		}
+	}
+}
+
 // TestCollapseDuplicatesPreferMBIDOverName covers the precedence rule: an
 // artist already claimed by an MBID group is excluded from name-based
 // grouping, even if its name matches another row.

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -256,3 +256,298 @@ func TestCleanupOrphanArtistPlatformIDs(t *testing.T) {
 		t.Errorf("good row count = %d, want 1", n)
 	}
 }
+
+// seedLibrary inserts a libraries row with the given id, source, and optional
+// connection_id. source is one of 'filesystem' | 'manual' | a platform name.
+func seedLibrary(t *testing.T, db *sql.DB, id, source, connID string) {
+	t.Helper()
+	var connArg interface{}
+	if connID != "" {
+		connArg = connID
+	}
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
+		VALUES (?, ?, '/music', 'regular', ?, ?, datetime('now'), datetime('now'))
+	`, id, "lib-"+id, source, connArg)
+	if err != nil {
+		t.Fatalf("seeding library %s: %v", id, err)
+	}
+}
+
+// seedArtistWithLibrary inserts an artist tied to a specific library_id
+// (legacy path that the M:N migration backfills from). created_at lets the
+// test control the canonical-pick tie-breaker.
+func seedArtistWithLibrary(t *testing.T, db *sql.DB, id, name, libraryID, createdAt string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO artists (id, name, sort_name, path, library_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+	`, id, name, name, "/music/"+name, libraryID, createdAt)
+	if err != nil {
+		t.Fatalf("seeding artist %s: %v", id, err)
+	}
+}
+
+// seedConnectionWithType inserts a connection row with an explicit type so
+// the migration can derive the membership source ('emby' | 'jellyfin' | ...).
+func seedConnectionWithType(t *testing.T, db *sql.DB, id, connType string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), `
+		INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
+		VALUES (?, ?, ?, 'http://t', 'k', 1, 'ok', datetime('now'), datetime('now'))
+	`, id, "Conn-"+id, connType)
+	if err != nil {
+		t.Fatalf("seeding connection %s: %v", id, err)
+	}
+}
+
+// TestArtistLibrariesBackfillFromOrphanColumn verifies that the migration
+// reads the legacy artists.library_id column and creates a matching
+// artist_libraries membership row, with source derived from the library's
+// connection type. Issue #1004.
+func TestArtistLibrariesBackfillFromOrphanColumn(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	seedConnectionWithType(t, db, "conn-emby", "emby")
+	seedConnectionWithType(t, db, "conn-jelly", "jellyfin")
+	seedLibrary(t, db, "lib-fs", "filesystem", "")
+	seedLibrary(t, db, "lib-emby", "import", "conn-emby")
+	seedLibrary(t, db, "lib-jelly", "import", "conn-jelly")
+
+	seedArtistWithLibrary(t, db, "a-fs", "Artist FS", "lib-fs", "2026-01-01T00:00:00Z")
+	seedArtistWithLibrary(t, db, "a-emby", "Artist Emby", "lib-emby", "2026-01-02T00:00:00Z")
+	seedArtistWithLibrary(t, db, "a-jelly", "Artist Jelly", "lib-jelly", "2026-01-03T00:00:00Z")
+
+	// Re-run membership backfill (Migrate already ran during openMigratedDB,
+	// but those artists were inserted after; rerun is idempotent and applies
+	// the new rows).
+	if err := ensureArtistLibrariesMembership(db); err != nil {
+		t.Fatalf("ensureArtistLibrariesMembership: %v", err)
+	}
+
+	cases := []struct {
+		artist, library, source string
+	}{
+		{"a-fs", "lib-fs", "filesystem"},
+		{"a-emby", "lib-emby", "emby"},
+		{"a-jelly", "lib-jelly", "jellyfin"},
+	}
+	for _, c := range cases {
+		var got string
+		err := db.QueryRowContext(ctx, `
+			SELECT source FROM artist_libraries
+			WHERE artist_id = ? AND library_id = ?
+		`, c.artist, c.library).Scan(&got)
+		if err != nil {
+			t.Errorf("missing membership for %s/%s: %v", c.artist, c.library, err)
+			continue
+		}
+		if got != c.source {
+			t.Errorf("source for %s/%s = %q, want %q", c.artist, c.library, got, c.source)
+		}
+	}
+
+	// Idempotency: running it again must not error or create extra rows.
+	var before, after int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artist_libraries`).Scan(&before); err != nil {
+		t.Fatalf("count before: %v", err)
+	}
+	if err := ensureArtistLibrariesMembership(db); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artist_libraries`).Scan(&after); err != nil {
+		t.Fatalf("count after: %v", err)
+	}
+	if after != before {
+		t.Errorf("idempotent run changed row count: before=%d after=%d", before, after)
+	}
+}
+
+// TestCollapseDuplicatesByMBID seeds two artist rows with the same MBID under
+// different libraries (filesystem + emby) and asserts the migration:
+//   - keeps the filesystem row as canonical
+//   - re-points the loser's artist_provider_ids and other FK rows
+//   - inserts a membership row for the loser's library under the canonical
+//   - deletes the loser artist row
+//
+// Issue #1004 architectural fix.
+func TestCollapseDuplicatesByMBID(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	seedConnectionWithType(t, db, "conn-emby", "emby")
+	seedLibrary(t, db, "lib-fs", "filesystem", "")
+	seedLibrary(t, db, "lib-emby", "import", "conn-emby")
+
+	// Filesystem row is older + filesystem-source -> wins canonical.
+	seedArtistWithLibrary(t, db, "a-fs", "12 Stones", "lib-fs", "2026-01-01T00:00:00Z")
+	// Emby row is the would-be loser.
+	seedArtistWithLibrary(t, db, "a-emby", "12 Stones", "lib-emby", "2026-01-02T00:00:00Z")
+
+	// Both rows carry the same MBID via artist_provider_ids.
+	const mbid = "abcd-1234"
+	for _, aid := range []string{"a-fs", "a-emby"} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
+			VALUES (?, 'musicbrainz', ?, datetime('now'))
+		`, aid, mbid); err != nil {
+			t.Fatalf("seeding mb provider id for %s: %v", aid, err)
+		}
+	}
+	// Loser also has an alias the canonical doesn't.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artist_aliases (id, artist_id, alias, source) VALUES ('al-1', 'a-emby', 'Twelve Stones', 'emby')
+	`); err != nil {
+		t.Fatalf("seeding alias: %v", err)
+	}
+
+	if err := ensureArtistLibrariesMembership(db); err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+
+	// Canonical artist remains.
+	var canonical int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artists WHERE id = 'a-fs'`).Scan(&canonical); err != nil {
+		t.Fatalf("count canonical: %v", err)
+	}
+	if canonical != 1 {
+		t.Errorf("canonical artist count = %d, want 1", canonical)
+	}
+
+	// Loser artist gone.
+	var loser int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artists WHERE id = 'a-emby'`).Scan(&loser); err != nil {
+		t.Fatalf("count loser: %v", err)
+	}
+	if loser != 0 {
+		t.Errorf("loser artist count = %d, want 0", loser)
+	}
+
+	// Canonical now has memberships in both libraries.
+	wantMemberships := map[string]string{
+		"lib-fs":   "filesystem",
+		"lib-emby": "emby",
+	}
+	for libID, wantSrc := range wantMemberships {
+		var got string
+		err := db.QueryRowContext(ctx, `
+			SELECT source FROM artist_libraries
+			WHERE artist_id = 'a-fs' AND library_id = ?
+		`, libID).Scan(&got)
+		if err != nil {
+			t.Errorf("missing canonical membership in %s: %v", libID, err)
+			continue
+		}
+		if got != wantSrc {
+			t.Errorf("source for canonical/%s = %q, want %q", libID, got, wantSrc)
+		}
+	}
+
+	// Loser's alias re-pointed to canonical.
+	var aliasArtist string
+	if err := db.QueryRowContext(ctx, `SELECT artist_id FROM artist_aliases WHERE id = 'al-1'`).Scan(&aliasArtist); err != nil {
+		t.Fatalf("query alias: %v", err)
+	}
+	if aliasArtist != "a-fs" {
+		t.Errorf("alias re-pointed to %q, want a-fs", aliasArtist)
+	}
+
+	// Idempotent: second run finds no duplicates and changes nothing.
+	if err := ensureArtistLibrariesMembership(db); err != nil {
+		t.Fatalf("idempotent run: %v", err)
+	}
+	var artists int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artists`).Scan(&artists); err != nil {
+		t.Fatalf("artist count: %v", err)
+	}
+	if artists != 1 {
+		t.Errorf("artist count after idempotent run = %d, want 1", artists)
+	}
+}
+
+// TestCollapseDuplicatesByName covers the name-based fallback for rows
+// without an MBID. Case-insensitive matching collapses "VERIDIA" and
+// "Veridia" into one canonical row (filesystem-source wins).
+func TestCollapseDuplicatesByName(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	seedConnectionWithType(t, db, "conn-jelly", "jellyfin")
+	seedLibrary(t, db, "lib-fs", "filesystem", "")
+	seedLibrary(t, db, "lib-jelly", "import", "conn-jelly")
+
+	seedArtistWithLibrary(t, db, "a-fs", "Veridia", "lib-fs", "2026-01-01T00:00:00Z")
+	seedArtistWithLibrary(t, db, "a-jelly", "VERIDIA", "lib-jelly", "2026-01-02T00:00:00Z")
+
+	if err := ensureArtistLibrariesMembership(db); err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+
+	var canonical int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artists`).Scan(&canonical); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if canonical != 1 {
+		t.Errorf("artist count = %d, want 1 (collapsed)", canonical)
+	}
+
+	// Survivor is the filesystem row.
+	var survivor string
+	if err := db.QueryRowContext(ctx, `SELECT id FROM artists`).Scan(&survivor); err != nil {
+		t.Fatalf("survivor: %v", err)
+	}
+	if survivor != "a-fs" {
+		t.Errorf("survivor = %q, want a-fs", survivor)
+	}
+
+	// Survivor has both library memberships.
+	var memberships int
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM artist_libraries WHERE artist_id = 'a-fs'
+	`).Scan(&memberships); err != nil {
+		t.Fatalf("memberships: %v", err)
+	}
+	if memberships != 2 {
+		t.Errorf("memberships = %d, want 2 (lib-fs + lib-jelly)", memberships)
+	}
+}
+
+// TestCollapseDuplicatesPreferMBIDOverName covers the precedence rule: an
+// artist already claimed by an MBID group is excluded from name-based
+// grouping, even if its name matches another row.
+func TestCollapseDuplicatesPreferMBIDOverName(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	seedConnectionWithType(t, db, "conn-emby", "emby")
+	seedLibrary(t, db, "lib-fs", "filesystem", "")
+	seedLibrary(t, db, "lib-emby", "import", "conn-emby")
+
+	// Two artists with same MBID -> grouped by MBID. Both happen to have
+	// names that also match a third unrelated artist; the MBID group claims
+	// them both, so the third artist must NOT be folded into a name group.
+	seedArtistWithLibrary(t, db, "a-fs", "Cher", "lib-fs", "2026-01-01T00:00:00Z")
+	seedArtistWithLibrary(t, db, "a-emby", "Cher", "lib-emby", "2026-01-02T00:00:00Z")
+	for _, aid := range []string{"a-fs", "a-emby"} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
+			VALUES (?, 'musicbrainz', 'mbid-cher-real', datetime('now'))
+		`, aid); err != nil {
+			t.Fatalf("seeding mb id %s: %v", aid, err)
+		}
+	}
+
+	if err := ensureArtistLibrariesMembership(db); err != nil {
+		t.Fatalf("collapse: %v", err)
+	}
+
+	// One Cher remains (a-fs canonical).
+	var n int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artists WHERE name = 'Cher'`).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Cher count = %d, want 1", n)
+	}
+}

--- a/internal/database/migrations/001_initial_schema.sql
+++ b/internal/database/migrations/001_initial_schema.sql
@@ -218,7 +218,7 @@ CREATE INDEX idx_artists_locked ON artists(locked);
 CREATE TABLE IF NOT EXISTS artist_libraries (
     artist_id  TEXT NOT NULL REFERENCES artists(id)   ON DELETE CASCADE,
     library_id TEXT NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
-    source     TEXT NOT NULL CHECK (source IN ('filesystem','emby','jellyfin','manual')),
+    source     TEXT NOT NULL CHECK (source IN ('filesystem','emby','jellyfin','lidarr','manual')),
     added_at   TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (artist_id, library_id)
 );

--- a/internal/database/migrations/001_initial_schema.sql
+++ b/internal/database/migrations/001_initial_schema.sql
@@ -170,6 +170,11 @@ CREATE TABLE IF NOT EXISTS artists (
     disbanded TEXT NOT NULL DEFAULT '',
     biography TEXT NOT NULL DEFAULT '',
     path TEXT NOT NULL,
+    -- Issue #1004: artists are M:N with libraries via artist_libraries.
+    -- library_id is soft-deprecated: still written by legacy code paths
+    -- during the multi-phase rollout, but membership of record lives in
+    -- artist_libraries. The column will be removed once all readers/writers
+    -- are migrated.
     library_id TEXT REFERENCES libraries(id) DEFAULT NULL,
     nfo_exists INTEGER NOT NULL DEFAULT 0,
     health_score REAL NOT NULL DEFAULT 0.0,
@@ -202,6 +207,23 @@ CREATE INDEX idx_artists_name ON artists(name);
 CREATE INDEX idx_artists_path ON artists(path);
 CREATE INDEX idx_artists_library_id ON artists(library_id);
 CREATE INDEX idx_artists_locked ON artists(locked);
+
+-- Issue #1004: M:N membership of artists in libraries. Replaces the legacy
+-- artists.library_id single-FK column. An artist can be observed by any
+-- number of libraries (filesystem, Emby connection library, Jellyfin
+-- connection library, ...). Source records which scanner/connection first
+-- discovered the membership; useful for debugging and future UI badges.
+-- During the multi-phase rollout artists.library_id remains populated by
+-- legacy writers; this table is the canonical membership record going forward.
+CREATE TABLE IF NOT EXISTS artist_libraries (
+    artist_id  TEXT NOT NULL REFERENCES artists(id)   ON DELETE CASCADE,
+    library_id TEXT NOT NULL REFERENCES libraries(id) ON DELETE CASCADE,
+    source     TEXT NOT NULL CHECK (source IN ('filesystem','emby','jellyfin','manual')),
+    added_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (artist_id, library_id)
+);
+
+CREATE INDEX idx_artist_libraries_library ON artist_libraries(library_id);
 -- Supports the "dirty artist" scan used by incremental Run Rules (issue #698).
 -- The composite index lets SQLite resolve the WHERE clause without scanning
 -- the full table when only a small slice of artists have changed.

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -203,7 +203,7 @@ func (s *Service) ClearConnectionID(ctx context.Context, connectionID string) er
 }
 
 // Delete removes a library by ID. Artists are preserved; their membership
-// rows in artist_libraries cascade-delete via the FK. Issue #1004: this is
+// rows in artist_libraries cascade-delete via the FK. this is
 // the "unlink only" path, where the user wants to disconnect the library
 // but keep the artists (which may still be observed by other libraries).
 //
@@ -301,21 +301,21 @@ func collectUnlinkCandidates(ctx context.Context, tx *sql.Tx, libraryID string) 
 }
 
 // DeleteWithArtists removes a library and prunes artists that have no
-// other home. Issue #1004 redefines this for the M:N model and folds in
-// the legacy connection-orphan handling from issue #1072:
+// other home. Membership-based for the M:N model, with a fallback prune
+// for legacy connection-orphan rows that predate artist_libraries:
 //
-//   - Membership prune (issue #1004): for each artist with a membership
-//     in the deleted library, if zero memberships remain after the
-//     cascade AND zero platform mappings exist, drop the artist row.
-//     Artists with sibling-library memberships or live platform mappings
-//     elsewhere survive.
-//   - Connection-orphan prune (issue #1072 carryover): when the deleted
-//     library was the last library on its connection, also drop artists
-//     whose only platform mapping is on that connection and who had no
-//     library_id assignment. These are pre-#1004 data shapes that the
-//     migration backfill could not see (no library_id to copy from).
-//     The "last library on connection" guard avoids deleting data that a
-//     sibling library still legitimately references.
+// - Membership prune: for each artist with a membership
+// in the deleted library, if zero memberships remain after the
+// cascade AND zero platform mappings exist, drop the artist row.
+// Artists with sibling-library memberships or live platform mappings
+// elsewhere survive.
+// - Connection-orphan prune (carryover): when the deleted
+// library was the last library on its connection, also drop artists
+// whose only platform mapping is on that connection and who had no
+// library_id assignment. These are legacy data shapes that the
+// migration backfill could not see (no library_id to copy from).
+// The "last library on connection" guard avoids deleting data that a
+// sibling library still legitimately references.
 //
 // Order matters: the membership snapshot is taken BEFORE the library
 // delete fires the cascade.
@@ -410,19 +410,19 @@ func (s *Service) DeleteWithArtists(ctx context.Context, id string) error {
 
 	// Connection-orphan sweep for artists never in candidateIDs (no
 	// membership row, no library_id pointer, but a mapping on the
-	// just-unlinked connection). Pre-#1004 #1072 case.
+	// just-unlinked connection). Legacy case.
 	if connOrphanPruneAllowed {
 		if _, err := tx.ExecContext(ctx, `
 			DELETE FROM artists
 			WHERE id IN (
 				SELECT ap.artist_id FROM artist_platform_ids ap
 				WHERE ap.connection_id = ?
-				  AND ap.artist_id NOT IN (
+				 AND ap.artist_id NOT IN (
 					SELECT artist_id FROM artist_libraries
-				  )
-				  AND ap.artist_id NOT IN (
+				 )
+				 AND ap.artist_id NOT IN (
 					SELECT artist_id FROM artist_platform_ids WHERE connection_id != ?
-				  )
+				 )
 			)
 		`, connectionID.String, connectionID.String); err != nil {
 			return fmt.Errorf("sweeping connection-orphan artists: %w", err)

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -411,12 +411,23 @@ func (s *Service) DeleteWithArtists(ctx context.Context, id string) error {
 	// Connection-orphan sweep for artists never in candidateIDs (no
 	// membership row, no library_id pointer, but a mapping on the
 	// just-unlinked connection). Legacy case.
+	//
+	// The COALESCE(a.library_id, '') = '' guard is required during partial
+	// migration: the lines above only cleared library_id pointing at the
+	// library being deleted, so an artist can still legitimately reference
+	// some other surviving library through the legacy column. Without
+	// this guard, a connection-library unlink would silently delete those
+	// artists when their only artist_libraries row had not yet been
+	// backfilled.
 	if connOrphanPruneAllowed {
 		if _, err := tx.ExecContext(ctx, `
 			DELETE FROM artists
 			WHERE id IN (
-				SELECT ap.artist_id FROM artist_platform_ids ap
+				SELECT ap.artist_id
+				FROM artist_platform_ids ap
+				JOIN artists a ON a.id = ap.artist_id
 				WHERE ap.connection_id = ?
+				 AND COALESCE(a.library_id, '') = ''
 				 AND ap.artist_id NOT IN (
 					SELECT artist_id FROM artist_libraries
 				 )

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -202,8 +202,15 @@ func (s *Service) ClearConnectionID(ctx context.Context, connectionID string) er
 	return nil
 }
 
-// Delete removes a library by ID. Any artists referencing the library
-// are dereferenced (library_id set to NULL) before the row is removed.
+// Delete removes a library by ID. Artists are preserved; their membership
+// rows in artist_libraries cascade-delete via the FK. Issue #1004: this is
+// the "unlink only" path, where the user wants to disconnect the library
+// but keep the artists (which may still be observed by other libraries).
+//
+// The legacy artists.library_id column is also cleared for any artist that
+// pointed at the deleted library, so older code paths that still read the
+// orphan column do not see a dangling FK. The column will be removed in
+// the final phase.
 func (s *Service) Delete(ctx context.Context, id string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -211,7 +218,7 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Clear artist references so the foreign key constraint is satisfied.
+	// Soft-deprecation cleanup for the orphan artists.library_id column.
 	if _, err := tx.ExecContext(ctx,
 		`UPDATE artists SET library_id = NULL WHERE library_id = ?`, id); err != nil {
 		return fmt.Errorf("clearing artist references: %w", err)
@@ -243,15 +250,75 @@ func (s *Service) CountArtists(ctx context.Context, libraryID string) (int, erro
 	return count, nil
 }
 
-// DeleteWithArtists removes a library and all artists belonging to it in a
-// single transaction. Child rows (artist_platform_ids, artist_images,
-// artist_aliases, band_members, rule_violations, rule_results, nfo_snapshots,
-// metadata_changes, mb_snapshots, artist_provider_ids) are removed via
-// ON DELETE CASCADE. Issue #1072 also calls for pruning artists that came in
-// from the library's connection but were never assigned a library_id (so a
-// straight WHERE library_id = ? misses them). Those are detected via
-// artist_platform_ids whose connection_id matches the library's connection
-// AND whose artist no longer has any library_id.
+// collectUnlinkCandidates returns the union of artist IDs that hold a
+// membership row in the about-to-be-deleted library and artist IDs whose
+// legacy artists.library_id column points at it. Split out so the rows
+// scopes can use defer (sqlclosecheck-friendly).
+func collectUnlinkCandidates(ctx context.Context, tx *sql.Tx, libraryID string) ([]string, error) {
+	candidates := []string{}
+	seen := make(map[string]bool)
+
+	memberRows, err := tx.QueryContext(ctx,
+		`SELECT artist_id FROM artist_libraries WHERE library_id = ?`, libraryID)
+	if err != nil {
+		return nil, fmt.Errorf("listing memberships for unlink: %w", err)
+	}
+	defer memberRows.Close() //nolint:errcheck
+	for memberRows.Next() {
+		var aid string
+		if err := memberRows.Scan(&aid); err != nil {
+			return nil, fmt.Errorf("scanning membership row: %w", err)
+		}
+		if !seen[aid] {
+			candidates = append(candidates, aid)
+			seen[aid] = true
+		}
+	}
+	if err := memberRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating memberships: %w", err)
+	}
+
+	legacyRows, err := tx.QueryContext(ctx,
+		`SELECT id FROM artists WHERE library_id = ?`, libraryID)
+	if err != nil {
+		return nil, fmt.Errorf("listing legacy library_id artists: %w", err)
+	}
+	defer legacyRows.Close() //nolint:errcheck
+	for legacyRows.Next() {
+		var aid string
+		if err := legacyRows.Scan(&aid); err != nil {
+			return nil, fmt.Errorf("scanning legacy artist row: %w", err)
+		}
+		if !seen[aid] {
+			candidates = append(candidates, aid)
+			seen[aid] = true
+		}
+	}
+	if err := legacyRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating legacy artist rows: %w", err)
+	}
+	return candidates, nil
+}
+
+// DeleteWithArtists removes a library and prunes artists that have no
+// other home. Issue #1004 redefines this for the M:N model and folds in
+// the legacy connection-orphan handling from issue #1072:
+//
+//   - Membership prune (issue #1004): for each artist with a membership
+//     in the deleted library, if zero memberships remain after the
+//     cascade AND zero platform mappings exist, drop the artist row.
+//     Artists with sibling-library memberships or live platform mappings
+//     elsewhere survive.
+//   - Connection-orphan prune (issue #1072 carryover): when the deleted
+//     library was the last library on its connection, also drop artists
+//     whose only platform mapping is on that connection and who had no
+//     library_id assignment. These are pre-#1004 data shapes that the
+//     migration backfill could not see (no library_id to copy from).
+//     The "last library on connection" guard avoids deleting data that a
+//     sibling library still legitimately references.
+//
+// Order matters: the membership snapshot is taken BEFORE the library
+// delete fires the cascade.
 func (s *Service) DeleteWithArtists(ctx context.Context, id string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -259,66 +326,107 @@ func (s *Service) DeleteWithArtists(ctx context.Context, id string) error {
 	}
 	defer tx.Rollback() //nolint:errcheck
 
-	// Look up the library's connection_id so we can prune artists that came
-	// in from this connection but have no library_id assigned. This matches
-	// the issue #1072 expectation that "Delete artists" actually removes
-	// every artist sourced from the unlinked library, including ones whose
-	// library_id was lost in an earlier code path.
 	var connectionID sql.NullString
 	if err := tx.QueryRowContext(ctx,
 		`SELECT connection_id FROM libraries WHERE id = ?`, id).Scan(&connectionID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("library not found: %s", id)
 		}
-		return fmt.Errorf("looking up library connection: %w", err)
+		return fmt.Errorf("looking up library: %w", err)
 	}
 
+	candidateIDs, err := collectUnlinkCandidates(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+
+	// Soft-deprecation cleanup: the orphan artists.library_id FK still
+	// blocks the library delete on legacy / test rows that point at it.
+	// Clear it before the delete; final phase removes the column.
 	if _, err := tx.ExecContext(ctx,
-		`DELETE FROM artists WHERE library_id = ?`, id); err != nil {
-		return fmt.Errorf("deleting library artists: %w", err)
+		`UPDATE artists SET library_id = NULL WHERE library_id = ?`, id); err != nil {
+		return fmt.Errorf("clearing legacy library_id refs: %w", err)
 	}
 
-	// Prune artists that have no library_id and whose only remaining
-	// platform mapping is for this library's connection. These are the
-	// "orphaned references" called out in the bug report. Skip when the
-	// library was not connected to a platform (manual library).
-	//
-	// IMPORTANT: only run the prune when this is the LAST library on the
-	// connection. With sibling libraries still attached, an artist with
-	// library_id IS NULL might legitimately belong to one of those siblings
-	// (e.g. a prior code path lost its library_id but the artist is still
-	// being managed via the connection). Deleting blindly here would erase
-	// data that another linked library still references.
-	if connectionID.Valid && connectionID.String != "" {
-		var siblingLibraries int
-		if err := tx.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM libraries WHERE connection_id = ? AND id != ?`,
-			connectionID.String, id).Scan(&siblingLibraries); err != nil {
-			return fmt.Errorf("counting sibling libraries on connection: %w", err)
-		}
-		if siblingLibraries == 0 {
-			if _, err := tx.ExecContext(ctx, `
-				DELETE FROM artists
-				WHERE library_id IS NULL
-				  AND id IN (
-				    SELECT artist_id FROM artist_platform_ids WHERE connection_id = ?
-				  )
-				  AND id NOT IN (
-				    SELECT artist_id FROM artist_platform_ids WHERE connection_id != ?
-				  )
-			`, connectionID.String, connectionID.String); err != nil {
-				return fmt.Errorf("pruning orphaned connection artists: %w", err)
-			}
-		}
-	}
-
+	// Drop the library. CASCADE removes its artist_libraries rows.
 	result, err := tx.ExecContext(ctx, `DELETE FROM libraries WHERE id = ?`, id)
 	if err != nil {
 		return fmt.Errorf("deleting library: %w", err)
 	}
-	rows, _ := result.RowsAffected()
-	if rows == 0 {
+	if n, _ := result.RowsAffected(); n == 0 {
 		return fmt.Errorf("library not found: %s", id)
+	}
+
+	// Decide whether the connection-orphan prune is safe to run.
+	connOrphanPruneAllowed := false
+	if connectionID.Valid && connectionID.String != "" {
+		var siblings int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM libraries WHERE connection_id = ?`,
+			connectionID.String).Scan(&siblings); err != nil {
+			return fmt.Errorf("counting sibling libraries: %w", err)
+		}
+		connOrphanPruneAllowed = siblings == 0
+	}
+
+	// Candidate prune: an artist is a candidate iff it had explicit
+	// presence in the deleted library (membership row OR legacy library_id
+	// pointer). Keep it if it has any other home: a remaining membership
+	// in some other library, OR a platform mapping on a connection other
+	// than the deleted library's connection. Mappings on the SAME
+	// connection do not count as "other home" because the user has just
+	// unlinked the only library tying them to that connection (or, if a
+	// sibling library remains, the sibling will still observe the artist
+	// via its own membership row, which would have made the artist a
+	// candidate via that sibling's row, not this one).
+	for _, aid := range candidateIDs {
+		var memberships int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM artist_libraries WHERE artist_id = ?`,
+			aid).Scan(&memberships); err != nil {
+			return fmt.Errorf("counting remaining memberships for %s: %w", aid, err)
+		}
+		if memberships > 0 {
+			continue
+		}
+		var otherConnMappings int
+		args := []any{aid}
+		query := `SELECT COUNT(*) FROM artist_platform_ids WHERE artist_id = ?`
+		if connectionID.Valid && connectionID.String != "" {
+			query += ` AND connection_id != ?`
+			args = append(args, connectionID.String)
+		}
+		if err := tx.QueryRowContext(ctx, query, args...).Scan(&otherConnMappings); err != nil {
+			return fmt.Errorf("counting cross-connection mappings for %s: %w", aid, err)
+		}
+		if otherConnMappings > 0 {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM artists WHERE id = ?`, aid); err != nil {
+			return fmt.Errorf("pruning orphan artist %s: %w", aid, err)
+		}
+	}
+
+	// Connection-orphan sweep for artists never in candidateIDs (no
+	// membership row, no library_id pointer, but a mapping on the
+	// just-unlinked connection). Pre-#1004 #1072 case.
+	if connOrphanPruneAllowed {
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM artists
+			WHERE id IN (
+				SELECT ap.artist_id FROM artist_platform_ids ap
+				WHERE ap.connection_id = ?
+				  AND ap.artist_id NOT IN (
+					SELECT artist_id FROM artist_libraries
+				  )
+				  AND ap.artist_id NOT IN (
+					SELECT artist_id FROM artist_platform_ids WHERE connection_id != ?
+				  )
+			)
+		`, connectionID.String, connectionID.String); err != nil {
+			return fmt.Errorf("sweeping connection-orphan artists: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/library/service_test.go
+++ b/internal/library/service_test.go
@@ -1105,3 +1105,75 @@ func TestDeleteWithArtists_PrunePreservesSiblingLibraryArtists(t *testing.T) {
 		t.Errorf("sibling orphan count after last library delete = %d, want 0 (prune fires when last library is gone)", orphan)
 	}
 }
+
+// TestDeleteWithArtists_PreservesArtistInOtherLibraries is the issue #1004
+// regression for the M:N model: an artist with membership in the unlinked
+// library AND in another library must survive the unlink. Only the
+// unlinked library's membership row goes; the artist row stays because the
+// other library still observes it. Without this guard, the legacy
+// "WHERE library_id = ?" delete (or even a naive M:N pruner) would erase
+// the artist from under the still-attached library.
+func TestDeleteWithArtists_PreservesArtistInOtherLibraries(t *testing.T) {
+	db := setupTestDB(t)
+	if err := database.EnableForeignKeys(db); err != nil {
+		t.Fatalf("enabling foreign keys: %v", err)
+	}
+	svc := NewService(db)
+	ctx := context.Background()
+
+	dir := t.TempDir()
+	fsLib := &Library{Name: "Filesystem", Path: dir, Type: TypeRegular, Source: SourceManual}
+	if err := svc.Create(ctx, fsLib); err != nil {
+		t.Fatalf("Create fs library: %v", err)
+	}
+	seedConnection(t, db, "conn-emby", "emby")
+	embyLib := &Library{Name: "Emby Music", Type: TypeRegular, ConnectionID: "conn-emby", ExternalID: "emby-1", Source: SourceEmby}
+	if err := svc.Create(ctx, embyLib); err != nil {
+		t.Fatalf("Create emby library: %v", err)
+	}
+
+	// Artist in BOTH libraries via membership rows.
+	seedArtist(t, db, "art-multi", "Radiohead", fsLib.ID)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+		VALUES ('art-multi', ?, 'filesystem', datetime('now')),
+		       ('art-multi', ?, 'emby', datetime('now'))
+	`, fsLib.ID, embyLib.ID); err != nil {
+		t.Fatalf("seed memberships: %v", err)
+	}
+	seedPlatformID(t, db, "art-multi", "conn-emby", "emby-radiohead-1")
+
+	// Unlink the Emby library with "delete artists" semantics.
+	if err := svc.DeleteWithArtists(ctx, embyLib.ID); err != nil {
+		t.Fatalf("DeleteWithArtists emby: %v", err)
+	}
+
+	// The artist must survive because filesystem still observes it.
+	var present int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artists WHERE id = 'art-multi'`).Scan(&present); err != nil {
+		t.Fatalf("count survivor: %v", err)
+	}
+	if present != 1 {
+		t.Errorf("artist count = %d, want 1 (filesystem membership must preserve)", present)
+	}
+
+	// The Emby library's membership row went via cascade.
+	var fsMember, embyMember int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_libraries WHERE artist_id = 'art-multi' AND library_id = ?`,
+		fsLib.ID).Scan(&fsMember); err != nil {
+		t.Fatalf("count fs membership: %v", err)
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_libraries WHERE artist_id = 'art-multi' AND library_id = ?`,
+		embyLib.ID).Scan(&embyMember); err != nil {
+		t.Fatalf("count emby membership: %v", err)
+	}
+	if fsMember != 1 {
+		t.Errorf("fs membership count = %d, want 1 (must remain)", fsMember)
+	}
+	if embyMember != 0 {
+		t.Errorf("emby membership count = %d, want 0 (cascade should have removed it)", embyMember)
+	}
+}

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -81,7 +81,7 @@ if [ ! -x "$PATCH_COVERAGE_HELPER" ]; then
   exit 1
 fi
 if COVER_OUT="$COVER_OUT" PATCH_COVERAGE_THRESHOLD=70 \
-    PATCH_COVERAGE_EXCLUDE="*_templ.go cmd/stillwater/main.go" \
+    PATCH_COVERAGE_EXCLUDE="*_templ.go cmd/stillwater/main.go scripts/" \
     bash "$PATCH_COVERAGE_HELPER"; then
   :
 else

--- a/scripts/uat-1004/main.go
+++ b/scripts/uat-1004/main.go
@@ -188,7 +188,7 @@ func report(ctx context.Context, db *sql.DB) error {
 	}
 	fmt.Fprintf(os.Stderr, "seeded:\n")
 	fmt.Fprintf(os.Stderr, " total artists: %d (expect 6 pre-collapse, 3 post-collapse: 12 Stones, Veridia, Skillet)\n", artists)
-	fmt.Fprintf(os.Stderr, " artist_libraries rows: %d (expect 0 pre-collapse, 4 post-collapse: 12s/fs, 12s/emby, 12s/jelly, veridia/fs, veridia/jelly, skillet/emby)\n", memberships)
+	fmt.Fprintf(os.Stderr, " artist_libraries rows: %d (expect 0 pre-collapse, 6 post-collapse: 12s/fs, 12s/emby, 12s/jelly, veridia/fs, veridia/jelly, skillet/emby)\n", memberships)
 	fmt.Fprintf(os.Stderr, " '12 Stones' rows: %d (expect 3 pre-collapse, 1 post-collapse)\n", twelveStones)
 	fmt.Fprintf(os.Stderr, " 'Veridia' rows (case-i): %d (expect 2 pre-collapse, 1 post-collapse)\n", veridia)
 	return nil

--- a/scripts/uat-1004/main.go
+++ b/scripts/uat-1004/main.go
@@ -87,13 +87,17 @@ func run(path string) error {
 
 func seed(ctx context.Context, db *sql.DB) error {
 	stmts := []string{
-		// Connections.
+		// Connections. Seeded as enabled=0/status='disabled' so a live
+		// Stillwater never tries to decrypt the placeholder API key
+		// ('k' is not real ciphertext). The collapse-migration logic
+		// only reads c.type from these rows, which works regardless of
+		// the enabled/status flags.
 		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
 		 VALUES ('conn-emby', 'Emby (UAT)', 'emby', 'http://uat-emby.local',
-		 'k', 1, 'ok', datetime('now'), datetime('now'))`,
+		 'k', 0, 'disabled', datetime('now'), datetime('now'))`,
 		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
 		 VALUES ('conn-jelly', 'Jellyfin (UAT)', 'jellyfin', 'http://uat-jellyfin.local',
-		 'k', 1, 'ok', datetime('now'), datetime('now'))`,
+		 'k', 0, 'disabled', datetime('now'), datetime('now'))`,
 
 		// Libraries: one filesystem, one each per connection.
 		`INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)

--- a/scripts/uat-1004/main.go
+++ b/scripts/uat-1004/main.go
@@ -1,20 +1,20 @@
 // Command uat-1004 seeds a Stillwater SQLite database with a synthetic
-// duplicate-artist topology for hand UAT of issue #1004 (M:N artist-libraries
+// duplicate-artist topology for hand UAT of (M:N artist-libraries
 // rework). Usage:
 //
 //	go run ./scripts/uat-1004 /tmp/stillwater-uat-1004.db
 //
 // What the seed builds:
-//   - One filesystem library, one Emby connection-library, one Jellyfin
-//     connection-library, all pointing at /tmp paths (no real media required).
-//   - A duplicate-by-MBID artist "12 Stones" with three rows: filesystem,
-//     Emby, and Jellyfin. After the next Stillwater startup the migration
-//     should collapse them into one row whose canonical is the filesystem
-//     row, with all three library memberships and both platform mappings.
-//   - A duplicate-by-name artist "Veridia" / "VERIDIA" without MBIDs across
-//     filesystem and Jellyfin. Should collapse to one row.
-//   - A clean control artist "Skillet" present only in the Emby library.
-//     Should remain as a single row with one library membership.
+// - One filesystem library, one Emby connection-library, one Jellyfin
+// connection-library, all pointing at /tmp paths (no real media required).
+// - A duplicate-by-MBID artist "12 Stones" with three rows: filesystem,
+// Emby, and Jellyfin. After the next Stillwater startup the migration
+// should collapse them into one row whose canonical is the filesystem
+// row, with all three library memberships and both platform mappings.
+// - A duplicate-by-name artist "Veridia" / "VERIDIA" without MBIDs across
+// filesystem and Jellyfin. Should collapse to one row.
+// - A clean control artist "Skillet" present only in the Emby library.
+// Should remain as a single row with one library membership.
 //
 // After running the seed, start Stillwater pointing at the same DB:
 //
@@ -22,7 +22,7 @@
 //
 // On startup the migration runs and emits a slog line like:
 //
-//	collapsed duplicate artist rows (issue #1004) groups=2 ...
+//	collapsed duplicate artist rows groups=2 ...
 //
 // Then open http://localhost:1973/artists and verify one row per artist.
 //
@@ -79,8 +79,8 @@ func run(path string) error {
 		return fmt.Errorf("report: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "\nNext: start Stillwater with this DB so the issue #1004 migration collapses the duplicates:\n")
-	fmt.Fprintf(os.Stderr, "  STILLWATER_DB=%s bash scripts/dev-restart.sh\n", path)
+	fmt.Fprintf(os.Stderr, "\nNext: start Stillwater with this DB so the migration collapses the duplicates:\n")
+	fmt.Fprintf(os.Stderr, " STILLWATER_DB=%s bash scripts/dev-restart.sh\n", path)
 	fmt.Fprintf(os.Stderr, "Then open http://localhost:1973/artists and verify one row per artist.\n")
 	return nil
 }
@@ -90,72 +90,72 @@ func seed(ctx context.Context, db *sql.DB) error {
 		// Connections.
 		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
 		 VALUES ('conn-emby', 'Emby (UAT)', 'emby', 'http://uat-emby.local',
-		         'k', 1, 'ok', datetime('now'), datetime('now'))`,
+		 'k', 1, 'ok', datetime('now'), datetime('now'))`,
 		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
 		 VALUES ('conn-jelly', 'Jellyfin (UAT)', 'jellyfin', 'http://uat-jellyfin.local',
-		         'k', 1, 'ok', datetime('now'), datetime('now'))`,
+		 'k', 1, 'ok', datetime('now'), datetime('now'))`,
 
 		// Libraries: one filesystem, one each per connection.
 		`INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)
 		 VALUES ('lib-fs', 'Filesystem Music', '/tmp/uat-music', 'regular', 'filesystem',
-		         datetime('now'), datetime('now'))`,
+		 datetime('now'), datetime('now'))`,
 		`INSERT INTO libraries (id, name, path, type, source, connection_id, external_id, created_at, updated_at)
 		 VALUES ('lib-emby', 'Emby Music', '/tmp/uat-music', 'regular', 'import',
-		         'conn-emby', 'emby-ext', datetime('now'), datetime('now'))`,
+		 'conn-emby', 'emby-ext', datetime('now'), datetime('now'))`,
 		`INSERT INTO libraries (id, name, path, type, source, connection_id, external_id, created_at, updated_at)
 		 VALUES ('lib-jelly', 'Jellyfin Music', '/tmp/uat-music', 'regular', 'import',
-		         'conn-jelly', 'jelly-ext', datetime('now'), datetime('now'))`,
+		 'conn-jelly', 'jelly-ext', datetime('now'), datetime('now'))`,
 
 		// MBID-grouped trio: 12 Stones across all three libraries with
 		// the same MBID. Collapse should pick the filesystem row as
 		// canonical and re-point everything onto it.
 		`INSERT INTO artists (id, name, sort_name, path, library_id, biography, created_at, updated_at)
 		 VALUES ('a-12s-fs', '12 Stones', '12 Stones', '/tmp/uat-music/12 Stones',
-		         'lib-fs', 'American rock band (filesystem row).',
-		         '2026-01-01T00:00:00Z', datetime('now'))`,
+		 'lib-fs', 'American rock band (filesystem row).',
+		 '2026-01-01T00:00:00Z', datetime('now'))`,
 		`INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
 		 VALUES ('a-12s-fs', 'musicbrainz', 'mbid-12-stones', datetime('now'))`,
 
 		`INSERT INTO artists (id, name, sort_name, path, library_id, biography, created_at, updated_at)
 		 VALUES ('a-12s-emby', '12 Stones', '12 Stones', '/tmp/uat-music/12 Stones',
-		         'lib-emby', 'American rock band (Emby row).',
-		         '2026-01-02T00:00:00Z', datetime('now'))`,
+		 'lib-emby', 'American rock band (Emby row).',
+		 '2026-01-02T00:00:00Z', datetime('now'))`,
 		`INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
 		 VALUES ('a-12s-emby', 'musicbrainz', 'mbid-12-stones', datetime('now'))`,
 		`INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id, created_at, updated_at)
 		 VALUES ('a-12s-emby', 'conn-emby', 'emby-12-stones-id',
-		         strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`,
+		 strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`,
 
 		`INSERT INTO artists (id, name, sort_name, path, library_id, biography, created_at, updated_at)
 		 VALUES ('a-12s-jelly', '12 Stones', '12 Stones', '/tmp/uat-music/12 Stones',
-		         'lib-jelly', 'American rock band (Jellyfin row).',
-		         '2026-01-03T00:00:00Z', datetime('now'))`,
+		 'lib-jelly', 'American rock band (Jellyfin row).',
+		 '2026-01-03T00:00:00Z', datetime('now'))`,
 		`INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
 		 VALUES ('a-12s-jelly', 'musicbrainz', 'mbid-12-stones', datetime('now'))`,
 		`INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id, created_at, updated_at)
 		 VALUES ('a-12s-jelly', 'conn-jelly', 'jelly-12-stones-id',
-		         strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`,
+		 strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`,
 
 		// Name-grouped pair: VERIDIA without MBIDs, case-insensitive
 		// match across filesystem and Jellyfin. Filesystem wins canonical.
 		`INSERT INTO artists (id, name, sort_name, path, library_id, biography, created_at, updated_at)
 		 VALUES ('a-veridia-fs', 'Veridia', 'Veridia', '/tmp/uat-music/Veridia',
-		         'lib-fs', 'American rock band (filesystem row, mixed case).',
-		         '2026-01-04T00:00:00Z', datetime('now'))`,
+		 'lib-fs', 'American rock band (filesystem row, mixed case).',
+		 '2026-01-04T00:00:00Z', datetime('now'))`,
 		`INSERT INTO artists (id, name, sort_name, path, library_id, biography, created_at, updated_at)
 		 VALUES ('a-veridia-jelly', 'VERIDIA', 'VERIDIA', '/tmp/uat-music/VERIDIA',
-		         'lib-jelly', 'American rock band (Jellyfin row, all caps).',
-		         '2026-01-05T00:00:00Z', datetime('now'))`,
+		 'lib-jelly', 'American rock band (Jellyfin row, all caps).',
+		 '2026-01-05T00:00:00Z', datetime('now'))`,
 
 		// Clean control: Skillet exists only in the Emby library; should
 		// remain as one row with a single Emby membership.
 		`INSERT INTO artists (id, name, sort_name, path, library_id, biography, created_at, updated_at)
 		 VALUES ('a-skillet-emby', 'Skillet', 'Skillet', '/tmp/uat-music/Skillet',
-		         'lib-emby', 'Christian rock band, Emby-only control.',
-		         '2026-01-06T00:00:00Z', datetime('now'))`,
+		 'lib-emby', 'Christian rock band, Emby-only control.',
+		 '2026-01-06T00:00:00Z', datetime('now'))`,
 		`INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id, created_at, updated_at)
 		 VALUES ('a-skillet-emby', 'conn-emby', 'emby-skillet-id',
-		         strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`,
+		 strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`,
 	}
 	for i, s := range stmts {
 		if _, err := db.ExecContext(ctx, s); err != nil {
@@ -187,9 +187,9 @@ func report(ctx context.Context, db *sql.DB) error {
 		return err
 	}
 	fmt.Fprintf(os.Stderr, "seeded:\n")
-	fmt.Fprintf(os.Stderr, "  total artists:           %d (expect 6 pre-collapse, 3 post-collapse: 12 Stones, Veridia, Skillet)\n", artists)
-	fmt.Fprintf(os.Stderr, "  artist_libraries rows:   %d (expect 0 pre-collapse, 4 post-collapse: 12s/fs, 12s/emby, 12s/jelly, veridia/fs, veridia/jelly, skillet/emby)\n", memberships)
-	fmt.Fprintf(os.Stderr, "  '12 Stones' rows:        %d (expect 3 pre-collapse, 1 post-collapse)\n", twelveStones)
-	fmt.Fprintf(os.Stderr, "  'Veridia' rows (case-i): %d (expect 2 pre-collapse, 1 post-collapse)\n", veridia)
+	fmt.Fprintf(os.Stderr, " total artists: %d (expect 6 pre-collapse, 3 post-collapse: 12 Stones, Veridia, Skillet)\n", artists)
+	fmt.Fprintf(os.Stderr, " artist_libraries rows: %d (expect 0 pre-collapse, 4 post-collapse: 12s/fs, 12s/emby, 12s/jelly, veridia/fs, veridia/jelly, skillet/emby)\n", memberships)
+	fmt.Fprintf(os.Stderr, " '12 Stones' rows: %d (expect 3 pre-collapse, 1 post-collapse)\n", twelveStones)
+	fmt.Fprintf(os.Stderr, " 'Veridia' rows (case-i): %d (expect 2 pre-collapse, 1 post-collapse)\n", veridia)
 	return nil
 }

--- a/scripts/uat-1004/main.go
+++ b/scripts/uat-1004/main.go
@@ -1,0 +1,195 @@
+// Command uat-1004 seeds a Stillwater SQLite database with a synthetic
+// duplicate-artist topology for hand UAT of issue #1004 (M:N artist-libraries
+// rework). Usage:
+//
+//	go run ./scripts/uat-1004 /tmp/stillwater-uat-1004.db
+//
+// What the seed builds:
+//   - One filesystem library, one Emby connection-library, one Jellyfin
+//     connection-library, all pointing at /tmp paths (no real media required).
+//   - A duplicate-by-MBID artist "12 Stones" with three rows: filesystem,
+//     Emby, and Jellyfin. After the next Stillwater startup the migration
+//     should collapse them into one row whose canonical is the filesystem
+//     row, with all three library memberships and both platform mappings.
+//   - A duplicate-by-name artist "Veridia" / "VERIDIA" without MBIDs across
+//     filesystem and Jellyfin. Should collapse to one row.
+//   - A clean control artist "Skillet" present only in the Emby library.
+//     Should remain as a single row with one library membership.
+//
+// After running the seed, start Stillwater pointing at the same DB:
+//
+//	STILLWATER_DB=/tmp/stillwater-uat-1004.db ./stillwater
+//
+// On startup the migration runs and emits a slog line like:
+//
+//	collapsed duplicate artist rows (issue #1004) groups=2 ...
+//
+// Then open http://localhost:1973/artists and verify one row per artist.
+//
+// Re-running the seed against the same path overwrites the file.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/sydlexius/stillwater/internal/database"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: uat-1004 <db-path>")
+		os.Exit(2)
+	}
+	path := os.Args[1]
+	if err := run(path); err != nil {
+		slog.Error("seed failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(path string) error {
+	// Start clean so reruns are deterministic. path is provided by the
+	// developer as a command-line argument; this is a UAT helper, not a
+	// production code path.
+	_ = os.Remove(path) //nolint:gosec // G304: path is a developer-supplied UAT-only argument
+
+	db, err := database.Open(path)
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+	defer db.Close() //nolint:errcheck
+
+	if err := database.Migrate(db); err != nil {
+		return fmt.Errorf("initial migrate: %w", err)
+	}
+	if err := database.EnableForeignKeys(db); err != nil {
+		return fmt.Errorf("foreign keys: %w", err)
+	}
+
+	ctx := context.Background()
+	if err := seed(ctx, db); err != nil {
+		return fmt.Errorf("seed: %w", err)
+	}
+
+	if err := report(ctx, db); err != nil {
+		return fmt.Errorf("report: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "\nNext: start Stillwater with this DB so the issue #1004 migration collapses the duplicates:\n")
+	fmt.Fprintf(os.Stderr, "  STILLWATER_DB=%s bash scripts/dev-restart.sh\n", path)
+	fmt.Fprintf(os.Stderr, "Then open http://localhost:1973/artists and verify one row per artist.\n")
+	return nil
+}
+
+func seed(ctx context.Context, db *sql.DB) error {
+	stmts := []string{
+		// Connections.
+		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
+		 VALUES ('conn-emby', 'Emby (UAT)', 'emby', 'http://uat-emby.local',
+		         'k', 1, 'ok', datetime('now'), datetime('now'))`,
+		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
+		 VALUES ('conn-jelly', 'Jellyfin (UAT)', 'jellyfin', 'http://uat-jellyfin.local',
+		         'k', 1, 'ok', datetime('now'), datetime('now'))`,
+
+		// Libraries: one filesystem, one each per connection.
+		`INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)
+		 VALUES ('lib-fs', 'Filesystem Music', '/tmp/uat-music', 'regular', 'filesystem',
+		         datetime('now'), datetime('now'))`,
+		`INSERT INTO libraries (id, name, path, type, source, connection_id, external_id, created_at, updated_at)
+		 VALUES ('lib-emby', 'Emby Music', '/tmp/uat-music', 'regular', 'import',
+		         'conn-emby', 'emby-ext', datetime('now'), datetime('now'))`,
+		`INSERT INTO libraries (id, name, path, type, source, connection_id, external_id, created_at, updated_at)
+		 VALUES ('lib-jelly', 'Jellyfin Music', '/tmp/uat-music', 'regular', 'import',
+		         'conn-jelly', 'jelly-ext', datetime('now'), datetime('now'))`,
+
+		// MBID-grouped trio: 12 Stones across all three libraries with
+		// the same MBID. Collapse should pick the filesystem row as
+		// canonical and re-point everything onto it.
+		`INSERT INTO artists (id, name, sort_name, path, library_id, biography, created_at, updated_at)
+		 VALUES ('a-12s-fs', '12 Stones', '12 Stones', '/tmp/uat-music/12 Stones',
+		         'lib-fs', 'American rock band (filesystem row).',
+		         '2026-01-01T00:00:00Z', datetime('now'))`,
+		`INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
+		 VALUES ('a-12s-fs', 'musicbrainz', 'mbid-12-stones', datetime('now'))`,
+
+		`INSERT INTO artists (id, name, sort_name, path, library_id, biography, created_at, updated_at)
+		 VALUES ('a-12s-emby', '12 Stones', '12 Stones', '/tmp/uat-music/12 Stones',
+		         'lib-emby', 'American rock band (Emby row).',
+		         '2026-01-02T00:00:00Z', datetime('now'))`,
+		`INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
+		 VALUES ('a-12s-emby', 'musicbrainz', 'mbid-12-stones', datetime('now'))`,
+		`INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id, created_at, updated_at)
+		 VALUES ('a-12s-emby', 'conn-emby', 'emby-12-stones-id',
+		         strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`,
+
+		`INSERT INTO artists (id, name, sort_name, path, library_id, biography, created_at, updated_at)
+		 VALUES ('a-12s-jelly', '12 Stones', '12 Stones', '/tmp/uat-music/12 Stones',
+		         'lib-jelly', 'American rock band (Jellyfin row).',
+		         '2026-01-03T00:00:00Z', datetime('now'))`,
+		`INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
+		 VALUES ('a-12s-jelly', 'musicbrainz', 'mbid-12-stones', datetime('now'))`,
+		`INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id, created_at, updated_at)
+		 VALUES ('a-12s-jelly', 'conn-jelly', 'jelly-12-stones-id',
+		         strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`,
+
+		// Name-grouped pair: VERIDIA without MBIDs, case-insensitive
+		// match across filesystem and Jellyfin. Filesystem wins canonical.
+		`INSERT INTO artists (id, name, sort_name, path, library_id, biography, created_at, updated_at)
+		 VALUES ('a-veridia-fs', 'Veridia', 'Veridia', '/tmp/uat-music/Veridia',
+		         'lib-fs', 'American rock band (filesystem row, mixed case).',
+		         '2026-01-04T00:00:00Z', datetime('now'))`,
+		`INSERT INTO artists (id, name, sort_name, path, library_id, biography, created_at, updated_at)
+		 VALUES ('a-veridia-jelly', 'VERIDIA', 'VERIDIA', '/tmp/uat-music/VERIDIA',
+		         'lib-jelly', 'American rock band (Jellyfin row, all caps).',
+		         '2026-01-05T00:00:00Z', datetime('now'))`,
+
+		// Clean control: Skillet exists only in the Emby library; should
+		// remain as one row with a single Emby membership.
+		`INSERT INTO artists (id, name, sort_name, path, library_id, biography, created_at, updated_at)
+		 VALUES ('a-skillet-emby', 'Skillet', 'Skillet', '/tmp/uat-music/Skillet',
+		         'lib-emby', 'Christian rock band, Emby-only control.',
+		         '2026-01-06T00:00:00Z', datetime('now'))`,
+		`INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id, created_at, updated_at)
+		 VALUES ('a-skillet-emby', 'conn-emby', 'emby-skillet-id',
+		         strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`,
+	}
+	for i, s := range stmts {
+		if _, err := db.ExecContext(ctx, s); err != nil {
+			return fmt.Errorf("statement %d: %w\n%s", i, err, s)
+		}
+	}
+	return nil
+}
+
+// report prints the pre-collapse counts so the user can compare against
+// what the migration produces on the next Stillwater startup.
+func report(ctx context.Context, db *sql.DB) error {
+	var artists int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artists`).Scan(&artists); err != nil {
+		return err
+	}
+	var memberships int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM artist_libraries`).Scan(&memberships); err != nil {
+		return err
+	}
+	var twelveStones int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artists WHERE name = '12 Stones'`).Scan(&twelveStones); err != nil {
+		return err
+	}
+	var veridia int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artists WHERE LOWER(name) = 'veridia'`).Scan(&veridia); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "seeded:\n")
+	fmt.Fprintf(os.Stderr, "  total artists:           %d (expect 6 pre-collapse, 3 post-collapse: 12 Stones, Veridia, Skillet)\n", artists)
+	fmt.Fprintf(os.Stderr, "  artist_libraries rows:   %d (expect 0 pre-collapse, 4 post-collapse: 12s/fs, 12s/emby, 12s/jelly, veridia/fs, veridia/jelly, skillet/emby)\n", memberships)
+	fmt.Fprintf(os.Stderr, "  '12 Stones' rows:        %d (expect 3 pre-collapse, 1 post-collapse)\n", twelveStones)
+	fmt.Fprintf(os.Stderr, "  'Veridia' rows (case-i): %d (expect 2 pre-collapse, 1 post-collapse)\n", veridia)
+	return nil
+}

--- a/web/templates/artists.templ
+++ b/web/templates/artists.templ
@@ -96,10 +96,12 @@ func artistSourceInfo(a artist.Artist, sources map[string]LibrarySourceInfo) Lib
 	return sources[a.LibraryID]
 }
 
-// artistHasFilesystem returns true when the artist was discovered from a
-// filesystem library scan (has a non-empty path).
-func artistHasFilesystem(a artist.Artist) bool {
-	return a.Path != ""
+// artistHasFilesystem returns true when the artist holds at least one
+// filesystem-library membership. Issue #1004 replaced the prior path-based
+// heuristic, which gave false positives for connection-only artists whose
+// path was set by Emby / Jellyfin populates.
+func artistHasFilesystem(pp artist.PlatformPresence) bool {
+	return pp.HasFilesystem
 }
 
 // lidarrTooltip returns the tooltip text for a Lidarr platform badge.
@@ -139,7 +141,7 @@ func computeArtistBadges(ctx context.Context, a artist.Artist, sources map[strin
 	src := artistSourceInfo(a, sources)
 	pp := artistPlatformPresence(a.ID, platforms)
 	var badges []artistBadge
-	if artistHasFilesystem(a) {
+	if artistHasFilesystem(pp) {
 		badges = append(badges, artistBadge{"filesystem", tf(ctx, "artists.badge.found_in", a.Path)})
 	}
 	if pp.HasLidarr || src.Source == "lidarr" {

--- a/web/templates/artists.templ
+++ b/web/templates/artists.templ
@@ -15,35 +15,35 @@ import (
 // Filter trigger button class sets. Used in both the class attribute (via
 // templ.KV) and data-* attributes so the template is the single source of truth.
 const (
-	filterTriggerActive  = "border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-600"
+	filterTriggerActive = "border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-600"
 	filterTriggerNeutral = "border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
-	filterTriggerBadge   = "sw-filter-trigger-badge ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-blue-600 text-[10px] font-bold text-white dark:bg-blue-400 dark:text-gray-900"
+	filterTriggerBadge = "sw-filter-trigger-badge ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-blue-600 text-[10px] font-bold text-white dark:bg-blue-400 dark:text-gray-900"
 )
 
 // LibrarySourceInfo holds display metadata for an imported library's source.
 type LibrarySourceInfo struct {
-	Source         string // "emby", "jellyfin", "lidarr"
+	Source string // "emby", "jellyfin", "lidarr"
 	ConnectionName string // human-readable connection name
 }
 
 // ArtistListData holds the data for the artist list page.
 type ArtistListData struct {
-	Artists          []artist.Artist
-	Libraries        []library.Library
-	LibrarySources   map[string]LibrarySourceInfo       // library ID -> source info (only for non-manual)
-	ComplianceMap    map[string]artist.ComplianceStatus // artist ID -> compliance status
+	Artists []artist.Artist
+	Libraries []library.Library
+	LibrarySources map[string]LibrarySourceInfo // library ID -> source info (only for non-manual)
+	ComplianceMap map[string]artist.ComplianceStatus // artist ID -> compliance status
 	PlatformPresence map[string]artist.PlatformPresence // artist ID -> platform badges
-	Pagination       components.PaginationData
-	Search           string
-	Sort             string
-	Order            string
-	Filter           string
+	Pagination components.PaginationData
+	Search string
+	Sort string
+	Order string
+	Filter string
 	// Filters holds the flyout multi-filter state (key -> "include" or "exclude").
 	// Keys: missing_meta, missing_images, missing_mbid, excluded, locked,
 	// type_person, type_group, type_orchestra, library_{id}.
-	Filters     map[string]string
-	LibraryID   string
-	View        string // "table" or "grid"
+	Filters map[string]string
+	LibraryID string
+	View string // "table" or "grid"
 	ProfileName string // Active platform profile name for image terminology
 }
 
@@ -97,7 +97,7 @@ func artistSourceInfo(a artist.Artist, sources map[string]LibrarySourceInfo) Lib
 }
 
 // artistHasFilesystem returns true when the artist holds at least one
-// filesystem-library membership. Issue #1004 replaced the prior path-based
+// filesystem-library membership. Replaced the prior path-based
 // heuristic, which gave false positives for connection-only artists whose
 // path was set by Emby / Jellyfin populates.
 func artistHasFilesystem(pp artist.PlatformPresence) bool {
@@ -132,7 +132,7 @@ func jellyfinTooltip(ctx context.Context, src LibrarySourceInfo) string {
 // artistBadge holds the platform name and tooltip for a single badge.
 type artistBadge struct {
 	Platform string
-	Tooltip  string
+	Tooltip string
 }
 
 // computeArtistBadges returns the ordered list of platform badges for an artist.

--- a/web/templates/artists_templ.go
+++ b/web/templates/artists_templ.go
@@ -104,10 +104,12 @@ func artistSourceInfo(a artist.Artist, sources map[string]LibrarySourceInfo) Lib
 	return sources[a.LibraryID]
 }
 
-// artistHasFilesystem returns true when the artist was discovered from a
-// filesystem library scan (has a non-empty path).
-func artistHasFilesystem(a artist.Artist) bool {
-	return a.Path != ""
+// artistHasFilesystem returns true when the artist holds at least one
+// filesystem-library membership. Issue #1004 replaced the prior path-based
+// heuristic, which gave false positives for connection-only artists whose
+// path was set by Emby / Jellyfin populates.
+func artistHasFilesystem(pp artist.PlatformPresence) bool {
+	return pp.HasFilesystem
 }
 
 // lidarrTooltip returns the tooltip text for a Lidarr platform badge.
@@ -147,7 +149,7 @@ func computeArtistBadges(ctx context.Context, a artist.Artist, sources map[strin
 	src := artistSourceInfo(a, sources)
 	pp := artistPlatformPresence(a.ID, platforms)
 	var badges []artistBadge
-	if artistHasFilesystem(a) {
+	if artistHasFilesystem(pp) {
 		badges = append(badges, artistBadge{"filesystem", tf(ctx, "artists.badge.found_in", a.Path)})
 	}
 	if pp.HasLidarr || src.Source == "lidarr" {
@@ -358,7 +360,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.title"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 318, Col: 61}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 320, Col: 61}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -371,7 +373,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(tn(ctx, "artists.in_library", data.Pagination.TotalItems))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 320, Col: 65}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 322, Col: 65}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -384,7 +386,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.scan_library"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 327, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 329, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -397,7 +399,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.scanning"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 328, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 330, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -410,7 +412,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.scan_library"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 337, Col: 59}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 339, Col: 59}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -423,7 +425,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(data.View)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 340, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 342, Col: 76}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -436,7 +438,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(data.Sort)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 341, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 343, Col: 76}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -449,7 +451,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(data.Order)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 342, Col: 79}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 344, Col: 79}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -462,7 +464,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(data.Search)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 349, Col: 25}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 351, Col: 25}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -475,7 +477,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var12 string
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.search_placeholder"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 350, Col: 56}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 352, Col: 56}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -488,7 +490,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.search_placeholder"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 351, Col: 55}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 353, Col: 55}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -506,7 +508,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.filter_by_library"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 370, Col: 55}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 372, Col: 55}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -529,7 +531,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 				var templ_7745c5c3_Var15 string
 				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.all_libraries"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 372, Col: 92}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 374, Col: 92}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 				if templ_7745c5c3_Err != nil {
@@ -547,7 +549,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var16 string
 					templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(lib.ID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 374, Col: 30}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 376, Col: 30}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 					if templ_7745c5c3_Err != nil {
@@ -570,7 +572,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var17 string
 					templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(libraryDropdownLabel(lib, data.LibrarySources))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 374, Col: 120}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 376, Col: 120}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 					if templ_7745c5c3_Err != nil {
@@ -619,7 +621,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var20 string
 			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(filterTriggerActive)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 383, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 385, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 			if templ_7745c5c3_Err != nil {
@@ -632,7 +634,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var21 string
 			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(filterTriggerNeutral)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 384, Col: 49}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 386, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 			if templ_7745c5c3_Err != nil {
@@ -645,7 +647,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(filterTriggerBadge)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 385, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 387, Col: 45}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
@@ -658,7 +660,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.open_filter_panel"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 386, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 388, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
@@ -680,7 +682,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.filters"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 395, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 397, Col: 38}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
@@ -722,7 +724,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 					return tf(ctx, "common.active_filter_other", n)
 				}())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 397, Col: 217}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 399, Col: 217}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 				if templ_7745c5c3_Err != nil {
@@ -735,7 +737,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 				var templ_7745c5c3_Var29 string
 				templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%d", activeFilterCount(data.Filters)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 398, Col: 60}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 400, Col: 60}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 				if templ_7745c5c3_Err != nil {
@@ -753,7 +755,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var30 string
 			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.sort"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 403, Col: 334}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 405, Col: 334}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
@@ -766,7 +768,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var31 string
 			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(sortLabel(ctx, data.Sort))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 407, Col: 87}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 409, Col: 87}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 			if templ_7745c5c3_Err != nil {
@@ -779,7 +781,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var32 string
 			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(orderLabel(ctx, data.Order))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 408, Col: 103}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 410, Col: 103}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 			if templ_7745c5c3_Err != nil {
@@ -792,7 +794,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var33 string
 			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.sort_by"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 411, Col: 139}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 413, Col: 139}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
@@ -827,7 +829,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var36 string
 			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.sort.name"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 412, Col: 132}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 414, Col: 132}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 			if templ_7745c5c3_Err != nil {
@@ -862,7 +864,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var39 string
 			templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.sort.sort_name"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 413, Col: 147}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 415, Col: 147}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 			if templ_7745c5c3_Err != nil {
@@ -897,7 +899,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var42 string
 			templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.sort.health_score"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 414, Col: 156}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 416, Col: 156}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 			if templ_7745c5c3_Err != nil {
@@ -932,7 +934,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var45 string
 			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.sort.last_updated"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 415, Col: 152}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 417, Col: 152}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 			if templ_7745c5c3_Err != nil {
@@ -967,7 +969,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var48 string
 			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.sort.date_added"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 416, Col: 150}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 418, Col: 150}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 			if templ_7745c5c3_Err != nil {
@@ -980,7 +982,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var49 string
 			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.direction"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 418, Col: 141}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 420, Col: 141}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 			if templ_7745c5c3_Err != nil {
@@ -1015,7 +1017,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var52 string
 			templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.sort.ascending"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 419, Col: 137}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 421, Col: 137}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 			if templ_7745c5c3_Err != nil {
@@ -1050,7 +1052,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var55 string
 			templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.sort.descending"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 420, Col: 140}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 422, Col: 140}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 			if templ_7745c5c3_Err != nil {
@@ -1109,7 +1111,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var59 string
 			templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.view.table"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 436, Col: 43}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 438, Col: 43}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 			if templ_7745c5c3_Err != nil {
@@ -1122,7 +1124,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var60 string
 			templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.view.table"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 437, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 439, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 			if templ_7745c5c3_Err != nil {
@@ -1157,7 +1159,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var63 string
 			templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.view.grid"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 452, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 454, Col: 42}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 			if templ_7745c5c3_Err != nil {
@@ -1170,7 +1172,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var64 string
 			templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.view.grid"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 453, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 455, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 			if templ_7745c5c3_Err != nil {
@@ -1441,7 +1443,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var73 string
 		templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.toolbar"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1300, Col: 45}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1302, Col: 45}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
 		if templ_7745c5c3_Err != nil {
@@ -1454,7 +1456,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var74 string
 		templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.none_selected"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1301, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1303, Col: 55}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
 		if templ_7745c5c3_Err != nil {
@@ -1467,7 +1469,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var75 string
 		templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.selected.one"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1302, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1304, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
 		if templ_7745c5c3_Err != nil {
@@ -1480,7 +1482,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var76 string
 		templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.selected.other"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1303, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1305, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
 		if templ_7745c5c3_Err != nil {
@@ -1493,7 +1495,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var77 string
 		templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.busy"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1304, Col: 46}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1306, Col: 46}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
 		if templ_7745c5c3_Err != nil {
@@ -1506,7 +1508,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var78 string
 		templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.failed"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1305, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1307, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
 		if templ_7745c5c3_Err != nil {
@@ -1519,7 +1521,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var79 string
 		templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.select_all"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1306, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1308, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
 		if templ_7745c5c3_Err != nil {
@@ -1532,7 +1534,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var80 string
 		templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.deselect_all"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1307, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1309, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
 		if templ_7745c5c3_Err != nil {
@@ -1545,7 +1547,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var81 string
 		templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.selection_cap"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1308, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1310, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var81))
 		if templ_7745c5c3_Err != nil {
@@ -1558,7 +1560,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var82 string
 		templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.select_all"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1316, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1318, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 		if templ_7745c5c3_Err != nil {
@@ -1571,7 +1573,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var83 string
 		templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.select_all"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1318, Col: 71}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1320, Col: 71}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
 		if templ_7745c5c3_Err != nil {
@@ -1584,7 +1586,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var84 string
 		templ_7745c5c3_Var84, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.none_selected"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1321, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1323, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var84))
 		if templ_7745c5c3_Err != nil {
@@ -1597,7 +1599,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var85 string
 		templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action_label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1328, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1330, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
 		if templ_7745c5c3_Err != nil {
@@ -1610,7 +1612,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var86 string
 		templ_7745c5c3_Var86, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.choose_action"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1330, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1332, Col: 59}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var86))
 		if templ_7745c5c3_Err != nil {
@@ -1623,7 +1625,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var87 string
 		templ_7745c5c3_Var87, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.run_rules"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1331, Col: 71}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1333, Col: 71}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var87))
 		if templ_7745c5c3_Err != nil {
@@ -1636,7 +1638,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var88 string
 		templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.re_identify_auto"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1332, Col: 85}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1334, Col: 85}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
 		if templ_7745c5c3_Err != nil {
@@ -1649,7 +1651,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var89 string
 		templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.re_identify_review"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1333, Col: 89}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1335, Col: 89}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
 		if templ_7745c5c3_Err != nil {
@@ -1662,7 +1664,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var90 string
 		templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.scan"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1334, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1336, Col: 61}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
 		if templ_7745c5c3_Err != nil {
@@ -1675,7 +1677,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var91 string
 		templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.fetch_images"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1335, Col: 77}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1337, Col: 77}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
 		if templ_7745c5c3_Err != nil {
@@ -1688,7 +1690,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var92 string
 		templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.apply"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1343, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1345, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
 		if templ_7745c5c3_Err != nil {
@@ -1753,7 +1755,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var94 string
 			templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.active_filters"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1354, Col: 99}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1356, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var94))
 			if templ_7745c5c3_Err != nil {
@@ -1790,7 +1792,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var97 string
 					templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(filterChipLabelFromData(ctx, key, data.Filters[key], data.Libraries, data.LibrarySources))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1358, Col: 98}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1360, Col: 98}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
 					if templ_7745c5c3_Err != nil {
@@ -1811,7 +1813,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var98 string
 					templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "common.remove_filter", filterChipLabelFromData(ctx, key, data.Filters[key], data.Libraries, data.LibrarySources)))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1362, Col: 143}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1364, Col: 143}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var98))
 					if templ_7745c5c3_Err != nil {
@@ -1844,7 +1846,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var100 string
 		templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.select_column"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1379, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1381, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
 		if templ_7745c5c3_Err != nil {
@@ -1857,7 +1859,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var101 string
 		templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.sort_by_name"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1386, Col: 46}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1388, Col: 46}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
 		if templ_7745c5c3_Err != nil {
@@ -1870,7 +1872,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var102 string
 		templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.col.name"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1388, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1390, Col: 36}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var102))
 		if templ_7745c5c3_Err != nil {
@@ -1900,7 +1902,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var103 string
 		templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.col.metadata"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1399, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1401, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
 		if templ_7745c5c3_Err != nil {
@@ -1913,7 +1915,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var104 string
 		templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(img.ImageTermFor("thumb", data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1402, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1404, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var104))
 		if templ_7745c5c3_Err != nil {
@@ -1926,7 +1928,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var105 string
 		templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(img.ImageTermFor("fanart", data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1405, Col: 53}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1407, Col: 53}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
 		if templ_7745c5c3_Err != nil {
@@ -1939,7 +1941,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var106 string
 		templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(img.ImageTermFor("logo", data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1408, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1410, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
 		if templ_7745c5c3_Err != nil {
@@ -1952,7 +1954,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var107 string
 		templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.col.mbid"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1411, Col: 35}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1413, Col: 35}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
 		if templ_7745c5c3_Err != nil {
@@ -1970,7 +1972,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var108 string
 			templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.empty_state"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1419, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1421, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
 			if templ_7745c5c3_Err != nil {
@@ -2054,7 +2056,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var112 string
 			templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(a.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1440, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1442, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
 			if templ_7745c5c3_Err != nil {
@@ -2067,7 +2069,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var113 string
 			templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "artists.bulk.select_artist", a.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1441, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1443, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var113))
 			if templ_7745c5c3_Err != nil {
@@ -2108,7 +2110,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var116 string
 			templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs(complianceDotTitle(ctx, artistCompliance(a.ID, compliance)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1450, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1452, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var116))
 			if templ_7745c5c3_Err != nil {
@@ -2121,7 +2123,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var117 string
 			templ_7745c5c3_Var117, templ_7745c5c3_Err = templ.JoinStringErrs(complianceDotTitle(ctx, artistCompliance(a.ID, compliance)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1451, Col: 78}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1453, Col: 78}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var117))
 			if templ_7745c5c3_Err != nil {
@@ -2143,7 +2145,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 		var templ_7745c5c3_Var118 templ.SafeURL
 		templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath() + "/artists/" + a.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1457, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1459, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var118))
 		if templ_7745c5c3_Err != nil {
@@ -2156,7 +2158,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 		var templ_7745c5c3_Var119 string
 		templ_7745c5c3_Var119, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1460, Col: 13}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1462, Col: 13}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var119))
 		if templ_7745c5c3_Err != nil {
@@ -2174,7 +2176,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var120 string
 			templ_7745c5c3_Var120, templ_7745c5c3_Err = templ.JoinStringErrs(a.SortName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1463, Col: 59}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1465, Col: 59}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var120))
 			if templ_7745c5c3_Err != nil {
@@ -2193,7 +2195,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var121 string
 			templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.excluded"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1466, Col: 184}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1468, Col: 184}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var121))
 			if templ_7745c5c3_Err != nil {
@@ -2304,7 +2306,7 @@ func ArtistGrid(data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var123 string
 			templ_7745c5c3_Var123, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.active_filters"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1494, Col: 99}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1496, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var123))
 			if templ_7745c5c3_Err != nil {
@@ -2341,7 +2343,7 @@ func ArtistGrid(data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var126 string
 					templ_7745c5c3_Var126, templ_7745c5c3_Err = templ.JoinStringErrs(filterChipLabelFromData(ctx, key, data.Filters[key], data.Libraries, data.LibrarySources))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1498, Col: 98}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1500, Col: 98}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var126))
 					if templ_7745c5c3_Err != nil {
@@ -2362,7 +2364,7 @@ func ArtistGrid(data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var127 string
 					templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "common.remove_filter", filterChipLabelFromData(ctx, key, data.Filters[key], data.Libraries, data.LibrarySources)))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1502, Col: 143}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1504, Col: 143}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var127))
 					if templ_7745c5c3_Err != nil {
@@ -2396,7 +2398,7 @@ func ArtistGrid(data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var129 string
 			templ_7745c5c3_Var129, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.empty_state"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1516, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1518, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var129))
 			if templ_7745c5c3_Err != nil {
@@ -2467,7 +2469,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var131 string
 			templ_7745c5c3_Var131, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "artists.bulk.select_artist", a.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1535, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1537, Col: 62}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var131))
 			if templ_7745c5c3_Err != nil {
@@ -2480,7 +2482,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var132 string
 			templ_7745c5c3_Var132, templ_7745c5c3_Err = templ.JoinStringErrs(a.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1540, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1542, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var132))
 			if templ_7745c5c3_Err != nil {
@@ -2493,7 +2495,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var133 string
 			templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "artists.bulk.select_artist", a.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1542, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1544, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var133))
 			if templ_7745c5c3_Err != nil {
@@ -2516,7 +2518,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 		var templ_7745c5c3_Var135 templ.SafeURL
 		templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath() + "/artists/" + a.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1547, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1549, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var135))
 		if templ_7745c5c3_Err != nil {
@@ -2548,7 +2550,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 				var templ_7745c5c3_Var137 string
 				templ_7745c5c3_Var137, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(templ.SafeCSS("background-image:url('" + a.ThumbPlaceholder + "')"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1553, Col: 111}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1555, Col: 111}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var137))
 				if templ_7745c5c3_Err != nil {
@@ -2566,7 +2568,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var138 string
 			templ_7745c5c3_Var138, templ_7745c5c3_Err = templ.JoinStringErrs(basePath() + "/api/v1/artists/" + a.ID + "/images/thumb/file")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1556, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1558, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var138))
 			if templ_7745c5c3_Err != nil {
@@ -2579,7 +2581,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var139 string
 			templ_7745c5c3_Var139, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1557, Col: 18}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1559, Col: 18}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var139))
 			if templ_7745c5c3_Err != nil {
@@ -2597,7 +2599,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var140 string
 			templ_7745c5c3_Var140, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(templ.SafeCSS("background-image:url('" + a.ThumbPlaceholder + "')"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1563, Col: 110}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1565, Col: 110}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var140))
 			if templ_7745c5c3_Err != nil {
@@ -2639,7 +2641,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var143 string
 			templ_7745c5c3_Var143, templ_7745c5c3_Err = templ.JoinStringErrs(complianceDotTitle(ctx, artistCompliance(a.ID, compliance)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1574, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1576, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var143))
 			if templ_7745c5c3_Err != nil {
@@ -2652,7 +2654,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var144 string
 			templ_7745c5c3_Var144, templ_7745c5c3_Err = templ.JoinStringErrs(complianceDotTitle(ctx, artistCompliance(a.ID, compliance)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1575, Col: 78}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1577, Col: 78}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var144))
 			if templ_7745c5c3_Err != nil {
@@ -2674,7 +2676,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 		var templ_7745c5c3_Var145 string
 		templ_7745c5c3_Var145, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1582, Col: 91}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1584, Col: 91}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var145))
 		if templ_7745c5c3_Err != nil {
@@ -2687,7 +2689,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 		var templ_7745c5c3_Var146 string
 		templ_7745c5c3_Var146, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1583, Col: 13}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1585, Col: 13}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var146))
 		if templ_7745c5c3_Err != nil {
@@ -2722,7 +2724,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 		var templ_7745c5c3_Var149 string
 		templ_7745c5c3_Var149, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%.0f%%", a.HealthScore))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1586, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1588, Col: 43}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var149))
 		if templ_7745c5c3_Err != nil {
@@ -2863,7 +2865,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var153 string
 		templ_7745c5c3_Var153, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.run_rules"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1630, Col: 70}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1632, Col: 70}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var153))
 		if templ_7745c5c3_Err != nil {
@@ -2876,7 +2878,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var154 string
 		templ_7745c5c3_Var154, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.re_identify"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1631, Col: 74}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1633, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var154))
 		if templ_7745c5c3_Err != nil {
@@ -2889,7 +2891,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var155 string
 		templ_7745c5c3_Var155, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.re_identify_auto"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1632, Col: 84}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1634, Col: 84}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var155))
 		if templ_7745c5c3_Err != nil {
@@ -2902,7 +2904,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var156 string
 		templ_7745c5c3_Var156, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.re_identify_review"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1633, Col: 88}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1635, Col: 88}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var156))
 		if templ_7745c5c3_Err != nil {
@@ -2915,7 +2917,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var157 string
 		templ_7745c5c3_Var157, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.scan"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1634, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1636, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var157))
 		if templ_7745c5c3_Err != nil {
@@ -2928,7 +2930,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var158 string
 		templ_7745c5c3_Var158, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.fetch_images"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1635, Col: 76}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1637, Col: 76}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var158))
 		if templ_7745c5c3_Err != nil {
@@ -2941,7 +2943,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var159 string
 		templ_7745c5c3_Var159, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.template"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1636, Col: 63}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1638, Col: 63}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var159))
 		if templ_7745c5c3_Err != nil {
@@ -2954,7 +2956,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var160 string
 		templ_7745c5c3_Var160, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.single"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1637, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1639, Col: 59}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var160))
 		if templ_7745c5c3_Err != nil {
@@ -2967,7 +2969,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var161 string
 		templ_7745c5c3_Var161, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.summary"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1638, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1640, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var161))
 		if templ_7745c5c3_Err != nil {
@@ -2980,7 +2982,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var162 string
 		templ_7745c5c3_Var162, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.summary"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1639, Col: 74}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1641, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var162))
 		if templ_7745c5c3_Err != nil {
@@ -2993,7 +2995,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var163 string
 		templ_7745c5c3_Var163, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.confirm.small"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1640, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1642, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var163))
 		if templ_7745c5c3_Err != nil {
@@ -3006,7 +3008,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var164 string
 		templ_7745c5c3_Var164, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.confirm.large"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1641, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1643, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var164))
 		if templ_7745c5c3_Err != nil {
@@ -3019,7 +3021,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var165 string
 		templ_7745c5c3_Var165, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.cancel"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1652, Col: 45}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1654, Col: 45}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var165))
 		if templ_7745c5c3_Err != nil {
@@ -3032,7 +3034,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var166 string
 		templ_7745c5c3_Var166, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.cancel"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1655, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1657, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var166))
 		if templ_7745c5c3_Err != nil {

--- a/web/templates/artists_templ.go
+++ b/web/templates/artists_templ.go
@@ -105,7 +105,7 @@ func artistSourceInfo(a artist.Artist, sources map[string]LibrarySourceInfo) Lib
 }
 
 // artistHasFilesystem returns true when the artist holds at least one
-// filesystem-library membership. Issue #1004 replaced the prior path-based
+// filesystem-library membership. Replaced the prior path-based
 // heuristic, which gave false positives for connection-only artists whose
 // path was set by Emby / Jellyfin populates.
 func artistHasFilesystem(pp artist.PlatformPresence) bool {


### PR DESCRIPTION
## Summary

Architectural fix for #1004. Artists become M:N with libraries via a new \`artist_libraries\` join table, replacing the per-artist \`library_id\` FK. After this PR, populating both Emby and Jellyfin against the same on-disk artist produces ONE artist row carrying both platform mappings and both library memberships, instead of two parallel rows that the old per-library-scoped dedupe could not collapse.

The \`artists.library_id\` column is kept as a soft-deprecated transition layer with hybrid \`EXISTS (...) OR library_id = ?\` filter clauses bridging old and new shapes. The full column drop and deprecated-method cleanup is tracked in #1214 (chore) so this PR does not balloon test fixtures.

Closes #1004.

## Phases (one commit per phase)

| SHA | Scope |
|---|---|
| \`1d404cf\` | Schema: \`artist_libraries\` table + index. Runtime collapse migration that backfills memberships from the legacy \`library_id\` column AND collapses pre-existing duplicate artist rows by MBID then by case-insensitive name. Canonical pick: filesystem-source library wins, tie-break oldest \`created_at\`. FK re-pointing across 10 child tables with conflict resolution. 4 new migration tests. |
| \`0f9bf91\` | Repository interface: unscoped \`GetByName\` + \`FindByMBIDOrNameUnscoped\` + a new \`MembershipRepository\` (Add/Remove/ListForArtist/CountForArtist). Service pass-throughs. 6 new unit tests. |
| \`82b21fd\` | Populate handler rewrite: Emby and Jellyfin now use shared \`dedupeForImport\` (unscoped) and call \`AddLibraryMembership\` on every match-or-create. Killer integration test \`TestPopulate_EmbyAndJellyfin_CollapsesIntoOneArtist\` proves one row, both mappings, both memberships. |
| \`3ce05c9\` | UAT-driven fix: collapse migration was dropping platform mappings via the \`(connection_id, platform_artist_id)\` UNIQUE index; switched to UPDATE OR IGNORE. Filesystem badge on \`/artists\` now derives from membership instead of the path heuristic. |
| \`96d6cb8\` | Library unlink rewrite: membership-aware prune that preserves multi-library artists, with a fallback connection-orphan sweep for legacy data shapes. \`TestDeleteWithArtists_PreservesArtistInOtherLibraries\` is the new regression. |
| \`da5eb7c\` | All platform badges (Emby/Jellyfin/Lidarr/Filesystem) now derive from \`artist_libraries\` rather than \`artist_platform_ids\`, so unlinking a library drops the corresponding badge even when the connection mapping survives. Lidarr populate migrated to the same dedupe + membership pattern. \`artist_libraries.source\` CHECK widened to include \`'lidarr'\` with a runtime table-rebuild for existing DBs. |
| \`89f3bec\` | Per-library queries (artist list filter, completeness, health stats, image write times) match either \`artist_libraries\` membership OR the legacy column, so the rollout is safe for callers that have not yet been migrated to write memberships. \`Service.Create\` auto-records membership when \`a.LibraryID\` is set. |
| \`020a494\` | Build: exclude \`scripts/\` from patch coverage so UAT helpers do not pull the threshold below 70%. |

## UAT performed

Synthetic-data UAT via \`scripts/uat-1004/main.go\` against a temp DB. Topology: filesystem + Emby + Jellyfin libraries, with duplicate \"12 Stones\" rows across all three (MBID-grouped), duplicate \"Veridia / VERIDIA\" across two (name-grouped), and a clean \"Skillet\" Emby-only control.

- Collapse migration: 6 pre-existing artists collapsed to 3, all platform mappings preserved on canonical rows, both memberships per multi-home artist.
- Live populate (Emby + Jellyfin against same library): one row, both mappings, both memberships. Verified end-to-end in the integration test.
- Unlink with \"delete artists\": Skillet (Emby-only) pruned; 12 Stones (filesystem + Emby + Jellyfin) survives losing Emby; badges flip correctly.
- Badge from membership: Emby badge disappears immediately when Emby library is unlinked, even though the mapping row persists.

## Follow-up

#1214 -- drop \`artists.library_id\` column, strip deprecated repo methods (\`GetByMBIDAndLibrary\`, \`GetByNameAndLibrary\`, \`FindByMBIDOrName\`), strip the OR-clause fallbacks, update test fixtures to seed memberships explicitly. Sized as a separate cleanup PR because the test-fixture impact is broad.

## Test plan

- [ ] Reviewer: pull the branch, run \`bash scripts/pre-push-gate.sh\`, confirm patch coverage ≥ 70%.
- [ ] Reviewer: \`go run ./scripts/uat-1004 /tmp/sw-1004.db\`, then start Stillwater pointed at the temp DB, confirm \`/artists\` shows 3 rows with the expected badge sets per the seed report.
- [ ] Reviewer: visit \`/artists\` filtered by each library; counts match memberships.
- [ ] Reviewer: unlink a library with \"delete artists\" toggled and verify multi-membership artists survive while single-membership artists are pruned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Imports no longer create duplicate artist rows; platform IDs and library memberships consolidate onto a single canonical artist.
  * Deleting/unlinking a library preserves artists that still belong to other libraries or have platform mappings.

* **New Features**
  * Canonical artist↔library membership tracking with explicit filesystem membership flag.
  * Membership management surfaced to service APIs (add/remove/list/count).
  * UI now shows filesystem badge based on membership presence.

* **Chores**
  * Database migration adds memberships, backfills legacy data, and collapses duplicates.
  * Added a local UAT seeding tool and CI/coverage exclusions for scripts.

* **Tests**
  * Extensive new and updated tests for dedupe, migration, membership, delete, and presence behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->