### PR TITLE
fix(artists): persist bulk selection across sort changes (#1081)

### DIFF
--- a/internal/api/handlers_artist_test.go
+++ b/internal/api/handlers_artist_test.go
@@ -102,6 +102,112 @@ func TestArtistsPageSortParams(t *testing.T) {
 	}
 }
 
+// TestArtistsPage_BulkSelectionSurvivesSort verifies the markup contract that
+// the client-side bulk-selection store relies on across sort changes. Issue
+// #1081: F1 (gallery) was reported to wipe selection on sort, F2 (table) was
+// reported to keep positional row state instead of artist-id state. The
+// client store keys selection by stable artist ID and re-derives the
+// `cb.checked` DOM state on every htmx swap, which only works if the server
+// (a) always emits a unique `data-artist-id` per row, (b) never bakes a
+// `checked` attribute into the freshly-rendered checkbox HTML, and (c)
+// excludes sort/order/page/page_size/view from the client-side
+// `currentScopeToken` so the sort-triggered swap does not look like a scope
+// change to the selection controller. This test pins (a)-(c) so a future
+// edit cannot regress the behavior described in #1081.
+func TestArtistsPage_BulkSelectionSurvivesSort(t *testing.T) {
+	r, _, artistSvc := testRouterWithLibrary(t)
+
+	// Two artists are enough to assert per-row uniqueness while keeping the
+	// rendered body small.
+	for _, name := range []string{"Zydeco Band", "Alpha Artist"} {
+		if err := artistSvc.Create(context.Background(), &artist.Artist{Name: name}); err != nil {
+			t.Fatalf("creating artist %q: %v", name, err)
+		}
+	}
+	listed, _, err := artistSvc.List(context.Background(), artist.ListParams{Page: 1, PageSize: 10})
+	if err != nil {
+		t.Fatalf("listing artists: %v", err)
+	}
+	if len(listed) != 2 {
+		t.Fatalf("len(listed) = %d, want 2", len(listed))
+	}
+
+	// Render both views (table + grid) and assert the same contract for each.
+	for _, view := range []string{"table", "grid"} {
+		t.Run("view="+view, func(t *testing.T) {
+			ctx := middleware.WithTestUserID(context.Background(), "test-user")
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/artists?view="+view+"&sort=name&order=asc", nil)
+			w := httptest.NewRecorder()
+			r.handleArtistsPage(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status %d, want 200", w.Code)
+			}
+			body := w.Body.String()
+
+			// (a) Each artist row carries its own `data-artist-id` so the
+			// client store can key by stable ID rather than row position.
+			for _, a := range listed {
+				wantAttr := fmt.Sprintf(`data-artist-id=%q`, a.ID)
+				if !strings.Contains(body, wantAttr) {
+					t.Errorf("rendered body missing %s for artist %q", wantAttr, a.Name)
+				}
+			}
+
+			// (b) No baked-in `checked` attribute on bulk-select inputs.
+			// updateBar() re-derives state after every swap; if the server
+			// pre-checks any box, sort swaps would race against the
+			// re-derivation and produce stale (positional) state.
+			for _, a := range listed {
+				marker := fmt.Sprintf(`data-artist-id=%q`, a.ID)
+				idx := strings.Index(body, marker)
+				if idx < 0 {
+					continue
+				}
+				// Look back to the input tag opening for this row's
+				// checkbox: the marker appears inside the <input ...>
+				// tag that opens a few characters earlier.
+				inputStart := strings.LastIndex(body[:idx], "<input")
+				if inputStart < 0 {
+					t.Errorf("could not locate <input opener for artist %q", a.Name)
+					continue
+				}
+				inputEnd := strings.Index(body[inputStart:], ">")
+				if inputEnd < 0 {
+					t.Errorf("malformed <input tag for artist %q", a.Name)
+					continue
+				}
+				inputTag := body[inputStart : inputStart+inputEnd+1]
+				if strings.Contains(inputTag, " checked") || strings.Contains(inputTag, "checked=") {
+					t.Errorf("bulk-select input has baked-in checked: %s", inputTag)
+				}
+			}
+
+			// (c) The client-side scope-token routine excludes the params
+			// that the issue called out as scope-irrelevant: sort, order,
+			// page, page_size, view. Pin the inclusion list to catch any
+			// drift that would re-introduce a wipe-on-sort regression.
+			scopeMarker := `if (k === 'search' || k === 'library_id' || k === 'filter' || k.indexOf('filter_') === 0)`
+			if !strings.Contains(body, scopeMarker) {
+				t.Errorf("rendered body missing scope-token allowlist: want %q", scopeMarker)
+			}
+			for _, irrelevant := range []string{"'sort'", "'order'", "'page'", "'page_size'", "'view'"} {
+				// The allowlist must NOT mention these as scope keys.
+				// Match within the allowlist line only to avoid catching
+				// hidden inputs and unrelated JS that legitimately
+				// reference these names.
+				lineIdx := strings.Index(body, scopeMarker)
+				if lineIdx < 0 {
+					continue
+				}
+				line := body[lineIdx : lineIdx+len(scopeMarker)]
+				if strings.Contains(line, irrelevant) {
+					t.Errorf("scope-token allowlist must not include %s", irrelevant)
+				}
+			}
+		})
+	}
+}
+
 // TestArtistDetailPage_TabDebugFallback verifies that tab=debug falls back to
 // overview when the setting is disabled, when no connections exist, or when
 // only non-debug-capable (Lidarr) connections exist.

--- a/internal/api/handlers_artist_test.go
+++ b/internal/api/handlers_artist_test.go
@@ -186,6 +186,10 @@ func TestArtistsPage_BulkSelectionSurvivesSort(t *testing.T) {
 			// that the issue called out as scope-irrelevant: sort, order,
 			// page, page_size, view. Pin the inclusion list to catch any
 			// drift that would re-introduce a wipe-on-sort regression.
+			// This is an exact-string match against the emitted JS; if the
+			// templ-side condition is reformatted or the variable is
+			// renamed, update this marker rather than converting to AST
+			// parsing (overkill for a contract test).
 			scopeMarker := `if (k === 'search' || k === 'library_id' || k === 'filter' || k.indexOf('filter_') === 0)`
 			if !strings.Contains(body, scopeMarker) {
 				t.Errorf("rendered body missing scope-token allowlist: want %q", scopeMarker)

--- a/web/templates/artists.templ
+++ b/web/templates/artists.templ
@@ -1254,14 +1254,17 @@ templ ArtistsPage(assets AssetPaths, data ArtistListData) {
 				// Compute the scope token from an htmx request URL. Used in
 				// the afterSwap handler to derive the new scope without
 				// depending on whether the URL-update listener has run yet.
-				// htmx 2.x exposes the request URL on evt.detail.pathInfo
-				// (requestPath / finalRequestPath); both are checked because
-				// hx-vals can rewrite the path between them. Falls through
-				// to the current window.location URL if neither is present.
+				// htmx 2.0.8 exposes the request configuration on
+				// evt.detail.requestConfig.path (the path htmx issued the
+				// request to) and the resolved URL on evt.detail.xhr.responseURL
+				// (post-redirect). We try requestConfig.path first because it
+				// reflects what htmx asked for, fall back to xhr.responseURL,
+				// then finally to window.location if neither is present.
 				function scopeTokenFromRequest(evt) {
 					try {
-						var pi = evt && evt.detail && evt.detail.pathInfo;
-						var path = pi && (pi.finalRequestPath || pi.requestPath);
+						var rc = evt && evt.detail && evt.detail.requestConfig;
+						var xhr = evt && evt.detail && evt.detail.xhr;
+						var path = (rc && rc.path) || (xhr && xhr.responseURL);
 						if (path) {
 							var u = new URL(path, window.location.origin);
 							return tokenFromParams(u.searchParams);

--- a/web/templates/artists.templ
+++ b/web/templates/artists.templ
@@ -15,35 +15,35 @@ import (
 // Filter trigger button class sets. Used in both the class attribute (via
 // templ.KV) and data-* attributes so the template is the single source of truth.
 const (
-	filterTriggerActive = "border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-600"
+	filterTriggerActive  = "border-blue-500 bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-600"
 	filterTriggerNeutral = "border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
-	filterTriggerBadge = "sw-filter-trigger-badge ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-blue-600 text-[10px] font-bold text-white dark:bg-blue-400 dark:text-gray-900"
+	filterTriggerBadge   = "sw-filter-trigger-badge ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-blue-600 text-[10px] font-bold text-white dark:bg-blue-400 dark:text-gray-900"
 )
 
 // LibrarySourceInfo holds display metadata for an imported library's source.
 type LibrarySourceInfo struct {
-	Source string // "emby", "jellyfin", "lidarr"
+	Source         string // "emby", "jellyfin", "lidarr"
 	ConnectionName string // human-readable connection name
 }
 
 // ArtistListData holds the data for the artist list page.
 type ArtistListData struct {
-	Artists []artist.Artist
-	Libraries []library.Library
-	LibrarySources map[string]LibrarySourceInfo // library ID -> source info (only for non-manual)
-	ComplianceMap map[string]artist.ComplianceStatus // artist ID -> compliance status
+	Artists          []artist.Artist
+	Libraries        []library.Library
+	LibrarySources   map[string]LibrarySourceInfo       // library ID -> source info (only for non-manual)
+	ComplianceMap    map[string]artist.ComplianceStatus // artist ID -> compliance status
 	PlatformPresence map[string]artist.PlatformPresence // artist ID -> platform badges
-	Pagination components.PaginationData
-	Search string
-	Sort string
-	Order string
-	Filter string
+	Pagination       components.PaginationData
+	Search           string
+	Sort             string
+	Order            string
+	Filter           string
 	// Filters holds the flyout multi-filter state (key -> "include" or "exclude").
 	// Keys: missing_meta, missing_images, missing_mbid, excluded, locked,
 	// type_person, type_group, type_orchestra, library_{id}.
-	Filters map[string]string
-	LibraryID string
-	View string // "table" or "grid"
+	Filters     map[string]string
+	LibraryID   string
+	View        string // "table" or "grid"
 	ProfileName string // Active platform profile name for image terminology
 }
 
@@ -132,7 +132,7 @@ func jellyfinTooltip(ctx context.Context, src LibrarySourceInfo) string {
 // artistBadge holds the platform name and tooltip for a single badge.
 type artistBadge struct {
 	Platform string
-	Tooltip string
+	Tooltip  string
 }
 
 // computeArtistBadges returns the ordered list of platform badges for an artist.
@@ -1229,11 +1229,16 @@ templ ArtistsPage(assets AssetPaths, data ArtistListData) {
 				// Scope token: filter-identifying params only. If any of
 				// these change across an htmx swap, the user is looking
 				// at a different result set and the previous selection is
-				// no longer meaningful. Pagination and sort do NOT reset
-				// selection so the user can page through filtered results
-				// while preserving their selection.
-				function currentScopeToken() {
-					var p = new URLSearchParams(window.location.search);
+				// no longer meaningful. Pagination, sort, order, and view
+				// do NOT reset selection so the user can re-sort, paginate,
+				// or switch table/grid while preserving their selection.
+				//
+				// Prefer the explicit URLSearchParams source over
+				// window.location.search so the same routine works whether
+				// we are reacting to an htmx swap (where the URL has
+				// already been updated by the listener at line 638) or
+				// computing the initial token at IIFE init.
+				function tokenFromParams(p) {
 					var keys = [];
 					p.forEach(function(_v, k) {
 						if (k === 'search' || k === 'library_id' || k === 'filter' || k.indexOf('filter_') === 0) {
@@ -1242,6 +1247,27 @@ templ ArtistsPage(assets AssetPaths, data ArtistListData) {
 					});
 					keys.sort();
 					return keys.map(function(k) { return k + '=' + p.get(k); }).join('&');
+				}
+				function currentScopeToken() {
+					return tokenFromParams(new URLSearchParams(window.location.search));
+				}
+				// Compute the scope token from an htmx request URL. Used in
+				// the afterSwap handler to derive the new scope without
+				// depending on whether the URL-update listener has run yet.
+				// htmx 2.x exposes the request URL on evt.detail.pathInfo
+				// (requestPath / finalRequestPath); both are checked because
+				// hx-vals can rewrite the path between them. Falls through
+				// to the current window.location URL if neither is present.
+				function scopeTokenFromRequest(evt) {
+					try {
+						var pi = evt && evt.detail && evt.detail.pathInfo;
+						var path = pi && (pi.finalRequestPath || pi.requestPath);
+						if (path) {
+							var u = new URL(path, window.location.origin);
+							return tokenFromParams(u.searchParams);
+						}
+					} catch (e) { /* fall through */ }
+					return currentScopeToken();
 				}
 				var lastScopeToken = currentScopeToken();
 
@@ -1268,7 +1294,12 @@ templ ArtistsPage(assets AssetPaths, data ArtistListData) {
 				});
 				document.body.addEventListener('htmx:afterSwap', function(evt) {
 					if (evt.detail.target && evt.detail.target.id === 'artist-content') {
-						var currentToken = currentScopeToken();
+						// Derive the new scope from the htmx request URL so
+						// the comparison does not depend on the URL-update
+						// listener (line 638) having fired first. This keeps
+						// selection stable across sort/order/page/view swaps
+						// (issue #1081 F1) regardless of listener ordering.
+						var currentToken = scopeTokenFromRequest(evt);
 						if (currentToken !== lastScopeToken) {
 							selected.clear();
 							capWarned = false;
@@ -1279,6 +1310,11 @@ templ ArtistsPage(assets AssetPaths, data ArtistListData) {
 						// applies, so an old anchor could select an unintended
 						// range on the next shift-click.
 						lastClickedId = null;
+						// Re-derive every checkbox's checked state from the
+						// `selected` Set. The freshly-swapped HTML never
+						// includes a `checked` attribute, so this is what
+						// keeps checkmarks attached to artist IDs (not row
+						// positions) across sort changes (issue #1081 F2).
 						updateBar();
 					}
 				});

--- a/web/templates/artists_templ.go
+++ b/web/templates/artists_templ.go
@@ -1394,7 +1394,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, " <script>\n\t\t\tvar _artistsBp = (document.querySelector('meta[name=\"htmx-base-path\"]') || {content: ''}).content;\n\t\t\t// Inject flyout filter params from the URL into HTMX requests that\n\t\t\t// target #artist-content. The flyout stores state in the URL only\n\t\t\t// (not in named form elements), so hx-include cannot pick it up.\n\t\t\tdocument.body.addEventListener('htmx:configRequest', function(evt) {\n\t\t\t\tif (evt.detail.target && evt.detail.target.id === 'artist-content') {\n\t\t\t\t\tvar urlParams = new URLSearchParams(window.location.search);\n\t\t\t\t\turlParams.forEach(function(val, key) {\n\t\t\t\t\t\tif (key.indexOf('filter_') === 0 && !(key in evt.detail.parameters)) {\n\t\t\t\t\t\t\tevt.detail.parameters[key] = val;\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t});\n\n\t\t\tvar _sortActiveClass = 'w-full text-left px-4 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 font-semibold text-blue-600 dark:text-blue-400';\n\t\t\tvar _sortInactiveClass = 'w-full text-left px-4 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200';\n\n\t\t\tfunction updateSortUI(sort, order) {\n\t\t\t\tvar fieldLabel = document.getElementById('sort-field-label');\n\t\t\t\tvar orderLabel = document.getElementById('sort-order-label');\n\t\t\t\tif (fieldLabel) {\n\t\t\t\t\tvar activeBtn = document.querySelector('#sort-dropdown button[onclick=\"setSort(\\'' + sort + '\\')\"]');\n\t\t\t\t\tfieldLabel.textContent = activeBtn ? activeBtn.textContent.trim() : sort;\n\t\t\t\t}\n\t\t\t\tif (orderLabel) {\n\t\t\t\t\tvar activeOrder = document.querySelector('#sort-dropdown button[onclick=\"setOrder(\\'' + order + '\\')\"]');\n\t\t\t\t\torderLabel.textContent = activeOrder ? activeOrder.textContent.trim() : order;\n\t\t\t\t}\n\t\t\t\t['name', 'sort_name', 'health_score', 'updated_at', 'created_at'].forEach(function(f) {\n\t\t\t\t\tvar btn = document.querySelector('#sort-dropdown button[onclick=\"setSort(\\'' + f + '\\')\"]');\n\t\t\t\t\tif (btn) btn.className = f === sort ? _sortActiveClass : _sortInactiveClass;\n\t\t\t\t});\n\t\t\t\t['asc', 'desc'].forEach(function(d) {\n\t\t\t\t\tvar btn = document.querySelector('#sort-dropdown button[onclick=\"setOrder(\\'' + d + '\\')\"]');\n\t\t\t\t\tif (btn) btn.className = d === order ? _sortActiveClass : _sortInactiveClass;\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction setSort(field) {\n\t\t\t\tvar sortInput = document.getElementById('artist-sort-input');\n\t\t\t\tvar orderInput = document.getElementById('artist-order-input');\n\t\t\t\tif (!sortInput || !orderInput) return;\n\t\t\t\tif (sortInput.value === field) {\n\t\t\t\t\torderInput.value = (orderInput.value === 'asc') ? 'desc' : 'asc';\n\t\t\t\t} else {\n\t\t\t\t\tsortInput.value = field;\n\t\t\t\t\torderInput.value = 'asc';\n\t\t\t\t}\n\t\t\t\tupdateSortUI(sortInput.value, orderInput.value);\n\t\t\t\tcloseSortDropdown();\n\t\t\t\thtmx.ajax('GET', '/artists', {\n\t\t\t\t\ttarget: '#artist-content',\n\t\t\t\t\tswap: 'outerHTML',\n\t\t\t\t\tvalues: buildArtistParams({page: '1'})\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction setOrder(dir) {\n\t\t\t\tvar sortInput = document.getElementById('artist-sort-input');\n\t\t\t\tvar orderInput = document.getElementById('artist-order-input');\n\t\t\t\tif (!orderInput) return;\n\t\t\t\torderInput.value = dir;\n\t\t\t\tupdateSortUI(sortInput ? sortInput.value : '', dir);\n\t\t\t\tcloseSortDropdown();\n\t\t\t\thtmx.ajax('GET', '/artists', {\n\t\t\t\t\ttarget: '#artist-content',\n\t\t\t\t\tswap: 'outerHTML',\n\t\t\t\t\tvalues: buildArtistParams({page: '1'})\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction closeSortDropdown() {\n\t\t\t\tvar d = document.getElementById('sort-dropdown');\n\t\t\t\tif (d) d.removeAttribute('open');\n\t\t\t}\n\n\t\t\tfunction buildArtistParams(overrides) {\n\t\t\t\tvar params = {};\n\t\t\t\t// Collect form-based params from named elements.\n\t\t\t\t['search', 'library_id', 'view', 'sort', 'order'].forEach(function(name) {\n\t\t\t\t\tvar el = document.querySelector('[name=\"' + name + '\"]');\n\t\t\t\t\tif (el) params[name] = el.value;\n\t\t\t\t});\n\t\t\t\t// Carry all flyout filter params from the current URL dynamically.\n\t\t\t\tvar urlParams = new URLSearchParams(window.location.search);\n\t\t\t\turlParams.forEach(function(val, key) {\n\t\t\t\t\tif (key.indexOf('filter_') === 0) {\n\t\t\t\t\t\tparams[key] = val;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn Object.assign(params, overrides);\n\t\t\t}\n\n\t\t\t// Update view toggle button classes to reflect the active view.\n\t\t\t// Mirrors the server-side templ.KV classes on the #view-toggle buttons.\n\t\t\tvar _viewActiveClass = 'p-2 transition-colors bg-blue-600 text-white';\n\t\t\tvar _viewInactiveClass = 'p-2 transition-colors bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700';\n\t\t\tfunction updateViewToggleUI(view) {\n\t\t\t\tvar toggle = document.getElementById('view-toggle');\n\t\t\t\tif (!toggle) return;\n\t\t\t\tvar tableBtn = toggle.querySelector('button[onclick=\"setView(\\'table\\')\"]');\n\t\t\t\tvar gridBtn = toggle.querySelector('button[onclick=\"setView(\\'grid\\')\"]');\n\t\t\t\tif (tableBtn) tableBtn.className = view === 'table' ? _viewActiveClass : _viewInactiveClass;\n\t\t\t\tif (gridBtn) gridBtn.className = view === 'grid' ? _viewActiveClass : _viewInactiveClass;\n\t\t\t}\n\n\t\t\tfunction setView(view) {\n\t\t\t\tvar input = document.getElementById('artist-view-input');\n\t\t\t\tif (input) input.value = view;\n\t\t\t\tupdateViewToggleUI(view);\n\t\t\t\t// Show/hide column toggle based on view\n\t\t\t\tvar colToggle = document.getElementById('col-toggle-wrapper');\n\t\t\t\tif (colToggle) {\n\t\t\t\t\tif (view === 'table') {\n\t\t\t\t\t\tcolToggle.classList.remove('hidden');\n\t\t\t\t\t} else {\n\t\t\t\t\t\tcolToggle.classList.add('hidden');\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\t// Fire-and-forget save preference\n\t\t\t\tvar csrfToken = document.cookie.replace(/(?:(?:^|.*;\\s*)csrf_token\\s*\\=\\s*([^;]*).*$)|^.*$/, \"$1\");\n\t\t\t\tfetch(_artistsBp + '/api/v1/settings', {\n\t\t\t\t\tmethod: 'PUT',\n\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},\n\t\t\t\t\tbody: JSON.stringify({\"ui.artists_view\": view})\n\t\t\t\t}).catch(function() {});\n\t\t\t}\n\n\t\t\t// After HTMX swaps artist content, push the current filter/sort state\n\t\t\t// into the URL so browser back-navigation restores the correct view.\n\t\t\t// Uses window.location.pathname (not hardcoded '/artists') for basePath\n\t\t\t// support, and carries over the page param from the HTMX request URL.\n\t\t\tdocument.body.addEventListener('htmx:afterSwap', function(evt) {\n\t\t\t\tif (evt.detail.target && evt.detail.target.id === 'artist-content') {\n\t\t\t\t\t// Re-sync flyout state from URL after any swap (including chip dismissals\n\t\t\t\t\t// via DismissFilterChip, which bypass the sw:filter-applied event).\n\t\t\t\t\tif (window.swFilterFlyout) {\n\t\t\t\t\t\tswFilterFlyout.initFromURL('artist-filters-flyout');\n\t\t\t\t\t}\n\n\t\t\t\t\tvar params = buildArtistParams({});\n\t\t\t\t\t// Extract page from the HTMX request URL if present.\n\t\t\t\t\ttry {\n\t\t\t\t\t\tvar reqUrl = new URL(evt.detail.requestInfo.path, window.location.origin);\n\t\t\t\t\t\tvar page = reqUrl.searchParams.get('page');\n\t\t\t\t\t\tif (page && page !== '1') params.page = page;\n\t\t\t\t\t\tvar pageSize = reqUrl.searchParams.get('page_size');\n\t\t\t\t\t\tif (pageSize) params.page_size = pageSize;\n\t\t\t\t\t} catch(e) { /* ignore parse errors */ }\n\t\t\t\t\tvar qs = Object.keys(params).filter(function(k) { return params[k]; }).map(function(k) {\n\t\t\t\t\t\treturn encodeURIComponent(k) + '=' + encodeURIComponent(params[k]);\n\t\t\t\t\t}).join('&');\n\t\t\t\t\thistory.replaceState(null, '', window.location.pathname + (qs ? '?' + qs : ''));\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Reload artist content when the filter flyout applies filters.\n\t\t\tdocument.body.addEventListener('sw:filter-applied', function(evt) {\n\t\t\t\tif (evt.target && evt.target.id === 'artist-content') {\n\t\t\t\t\t// Strip the base path from location.pathname before passing to htmx.ajax\n\t\t\t\t\t// to avoid a double-prefix from the htmx:configRequest hook.\n\t\t\t\t\tvar bpMeta = document.querySelector('meta[name=\"htmx-base-path\"]');\n\t\t\t\t\tvar bp = bpMeta ? bpMeta.content : '';\n\t\t\t\t\tvar path = window.location.pathname;\n\t\t\t\t\tif (bp && path.startsWith(bp)) {\n\t\t\t\t\t\tpath = path.slice(bp.length) || '/';\n\t\t\t\t\t}\n\t\t\t\t\thtmx.ajax('GET', path + window.location.search, {target: '#artist-content', swap: 'outerHTML'});\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Initialise the flyout from URL params on first page load.\n\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\tif (window.swFilterFlyout) {\n\t\t\t\t\tswFilterFlyout.initFromURL('artist-filters-flyout');\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// restoreStateFromURL syncs all filter controls, hidden inputs,\n\t\t\t// sort labels, and view toggle from the current URL query params,\n\t\t\t// then triggers an HTMX content reload so the artist list matches\n\t\t\t// the URL state. Used by both pageshow (bfcache) and popstate\n\t\t\t// (history back/forward) handlers.\n\t\t\t//\n\t\t\t// A debounce guard prevents duplicate calls when bfcache restore\n\t\t\t// fires both pageshow and popstate in quick succession.\n\t\t\tvar _restoreLastRun = 0;\n\t\t\tvar _restoreLastHref = '';\n\t\t\tfunction restoreStateFromURL() {\n\t\t\t\tvar now = Date.now();\n\t\t\t\tvar href = window.location.href;\n\t\t\t\tif (href === _restoreLastHref && now - _restoreLastRun < 100) return;\n\t\t\t\t_restoreLastHref = href;\n\t\t\t\t_restoreLastRun = now;\n\t\t\t\tvar params = new URLSearchParams(window.location.search);\n\t\t\t\t// Re-sync flyout chip states from URL.\n\t\t\t\tif (window.swFilterFlyout) {\n\t\t\t\t\tswFilterFlyout.initFromURL('artist-filters-flyout');\n\t\t\t\t}\n\t\t\t\t// Sync the search input from URL params.\n\t\t\t\tvar searchEl = document.getElementById('artist-search');\n\t\t\t\tif (searchEl) searchEl.value = params.get('search') || '';\n\t\t\t\t// Sync select elements from URL params.\n\t\t\t\t['library_id'].forEach(function(name) {\n\t\t\t\t\tvar val = params.get(name);\n\t\t\t\t\tvar el = document.querySelector('select[name=\"' + name + '\"]');\n\t\t\t\t\tif (el) el.value = (val !== null) ? val : '';\n\t\t\t\t});\n\t\t\t\t// Sync hidden inputs from URL params, resetting to markup\n\t\t\t\t// defaults when a param is absent so browser history\n\t\t\t\t// restoration cannot retain stale values from a newer state.\n\t\t\t\t['view', 'sort', 'order'].forEach(function(name) {\n\t\t\t\t\tvar val = params.get(name);\n\t\t\t\t\tvar el = document.getElementById('artist-' + name + '-input');\n\t\t\t\t\tif (el) el.value = (val !== null) ? val : el.defaultValue;\n\t\t\t\t});\n\t\t\t\t// Update visible sort labels and view toggle to match restored state.\n\t\t\t\tvar sortInput = document.getElementById('artist-sort-input');\n\t\t\t\tvar orderInput = document.getElementById('artist-order-input');\n\t\t\t\tif (sortInput && orderInput) updateSortUI(sortInput.value, orderInput.value);\n\t\t\t\tvar viewInput = document.getElementById('artist-view-input');\n\t\t\t\tif (viewInput) {\n\t\t\t\t\tupdateViewToggleUI(viewInput.value);\n\t\t\t\t\tvar colToggle = document.getElementById('col-toggle-wrapper');\n\t\t\t\t\tif (colToggle) colToggle.classList.toggle('hidden', viewInput.value !== 'table');\n\t\t\t\t}\n\t\t\t\tvar _rsMeta = document.querySelector('meta[name=\"htmx-base-path\"]');\n\t\t\t\tvar _rsBp = _rsMeta ? _rsMeta.content : '';\n\t\t\t\tvar _rsPath = window.location.pathname;\n\t\t\t\tif (_rsBp && _rsPath.startsWith(_rsBp)) { _rsPath = _rsPath.slice(_rsBp.length) || '/'; }\n\t\t\t\thtmx.ajax('GET', _rsPath + window.location.search, {target: '#artist-content', swap: 'outerHTML'});\n\t\t\t}\n\n\t\t\t// When the page is restored from bfcache (browser back/forward navigation),\n\t\t\t// sync filter controls from the URL query params and reload content so\n\t\t\t// status badges reflect the latest state.\n\t\t\twindow.addEventListener('pageshow', function(evt) {\n\t\t\t\tif (evt.persisted) {\n\t\t\t\t\trestoreStateFromURL();\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Handle browser back/forward navigation between pushState entries\n\t\t\t// (e.g. filter changes, pagination). Without this, pressing back after\n\t\t\t// applying filters and navigating away would show stale content even\n\t\t\t// though the URL contains the correct filter params. Works in Firefox\n\t\t\t// and all major browsers.\n\t\t\twindow.addEventListener('popstate', function() {\n\t\t\t\trestoreStateFromURL();\n\t\t\t});\n\n\t\t\t(function() {\n\t\t\t\tvar btn = document.getElementById('scan-btn');\n\t\t\t\tif (!btn) return;\n\n\t\t\t\tdocument.body.addEventListener('htmx:afterRequest', function(evt) {\n\t\t\t\t\tif (evt.detail.elt !== btn) return;\n\t\t\t\t\tif (!evt.detail.successful) return;\n\n\t\t\t\t\tvar spinner = document.getElementById('scan-spinner');\n\t\t\t\t\tvar label = document.getElementById('scan-label');\n\t\t\t\t\tbtn.disabled = true;\n\t\t\t\t\tspinner.classList.remove('hidden');\n\t\t\t\t\tlabel.textContent = btn.dataset.labelScanning || 'Scanning...';\n\n\t\t\t\t\tfunction resetScanUI() {\n\t\t\t\t\t\tbtn.disabled = false;\n\t\t\t\t\t\tspinner.classList.add('hidden');\n\t\t\t\t\t\tlabel.textContent = btn.dataset.labelScan || 'Scan Library';\n\t\t\t\t\t}\n\t\t\t\t\tpollAsyncStatus(_artistsBp + '/api/v1/scanner/status', {\n\t\t\t\t\t\tonData: function(data) {\n\t\t\t\t\t\t\tif (data.status === 'completed' || data.status === 'failed' || data.status === 'canceled') {\n\t\t\t\t\t\t\t\tresetScanUI();\n\t\t\t\t\t\t\t\tvar _scMeta = document.querySelector('meta[name=\"htmx-base-path\"]');\n\t\t\t\t\t\t\t\tvar _scBp = _scMeta ? _scMeta.content : '';\n\t\t\t\t\t\t\t\tvar _scPath = window.location.pathname;\n\t\t\t\t\t\t\t\tif (_scBp && _scPath.startsWith(_scBp)) { _scPath = _scPath.slice(_scBp.length) || '/'; }\n\t\t\t\t\t\t\t\thtmx.ajax('GET', _scPath + window.location.search, {target: '#artist-content', swap: 'outerHTML'});\n\t\t\t\t\t\t\t\treturn true;\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\treturn false;\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonHTTPError: function() {\n\t\t\t\t\t\t\tresetScanUI();\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonNetworkError: function() {\n\t\t\t\t\t\t\tresetScanUI();\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t});\n\t\t\t})();\n\n\t\t\t// Bulk-action controller. Wires the Select-All checkbox, per-row\n\t\t\t// checkboxes, the \"N selected\" indicator, and the action dropdown\n\t\t\t// to the /api/v1/artists/bulk-actions endpoint. The controller is\n\t\t\t// idempotent: it attaches listeners via event delegation so it\n\t\t\t// works across HTMX swaps of #artist-content without re-binding.\n\t\t\t(function() {\n\t\t\t\t// Selection state persists across HTMX swaps of the list so\n\t\t\t\t// the user can paginate while keeping earlier selections.\n\t\t\t\tvar selected = new Set();\n\t\t\t\t// Matches the backend cap in handlers_bulk_actions.go; keeps\n\t\t\t\t// the UI in sync so we never POST a payload the server will\n\t\t\t\t// reject with a generic \"failed to start\" toast.\n\t\t\t\tvar MAX_BULK_SELECTION = 1000;\n\t\t\t\tvar capWarned = false;\n\t\t\t\t// Tracks the last checkbox clicked for shift-click range\n\t\t\t\t// selection (Gmail/GitHub-style). Reset on scope change.\n\t\t\t\tvar lastClickedId = null;\n\t\t\t\t// Polling handle for the in-flight bulk action status. Non-null\n\t\t\t\t// while a bulk or single-artist run-rules action is running.\n\t\t\t\tvar progressPoll = null;\n\t\t\t\t// Tracks whether a bulk action is running end-to-end. Gates the\n\t\t\t\t// Apply button so checkbox/dropdown changes cannot re-enable it\n\t\t\t\t// mid-flight and queue a second POST (which would 409-loop).\n\t\t\t\tvar bulkActionRunning = false;\n\n\t\t\t\tfunction warnCap() {\n\t\t\t\t\tif (capWarned) return;\n\t\t\t\t\tcapWarned = true;\n\t\t\t\t\tvar bar = document.getElementById('bulk-action-bar');\n\t\t\t\t\tvar tpl = (bar && bar.getAttribute('data-i18n-selection-cap')) || 'You can select up to {count} artists at a time.';\n\t\t\t\t\talert(tpl.replace('{count}', String(MAX_BULK_SELECTION)));\n\t\t\t\t}\n\n\t\t\t\tfunction tryAdd(id) {\n\t\t\t\t\tif (selected.has(id)) return true;\n\t\t\t\t\tif (selected.size >= MAX_BULK_SELECTION) {\n\t\t\t\t\t\twarnCap();\n\t\t\t\t\t\treturn false;\n\t\t\t\t\t}\n\t\t\t\t\tselected.add(id);\n\t\t\t\t\treturn true;\n\t\t\t\t}\n\n\t\t\t\tfunction updateBar() {\n\t\t\t\t\tvar bar = document.getElementById('bulk-action-bar');\n\t\t\t\t\tif (!bar) return;\n\t\t\t\t\tvar countEl = document.getElementById('bulk-selected-count');\n\t\t\t\t\tvar applyBtn = document.getElementById('bulk-action-apply');\n\t\t\t\t\tvar selectEl = document.getElementById('bulk-action-select');\n\t\t\t\t\tvar selectAll = document.getElementById('bulk-select-all');\n\t\t\t\t\tvar boxes = document.querySelectorAll('#artist-content .sw-bulk-select');\n\t\t\t\t\tvar i18nNone = bar.getAttribute('data-i18n-none') || 'None selected';\n\t\t\t\t\tvar i18nSelectedOne = bar.getAttribute('data-i18n-selected-one') || '1 selected';\n\t\t\t\t\tvar i18nSelectedOther = bar.getAttribute('data-i18n-selected-other') || '{count} selected';\n\t\t\t\t\tif (countEl) {\n\t\t\t\t\t\tif (selected.size === 0) {\n\t\t\t\t\t\t\tcountEl.textContent = i18nNone;\n\t\t\t\t\t\t} else if (selected.size === 1) {\n\t\t\t\t\t\t\tcountEl.textContent = i18nSelectedOne;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tcountEl.textContent = i18nSelectedOther.replace('{count}', String(selected.size));\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\tif (applyBtn) applyBtn.disabled = bulkActionRunning || selected.size === 0 || !selectEl || !selectEl.value;\n\t\t\t\t\tif (selectEl) selectEl.disabled = bulkActionRunning || selected.size === 0;\n\t\t\t\t\t// Sync per-row checkboxes with persisted selection state.\n\t\t\t\t\tvar visibleChecked = 0;\n\t\t\t\t\tboxes.forEach(function(cb) {\n\t\t\t\t\t\tvar id = cb.getAttribute('data-artist-id');\n\t\t\t\t\t\tcb.checked = selected.has(id);\n\t\t\t\t\t\tif (cb.checked) visibleChecked++;\n\t\t\t\t\t});\n\t\t\t\t\t// Select-All indeterminate state.\n\t\t\t\t\tvar allChecked = false;\n\t\t\t\t\tif (selectAll) {\n\t\t\t\t\t\tif (boxes.length === 0) {\n\t\t\t\t\t\t\tselectAll.checked = false;\n\t\t\t\t\t\t\tselectAll.indeterminate = false;\n\t\t\t\t\t\t} else if (visibleChecked === 0) {\n\t\t\t\t\t\t\tselectAll.checked = false;\n\t\t\t\t\t\t\tselectAll.indeterminate = false;\n\t\t\t\t\t\t} else if (visibleChecked === boxes.length) {\n\t\t\t\t\t\t\tselectAll.checked = true;\n\t\t\t\t\t\t\tselectAll.indeterminate = false;\n\t\t\t\t\t\t\tallChecked = true;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tselectAll.checked = false;\n\t\t\t\t\t\t\tselectAll.indeterminate = true;\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\t// Swap the checkbox label between Select all / Deselect all\n\t\t\t\t\t// so screen readers and sighted users both see the action\n\t\t\t\t\t// that a click will perform next.\n\t\t\t\t\tvar labelEl = document.getElementById('bulk-select-all-label');\n\t\t\t\t\tif (labelEl) {\n\t\t\t\t\t\tvar i18nSelectAll = bar.getAttribute('data-i18n-select-all') || 'Select all on page';\n\t\t\t\t\t\tvar i18nDeselectAll = bar.getAttribute('data-i18n-deselect-all') || 'Deselect all on page';\n\t\t\t\t\t\tlabelEl.textContent = allChecked ? i18nDeselectAll : i18nSelectAll;\n\t\t\t\t\t}\n\t\t\t\t\tif (selectAll) {\n\t\t\t\t\t\tvar i18nSelectAllAria = bar.getAttribute('data-i18n-select-all') || 'Select all on page';\n\t\t\t\t\t\tvar i18nDeselectAllAria = bar.getAttribute('data-i18n-deselect-all') || 'Deselect all on page';\n\t\t\t\t\t\tselectAll.setAttribute('aria-label', allChecked ? i18nDeselectAllAria : i18nSelectAllAria);\n\t\t\t\t\t}\n\t\t\t\t}\n\n\t\t\t\t// Shift-click range selection: capture on click (before the\n\t\t\t\t// change event) so we can see event.shiftKey. If shift is\n\t\t\t\t// held and we have a prior lastClickedId, select/deselect\n\t\t\t\t// every checkbox between the two anchors in DOM order.\n\t\t\t\tdocument.body.addEventListener('click', function(ev) {\n\t\t\t\t\tvar t = ev.target;\n\t\t\t\t\tif (!t || !t.classList || !t.classList.contains('sw-bulk-select')) return;\n\t\t\t\t\tvar id = t.getAttribute('data-artist-id');\n\t\t\t\t\tif (!id) return;\n\t\t\t\t\t// Keyboard Shift+Space triggers a click with shiftKey.\n\t\t\t\t\tif (ev.shiftKey && lastClickedId && lastClickedId !== id) {\n\t\t\t\t\t\tvar boxes = Array.prototype.slice.call(\n\t\t\t\t\t\t\tdocument.querySelectorAll('#artist-content .sw-bulk-select')\n\t\t\t\t\t\t);\n\t\t\t\t\t\tvar idx1 = -1, idx2 = -1;\n\t\t\t\t\t\tfor (var i = 0; i < boxes.length; i++) {\n\t\t\t\t\t\t\tvar bid = boxes[i].getAttribute('data-artist-id');\n\t\t\t\t\t\t\tif (bid === lastClickedId) idx1 = i;\n\t\t\t\t\t\t\tif (bid === id) idx2 = i;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tif (idx1 >= 0 && idx2 >= 0) {\n\t\t\t\t\t\t\tvar lo = Math.min(idx1, idx2), hi = Math.max(idx1, idx2);\n\t\t\t\t\t\t\t// Target state follows the just-clicked checkbox's\n\t\t\t\t\t\t\t// post-click state (which the browser has already\n\t\t\t\t\t\t\t// set by the time this click handler runs).\n\t\t\t\t\t\t\tvar target = t.checked;\n\t\t\t\t\t\t\tfor (var j = lo; j <= hi; j++) {\n\t\t\t\t\t\t\t\tvar cb = boxes[j];\n\t\t\t\t\t\t\t\tvar cid = cb.getAttribute('data-artist-id');\n\t\t\t\t\t\t\t\tif (!cid) continue;\n\t\t\t\t\t\t\t\tif (target) {\n\t\t\t\t\t\t\t\t\tif (!tryAdd(cid)) { cb.checked = false; continue; }\n\t\t\t\t\t\t\t\t\tcb.checked = true;\n\t\t\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t\t\tselected.delete(cid);\n\t\t\t\t\t\t\t\t\tcb.checked = false;\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\tif (!target) capWarned = false;\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\tlastClickedId = id;\n\t\t\t\t}, true);\n\n\t\t\t\tdocument.body.addEventListener('change', function(ev) {\n\t\t\t\t\tvar t = ev.target;\n\t\t\t\t\tif (!t) return;\n\t\t\t\t\tif (t.classList && t.classList.contains('sw-bulk-select')) {\n\t\t\t\t\t\tvar id = t.getAttribute('data-artist-id');\n\t\t\t\t\t\tif (!id) return;\n\t\t\t\t\t\tif (t.checked) {\n\t\t\t\t\t\t\tif (!tryAdd(id)) { t.checked = false; }\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tselected.delete(id);\n\t\t\t\t\t\t\tcapWarned = false;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t} else if (t.id === 'bulk-select-all') {\n\t\t\t\t\t\tvar boxes = document.querySelectorAll('#artist-content .sw-bulk-select');\n\t\t\t\t\t\tboxes.forEach(function(cb) {\n\t\t\t\t\t\t\tvar id = cb.getAttribute('data-artist-id');\n\t\t\t\t\t\t\tif (!id) return;\n\t\t\t\t\t\t\tif (t.checked) {\n\t\t\t\t\t\t\t\tcb.checked = tryAdd(id);\n\t\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t\tcb.checked = false;\n\t\t\t\t\t\t\t\tselected.delete(id);\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t});\n\t\t\t\t\t\tif (!t.checked) capWarned = false;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t} else if (t.id === 'bulk-action-select') {\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t}\n\t\t\t\t});\n\n\t\t\t\t// Build the localized verb label for a bulk action from the\n\t\t\t\t// data attributes on the progress pill. Falls back to the\n\t\t\t\t// raw action key if a verb is missing.\n\t\t\t\tfunction actionVerb(action) {\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\tif (!pill) return action;\n\t\t\t\t\tvar key = 'data-i18n-verb-' + action.replace(/_/g, '-');\n\t\t\t\t\treturn pill.getAttribute(key) || action;\n\t\t\t\t}\n\n\t\t\t\t// Render the progress pill with the current snapshot. Called\n\t\t\t\t// from both the initial 202 response and the poll callback.\n\t\t\t\tfunction renderProgressPill(action, processed, total) {\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\tvar txt = document.getElementById('bulk-progress-text');\n\t\t\t\t\tif (!pill || !txt) return;\n\t\t\t\t\tvar tpl = pill.getAttribute('data-i18n-template') || '{verb}: {processed} of {total} artists';\n\t\t\t\t\tvar verb = actionVerb(action);\n\t\t\t\t\ttxt.textContent = tpl\n\t\t\t\t\t\t.replace('{verb}', verb)\n\t\t\t\t\t\t.replace('{processed}', String(processed))\n\t\t\t\t\t\t.replace('{total}', String(total));\n\t\t\t\t\tpill.classList.remove('hidden');\n\t\t\t\t\t// Re-enable the cancel button each render tick so a prior\n\t\t\t\t\t// canceled run does not leave the button disabled on the\n\t\t\t\t\t// next action.\n\t\t\t\t\tvar cancelBtn = document.getElementById('bulk-progress-cancel');\n\t\t\t\t\tif (cancelBtn) cancelBtn.disabled = false;\n\t\t\t\t}\n\n\t\t\t\tfunction hideProgressPill() {\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\tif (pill) pill.classList.add('hidden');\n\t\t\t\t}\n\n\t\t\t\t// Start polling bulk-actions/status every 2s. Stops on terminal\n\t\t\t\t// status and surfaces an outcome-breakdown toast. Page reloads\n\t\t\t\t// mid-action re-attach by calling this on DOMContentLoaded.\n\t\t\t\t// Process one /status snapshot. Returns true when the status\n\t\t\t\t// is terminal (idle/completed/failed) so callers know to stop\n\t\t\t\t// polling and do not need to start one. Shared between the\n\t\t\t\t// active poll callback and the DOMContentLoaded recovery\n\t\t\t\t// path so a page reload near the end of a bulk job still\n\t\t\t\t// surfaces the summary toast from the terminal snapshot.\n\t\t\t\tfunction handleProgressSnapshot(data, initialAction) {\n\t\t\t\t\tif (!data || data.status === 'idle') {\n\t\t\t\t\t\thideProgressPill();\n\t\t\t\t\t\tbulkActionRunning = false;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\treturn true;\n\t\t\t\t\t}\n\t\t\t\t\trenderProgressPill(data.action || initialAction || '', data.processed || 0, data.total || 0);\n\t\t\t\t\t// Reveal the cancel button only for bulk-actions runs.\n\t\t\t\t\t// The pill is reused by single-artist flows (e.g. the\n\t\t\t\t\t// detail-page run-rules) that do not go through /bulk-\n\t\t\t\t\t// actions/cancel and have no cancel affordance.\n\t\t\t\t\tvar _cancelBtn = document.getElementById('bulk-progress-cancel');\n\t\t\t\t\tif (_cancelBtn) _cancelBtn.classList.remove('hidden');\n\t\t\t\t\tif (data.status === 'completed' || data.status === 'failed' || data.status === 'canceled') {\n\t\t\t\t\t\thideProgressPill();\n\t\t\t\t\t\tbulkActionRunning = false;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\t\t// Re-identify auto breaks out auto_linked/queued/\n\t\t\t\t\t\t// no_match counters so the toast can say \"3 auto-\n\t\t\t\t\t\t// linked, 2 queued, 1 no match\" instead of the\n\t\t\t\t\t\t// generic succeeded/skipped triad. Other actions\n\t\t\t\t\t\t// keep the existing summary text.\n\t\t\t\t\t\tvar msg;\n\t\t\t\t\t\tif ((data.action === 're_identify_auto' || data.action === 're_identify') &&\n\t\t\t\t\t\t\t((data.auto_linked || 0) + (data.queued || 0) + (data.no_match || 0) + (data.failed || 0) > 0)) {\n\t\t\t\t\t\t\tvar rtpl = (pill && pill.getAttribute('data-i18n-reidentify-summary')) ||\n\t\t\t\t\t\t\t\t'{auto_linked} auto-linked, {queued} queued, {no_match} no match';\n\t\t\t\t\t\t\tmsg = rtpl\n\t\t\t\t\t\t\t\t.replace('{auto_linked}', String(data.auto_linked || 0))\n\t\t\t\t\t\t\t\t.replace('{queued}', String(data.queued || 0))\n\t\t\t\t\t\t\t\t.replace('{no_match}', String(data.no_match || 0))\n\t\t\t\t\t\t\t\t.replace('{failed}', String(data.failed || 0));\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tvar tpl = (pill && pill.getAttribute('data-i18n-summary')) || '{succeeded} succeeded, {failed} failed, {skipped} skipped';\n\t\t\t\t\t\t\tmsg = tpl\n\t\t\t\t\t\t\t\t.replace('{succeeded}', String(data.succeeded || 0))\n\t\t\t\t\t\t\t\t.replace('{failed}', String(data.failed || 0))\n\t\t\t\t\t\t\t\t.replace('{skipped}', String(data.skipped || 0));\n\t\t\t\t\t\t}\n\t\t\t\t\t\tif (typeof window.showSuccessToast === 'function' && (data.failed || 0) === 0) {\n\t\t\t\t\t\t\twindow.showSuccessToast(msg);\n\t\t\t\t\t\t} else if (typeof window.showToast === 'function') {\n\t\t\t\t\t\t\twindow.showToast(msg);\n\t\t\t\t\t\t}\n\t\t\t\t\t\treturn true;\n\t\t\t\t\t}\n\t\t\t\t\treturn false;\n\t\t\t\t}\n\n\t\t\t\tfunction startProgressPoll(initialAction) {\n\t\t\t\t\tif (progressPoll) { progressPoll.stop(); progressPoll = null; }\n\t\t\t\t\tbulkActionRunning = true;\n\t\t\t\t\tupdateBar();\n\t\t\t\t\tprogressPoll = pollAsyncStatus(_artistsBp + '/api/v1/artists/bulk-actions/status', {\n\t\t\t\t\t\tonData: function(data) {\n\t\t\t\t\t\t\treturn handleProgressSnapshot(data, initialAction);\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonHTTPError: function() {\n\t\t\t\t\t\t\t// Transport/HTTP errors are non-terminal: the backend\n\t\t\t\t\t\t\t// job may still be running. Keep bulkActionRunning set\n\t\t\t\t\t\t\t// so Apply stays disabled; a later idle/completed/\n\t\t\t\t\t\t\t// failed snapshot from the polling retry will clear\n\t\t\t\t\t\t\t// the lock. Releasing here would reopen the duplicate-\n\t\t\t\t\t\t\t// submit window and reintroduce the 409 loop.\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonNetworkError: function() {\n\t\t\t\t\t\t\t// Same rationale as onHTTPError: the status endpoint\n\t\t\t\t\t\t\t// may be transiently unreachable while the action is\n\t\t\t\t\t\t\t// still running. Do not clear the lock on an unknown\n\t\t\t\t\t\t\t// status.\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t\t// Expose so other controllers (single-artist run-rules on the\n\t\t\t\t// artist detail page) can attach to an in-flight action.\n\t\t\t\twindow.swBulkProgress = {\n\t\t\t\t\tstart: startProgressPoll,\n\t\t\t\t\trender: renderProgressPill,\n\t\t\t\t\thide: hideProgressPill\n\t\t\t\t};\n\n\t\t\t\t// Cancel the in-flight bulk action. The button is wired via\n\t\t\t\t// onclick on the pill; the poll loop picks up the terminal\n\t\t\t\t// \"canceled\" status on the next tick and clears the pill.\n\t\t\t\twindow.swCancelBulkAction = function() {\n\t\t\t\t\tvar btn = document.getElementById('bulk-progress-cancel');\n\t\t\t\t\tif (btn) btn.disabled = true;\n\t\t\t\t\tvar csrfToken = document.cookie.replace(/(?:(?:^|.*;\\s*)csrf_token\\s*\\=\\s*([^;]*).*$)|^.*$/, \"$1\");\n\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/bulk-actions/cancel', {\n\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\tcredentials: 'same-origin',\n\t\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken}\n\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\tif (btn) btn.disabled = false;\n\t\t\t\t\t});\n\t\t\t\t};\n\n\t\t\t\t// Size-aware confirm dialog. <=50: no dialog; >50 and <=500:\n\t\t\t\t// simple confirm with action + count; >500: stronger warning\n\t\t\t\t// that names external API impact for re-identify and\n\t\t\t\t// fetch_images. Returns true when the user confirmed.\n\t\t\t\tfunction confirmBulkAction(action, count) {\n\t\t\t\t\tif (count <= 50) return true;\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\t// Use the action-dropdown's selected option label so the\n\t\t\t\t\t// confirm text reads naturally (e.g. \"Apply Run rules to\n\t\t\t\t\t// 100 artists?\") rather than the progress-verb form.\n\t\t\t\t\tvar selectEl = document.getElementById('bulk-action-select');\n\t\t\t\t\tvar verb = action;\n\t\t\t\t\tif (selectEl && selectEl.selectedOptions && selectEl.selectedOptions[0]) {\n\t\t\t\t\t\tverb = selectEl.selectedOptions[0].textContent || action;\n\t\t\t\t\t}\n\t\t\t\t\t// The large-count copy names external provider APIs, so\n\t\t\t\t\t// only use it for actions that actually hit them. Local\n\t\t\t\t\t// actions (scan, run_rules) get the plain small template\n\t\t\t\t\t// regardless of count to avoid misleading warnings.\n\t\t\t\t\tvar usesExternalProviders = action === 're_identify_auto' || action === 're_identify_review' || action === 'fetch_images';\n\t\t\t\t\tvar tpl;\n\t\t\t\t\tif (count > 500 && usesExternalProviders) {\n\t\t\t\t\t\ttpl = (pill && pill.getAttribute('data-i18n-confirm-large')) || 'You are about to apply {action} to {count} artists. This may take a while and will hit external provider APIs (MusicBrainz, Fanart.tv, etc.). Continue?';\n\t\t\t\t\t} else {\n\t\t\t\t\t\ttpl = (pill && pill.getAttribute('data-i18n-confirm-small')) || 'Apply {action} to {count} artists?';\n\t\t\t\t\t}\n\t\t\t\t\tvar msg = tpl.replace('{action}', verb).replace('{count}', String(count));\n\t\t\t\t\treturn window.confirm(msg);\n\t\t\t\t}\n\n\t\t\t\tdocument.body.addEventListener('click', function(ev) {\n\t\t\t\t\tvar t = ev.target;\n\t\t\t\t\tif (!t || t.id !== 'bulk-action-apply') return;\n\t\t\t\t\tvar selectEl = document.getElementById('bulk-action-select');\n\t\t\t\t\tif (!selectEl || !selectEl.value || selected.size === 0) return;\n\t\t\t\t\tvar action = selectEl.value;\n\t\t\t\t\t// Defensive truncation: the UI cap should already prevent\n\t\t\t\t\t// this, but guard against any drift so we never hit the\n\t\t\t\t\t// backend's hard 1000-ID rejection with a generic toast.\n\t\t\t\t\tvar ids = Array.from(selected).slice(0, MAX_BULK_SELECTION);\n\t\t\t\t\tif (!confirmBulkAction(action, ids.length)) return;\n\t\t\t\t\tvar csrfToken = document.cookie.replace(/(?:(?:^|.*;\\s*)csrf_token\\s*\\=\\s*([^;]*).*$)|^.*$/, \"$1\");\n\t\t\t\t\tt.disabled = true;\n\t\t\t\t\t// Re-identify (review) dispatches to the wizard flow\n\t\t\t\t\t// rather than the bulk-actions endpoint: the wizard is\n\t\t\t\t\t// interactive and owns its own session state, so routing\n\t\t\t\t\t// it through the singleton bulk-action slot would be\n\t\t\t\t\t// misleading. Start the wizard then redirect the user to\n\t\t\t\t\t// its first step.\n\t\t\t\t\tif (action === 're_identify_review') {\n\t\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/re-identify/wizard', {\n\t\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},\n\t\t\t\t\t\t\tbody: JSON.stringify({ids: ids})\n\t\t\t\t\t\t}).then(function(r) {\n\t\t\t\t\t\t\tif (!r.ok) {\n\t\t\t\t\t\t\t\tvar bar3 = document.getElementById('bulk-action-bar');\n\t\t\t\t\t\t\t\talert((bar3 && bar3.getAttribute('data-i18n-failed')) || 'Bulk action failed to start.');\n\t\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\treturn r.json();\n\t\t\t\t\t\t}).then(function(data) {\n\t\t\t\t\t\t\tif (!data || !data.session_id) return;\n\t\t\t\t\t\t\twindow.location.href = _artistsBp + '/artists/re-identify/wizard/' + data.session_id + '/step/0';\n\t\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t});\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/bulk-actions', {\n\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},\n\t\t\t\t\t\tbody: JSON.stringify({action: action, ids: ids})\n\t\t\t\t\t}).then(function(r) {\n\t\t\t\t\t\tvar bar = document.getElementById('bulk-action-bar');\n\t\t\t\t\t\tvar i18nBusy = (bar && bar.getAttribute('data-i18n-busy')) || 'A bulk action is already running. Please wait for it to finish.';\n\t\t\t\t\t\tvar i18nFailed = (bar && bar.getAttribute('data-i18n-failed')) || 'Bulk action failed to start.';\n\t\t\t\t\t\tif (r.status === 409) {\n\t\t\t\t\t\t\talert(i18nBusy);\n\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t} else if (!r.ok) {\n\t\t\t\t\t\t\talert(i18nFailed);\n\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t// Render an immediate 0-of-total pill so the user sees\n\t\t\t\t\t\t\t// feedback before the first poll tick lands, then\n\t\t\t\t\t\t\t// start polling. Apply-disabled stays true until the\n\t\t\t\t\t\t\t// poll observes a terminal status.\n\t\t\t\t\t\t\trenderProgressPill(action, 0, ids.length);\n\t\t\t\t\t\t\tselected.clear();\n\t\t\t\t\t\t\tcapWarned = false;\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t\tstartProgressPoll(action);\n\t\t\t\t\t\t}\n\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\tvar bar2 = document.getElementById('bulk-action-bar');\n\t\t\t\t\t\talert((bar2 && bar2.getAttribute('data-i18n-failed')) || 'Bulk action failed to start.');\n\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t});\n\t\t\t\t});\n\n\t\t\t\t// Scope token: filter-identifying params only. If any of\n\t\t\t\t// these change across an htmx swap, the user is looking\n\t\t\t\t// at a different result set and the previous selection is\n\t\t\t\t// no longer meaningful. Pagination and sort do NOT reset\n\t\t\t\t// selection so the user can page through filtered results\n\t\t\t\t// while preserving their selection.\n\t\t\t\tfunction currentScopeToken() {\n\t\t\t\t\tvar p = new URLSearchParams(window.location.search);\n\t\t\t\t\tvar keys = [];\n\t\t\t\t\tp.forEach(function(_v, k) {\n\t\t\t\t\t\tif (k === 'search' || k === 'library_id' || k === 'filter' || k.indexOf('filter_') === 0) {\n\t\t\t\t\t\t\tkeys.push(k);\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t\tkeys.sort();\n\t\t\t\t\treturn keys.map(function(k) { return k + '=' + p.get(k); }).join('&');\n\t\t\t\t}\n\t\t\t\tvar lastScopeToken = currentScopeToken();\n\n\t\t\t\t// Re-sync on initial load and after every HTMX swap of the\n\t\t\t\t// artist content (pagination, filter change, etc.). Also\n\t\t\t\t// probe the bulk-actions/status endpoint on load so a page\n\t\t\t\t// reload mid-action re-attaches the progress pill.\n\t\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\t\tupdateBar();\n\t\t\t\t\t// Fire-and-forget status probe. If an action is in flight\n\t\t\t\t\t// the poll attaches; otherwise the pill stays hidden.\n\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/bulk-actions/status', {credentials: 'same-origin'})\n\t\t\t\t\t\t.then(function(r) { return r.ok ? r.json() : null; })\n\t\t\t\t\t\t.then(function(data) {\n\t\t\t\t\t\t\t// Terminal snapshots (completed/failed/idle) are\n\t\t\t\t\t\t\t// handled in-place so the summary toast is not\n\t\t\t\t\t\t\t// dropped on reload-near-end. Non-terminal returns\n\t\t\t\t\t\t\t// false and we start the normal poll.\n\t\t\t\t\t\t\tif (!data) return;\n\t\t\t\t\t\t\tif (handleProgressSnapshot(data, data.action || '')) return;\n\t\t\t\t\t\t\tstartProgressPoll(data.action || '');\n\t\t\t\t\t\t})\n\t\t\t\t\t\t.catch(function(){ /* ignore */ });\n\t\t\t\t});\n\t\t\t\tdocument.body.addEventListener('htmx:afterSwap', function(evt) {\n\t\t\t\t\tif (evt.detail.target && evt.detail.target.id === 'artist-content') {\n\t\t\t\t\t\tvar currentToken = currentScopeToken();\n\t\t\t\t\t\tif (currentToken !== lastScopeToken) {\n\t\t\t\t\t\t\tselected.clear();\n\t\t\t\t\t\t\tcapWarned = false;\n\t\t\t\t\t\t\tlastScopeToken = currentToken;\n\t\t\t\t\t\t}\n\t\t\t\t\t\t// Reset the shift-click anchor on every swap: after\n\t\t\t\t\t\t// pagination or sort the prior DOM ordering no longer\n\t\t\t\t\t\t// applies, so an old anchor could select an unintended\n\t\t\t\t\t\t// range on the next shift-click.\n\t\t\t\t\t\tlastClickedId = null;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t})();\n\t\t</script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, " <script>\n\t\t\tvar _artistsBp = (document.querySelector('meta[name=\"htmx-base-path\"]') || {content: ''}).content;\n\t\t\t// Inject flyout filter params from the URL into HTMX requests that\n\t\t\t// target #artist-content. The flyout stores state in the URL only\n\t\t\t// (not in named form elements), so hx-include cannot pick it up.\n\t\t\tdocument.body.addEventListener('htmx:configRequest', function(evt) {\n\t\t\t\tif (evt.detail.target && evt.detail.target.id === 'artist-content') {\n\t\t\t\t\tvar urlParams = new URLSearchParams(window.location.search);\n\t\t\t\t\turlParams.forEach(function(val, key) {\n\t\t\t\t\t\tif (key.indexOf('filter_') === 0 && !(key in evt.detail.parameters)) {\n\t\t\t\t\t\t\tevt.detail.parameters[key] = val;\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t});\n\n\t\t\tvar _sortActiveClass = 'w-full text-left px-4 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 font-semibold text-blue-600 dark:text-blue-400';\n\t\t\tvar _sortInactiveClass = 'w-full text-left px-4 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200';\n\n\t\t\tfunction updateSortUI(sort, order) {\n\t\t\t\tvar fieldLabel = document.getElementById('sort-field-label');\n\t\t\t\tvar orderLabel = document.getElementById('sort-order-label');\n\t\t\t\tif (fieldLabel) {\n\t\t\t\t\tvar activeBtn = document.querySelector('#sort-dropdown button[onclick=\"setSort(\\'' + sort + '\\')\"]');\n\t\t\t\t\tfieldLabel.textContent = activeBtn ? activeBtn.textContent.trim() : sort;\n\t\t\t\t}\n\t\t\t\tif (orderLabel) {\n\t\t\t\t\tvar activeOrder = document.querySelector('#sort-dropdown button[onclick=\"setOrder(\\'' + order + '\\')\"]');\n\t\t\t\t\torderLabel.textContent = activeOrder ? activeOrder.textContent.trim() : order;\n\t\t\t\t}\n\t\t\t\t['name', 'sort_name', 'health_score', 'updated_at', 'created_at'].forEach(function(f) {\n\t\t\t\t\tvar btn = document.querySelector('#sort-dropdown button[onclick=\"setSort(\\'' + f + '\\')\"]');\n\t\t\t\t\tif (btn) btn.className = f === sort ? _sortActiveClass : _sortInactiveClass;\n\t\t\t\t});\n\t\t\t\t['asc', 'desc'].forEach(function(d) {\n\t\t\t\t\tvar btn = document.querySelector('#sort-dropdown button[onclick=\"setOrder(\\'' + d + '\\')\"]');\n\t\t\t\t\tif (btn) btn.className = d === order ? _sortActiveClass : _sortInactiveClass;\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction setSort(field) {\n\t\t\t\tvar sortInput = document.getElementById('artist-sort-input');\n\t\t\t\tvar orderInput = document.getElementById('artist-order-input');\n\t\t\t\tif (!sortInput || !orderInput) return;\n\t\t\t\tif (sortInput.value === field) {\n\t\t\t\t\torderInput.value = (orderInput.value === 'asc') ? 'desc' : 'asc';\n\t\t\t\t} else {\n\t\t\t\t\tsortInput.value = field;\n\t\t\t\t\torderInput.value = 'asc';\n\t\t\t\t}\n\t\t\t\tupdateSortUI(sortInput.value, orderInput.value);\n\t\t\t\tcloseSortDropdown();\n\t\t\t\thtmx.ajax('GET', '/artists', {\n\t\t\t\t\ttarget: '#artist-content',\n\t\t\t\t\tswap: 'outerHTML',\n\t\t\t\t\tvalues: buildArtistParams({page: '1'})\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction setOrder(dir) {\n\t\t\t\tvar sortInput = document.getElementById('artist-sort-input');\n\t\t\t\tvar orderInput = document.getElementById('artist-order-input');\n\t\t\t\tif (!orderInput) return;\n\t\t\t\torderInput.value = dir;\n\t\t\t\tupdateSortUI(sortInput ? sortInput.value : '', dir);\n\t\t\t\tcloseSortDropdown();\n\t\t\t\thtmx.ajax('GET', '/artists', {\n\t\t\t\t\ttarget: '#artist-content',\n\t\t\t\t\tswap: 'outerHTML',\n\t\t\t\t\tvalues: buildArtistParams({page: '1'})\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction closeSortDropdown() {\n\t\t\t\tvar d = document.getElementById('sort-dropdown');\n\t\t\t\tif (d) d.removeAttribute('open');\n\t\t\t}\n\n\t\t\tfunction buildArtistParams(overrides) {\n\t\t\t\tvar params = {};\n\t\t\t\t// Collect form-based params from named elements.\n\t\t\t\t['search', 'library_id', 'view', 'sort', 'order'].forEach(function(name) {\n\t\t\t\t\tvar el = document.querySelector('[name=\"' + name + '\"]');\n\t\t\t\t\tif (el) params[name] = el.value;\n\t\t\t\t});\n\t\t\t\t// Carry all flyout filter params from the current URL dynamically.\n\t\t\t\tvar urlParams = new URLSearchParams(window.location.search);\n\t\t\t\turlParams.forEach(function(val, key) {\n\t\t\t\t\tif (key.indexOf('filter_') === 0) {\n\t\t\t\t\t\tparams[key] = val;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn Object.assign(params, overrides);\n\t\t\t}\n\n\t\t\t// Update view toggle button classes to reflect the active view.\n\t\t\t// Mirrors the server-side templ.KV classes on the #view-toggle buttons.\n\t\t\tvar _viewActiveClass = 'p-2 transition-colors bg-blue-600 text-white';\n\t\t\tvar _viewInactiveClass = 'p-2 transition-colors bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700';\n\t\t\tfunction updateViewToggleUI(view) {\n\t\t\t\tvar toggle = document.getElementById('view-toggle');\n\t\t\t\tif (!toggle) return;\n\t\t\t\tvar tableBtn = toggle.querySelector('button[onclick=\"setView(\\'table\\')\"]');\n\t\t\t\tvar gridBtn = toggle.querySelector('button[onclick=\"setView(\\'grid\\')\"]');\n\t\t\t\tif (tableBtn) tableBtn.className = view === 'table' ? _viewActiveClass : _viewInactiveClass;\n\t\t\t\tif (gridBtn) gridBtn.className = view === 'grid' ? _viewActiveClass : _viewInactiveClass;\n\t\t\t}\n\n\t\t\tfunction setView(view) {\n\t\t\t\tvar input = document.getElementById('artist-view-input');\n\t\t\t\tif (input) input.value = view;\n\t\t\t\tupdateViewToggleUI(view);\n\t\t\t\t// Show/hide column toggle based on view\n\t\t\t\tvar colToggle = document.getElementById('col-toggle-wrapper');\n\t\t\t\tif (colToggle) {\n\t\t\t\t\tif (view === 'table') {\n\t\t\t\t\t\tcolToggle.classList.remove('hidden');\n\t\t\t\t\t} else {\n\t\t\t\t\t\tcolToggle.classList.add('hidden');\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\t// Fire-and-forget save preference\n\t\t\t\tvar csrfToken = document.cookie.replace(/(?:(?:^|.*;\\s*)csrf_token\\s*\\=\\s*([^;]*).*$)|^.*$/, \"$1\");\n\t\t\t\tfetch(_artistsBp + '/api/v1/settings', {\n\t\t\t\t\tmethod: 'PUT',\n\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},\n\t\t\t\t\tbody: JSON.stringify({\"ui.artists_view\": view})\n\t\t\t\t}).catch(function() {});\n\t\t\t}\n\n\t\t\t// After HTMX swaps artist content, push the current filter/sort state\n\t\t\t// into the URL so browser back-navigation restores the correct view.\n\t\t\t// Uses window.location.pathname (not hardcoded '/artists') for basePath\n\t\t\t// support, and carries over the page param from the HTMX request URL.\n\t\t\tdocument.body.addEventListener('htmx:afterSwap', function(evt) {\n\t\t\t\tif (evt.detail.target && evt.detail.target.id === 'artist-content') {\n\t\t\t\t\t// Re-sync flyout state from URL after any swap (including chip dismissals\n\t\t\t\t\t// via DismissFilterChip, which bypass the sw:filter-applied event).\n\t\t\t\t\tif (window.swFilterFlyout) {\n\t\t\t\t\t\tswFilterFlyout.initFromURL('artist-filters-flyout');\n\t\t\t\t\t}\n\n\t\t\t\t\tvar params = buildArtistParams({});\n\t\t\t\t\t// Extract page from the HTMX request URL if present.\n\t\t\t\t\ttry {\n\t\t\t\t\t\tvar reqUrl = new URL(evt.detail.requestInfo.path, window.location.origin);\n\t\t\t\t\t\tvar page = reqUrl.searchParams.get('page');\n\t\t\t\t\t\tif (page && page !== '1') params.page = page;\n\t\t\t\t\t\tvar pageSize = reqUrl.searchParams.get('page_size');\n\t\t\t\t\t\tif (pageSize) params.page_size = pageSize;\n\t\t\t\t\t} catch(e) { /* ignore parse errors */ }\n\t\t\t\t\tvar qs = Object.keys(params).filter(function(k) { return params[k]; }).map(function(k) {\n\t\t\t\t\t\treturn encodeURIComponent(k) + '=' + encodeURIComponent(params[k]);\n\t\t\t\t\t}).join('&');\n\t\t\t\t\thistory.replaceState(null, '', window.location.pathname + (qs ? '?' + qs : ''));\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Reload artist content when the filter flyout applies filters.\n\t\t\tdocument.body.addEventListener('sw:filter-applied', function(evt) {\n\t\t\t\tif (evt.target && evt.target.id === 'artist-content') {\n\t\t\t\t\t// Strip the base path from location.pathname before passing to htmx.ajax\n\t\t\t\t\t// to avoid a double-prefix from the htmx:configRequest hook.\n\t\t\t\t\tvar bpMeta = document.querySelector('meta[name=\"htmx-base-path\"]');\n\t\t\t\t\tvar bp = bpMeta ? bpMeta.content : '';\n\t\t\t\t\tvar path = window.location.pathname;\n\t\t\t\t\tif (bp && path.startsWith(bp)) {\n\t\t\t\t\t\tpath = path.slice(bp.length) || '/';\n\t\t\t\t\t}\n\t\t\t\t\thtmx.ajax('GET', path + window.location.search, {target: '#artist-content', swap: 'outerHTML'});\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Initialise the flyout from URL params on first page load.\n\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\tif (window.swFilterFlyout) {\n\t\t\t\t\tswFilterFlyout.initFromURL('artist-filters-flyout');\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// restoreStateFromURL syncs all filter controls, hidden inputs,\n\t\t\t// sort labels, and view toggle from the current URL query params,\n\t\t\t// then triggers an HTMX content reload so the artist list matches\n\t\t\t// the URL state. Used by both pageshow (bfcache) and popstate\n\t\t\t// (history back/forward) handlers.\n\t\t\t//\n\t\t\t// A debounce guard prevents duplicate calls when bfcache restore\n\t\t\t// fires both pageshow and popstate in quick succession.\n\t\t\tvar _restoreLastRun = 0;\n\t\t\tvar _restoreLastHref = '';\n\t\t\tfunction restoreStateFromURL() {\n\t\t\t\tvar now = Date.now();\n\t\t\t\tvar href = window.location.href;\n\t\t\t\tif (href === _restoreLastHref && now - _restoreLastRun < 100) return;\n\t\t\t\t_restoreLastHref = href;\n\t\t\t\t_restoreLastRun = now;\n\t\t\t\tvar params = new URLSearchParams(window.location.search);\n\t\t\t\t// Re-sync flyout chip states from URL.\n\t\t\t\tif (window.swFilterFlyout) {\n\t\t\t\t\tswFilterFlyout.initFromURL('artist-filters-flyout');\n\t\t\t\t}\n\t\t\t\t// Sync the search input from URL params.\n\t\t\t\tvar searchEl = document.getElementById('artist-search');\n\t\t\t\tif (searchEl) searchEl.value = params.get('search') || '';\n\t\t\t\t// Sync select elements from URL params.\n\t\t\t\t['library_id'].forEach(function(name) {\n\t\t\t\t\tvar val = params.get(name);\n\t\t\t\t\tvar el = document.querySelector('select[name=\"' + name + '\"]');\n\t\t\t\t\tif (el) el.value = (val !== null) ? val : '';\n\t\t\t\t});\n\t\t\t\t// Sync hidden inputs from URL params, resetting to markup\n\t\t\t\t// defaults when a param is absent so browser history\n\t\t\t\t// restoration cannot retain stale values from a newer state.\n\t\t\t\t['view', 'sort', 'order'].forEach(function(name) {\n\t\t\t\t\tvar val = params.get(name);\n\t\t\t\t\tvar el = document.getElementById('artist-' + name + '-input');\n\t\t\t\t\tif (el) el.value = (val !== null) ? val : el.defaultValue;\n\t\t\t\t});\n\t\t\t\t// Update visible sort labels and view toggle to match restored state.\n\t\t\t\tvar sortInput = document.getElementById('artist-sort-input');\n\t\t\t\tvar orderInput = document.getElementById('artist-order-input');\n\t\t\t\tif (sortInput && orderInput) updateSortUI(sortInput.value, orderInput.value);\n\t\t\t\tvar viewInput = document.getElementById('artist-view-input');\n\t\t\t\tif (viewInput) {\n\t\t\t\t\tupdateViewToggleUI(viewInput.value);\n\t\t\t\t\tvar colToggle = document.getElementById('col-toggle-wrapper');\n\t\t\t\t\tif (colToggle) colToggle.classList.toggle('hidden', viewInput.value !== 'table');\n\t\t\t\t}\n\t\t\t\tvar _rsMeta = document.querySelector('meta[name=\"htmx-base-path\"]');\n\t\t\t\tvar _rsBp = _rsMeta ? _rsMeta.content : '';\n\t\t\t\tvar _rsPath = window.location.pathname;\n\t\t\t\tif (_rsBp && _rsPath.startsWith(_rsBp)) { _rsPath = _rsPath.slice(_rsBp.length) || '/'; }\n\t\t\t\thtmx.ajax('GET', _rsPath + window.location.search, {target: '#artist-content', swap: 'outerHTML'});\n\t\t\t}\n\n\t\t\t// When the page is restored from bfcache (browser back/forward navigation),\n\t\t\t// sync filter controls from the URL query params and reload content so\n\t\t\t// status badges reflect the latest state.\n\t\t\twindow.addEventListener('pageshow', function(evt) {\n\t\t\t\tif (evt.persisted) {\n\t\t\t\t\trestoreStateFromURL();\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Handle browser back/forward navigation between pushState entries\n\t\t\t// (e.g. filter changes, pagination). Without this, pressing back after\n\t\t\t// applying filters and navigating away would show stale content even\n\t\t\t// though the URL contains the correct filter params. Works in Firefox\n\t\t\t// and all major browsers.\n\t\t\twindow.addEventListener('popstate', function() {\n\t\t\t\trestoreStateFromURL();\n\t\t\t});\n\n\t\t\t(function() {\n\t\t\t\tvar btn = document.getElementById('scan-btn');\n\t\t\t\tif (!btn) return;\n\n\t\t\t\tdocument.body.addEventListener('htmx:afterRequest', function(evt) {\n\t\t\t\t\tif (evt.detail.elt !== btn) return;\n\t\t\t\t\tif (!evt.detail.successful) return;\n\n\t\t\t\t\tvar spinner = document.getElementById('scan-spinner');\n\t\t\t\t\tvar label = document.getElementById('scan-label');\n\t\t\t\t\tbtn.disabled = true;\n\t\t\t\t\tspinner.classList.remove('hidden');\n\t\t\t\t\tlabel.textContent = btn.dataset.labelScanning || 'Scanning...';\n\n\t\t\t\t\tfunction resetScanUI() {\n\t\t\t\t\t\tbtn.disabled = false;\n\t\t\t\t\t\tspinner.classList.add('hidden');\n\t\t\t\t\t\tlabel.textContent = btn.dataset.labelScan || 'Scan Library';\n\t\t\t\t\t}\n\t\t\t\t\tpollAsyncStatus(_artistsBp + '/api/v1/scanner/status', {\n\t\t\t\t\t\tonData: function(data) {\n\t\t\t\t\t\t\tif (data.status === 'completed' || data.status === 'failed' || data.status === 'canceled') {\n\t\t\t\t\t\t\t\tresetScanUI();\n\t\t\t\t\t\t\t\tvar _scMeta = document.querySelector('meta[name=\"htmx-base-path\"]');\n\t\t\t\t\t\t\t\tvar _scBp = _scMeta ? _scMeta.content : '';\n\t\t\t\t\t\t\t\tvar _scPath = window.location.pathname;\n\t\t\t\t\t\t\t\tif (_scBp && _scPath.startsWith(_scBp)) { _scPath = _scPath.slice(_scBp.length) || '/'; }\n\t\t\t\t\t\t\t\thtmx.ajax('GET', _scPath + window.location.search, {target: '#artist-content', swap: 'outerHTML'});\n\t\t\t\t\t\t\t\treturn true;\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\treturn false;\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonHTTPError: function() {\n\t\t\t\t\t\t\tresetScanUI();\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonNetworkError: function() {\n\t\t\t\t\t\t\tresetScanUI();\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t});\n\t\t\t})();\n\n\t\t\t// Bulk-action controller. Wires the Select-All checkbox, per-row\n\t\t\t// checkboxes, the \"N selected\" indicator, and the action dropdown\n\t\t\t// to the /api/v1/artists/bulk-actions endpoint. The controller is\n\t\t\t// idempotent: it attaches listeners via event delegation so it\n\t\t\t// works across HTMX swaps of #artist-content without re-binding.\n\t\t\t(function() {\n\t\t\t\t// Selection state persists across HTMX swaps of the list so\n\t\t\t\t// the user can paginate while keeping earlier selections.\n\t\t\t\tvar selected = new Set();\n\t\t\t\t// Matches the backend cap in handlers_bulk_actions.go; keeps\n\t\t\t\t// the UI in sync so we never POST a payload the server will\n\t\t\t\t// reject with a generic \"failed to start\" toast.\n\t\t\t\tvar MAX_BULK_SELECTION = 1000;\n\t\t\t\tvar capWarned = false;\n\t\t\t\t// Tracks the last checkbox clicked for shift-click range\n\t\t\t\t// selection (Gmail/GitHub-style). Reset on scope change.\n\t\t\t\tvar lastClickedId = null;\n\t\t\t\t// Polling handle for the in-flight bulk action status. Non-null\n\t\t\t\t// while a bulk or single-artist run-rules action is running.\n\t\t\t\tvar progressPoll = null;\n\t\t\t\t// Tracks whether a bulk action is running end-to-end. Gates the\n\t\t\t\t// Apply button so checkbox/dropdown changes cannot re-enable it\n\t\t\t\t// mid-flight and queue a second POST (which would 409-loop).\n\t\t\t\tvar bulkActionRunning = false;\n\n\t\t\t\tfunction warnCap() {\n\t\t\t\t\tif (capWarned) return;\n\t\t\t\t\tcapWarned = true;\n\t\t\t\t\tvar bar = document.getElementById('bulk-action-bar');\n\t\t\t\t\tvar tpl = (bar && bar.getAttribute('data-i18n-selection-cap')) || 'You can select up to {count} artists at a time.';\n\t\t\t\t\talert(tpl.replace('{count}', String(MAX_BULK_SELECTION)));\n\t\t\t\t}\n\n\t\t\t\tfunction tryAdd(id) {\n\t\t\t\t\tif (selected.has(id)) return true;\n\t\t\t\t\tif (selected.size >= MAX_BULK_SELECTION) {\n\t\t\t\t\t\twarnCap();\n\t\t\t\t\t\treturn false;\n\t\t\t\t\t}\n\t\t\t\t\tselected.add(id);\n\t\t\t\t\treturn true;\n\t\t\t\t}\n\n\t\t\t\tfunction updateBar() {\n\t\t\t\t\tvar bar = document.getElementById('bulk-action-bar');\n\t\t\t\t\tif (!bar) return;\n\t\t\t\t\tvar countEl = document.getElementById('bulk-selected-count');\n\t\t\t\t\tvar applyBtn = document.getElementById('bulk-action-apply');\n\t\t\t\t\tvar selectEl = document.getElementById('bulk-action-select');\n\t\t\t\t\tvar selectAll = document.getElementById('bulk-select-all');\n\t\t\t\t\tvar boxes = document.querySelectorAll('#artist-content .sw-bulk-select');\n\t\t\t\t\tvar i18nNone = bar.getAttribute('data-i18n-none') || 'None selected';\n\t\t\t\t\tvar i18nSelectedOne = bar.getAttribute('data-i18n-selected-one') || '1 selected';\n\t\t\t\t\tvar i18nSelectedOther = bar.getAttribute('data-i18n-selected-other') || '{count} selected';\n\t\t\t\t\tif (countEl) {\n\t\t\t\t\t\tif (selected.size === 0) {\n\t\t\t\t\t\t\tcountEl.textContent = i18nNone;\n\t\t\t\t\t\t} else if (selected.size === 1) {\n\t\t\t\t\t\t\tcountEl.textContent = i18nSelectedOne;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tcountEl.textContent = i18nSelectedOther.replace('{count}', String(selected.size));\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\tif (applyBtn) applyBtn.disabled = bulkActionRunning || selected.size === 0 || !selectEl || !selectEl.value;\n\t\t\t\t\tif (selectEl) selectEl.disabled = bulkActionRunning || selected.size === 0;\n\t\t\t\t\t// Sync per-row checkboxes with persisted selection state.\n\t\t\t\t\tvar visibleChecked = 0;\n\t\t\t\t\tboxes.forEach(function(cb) {\n\t\t\t\t\t\tvar id = cb.getAttribute('data-artist-id');\n\t\t\t\t\t\tcb.checked = selected.has(id);\n\t\t\t\t\t\tif (cb.checked) visibleChecked++;\n\t\t\t\t\t});\n\t\t\t\t\t// Select-All indeterminate state.\n\t\t\t\t\tvar allChecked = false;\n\t\t\t\t\tif (selectAll) {\n\t\t\t\t\t\tif (boxes.length === 0) {\n\t\t\t\t\t\t\tselectAll.checked = false;\n\t\t\t\t\t\t\tselectAll.indeterminate = false;\n\t\t\t\t\t\t} else if (visibleChecked === 0) {\n\t\t\t\t\t\t\tselectAll.checked = false;\n\t\t\t\t\t\t\tselectAll.indeterminate = false;\n\t\t\t\t\t\t} else if (visibleChecked === boxes.length) {\n\t\t\t\t\t\t\tselectAll.checked = true;\n\t\t\t\t\t\t\tselectAll.indeterminate = false;\n\t\t\t\t\t\t\tallChecked = true;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tselectAll.checked = false;\n\t\t\t\t\t\t\tselectAll.indeterminate = true;\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\t// Swap the checkbox label between Select all / Deselect all\n\t\t\t\t\t// so screen readers and sighted users both see the action\n\t\t\t\t\t// that a click will perform next.\n\t\t\t\t\tvar labelEl = document.getElementById('bulk-select-all-label');\n\t\t\t\t\tif (labelEl) {\n\t\t\t\t\t\tvar i18nSelectAll = bar.getAttribute('data-i18n-select-all') || 'Select all on page';\n\t\t\t\t\t\tvar i18nDeselectAll = bar.getAttribute('data-i18n-deselect-all') || 'Deselect all on page';\n\t\t\t\t\t\tlabelEl.textContent = allChecked ? i18nDeselectAll : i18nSelectAll;\n\t\t\t\t\t}\n\t\t\t\t\tif (selectAll) {\n\t\t\t\t\t\tvar i18nSelectAllAria = bar.getAttribute('data-i18n-select-all') || 'Select all on page';\n\t\t\t\t\t\tvar i18nDeselectAllAria = bar.getAttribute('data-i18n-deselect-all') || 'Deselect all on page';\n\t\t\t\t\t\tselectAll.setAttribute('aria-label', allChecked ? i18nDeselectAllAria : i18nSelectAllAria);\n\t\t\t\t\t}\n\t\t\t\t}\n\n\t\t\t\t// Shift-click range selection: capture on click (before the\n\t\t\t\t// change event) so we can see event.shiftKey. If shift is\n\t\t\t\t// held and we have a prior lastClickedId, select/deselect\n\t\t\t\t// every checkbox between the two anchors in DOM order.\n\t\t\t\tdocument.body.addEventListener('click', function(ev) {\n\t\t\t\t\tvar t = ev.target;\n\t\t\t\t\tif (!t || !t.classList || !t.classList.contains('sw-bulk-select')) return;\n\t\t\t\t\tvar id = t.getAttribute('data-artist-id');\n\t\t\t\t\tif (!id) return;\n\t\t\t\t\t// Keyboard Shift+Space triggers a click with shiftKey.\n\t\t\t\t\tif (ev.shiftKey && lastClickedId && lastClickedId !== id) {\n\t\t\t\t\t\tvar boxes = Array.prototype.slice.call(\n\t\t\t\t\t\t\tdocument.querySelectorAll('#artist-content .sw-bulk-select')\n\t\t\t\t\t\t);\n\t\t\t\t\t\tvar idx1 = -1, idx2 = -1;\n\t\t\t\t\t\tfor (var i = 0; i < boxes.length; i++) {\n\t\t\t\t\t\t\tvar bid = boxes[i].getAttribute('data-artist-id');\n\t\t\t\t\t\t\tif (bid === lastClickedId) idx1 = i;\n\t\t\t\t\t\t\tif (bid === id) idx2 = i;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tif (idx1 >= 0 && idx2 >= 0) {\n\t\t\t\t\t\t\tvar lo = Math.min(idx1, idx2), hi = Math.max(idx1, idx2);\n\t\t\t\t\t\t\t// Target state follows the just-clicked checkbox's\n\t\t\t\t\t\t\t// post-click state (which the browser has already\n\t\t\t\t\t\t\t// set by the time this click handler runs).\n\t\t\t\t\t\t\tvar target = t.checked;\n\t\t\t\t\t\t\tfor (var j = lo; j <= hi; j++) {\n\t\t\t\t\t\t\t\tvar cb = boxes[j];\n\t\t\t\t\t\t\t\tvar cid = cb.getAttribute('data-artist-id');\n\t\t\t\t\t\t\t\tif (!cid) continue;\n\t\t\t\t\t\t\t\tif (target) {\n\t\t\t\t\t\t\t\t\tif (!tryAdd(cid)) { cb.checked = false; continue; }\n\t\t\t\t\t\t\t\t\tcb.checked = true;\n\t\t\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t\t\tselected.delete(cid);\n\t\t\t\t\t\t\t\t\tcb.checked = false;\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\tif (!target) capWarned = false;\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\tlastClickedId = id;\n\t\t\t\t}, true);\n\n\t\t\t\tdocument.body.addEventListener('change', function(ev) {\n\t\t\t\t\tvar t = ev.target;\n\t\t\t\t\tif (!t) return;\n\t\t\t\t\tif (t.classList && t.classList.contains('sw-bulk-select')) {\n\t\t\t\t\t\tvar id = t.getAttribute('data-artist-id');\n\t\t\t\t\t\tif (!id) return;\n\t\t\t\t\t\tif (t.checked) {\n\t\t\t\t\t\t\tif (!tryAdd(id)) { t.checked = false; }\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tselected.delete(id);\n\t\t\t\t\t\t\tcapWarned = false;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t} else if (t.id === 'bulk-select-all') {\n\t\t\t\t\t\tvar boxes = document.querySelectorAll('#artist-content .sw-bulk-select');\n\t\t\t\t\t\tboxes.forEach(function(cb) {\n\t\t\t\t\t\t\tvar id = cb.getAttribute('data-artist-id');\n\t\t\t\t\t\t\tif (!id) return;\n\t\t\t\t\t\t\tif (t.checked) {\n\t\t\t\t\t\t\t\tcb.checked = tryAdd(id);\n\t\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t\tcb.checked = false;\n\t\t\t\t\t\t\t\tselected.delete(id);\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t});\n\t\t\t\t\t\tif (!t.checked) capWarned = false;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t} else if (t.id === 'bulk-action-select') {\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t}\n\t\t\t\t});\n\n\t\t\t\t// Build the localized verb label for a bulk action from the\n\t\t\t\t// data attributes on the progress pill. Falls back to the\n\t\t\t\t// raw action key if a verb is missing.\n\t\t\t\tfunction actionVerb(action) {\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\tif (!pill) return action;\n\t\t\t\t\tvar key = 'data-i18n-verb-' + action.replace(/_/g, '-');\n\t\t\t\t\treturn pill.getAttribute(key) || action;\n\t\t\t\t}\n\n\t\t\t\t// Render the progress pill with the current snapshot. Called\n\t\t\t\t// from both the initial 202 response and the poll callback.\n\t\t\t\tfunction renderProgressPill(action, processed, total) {\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\tvar txt = document.getElementById('bulk-progress-text');\n\t\t\t\t\tif (!pill || !txt) return;\n\t\t\t\t\tvar tpl = pill.getAttribute('data-i18n-template') || '{verb}: {processed} of {total} artists';\n\t\t\t\t\tvar verb = actionVerb(action);\n\t\t\t\t\ttxt.textContent = tpl\n\t\t\t\t\t\t.replace('{verb}', verb)\n\t\t\t\t\t\t.replace('{processed}', String(processed))\n\t\t\t\t\t\t.replace('{total}', String(total));\n\t\t\t\t\tpill.classList.remove('hidden');\n\t\t\t\t\t// Re-enable the cancel button each render tick so a prior\n\t\t\t\t\t// canceled run does not leave the button disabled on the\n\t\t\t\t\t// next action.\n\t\t\t\t\tvar cancelBtn = document.getElementById('bulk-progress-cancel');\n\t\t\t\t\tif (cancelBtn) cancelBtn.disabled = false;\n\t\t\t\t}\n\n\t\t\t\tfunction hideProgressPill() {\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\tif (pill) pill.classList.add('hidden');\n\t\t\t\t}\n\n\t\t\t\t// Start polling bulk-actions/status every 2s. Stops on terminal\n\t\t\t\t// status and surfaces an outcome-breakdown toast. Page reloads\n\t\t\t\t// mid-action re-attach by calling this on DOMContentLoaded.\n\t\t\t\t// Process one /status snapshot. Returns true when the status\n\t\t\t\t// is terminal (idle/completed/failed) so callers know to stop\n\t\t\t\t// polling and do not need to start one. Shared between the\n\t\t\t\t// active poll callback and the DOMContentLoaded recovery\n\t\t\t\t// path so a page reload near the end of a bulk job still\n\t\t\t\t// surfaces the summary toast from the terminal snapshot.\n\t\t\t\tfunction handleProgressSnapshot(data, initialAction) {\n\t\t\t\t\tif (!data || data.status === 'idle') {\n\t\t\t\t\t\thideProgressPill();\n\t\t\t\t\t\tbulkActionRunning = false;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\treturn true;\n\t\t\t\t\t}\n\t\t\t\t\trenderProgressPill(data.action || initialAction || '', data.processed || 0, data.total || 0);\n\t\t\t\t\t// Reveal the cancel button only for bulk-actions runs.\n\t\t\t\t\t// The pill is reused by single-artist flows (e.g. the\n\t\t\t\t\t// detail-page run-rules) that do not go through /bulk-\n\t\t\t\t\t// actions/cancel and have no cancel affordance.\n\t\t\t\t\tvar _cancelBtn = document.getElementById('bulk-progress-cancel');\n\t\t\t\t\tif (_cancelBtn) _cancelBtn.classList.remove('hidden');\n\t\t\t\t\tif (data.status === 'completed' || data.status === 'failed' || data.status === 'canceled') {\n\t\t\t\t\t\thideProgressPill();\n\t\t\t\t\t\tbulkActionRunning = false;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\t\t// Re-identify auto breaks out auto_linked/queued/\n\t\t\t\t\t\t// no_match counters so the toast can say \"3 auto-\n\t\t\t\t\t\t// linked, 2 queued, 1 no match\" instead of the\n\t\t\t\t\t\t// generic succeeded/skipped triad. Other actions\n\t\t\t\t\t\t// keep the existing summary text.\n\t\t\t\t\t\tvar msg;\n\t\t\t\t\t\tif ((data.action === 're_identify_auto' || data.action === 're_identify') &&\n\t\t\t\t\t\t\t((data.auto_linked || 0) + (data.queued || 0) + (data.no_match || 0) + (data.failed || 0) > 0)) {\n\t\t\t\t\t\t\tvar rtpl = (pill && pill.getAttribute('data-i18n-reidentify-summary')) ||\n\t\t\t\t\t\t\t\t'{auto_linked} auto-linked, {queued} queued, {no_match} no match';\n\t\t\t\t\t\t\tmsg = rtpl\n\t\t\t\t\t\t\t\t.replace('{auto_linked}', String(data.auto_linked || 0))\n\t\t\t\t\t\t\t\t.replace('{queued}', String(data.queued || 0))\n\t\t\t\t\t\t\t\t.replace('{no_match}', String(data.no_match || 0))\n\t\t\t\t\t\t\t\t.replace('{failed}', String(data.failed || 0));\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tvar tpl = (pill && pill.getAttribute('data-i18n-summary')) || '{succeeded} succeeded, {failed} failed, {skipped} skipped';\n\t\t\t\t\t\t\tmsg = tpl\n\t\t\t\t\t\t\t\t.replace('{succeeded}', String(data.succeeded || 0))\n\t\t\t\t\t\t\t\t.replace('{failed}', String(data.failed || 0))\n\t\t\t\t\t\t\t\t.replace('{skipped}', String(data.skipped || 0));\n\t\t\t\t\t\t}\n\t\t\t\t\t\tif (typeof window.showSuccessToast === 'function' && (data.failed || 0) === 0) {\n\t\t\t\t\t\t\twindow.showSuccessToast(msg);\n\t\t\t\t\t\t} else if (typeof window.showToast === 'function') {\n\t\t\t\t\t\t\twindow.showToast(msg);\n\t\t\t\t\t\t}\n\t\t\t\t\t\treturn true;\n\t\t\t\t\t}\n\t\t\t\t\treturn false;\n\t\t\t\t}\n\n\t\t\t\tfunction startProgressPoll(initialAction) {\n\t\t\t\t\tif (progressPoll) { progressPoll.stop(); progressPoll = null; }\n\t\t\t\t\tbulkActionRunning = true;\n\t\t\t\t\tupdateBar();\n\t\t\t\t\tprogressPoll = pollAsyncStatus(_artistsBp + '/api/v1/artists/bulk-actions/status', {\n\t\t\t\t\t\tonData: function(data) {\n\t\t\t\t\t\t\treturn handleProgressSnapshot(data, initialAction);\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonHTTPError: function() {\n\t\t\t\t\t\t\t// Transport/HTTP errors are non-terminal: the backend\n\t\t\t\t\t\t\t// job may still be running. Keep bulkActionRunning set\n\t\t\t\t\t\t\t// so Apply stays disabled; a later idle/completed/\n\t\t\t\t\t\t\t// failed snapshot from the polling retry will clear\n\t\t\t\t\t\t\t// the lock. Releasing here would reopen the duplicate-\n\t\t\t\t\t\t\t// submit window and reintroduce the 409 loop.\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonNetworkError: function() {\n\t\t\t\t\t\t\t// Same rationale as onHTTPError: the status endpoint\n\t\t\t\t\t\t\t// may be transiently unreachable while the action is\n\t\t\t\t\t\t\t// still running. Do not clear the lock on an unknown\n\t\t\t\t\t\t\t// status.\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t\t// Expose so other controllers (single-artist run-rules on the\n\t\t\t\t// artist detail page) can attach to an in-flight action.\n\t\t\t\twindow.swBulkProgress = {\n\t\t\t\t\tstart: startProgressPoll,\n\t\t\t\t\trender: renderProgressPill,\n\t\t\t\t\thide: hideProgressPill\n\t\t\t\t};\n\n\t\t\t\t// Cancel the in-flight bulk action. The button is wired via\n\t\t\t\t// onclick on the pill; the poll loop picks up the terminal\n\t\t\t\t// \"canceled\" status on the next tick and clears the pill.\n\t\t\t\twindow.swCancelBulkAction = function() {\n\t\t\t\t\tvar btn = document.getElementById('bulk-progress-cancel');\n\t\t\t\t\tif (btn) btn.disabled = true;\n\t\t\t\t\tvar csrfToken = document.cookie.replace(/(?:(?:^|.*;\\s*)csrf_token\\s*\\=\\s*([^;]*).*$)|^.*$/, \"$1\");\n\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/bulk-actions/cancel', {\n\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\tcredentials: 'same-origin',\n\t\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken}\n\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\tif (btn) btn.disabled = false;\n\t\t\t\t\t});\n\t\t\t\t};\n\n\t\t\t\t// Size-aware confirm dialog. <=50: no dialog; >50 and <=500:\n\t\t\t\t// simple confirm with action + count; >500: stronger warning\n\t\t\t\t// that names external API impact for re-identify and\n\t\t\t\t// fetch_images. Returns true when the user confirmed.\n\t\t\t\tfunction confirmBulkAction(action, count) {\n\t\t\t\t\tif (count <= 50) return true;\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\t// Use the action-dropdown's selected option label so the\n\t\t\t\t\t// confirm text reads naturally (e.g. \"Apply Run rules to\n\t\t\t\t\t// 100 artists?\") rather than the progress-verb form.\n\t\t\t\t\tvar selectEl = document.getElementById('bulk-action-select');\n\t\t\t\t\tvar verb = action;\n\t\t\t\t\tif (selectEl && selectEl.selectedOptions && selectEl.selectedOptions[0]) {\n\t\t\t\t\t\tverb = selectEl.selectedOptions[0].textContent || action;\n\t\t\t\t\t}\n\t\t\t\t\t// The large-count copy names external provider APIs, so\n\t\t\t\t\t// only use it for actions that actually hit them. Local\n\t\t\t\t\t// actions (scan, run_rules) get the plain small template\n\t\t\t\t\t// regardless of count to avoid misleading warnings.\n\t\t\t\t\tvar usesExternalProviders = action === 're_identify_auto' || action === 're_identify_review' || action === 'fetch_images';\n\t\t\t\t\tvar tpl;\n\t\t\t\t\tif (count > 500 && usesExternalProviders) {\n\t\t\t\t\t\ttpl = (pill && pill.getAttribute('data-i18n-confirm-large')) || 'You are about to apply {action} to {count} artists. This may take a while and will hit external provider APIs (MusicBrainz, Fanart.tv, etc.). Continue?';\n\t\t\t\t\t} else {\n\t\t\t\t\t\ttpl = (pill && pill.getAttribute('data-i18n-confirm-small')) || 'Apply {action} to {count} artists?';\n\t\t\t\t\t}\n\t\t\t\t\tvar msg = tpl.replace('{action}', verb).replace('{count}', String(count));\n\t\t\t\t\treturn window.confirm(msg);\n\t\t\t\t}\n\n\t\t\t\tdocument.body.addEventListener('click', function(ev) {\n\t\t\t\t\tvar t = ev.target;\n\t\t\t\t\tif (!t || t.id !== 'bulk-action-apply') return;\n\t\t\t\t\tvar selectEl = document.getElementById('bulk-action-select');\n\t\t\t\t\tif (!selectEl || !selectEl.value || selected.size === 0) return;\n\t\t\t\t\tvar action = selectEl.value;\n\t\t\t\t\t// Defensive truncation: the UI cap should already prevent\n\t\t\t\t\t// this, but guard against any drift so we never hit the\n\t\t\t\t\t// backend's hard 1000-ID rejection with a generic toast.\n\t\t\t\t\tvar ids = Array.from(selected).slice(0, MAX_BULK_SELECTION);\n\t\t\t\t\tif (!confirmBulkAction(action, ids.length)) return;\n\t\t\t\t\tvar csrfToken = document.cookie.replace(/(?:(?:^|.*;\\s*)csrf_token\\s*\\=\\s*([^;]*).*$)|^.*$/, \"$1\");\n\t\t\t\t\tt.disabled = true;\n\t\t\t\t\t// Re-identify (review) dispatches to the wizard flow\n\t\t\t\t\t// rather than the bulk-actions endpoint: the wizard is\n\t\t\t\t\t// interactive and owns its own session state, so routing\n\t\t\t\t\t// it through the singleton bulk-action slot would be\n\t\t\t\t\t// misleading. Start the wizard then redirect the user to\n\t\t\t\t\t// its first step.\n\t\t\t\t\tif (action === 're_identify_review') {\n\t\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/re-identify/wizard', {\n\t\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},\n\t\t\t\t\t\t\tbody: JSON.stringify({ids: ids})\n\t\t\t\t\t\t}).then(function(r) {\n\t\t\t\t\t\t\tif (!r.ok) {\n\t\t\t\t\t\t\t\tvar bar3 = document.getElementById('bulk-action-bar');\n\t\t\t\t\t\t\t\talert((bar3 && bar3.getAttribute('data-i18n-failed')) || 'Bulk action failed to start.');\n\t\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\treturn r.json();\n\t\t\t\t\t\t}).then(function(data) {\n\t\t\t\t\t\t\tif (!data || !data.session_id) return;\n\t\t\t\t\t\t\twindow.location.href = _artistsBp + '/artists/re-identify/wizard/' + data.session_id + '/step/0';\n\t\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t});\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/bulk-actions', {\n\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},\n\t\t\t\t\t\tbody: JSON.stringify({action: action, ids: ids})\n\t\t\t\t\t}).then(function(r) {\n\t\t\t\t\t\tvar bar = document.getElementById('bulk-action-bar');\n\t\t\t\t\t\tvar i18nBusy = (bar && bar.getAttribute('data-i18n-busy')) || 'A bulk action is already running. Please wait for it to finish.';\n\t\t\t\t\t\tvar i18nFailed = (bar && bar.getAttribute('data-i18n-failed')) || 'Bulk action failed to start.';\n\t\t\t\t\t\tif (r.status === 409) {\n\t\t\t\t\t\t\talert(i18nBusy);\n\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t} else if (!r.ok) {\n\t\t\t\t\t\t\talert(i18nFailed);\n\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t// Render an immediate 0-of-total pill so the user sees\n\t\t\t\t\t\t\t// feedback before the first poll tick lands, then\n\t\t\t\t\t\t\t// start polling. Apply-disabled stays true until the\n\t\t\t\t\t\t\t// poll observes a terminal status.\n\t\t\t\t\t\t\trenderProgressPill(action, 0, ids.length);\n\t\t\t\t\t\t\tselected.clear();\n\t\t\t\t\t\t\tcapWarned = false;\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t\tstartProgressPoll(action);\n\t\t\t\t\t\t}\n\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\tvar bar2 = document.getElementById('bulk-action-bar');\n\t\t\t\t\t\talert((bar2 && bar2.getAttribute('data-i18n-failed')) || 'Bulk action failed to start.');\n\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t});\n\t\t\t\t});\n\n\t\t\t\t// Scope token: filter-identifying params only. If any of\n\t\t\t\t// these change across an htmx swap, the user is looking\n\t\t\t\t// at a different result set and the previous selection is\n\t\t\t\t// no longer meaningful. Pagination, sort, order, and view\n\t\t\t\t// do NOT reset selection so the user can re-sort, paginate,\n\t\t\t\t// or switch table/grid while preserving their selection.\n\t\t\t\t//\n\t\t\t\t// Prefer the explicit URLSearchParams source over\n\t\t\t\t// window.location.search so the same routine works whether\n\t\t\t\t// we are reacting to an htmx swap (where the URL has\n\t\t\t\t// already been updated by the listener at line 638) or\n\t\t\t\t// computing the initial token at IIFE init.\n\t\t\t\tfunction tokenFromParams(p) {\n\t\t\t\t\tvar keys = [];\n\t\t\t\t\tp.forEach(function(_v, k) {\n\t\t\t\t\t\tif (k === 'search' || k === 'library_id' || k === 'filter' || k.indexOf('filter_') === 0) {\n\t\t\t\t\t\t\tkeys.push(k);\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t\tkeys.sort();\n\t\t\t\t\treturn keys.map(function(k) { return k + '=' + p.get(k); }).join('&');\n\t\t\t\t}\n\t\t\t\tfunction currentScopeToken() {\n\t\t\t\t\treturn tokenFromParams(new URLSearchParams(window.location.search));\n\t\t\t\t}\n\t\t\t\t// Compute the scope token from an htmx request URL. Used in\n\t\t\t\t// the afterSwap handler to derive the new scope without\n\t\t\t\t// depending on whether the URL-update listener has run yet.\n\t\t\t\t// htmx 2.x exposes the request URL on evt.detail.pathInfo\n\t\t\t\t// (requestPath / finalRequestPath); both are checked because\n\t\t\t\t// hx-vals can rewrite the path between them. Falls through\n\t\t\t\t// to the current window.location URL if neither is present.\n\t\t\t\tfunction scopeTokenFromRequest(evt) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tvar pi = evt && evt.detail && evt.detail.pathInfo;\n\t\t\t\t\t\tvar path = pi && (pi.finalRequestPath || pi.requestPath);\n\t\t\t\t\t\tif (path) {\n\t\t\t\t\t\t\tvar u = new URL(path, window.location.origin);\n\t\t\t\t\t\t\treturn tokenFromParams(u.searchParams);\n\t\t\t\t\t\t}\n\t\t\t\t\t} catch (e) { /* fall through */ }\n\t\t\t\t\treturn currentScopeToken();\n\t\t\t\t}\n\t\t\t\tvar lastScopeToken = currentScopeToken();\n\n\t\t\t\t// Re-sync on initial load and after every HTMX swap of the\n\t\t\t\t// artist content (pagination, filter change, etc.). Also\n\t\t\t\t// probe the bulk-actions/status endpoint on load so a page\n\t\t\t\t// reload mid-action re-attaches the progress pill.\n\t\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\t\tupdateBar();\n\t\t\t\t\t// Fire-and-forget status probe. If an action is in flight\n\t\t\t\t\t// the poll attaches; otherwise the pill stays hidden.\n\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/bulk-actions/status', {credentials: 'same-origin'})\n\t\t\t\t\t\t.then(function(r) { return r.ok ? r.json() : null; })\n\t\t\t\t\t\t.then(function(data) {\n\t\t\t\t\t\t\t// Terminal snapshots (completed/failed/idle) are\n\t\t\t\t\t\t\t// handled in-place so the summary toast is not\n\t\t\t\t\t\t\t// dropped on reload-near-end. Non-terminal returns\n\t\t\t\t\t\t\t// false and we start the normal poll.\n\t\t\t\t\t\t\tif (!data) return;\n\t\t\t\t\t\t\tif (handleProgressSnapshot(data, data.action || '')) return;\n\t\t\t\t\t\t\tstartProgressPoll(data.action || '');\n\t\t\t\t\t\t})\n\t\t\t\t\t\t.catch(function(){ /* ignore */ });\n\t\t\t\t});\n\t\t\t\tdocument.body.addEventListener('htmx:afterSwap', function(evt) {\n\t\t\t\t\tif (evt.detail.target && evt.detail.target.id === 'artist-content') {\n\t\t\t\t\t\t// Derive the new scope from the htmx request URL so\n\t\t\t\t\t\t// the comparison does not depend on the URL-update\n\t\t\t\t\t\t// listener (line 638) having fired first. This keeps\n\t\t\t\t\t\t// selection stable across sort/order/page/view swaps\n\t\t\t\t\t\t// (issue #1081 F1) regardless of listener ordering.\n\t\t\t\t\t\tvar currentToken = scopeTokenFromRequest(evt);\n\t\t\t\t\t\tif (currentToken !== lastScopeToken) {\n\t\t\t\t\t\t\tselected.clear();\n\t\t\t\t\t\t\tcapWarned = false;\n\t\t\t\t\t\t\tlastScopeToken = currentToken;\n\t\t\t\t\t\t}\n\t\t\t\t\t\t// Reset the shift-click anchor on every swap: after\n\t\t\t\t\t\t// pagination or sort the prior DOM ordering no longer\n\t\t\t\t\t\t// applies, so an old anchor could select an unintended\n\t\t\t\t\t\t// range on the next shift-click.\n\t\t\t\t\t\tlastClickedId = null;\n\t\t\t\t\t\t// Re-derive every checkbox's checked state from the\n\t\t\t\t\t\t// `selected` Set. The freshly-swapped HTML never\n\t\t\t\t\t\t// includes a `checked` attribute, so this is what\n\t\t\t\t\t\t// keeps checkmarks attached to artist IDs (not row\n\t\t\t\t\t\t// positions) across sort changes (issue #1081 F2).\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t})();\n\t\t</script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1443,7 +1443,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var73 string
 		templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.toolbar"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1302, Col: 45}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1338, Col: 45}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
 		if templ_7745c5c3_Err != nil {
@@ -1456,7 +1456,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var74 string
 		templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.none_selected"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1303, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1339, Col: 55}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
 		if templ_7745c5c3_Err != nil {
@@ -1469,7 +1469,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var75 string
 		templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.selected.one"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1304, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1340, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
 		if templ_7745c5c3_Err != nil {
@@ -1482,7 +1482,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var76 string
 		templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.selected.other"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1305, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1341, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
 		if templ_7745c5c3_Err != nil {
@@ -1495,7 +1495,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var77 string
 		templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.busy"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1306, Col: 46}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1342, Col: 46}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
 		if templ_7745c5c3_Err != nil {
@@ -1508,7 +1508,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var78 string
 		templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.failed"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1307, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1343, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
 		if templ_7745c5c3_Err != nil {
@@ -1521,7 +1521,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var79 string
 		templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.select_all"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1308, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1344, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
 		if templ_7745c5c3_Err != nil {
@@ -1534,7 +1534,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var80 string
 		templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.deselect_all"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1309, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1345, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
 		if templ_7745c5c3_Err != nil {
@@ -1547,7 +1547,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var81 string
 		templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.selection_cap"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1310, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1346, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var81))
 		if templ_7745c5c3_Err != nil {
@@ -1560,7 +1560,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var82 string
 		templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.select_all"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1318, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1354, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 		if templ_7745c5c3_Err != nil {
@@ -1573,7 +1573,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var83 string
 		templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.select_all"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1320, Col: 71}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1356, Col: 71}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
 		if templ_7745c5c3_Err != nil {
@@ -1586,7 +1586,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var84 string
 		templ_7745c5c3_Var84, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.none_selected"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1323, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1359, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var84))
 		if templ_7745c5c3_Err != nil {
@@ -1599,7 +1599,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var85 string
 		templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action_label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1330, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1366, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
 		if templ_7745c5c3_Err != nil {
@@ -1612,7 +1612,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var86 string
 		templ_7745c5c3_Var86, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.choose_action"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1332, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1368, Col: 59}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var86))
 		if templ_7745c5c3_Err != nil {
@@ -1625,7 +1625,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var87 string
 		templ_7745c5c3_Var87, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.run_rules"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1333, Col: 71}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1369, Col: 71}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var87))
 		if templ_7745c5c3_Err != nil {
@@ -1638,7 +1638,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var88 string
 		templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.re_identify_auto"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1334, Col: 85}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1370, Col: 85}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
 		if templ_7745c5c3_Err != nil {
@@ -1651,7 +1651,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var89 string
 		templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.re_identify_review"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1335, Col: 89}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1371, Col: 89}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
 		if templ_7745c5c3_Err != nil {
@@ -1664,7 +1664,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var90 string
 		templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.scan"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1336, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1372, Col: 61}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
 		if templ_7745c5c3_Err != nil {
@@ -1677,7 +1677,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var91 string
 		templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.fetch_images"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1337, Col: 77}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1373, Col: 77}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
 		if templ_7745c5c3_Err != nil {
@@ -1690,7 +1690,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var92 string
 		templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.apply"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1345, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1381, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
 		if templ_7745c5c3_Err != nil {
@@ -1755,7 +1755,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var94 string
 			templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.active_filters"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1356, Col: 99}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1392, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var94))
 			if templ_7745c5c3_Err != nil {
@@ -1792,7 +1792,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var97 string
 					templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(filterChipLabelFromData(ctx, key, data.Filters[key], data.Libraries, data.LibrarySources))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1360, Col: 98}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1396, Col: 98}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
 					if templ_7745c5c3_Err != nil {
@@ -1813,7 +1813,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var98 string
 					templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "common.remove_filter", filterChipLabelFromData(ctx, key, data.Filters[key], data.Libraries, data.LibrarySources)))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1364, Col: 143}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1400, Col: 143}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var98))
 					if templ_7745c5c3_Err != nil {
@@ -1846,7 +1846,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var100 string
 		templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.select_column"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1381, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1417, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
 		if templ_7745c5c3_Err != nil {
@@ -1859,7 +1859,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var101 string
 		templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.sort_by_name"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1388, Col: 46}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1424, Col: 46}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
 		if templ_7745c5c3_Err != nil {
@@ -1872,7 +1872,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var102 string
 		templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.col.name"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1390, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1426, Col: 36}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var102))
 		if templ_7745c5c3_Err != nil {
@@ -1902,7 +1902,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var103 string
 		templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.col.metadata"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1401, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1437, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
 		if templ_7745c5c3_Err != nil {
@@ -1915,7 +1915,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var104 string
 		templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(img.ImageTermFor("thumb", data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1404, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1440, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var104))
 		if templ_7745c5c3_Err != nil {
@@ -1928,7 +1928,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var105 string
 		templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(img.ImageTermFor("fanart", data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1407, Col: 53}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1443, Col: 53}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
 		if templ_7745c5c3_Err != nil {
@@ -1941,7 +1941,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var106 string
 		templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(img.ImageTermFor("logo", data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1410, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1446, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
 		if templ_7745c5c3_Err != nil {
@@ -1954,7 +1954,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var107 string
 		templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.col.mbid"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1413, Col: 35}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1449, Col: 35}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
 		if templ_7745c5c3_Err != nil {
@@ -1972,7 +1972,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var108 string
 			templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.empty_state"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1421, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1457, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
 			if templ_7745c5c3_Err != nil {
@@ -2056,7 +2056,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var112 string
 			templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(a.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1442, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1478, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
 			if templ_7745c5c3_Err != nil {
@@ -2069,7 +2069,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var113 string
 			templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "artists.bulk.select_artist", a.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1443, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1479, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var113))
 			if templ_7745c5c3_Err != nil {
@@ -2110,7 +2110,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var116 string
 			templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs(complianceDotTitle(ctx, artistCompliance(a.ID, compliance)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1452, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1488, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var116))
 			if templ_7745c5c3_Err != nil {
@@ -2123,7 +2123,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var117 string
 			templ_7745c5c3_Var117, templ_7745c5c3_Err = templ.JoinStringErrs(complianceDotTitle(ctx, artistCompliance(a.ID, compliance)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1453, Col: 78}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1489, Col: 78}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var117))
 			if templ_7745c5c3_Err != nil {
@@ -2145,7 +2145,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 		var templ_7745c5c3_Var118 templ.SafeURL
 		templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath() + "/artists/" + a.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1459, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1495, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var118))
 		if templ_7745c5c3_Err != nil {
@@ -2158,7 +2158,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 		var templ_7745c5c3_Var119 string
 		templ_7745c5c3_Var119, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1462, Col: 13}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1498, Col: 13}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var119))
 		if templ_7745c5c3_Err != nil {
@@ -2176,7 +2176,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var120 string
 			templ_7745c5c3_Var120, templ_7745c5c3_Err = templ.JoinStringErrs(a.SortName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1465, Col: 59}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1501, Col: 59}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var120))
 			if templ_7745c5c3_Err != nil {
@@ -2195,7 +2195,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var121 string
 			templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.excluded"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1468, Col: 184}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1504, Col: 184}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var121))
 			if templ_7745c5c3_Err != nil {
@@ -2306,7 +2306,7 @@ func ArtistGrid(data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var123 string
 			templ_7745c5c3_Var123, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.active_filters"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1496, Col: 99}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1532, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var123))
 			if templ_7745c5c3_Err != nil {
@@ -2343,7 +2343,7 @@ func ArtistGrid(data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var126 string
 					templ_7745c5c3_Var126, templ_7745c5c3_Err = templ.JoinStringErrs(filterChipLabelFromData(ctx, key, data.Filters[key], data.Libraries, data.LibrarySources))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1500, Col: 98}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1536, Col: 98}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var126))
 					if templ_7745c5c3_Err != nil {
@@ -2364,7 +2364,7 @@ func ArtistGrid(data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var127 string
 					templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "common.remove_filter", filterChipLabelFromData(ctx, key, data.Filters[key], data.Libraries, data.LibrarySources)))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1504, Col: 143}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1540, Col: 143}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var127))
 					if templ_7745c5c3_Err != nil {
@@ -2398,7 +2398,7 @@ func ArtistGrid(data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var129 string
 			templ_7745c5c3_Var129, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.empty_state"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1518, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1554, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var129))
 			if templ_7745c5c3_Err != nil {
@@ -2469,7 +2469,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var131 string
 			templ_7745c5c3_Var131, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "artists.bulk.select_artist", a.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1537, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1573, Col: 62}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var131))
 			if templ_7745c5c3_Err != nil {
@@ -2482,7 +2482,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var132 string
 			templ_7745c5c3_Var132, templ_7745c5c3_Err = templ.JoinStringErrs(a.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1542, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1578, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var132))
 			if templ_7745c5c3_Err != nil {
@@ -2495,7 +2495,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var133 string
 			templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "artists.bulk.select_artist", a.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1544, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1580, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var133))
 			if templ_7745c5c3_Err != nil {
@@ -2518,7 +2518,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 		var templ_7745c5c3_Var135 templ.SafeURL
 		templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath() + "/artists/" + a.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1549, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1585, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var135))
 		if templ_7745c5c3_Err != nil {
@@ -2550,7 +2550,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 				var templ_7745c5c3_Var137 string
 				templ_7745c5c3_Var137, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(templ.SafeCSS("background-image:url('" + a.ThumbPlaceholder + "')"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1555, Col: 111}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1591, Col: 111}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var137))
 				if templ_7745c5c3_Err != nil {
@@ -2568,7 +2568,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var138 string
 			templ_7745c5c3_Var138, templ_7745c5c3_Err = templ.JoinStringErrs(basePath() + "/api/v1/artists/" + a.ID + "/images/thumb/file")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1558, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1594, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var138))
 			if templ_7745c5c3_Err != nil {
@@ -2581,7 +2581,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var139 string
 			templ_7745c5c3_Var139, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1559, Col: 18}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1595, Col: 18}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var139))
 			if templ_7745c5c3_Err != nil {
@@ -2599,7 +2599,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var140 string
 			templ_7745c5c3_Var140, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(templ.SafeCSS("background-image:url('" + a.ThumbPlaceholder + "')"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1565, Col: 110}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1601, Col: 110}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var140))
 			if templ_7745c5c3_Err != nil {
@@ -2641,7 +2641,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var143 string
 			templ_7745c5c3_Var143, templ_7745c5c3_Err = templ.JoinStringErrs(complianceDotTitle(ctx, artistCompliance(a.ID, compliance)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1576, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1612, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var143))
 			if templ_7745c5c3_Err != nil {
@@ -2654,7 +2654,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var144 string
 			templ_7745c5c3_Var144, templ_7745c5c3_Err = templ.JoinStringErrs(complianceDotTitle(ctx, artistCompliance(a.ID, compliance)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1577, Col: 78}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1613, Col: 78}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var144))
 			if templ_7745c5c3_Err != nil {
@@ -2676,7 +2676,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 		var templ_7745c5c3_Var145 string
 		templ_7745c5c3_Var145, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1584, Col: 91}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1620, Col: 91}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var145))
 		if templ_7745c5c3_Err != nil {
@@ -2689,7 +2689,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 		var templ_7745c5c3_Var146 string
 		templ_7745c5c3_Var146, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1585, Col: 13}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1621, Col: 13}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var146))
 		if templ_7745c5c3_Err != nil {
@@ -2724,7 +2724,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 		var templ_7745c5c3_Var149 string
 		templ_7745c5c3_Var149, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%.0f%%", a.HealthScore))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1588, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1624, Col: 43}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var149))
 		if templ_7745c5c3_Err != nil {
@@ -2865,7 +2865,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var153 string
 		templ_7745c5c3_Var153, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.run_rules"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1632, Col: 70}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1668, Col: 70}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var153))
 		if templ_7745c5c3_Err != nil {
@@ -2878,7 +2878,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var154 string
 		templ_7745c5c3_Var154, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.re_identify"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1633, Col: 74}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1669, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var154))
 		if templ_7745c5c3_Err != nil {
@@ -2891,7 +2891,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var155 string
 		templ_7745c5c3_Var155, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.re_identify_auto"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1634, Col: 84}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1670, Col: 84}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var155))
 		if templ_7745c5c3_Err != nil {
@@ -2904,7 +2904,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var156 string
 		templ_7745c5c3_Var156, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.re_identify_review"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1635, Col: 88}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1671, Col: 88}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var156))
 		if templ_7745c5c3_Err != nil {
@@ -2917,7 +2917,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var157 string
 		templ_7745c5c3_Var157, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.scan"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1636, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1672, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var157))
 		if templ_7745c5c3_Err != nil {
@@ -2930,7 +2930,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var158 string
 		templ_7745c5c3_Var158, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.fetch_images"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1637, Col: 76}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1673, Col: 76}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var158))
 		if templ_7745c5c3_Err != nil {
@@ -2943,7 +2943,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var159 string
 		templ_7745c5c3_Var159, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.template"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1638, Col: 63}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1674, Col: 63}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var159))
 		if templ_7745c5c3_Err != nil {
@@ -2956,7 +2956,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var160 string
 		templ_7745c5c3_Var160, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.single"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1639, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1675, Col: 59}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var160))
 		if templ_7745c5c3_Err != nil {
@@ -2969,7 +2969,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var161 string
 		templ_7745c5c3_Var161, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.summary"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1640, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1676, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var161))
 		if templ_7745c5c3_Err != nil {
@@ -2982,7 +2982,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var162 string
 		templ_7745c5c3_Var162, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.summary"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1641, Col: 74}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1677, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var162))
 		if templ_7745c5c3_Err != nil {
@@ -2995,7 +2995,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var163 string
 		templ_7745c5c3_Var163, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.confirm.small"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1642, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1678, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var163))
 		if templ_7745c5c3_Err != nil {
@@ -3008,7 +3008,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var164 string
 		templ_7745c5c3_Var164, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.confirm.large"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1643, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1679, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var164))
 		if templ_7745c5c3_Err != nil {
@@ -3021,7 +3021,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var165 string
 		templ_7745c5c3_Var165, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.cancel"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1654, Col: 45}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1690, Col: 45}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var165))
 		if templ_7745c5c3_Err != nil {
@@ -3034,7 +3034,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var166 string
 		templ_7745c5c3_Var166, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.cancel"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1657, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1693, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var166))
 		if templ_7745c5c3_Err != nil {

--- a/web/templates/artists_templ.go
+++ b/web/templates/artists_templ.go
@@ -1394,7 +1394,7 @@ func ArtistsPage(assets AssetPaths, data ArtistListData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, " <script>\n\t\t\tvar _artistsBp = (document.querySelector('meta[name=\"htmx-base-path\"]') || {content: ''}).content;\n\t\t\t// Inject flyout filter params from the URL into HTMX requests that\n\t\t\t// target #artist-content. The flyout stores state in the URL only\n\t\t\t// (not in named form elements), so hx-include cannot pick it up.\n\t\t\tdocument.body.addEventListener('htmx:configRequest', function(evt) {\n\t\t\t\tif (evt.detail.target && evt.detail.target.id === 'artist-content') {\n\t\t\t\t\tvar urlParams = new URLSearchParams(window.location.search);\n\t\t\t\t\turlParams.forEach(function(val, key) {\n\t\t\t\t\t\tif (key.indexOf('filter_') === 0 && !(key in evt.detail.parameters)) {\n\t\t\t\t\t\t\tevt.detail.parameters[key] = val;\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t});\n\n\t\t\tvar _sortActiveClass = 'w-full text-left px-4 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 font-semibold text-blue-600 dark:text-blue-400';\n\t\t\tvar _sortInactiveClass = 'w-full text-left px-4 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200';\n\n\t\t\tfunction updateSortUI(sort, order) {\n\t\t\t\tvar fieldLabel = document.getElementById('sort-field-label');\n\t\t\t\tvar orderLabel = document.getElementById('sort-order-label');\n\t\t\t\tif (fieldLabel) {\n\t\t\t\t\tvar activeBtn = document.querySelector('#sort-dropdown button[onclick=\"setSort(\\'' + sort + '\\')\"]');\n\t\t\t\t\tfieldLabel.textContent = activeBtn ? activeBtn.textContent.trim() : sort;\n\t\t\t\t}\n\t\t\t\tif (orderLabel) {\n\t\t\t\t\tvar activeOrder = document.querySelector('#sort-dropdown button[onclick=\"setOrder(\\'' + order + '\\')\"]');\n\t\t\t\t\torderLabel.textContent = activeOrder ? activeOrder.textContent.trim() : order;\n\t\t\t\t}\n\t\t\t\t['name', 'sort_name', 'health_score', 'updated_at', 'created_at'].forEach(function(f) {\n\t\t\t\t\tvar btn = document.querySelector('#sort-dropdown button[onclick=\"setSort(\\'' + f + '\\')\"]');\n\t\t\t\t\tif (btn) btn.className = f === sort ? _sortActiveClass : _sortInactiveClass;\n\t\t\t\t});\n\t\t\t\t['asc', 'desc'].forEach(function(d) {\n\t\t\t\t\tvar btn = document.querySelector('#sort-dropdown button[onclick=\"setOrder(\\'' + d + '\\')\"]');\n\t\t\t\t\tif (btn) btn.className = d === order ? _sortActiveClass : _sortInactiveClass;\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction setSort(field) {\n\t\t\t\tvar sortInput = document.getElementById('artist-sort-input');\n\t\t\t\tvar orderInput = document.getElementById('artist-order-input');\n\t\t\t\tif (!sortInput || !orderInput) return;\n\t\t\t\tif (sortInput.value === field) {\n\t\t\t\t\torderInput.value = (orderInput.value === 'asc') ? 'desc' : 'asc';\n\t\t\t\t} else {\n\t\t\t\t\tsortInput.value = field;\n\t\t\t\t\torderInput.value = 'asc';\n\t\t\t\t}\n\t\t\t\tupdateSortUI(sortInput.value, orderInput.value);\n\t\t\t\tcloseSortDropdown();\n\t\t\t\thtmx.ajax('GET', '/artists', {\n\t\t\t\t\ttarget: '#artist-content',\n\t\t\t\t\tswap: 'outerHTML',\n\t\t\t\t\tvalues: buildArtistParams({page: '1'})\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction setOrder(dir) {\n\t\t\t\tvar sortInput = document.getElementById('artist-sort-input');\n\t\t\t\tvar orderInput = document.getElementById('artist-order-input');\n\t\t\t\tif (!orderInput) return;\n\t\t\t\torderInput.value = dir;\n\t\t\t\tupdateSortUI(sortInput ? sortInput.value : '', dir);\n\t\t\t\tcloseSortDropdown();\n\t\t\t\thtmx.ajax('GET', '/artists', {\n\t\t\t\t\ttarget: '#artist-content',\n\t\t\t\t\tswap: 'outerHTML',\n\t\t\t\t\tvalues: buildArtistParams({page: '1'})\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction closeSortDropdown() {\n\t\t\t\tvar d = document.getElementById('sort-dropdown');\n\t\t\t\tif (d) d.removeAttribute('open');\n\t\t\t}\n\n\t\t\tfunction buildArtistParams(overrides) {\n\t\t\t\tvar params = {};\n\t\t\t\t// Collect form-based params from named elements.\n\t\t\t\t['search', 'library_id', 'view', 'sort', 'order'].forEach(function(name) {\n\t\t\t\t\tvar el = document.querySelector('[name=\"' + name + '\"]');\n\t\t\t\t\tif (el) params[name] = el.value;\n\t\t\t\t});\n\t\t\t\t// Carry all flyout filter params from the current URL dynamically.\n\t\t\t\tvar urlParams = new URLSearchParams(window.location.search);\n\t\t\t\turlParams.forEach(function(val, key) {\n\t\t\t\t\tif (key.indexOf('filter_') === 0) {\n\t\t\t\t\t\tparams[key] = val;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn Object.assign(params, overrides);\n\t\t\t}\n\n\t\t\t// Update view toggle button classes to reflect the active view.\n\t\t\t// Mirrors the server-side templ.KV classes on the #view-toggle buttons.\n\t\t\tvar _viewActiveClass = 'p-2 transition-colors bg-blue-600 text-white';\n\t\t\tvar _viewInactiveClass = 'p-2 transition-colors bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700';\n\t\t\tfunction updateViewToggleUI(view) {\n\t\t\t\tvar toggle = document.getElementById('view-toggle');\n\t\t\t\tif (!toggle) return;\n\t\t\t\tvar tableBtn = toggle.querySelector('button[onclick=\"setView(\\'table\\')\"]');\n\t\t\t\tvar gridBtn = toggle.querySelector('button[onclick=\"setView(\\'grid\\')\"]');\n\t\t\t\tif (tableBtn) tableBtn.className = view === 'table' ? _viewActiveClass : _viewInactiveClass;\n\t\t\t\tif (gridBtn) gridBtn.className = view === 'grid' ? _viewActiveClass : _viewInactiveClass;\n\t\t\t}\n\n\t\t\tfunction setView(view) {\n\t\t\t\tvar input = document.getElementById('artist-view-input');\n\t\t\t\tif (input) input.value = view;\n\t\t\t\tupdateViewToggleUI(view);\n\t\t\t\t// Show/hide column toggle based on view\n\t\t\t\tvar colToggle = document.getElementById('col-toggle-wrapper');\n\t\t\t\tif (colToggle) {\n\t\t\t\t\tif (view === 'table') {\n\t\t\t\t\t\tcolToggle.classList.remove('hidden');\n\t\t\t\t\t} else {\n\t\t\t\t\t\tcolToggle.classList.add('hidden');\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\t// Fire-and-forget save preference\n\t\t\t\tvar csrfToken = document.cookie.replace(/(?:(?:^|.*;\\s*)csrf_token\\s*\\=\\s*([^;]*).*$)|^.*$/, \"$1\");\n\t\t\t\tfetch(_artistsBp + '/api/v1/settings', {\n\t\t\t\t\tmethod: 'PUT',\n\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},\n\t\t\t\t\tbody: JSON.stringify({\"ui.artists_view\": view})\n\t\t\t\t}).catch(function() {});\n\t\t\t}\n\n\t\t\t// After HTMX swaps artist content, push the current filter/sort state\n\t\t\t// into the URL so browser back-navigation restores the correct view.\n\t\t\t// Uses window.location.pathname (not hardcoded '/artists') for basePath\n\t\t\t// support, and carries over the page param from the HTMX request URL.\n\t\t\tdocument.body.addEventListener('htmx:afterSwap', function(evt) {\n\t\t\t\tif (evt.detail.target && evt.detail.target.id === 'artist-content') {\n\t\t\t\t\t// Re-sync flyout state from URL after any swap (including chip dismissals\n\t\t\t\t\t// via DismissFilterChip, which bypass the sw:filter-applied event).\n\t\t\t\t\tif (window.swFilterFlyout) {\n\t\t\t\t\t\tswFilterFlyout.initFromURL('artist-filters-flyout');\n\t\t\t\t\t}\n\n\t\t\t\t\tvar params = buildArtistParams({});\n\t\t\t\t\t// Extract page from the HTMX request URL if present.\n\t\t\t\t\ttry {\n\t\t\t\t\t\tvar reqUrl = new URL(evt.detail.requestInfo.path, window.location.origin);\n\t\t\t\t\t\tvar page = reqUrl.searchParams.get('page');\n\t\t\t\t\t\tif (page && page !== '1') params.page = page;\n\t\t\t\t\t\tvar pageSize = reqUrl.searchParams.get('page_size');\n\t\t\t\t\t\tif (pageSize) params.page_size = pageSize;\n\t\t\t\t\t} catch(e) { /* ignore parse errors */ }\n\t\t\t\t\tvar qs = Object.keys(params).filter(function(k) { return params[k]; }).map(function(k) {\n\t\t\t\t\t\treturn encodeURIComponent(k) + '=' + encodeURIComponent(params[k]);\n\t\t\t\t\t}).join('&');\n\t\t\t\t\thistory.replaceState(null, '', window.location.pathname + (qs ? '?' + qs : ''));\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Reload artist content when the filter flyout applies filters.\n\t\t\tdocument.body.addEventListener('sw:filter-applied', function(evt) {\n\t\t\t\tif (evt.target && evt.target.id === 'artist-content') {\n\t\t\t\t\t// Strip the base path from location.pathname before passing to htmx.ajax\n\t\t\t\t\t// to avoid a double-prefix from the htmx:configRequest hook.\n\t\t\t\t\tvar bpMeta = document.querySelector('meta[name=\"htmx-base-path\"]');\n\t\t\t\t\tvar bp = bpMeta ? bpMeta.content : '';\n\t\t\t\t\tvar path = window.location.pathname;\n\t\t\t\t\tif (bp && path.startsWith(bp)) {\n\t\t\t\t\t\tpath = path.slice(bp.length) || '/';\n\t\t\t\t\t}\n\t\t\t\t\thtmx.ajax('GET', path + window.location.search, {target: '#artist-content', swap: 'outerHTML'});\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Initialise the flyout from URL params on first page load.\n\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\tif (window.swFilterFlyout) {\n\t\t\t\t\tswFilterFlyout.initFromURL('artist-filters-flyout');\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// restoreStateFromURL syncs all filter controls, hidden inputs,\n\t\t\t// sort labels, and view toggle from the current URL query params,\n\t\t\t// then triggers an HTMX content reload so the artist list matches\n\t\t\t// the URL state. Used by both pageshow (bfcache) and popstate\n\t\t\t// (history back/forward) handlers.\n\t\t\t//\n\t\t\t// A debounce guard prevents duplicate calls when bfcache restore\n\t\t\t// fires both pageshow and popstate in quick succession.\n\t\t\tvar _restoreLastRun = 0;\n\t\t\tvar _restoreLastHref = '';\n\t\t\tfunction restoreStateFromURL() {\n\t\t\t\tvar now = Date.now();\n\t\t\t\tvar href = window.location.href;\n\t\t\t\tif (href === _restoreLastHref && now - _restoreLastRun < 100) return;\n\t\t\t\t_restoreLastHref = href;\n\t\t\t\t_restoreLastRun = now;\n\t\t\t\tvar params = new URLSearchParams(window.location.search);\n\t\t\t\t// Re-sync flyout chip states from URL.\n\t\t\t\tif (window.swFilterFlyout) {\n\t\t\t\t\tswFilterFlyout.initFromURL('artist-filters-flyout');\n\t\t\t\t}\n\t\t\t\t// Sync the search input from URL params.\n\t\t\t\tvar searchEl = document.getElementById('artist-search');\n\t\t\t\tif (searchEl) searchEl.value = params.get('search') || '';\n\t\t\t\t// Sync select elements from URL params.\n\t\t\t\t['library_id'].forEach(function(name) {\n\t\t\t\t\tvar val = params.get(name);\n\t\t\t\t\tvar el = document.querySelector('select[name=\"' + name + '\"]');\n\t\t\t\t\tif (el) el.value = (val !== null) ? val : '';\n\t\t\t\t});\n\t\t\t\t// Sync hidden inputs from URL params, resetting to markup\n\t\t\t\t// defaults when a param is absent so browser history\n\t\t\t\t// restoration cannot retain stale values from a newer state.\n\t\t\t\t['view', 'sort', 'order'].forEach(function(name) {\n\t\t\t\t\tvar val = params.get(name);\n\t\t\t\t\tvar el = document.getElementById('artist-' + name + '-input');\n\t\t\t\t\tif (el) el.value = (val !== null) ? val : el.defaultValue;\n\t\t\t\t});\n\t\t\t\t// Update visible sort labels and view toggle to match restored state.\n\t\t\t\tvar sortInput = document.getElementById('artist-sort-input');\n\t\t\t\tvar orderInput = document.getElementById('artist-order-input');\n\t\t\t\tif (sortInput && orderInput) updateSortUI(sortInput.value, orderInput.value);\n\t\t\t\tvar viewInput = document.getElementById('artist-view-input');\n\t\t\t\tif (viewInput) {\n\t\t\t\t\tupdateViewToggleUI(viewInput.value);\n\t\t\t\t\tvar colToggle = document.getElementById('col-toggle-wrapper');\n\t\t\t\t\tif (colToggle) colToggle.classList.toggle('hidden', viewInput.value !== 'table');\n\t\t\t\t}\n\t\t\t\tvar _rsMeta = document.querySelector('meta[name=\"htmx-base-path\"]');\n\t\t\t\tvar _rsBp = _rsMeta ? _rsMeta.content : '';\n\t\t\t\tvar _rsPath = window.location.pathname;\n\t\t\t\tif (_rsBp && _rsPath.startsWith(_rsBp)) { _rsPath = _rsPath.slice(_rsBp.length) || '/'; }\n\t\t\t\thtmx.ajax('GET', _rsPath + window.location.search, {target: '#artist-content', swap: 'outerHTML'});\n\t\t\t}\n\n\t\t\t// When the page is restored from bfcache (browser back/forward navigation),\n\t\t\t// sync filter controls from the URL query params and reload content so\n\t\t\t// status badges reflect the latest state.\n\t\t\twindow.addEventListener('pageshow', function(evt) {\n\t\t\t\tif (evt.persisted) {\n\t\t\t\t\trestoreStateFromURL();\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Handle browser back/forward navigation between pushState entries\n\t\t\t// (e.g. filter changes, pagination). Without this, pressing back after\n\t\t\t// applying filters and navigating away would show stale content even\n\t\t\t// though the URL contains the correct filter params. Works in Firefox\n\t\t\t// and all major browsers.\n\t\t\twindow.addEventListener('popstate', function() {\n\t\t\t\trestoreStateFromURL();\n\t\t\t});\n\n\t\t\t(function() {\n\t\t\t\tvar btn = document.getElementById('scan-btn');\n\t\t\t\tif (!btn) return;\n\n\t\t\t\tdocument.body.addEventListener('htmx:afterRequest', function(evt) {\n\t\t\t\t\tif (evt.detail.elt !== btn) return;\n\t\t\t\t\tif (!evt.detail.successful) return;\n\n\t\t\t\t\tvar spinner = document.getElementById('scan-spinner');\n\t\t\t\t\tvar label = document.getElementById('scan-label');\n\t\t\t\t\tbtn.disabled = true;\n\t\t\t\t\tspinner.classList.remove('hidden');\n\t\t\t\t\tlabel.textContent = btn.dataset.labelScanning || 'Scanning...';\n\n\t\t\t\t\tfunction resetScanUI() {\n\t\t\t\t\t\tbtn.disabled = false;\n\t\t\t\t\t\tspinner.classList.add('hidden');\n\t\t\t\t\t\tlabel.textContent = btn.dataset.labelScan || 'Scan Library';\n\t\t\t\t\t}\n\t\t\t\t\tpollAsyncStatus(_artistsBp + '/api/v1/scanner/status', {\n\t\t\t\t\t\tonData: function(data) {\n\t\t\t\t\t\t\tif (data.status === 'completed' || data.status === 'failed' || data.status === 'canceled') {\n\t\t\t\t\t\t\t\tresetScanUI();\n\t\t\t\t\t\t\t\tvar _scMeta = document.querySelector('meta[name=\"htmx-base-path\"]');\n\t\t\t\t\t\t\t\tvar _scBp = _scMeta ? _scMeta.content : '';\n\t\t\t\t\t\t\t\tvar _scPath = window.location.pathname;\n\t\t\t\t\t\t\t\tif (_scBp && _scPath.startsWith(_scBp)) { _scPath = _scPath.slice(_scBp.length) || '/'; }\n\t\t\t\t\t\t\t\thtmx.ajax('GET', _scPath + window.location.search, {target: '#artist-content', swap: 'outerHTML'});\n\t\t\t\t\t\t\t\treturn true;\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\treturn false;\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonHTTPError: function() {\n\t\t\t\t\t\t\tresetScanUI();\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonNetworkError: function() {\n\t\t\t\t\t\t\tresetScanUI();\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t});\n\t\t\t})();\n\n\t\t\t// Bulk-action controller. Wires the Select-All checkbox, per-row\n\t\t\t// checkboxes, the \"N selected\" indicator, and the action dropdown\n\t\t\t// to the /api/v1/artists/bulk-actions endpoint. The controller is\n\t\t\t// idempotent: it attaches listeners via event delegation so it\n\t\t\t// works across HTMX swaps of #artist-content without re-binding.\n\t\t\t(function() {\n\t\t\t\t// Selection state persists across HTMX swaps of the list so\n\t\t\t\t// the user can paginate while keeping earlier selections.\n\t\t\t\tvar selected = new Set();\n\t\t\t\t// Matches the backend cap in handlers_bulk_actions.go; keeps\n\t\t\t\t// the UI in sync so we never POST a payload the server will\n\t\t\t\t// reject with a generic \"failed to start\" toast.\n\t\t\t\tvar MAX_BULK_SELECTION = 1000;\n\t\t\t\tvar capWarned = false;\n\t\t\t\t// Tracks the last checkbox clicked for shift-click range\n\t\t\t\t// selection (Gmail/GitHub-style). Reset on scope change.\n\t\t\t\tvar lastClickedId = null;\n\t\t\t\t// Polling handle for the in-flight bulk action status. Non-null\n\t\t\t\t// while a bulk or single-artist run-rules action is running.\n\t\t\t\tvar progressPoll = null;\n\t\t\t\t// Tracks whether a bulk action is running end-to-end. Gates the\n\t\t\t\t// Apply button so checkbox/dropdown changes cannot re-enable it\n\t\t\t\t// mid-flight and queue a second POST (which would 409-loop).\n\t\t\t\tvar bulkActionRunning = false;\n\n\t\t\t\tfunction warnCap() {\n\t\t\t\t\tif (capWarned) return;\n\t\t\t\t\tcapWarned = true;\n\t\t\t\t\tvar bar = document.getElementById('bulk-action-bar');\n\t\t\t\t\tvar tpl = (bar && bar.getAttribute('data-i18n-selection-cap')) || 'You can select up to {count} artists at a time.';\n\t\t\t\t\talert(tpl.replace('{count}', String(MAX_BULK_SELECTION)));\n\t\t\t\t}\n\n\t\t\t\tfunction tryAdd(id) {\n\t\t\t\t\tif (selected.has(id)) return true;\n\t\t\t\t\tif (selected.size >= MAX_BULK_SELECTION) {\n\t\t\t\t\t\twarnCap();\n\t\t\t\t\t\treturn false;\n\t\t\t\t\t}\n\t\t\t\t\tselected.add(id);\n\t\t\t\t\treturn true;\n\t\t\t\t}\n\n\t\t\t\tfunction updateBar() {\n\t\t\t\t\tvar bar = document.getElementById('bulk-action-bar');\n\t\t\t\t\tif (!bar) return;\n\t\t\t\t\tvar countEl = document.getElementById('bulk-selected-count');\n\t\t\t\t\tvar applyBtn = document.getElementById('bulk-action-apply');\n\t\t\t\t\tvar selectEl = document.getElementById('bulk-action-select');\n\t\t\t\t\tvar selectAll = document.getElementById('bulk-select-all');\n\t\t\t\t\tvar boxes = document.querySelectorAll('#artist-content .sw-bulk-select');\n\t\t\t\t\tvar i18nNone = bar.getAttribute('data-i18n-none') || 'None selected';\n\t\t\t\t\tvar i18nSelectedOne = bar.getAttribute('data-i18n-selected-one') || '1 selected';\n\t\t\t\t\tvar i18nSelectedOther = bar.getAttribute('data-i18n-selected-other') || '{count} selected';\n\t\t\t\t\tif (countEl) {\n\t\t\t\t\t\tif (selected.size === 0) {\n\t\t\t\t\t\t\tcountEl.textContent = i18nNone;\n\t\t\t\t\t\t} else if (selected.size === 1) {\n\t\t\t\t\t\t\tcountEl.textContent = i18nSelectedOne;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tcountEl.textContent = i18nSelectedOther.replace('{count}', String(selected.size));\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\tif (applyBtn) applyBtn.disabled = bulkActionRunning || selected.size === 0 || !selectEl || !selectEl.value;\n\t\t\t\t\tif (selectEl) selectEl.disabled = bulkActionRunning || selected.size === 0;\n\t\t\t\t\t// Sync per-row checkboxes with persisted selection state.\n\t\t\t\t\tvar visibleChecked = 0;\n\t\t\t\t\tboxes.forEach(function(cb) {\n\t\t\t\t\t\tvar id = cb.getAttribute('data-artist-id');\n\t\t\t\t\t\tcb.checked = selected.has(id);\n\t\t\t\t\t\tif (cb.checked) visibleChecked++;\n\t\t\t\t\t});\n\t\t\t\t\t// Select-All indeterminate state.\n\t\t\t\t\tvar allChecked = false;\n\t\t\t\t\tif (selectAll) {\n\t\t\t\t\t\tif (boxes.length === 0) {\n\t\t\t\t\t\t\tselectAll.checked = false;\n\t\t\t\t\t\t\tselectAll.indeterminate = false;\n\t\t\t\t\t\t} else if (visibleChecked === 0) {\n\t\t\t\t\t\t\tselectAll.checked = false;\n\t\t\t\t\t\t\tselectAll.indeterminate = false;\n\t\t\t\t\t\t} else if (visibleChecked === boxes.length) {\n\t\t\t\t\t\t\tselectAll.checked = true;\n\t\t\t\t\t\t\tselectAll.indeterminate = false;\n\t\t\t\t\t\t\tallChecked = true;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tselectAll.checked = false;\n\t\t\t\t\t\t\tselectAll.indeterminate = true;\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\t// Swap the checkbox label between Select all / Deselect all\n\t\t\t\t\t// so screen readers and sighted users both see the action\n\t\t\t\t\t// that a click will perform next.\n\t\t\t\t\tvar labelEl = document.getElementById('bulk-select-all-label');\n\t\t\t\t\tif (labelEl) {\n\t\t\t\t\t\tvar i18nSelectAll = bar.getAttribute('data-i18n-select-all') || 'Select all on page';\n\t\t\t\t\t\tvar i18nDeselectAll = bar.getAttribute('data-i18n-deselect-all') || 'Deselect all on page';\n\t\t\t\t\t\tlabelEl.textContent = allChecked ? i18nDeselectAll : i18nSelectAll;\n\t\t\t\t\t}\n\t\t\t\t\tif (selectAll) {\n\t\t\t\t\t\tvar i18nSelectAllAria = bar.getAttribute('data-i18n-select-all') || 'Select all on page';\n\t\t\t\t\t\tvar i18nDeselectAllAria = bar.getAttribute('data-i18n-deselect-all') || 'Deselect all on page';\n\t\t\t\t\t\tselectAll.setAttribute('aria-label', allChecked ? i18nDeselectAllAria : i18nSelectAllAria);\n\t\t\t\t\t}\n\t\t\t\t}\n\n\t\t\t\t// Shift-click range selection: capture on click (before the\n\t\t\t\t// change event) so we can see event.shiftKey. If shift is\n\t\t\t\t// held and we have a prior lastClickedId, select/deselect\n\t\t\t\t// every checkbox between the two anchors in DOM order.\n\t\t\t\tdocument.body.addEventListener('click', function(ev) {\n\t\t\t\t\tvar t = ev.target;\n\t\t\t\t\tif (!t || !t.classList || !t.classList.contains('sw-bulk-select')) return;\n\t\t\t\t\tvar id = t.getAttribute('data-artist-id');\n\t\t\t\t\tif (!id) return;\n\t\t\t\t\t// Keyboard Shift+Space triggers a click with shiftKey.\n\t\t\t\t\tif (ev.shiftKey && lastClickedId && lastClickedId !== id) {\n\t\t\t\t\t\tvar boxes = Array.prototype.slice.call(\n\t\t\t\t\t\t\tdocument.querySelectorAll('#artist-content .sw-bulk-select')\n\t\t\t\t\t\t);\n\t\t\t\t\t\tvar idx1 = -1, idx2 = -1;\n\t\t\t\t\t\tfor (var i = 0; i < boxes.length; i++) {\n\t\t\t\t\t\t\tvar bid = boxes[i].getAttribute('data-artist-id');\n\t\t\t\t\t\t\tif (bid === lastClickedId) idx1 = i;\n\t\t\t\t\t\t\tif (bid === id) idx2 = i;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tif (idx1 >= 0 && idx2 >= 0) {\n\t\t\t\t\t\t\tvar lo = Math.min(idx1, idx2), hi = Math.max(idx1, idx2);\n\t\t\t\t\t\t\t// Target state follows the just-clicked checkbox's\n\t\t\t\t\t\t\t// post-click state (which the browser has already\n\t\t\t\t\t\t\t// set by the time this click handler runs).\n\t\t\t\t\t\t\tvar target = t.checked;\n\t\t\t\t\t\t\tfor (var j = lo; j <= hi; j++) {\n\t\t\t\t\t\t\t\tvar cb = boxes[j];\n\t\t\t\t\t\t\t\tvar cid = cb.getAttribute('data-artist-id');\n\t\t\t\t\t\t\t\tif (!cid) continue;\n\t\t\t\t\t\t\t\tif (target) {\n\t\t\t\t\t\t\t\t\tif (!tryAdd(cid)) { cb.checked = false; continue; }\n\t\t\t\t\t\t\t\t\tcb.checked = true;\n\t\t\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t\t\tselected.delete(cid);\n\t\t\t\t\t\t\t\t\tcb.checked = false;\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\tif (!target) capWarned = false;\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\tlastClickedId = id;\n\t\t\t\t}, true);\n\n\t\t\t\tdocument.body.addEventListener('change', function(ev) {\n\t\t\t\t\tvar t = ev.target;\n\t\t\t\t\tif (!t) return;\n\t\t\t\t\tif (t.classList && t.classList.contains('sw-bulk-select')) {\n\t\t\t\t\t\tvar id = t.getAttribute('data-artist-id');\n\t\t\t\t\t\tif (!id) return;\n\t\t\t\t\t\tif (t.checked) {\n\t\t\t\t\t\t\tif (!tryAdd(id)) { t.checked = false; }\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tselected.delete(id);\n\t\t\t\t\t\t\tcapWarned = false;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t} else if (t.id === 'bulk-select-all') {\n\t\t\t\t\t\tvar boxes = document.querySelectorAll('#artist-content .sw-bulk-select');\n\t\t\t\t\t\tboxes.forEach(function(cb) {\n\t\t\t\t\t\t\tvar id = cb.getAttribute('data-artist-id');\n\t\t\t\t\t\t\tif (!id) return;\n\t\t\t\t\t\t\tif (t.checked) {\n\t\t\t\t\t\t\t\tcb.checked = tryAdd(id);\n\t\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t\tcb.checked = false;\n\t\t\t\t\t\t\t\tselected.delete(id);\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t});\n\t\t\t\t\t\tif (!t.checked) capWarned = false;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t} else if (t.id === 'bulk-action-select') {\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t}\n\t\t\t\t});\n\n\t\t\t\t// Build the localized verb label for a bulk action from the\n\t\t\t\t// data attributes on the progress pill. Falls back to the\n\t\t\t\t// raw action key if a verb is missing.\n\t\t\t\tfunction actionVerb(action) {\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\tif (!pill) return action;\n\t\t\t\t\tvar key = 'data-i18n-verb-' + action.replace(/_/g, '-');\n\t\t\t\t\treturn pill.getAttribute(key) || action;\n\t\t\t\t}\n\n\t\t\t\t// Render the progress pill with the current snapshot. Called\n\t\t\t\t// from both the initial 202 response and the poll callback.\n\t\t\t\tfunction renderProgressPill(action, processed, total) {\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\tvar txt = document.getElementById('bulk-progress-text');\n\t\t\t\t\tif (!pill || !txt) return;\n\t\t\t\t\tvar tpl = pill.getAttribute('data-i18n-template') || '{verb}: {processed} of {total} artists';\n\t\t\t\t\tvar verb = actionVerb(action);\n\t\t\t\t\ttxt.textContent = tpl\n\t\t\t\t\t\t.replace('{verb}', verb)\n\t\t\t\t\t\t.replace('{processed}', String(processed))\n\t\t\t\t\t\t.replace('{total}', String(total));\n\t\t\t\t\tpill.classList.remove('hidden');\n\t\t\t\t\t// Re-enable the cancel button each render tick so a prior\n\t\t\t\t\t// canceled run does not leave the button disabled on the\n\t\t\t\t\t// next action.\n\t\t\t\t\tvar cancelBtn = document.getElementById('bulk-progress-cancel');\n\t\t\t\t\tif (cancelBtn) cancelBtn.disabled = false;\n\t\t\t\t}\n\n\t\t\t\tfunction hideProgressPill() {\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\tif (pill) pill.classList.add('hidden');\n\t\t\t\t}\n\n\t\t\t\t// Start polling bulk-actions/status every 2s. Stops on terminal\n\t\t\t\t// status and surfaces an outcome-breakdown toast. Page reloads\n\t\t\t\t// mid-action re-attach by calling this on DOMContentLoaded.\n\t\t\t\t// Process one /status snapshot. Returns true when the status\n\t\t\t\t// is terminal (idle/completed/failed) so callers know to stop\n\t\t\t\t// polling and do not need to start one. Shared between the\n\t\t\t\t// active poll callback and the DOMContentLoaded recovery\n\t\t\t\t// path so a page reload near the end of a bulk job still\n\t\t\t\t// surfaces the summary toast from the terminal snapshot.\n\t\t\t\tfunction handleProgressSnapshot(data, initialAction) {\n\t\t\t\t\tif (!data || data.status === 'idle') {\n\t\t\t\t\t\thideProgressPill();\n\t\t\t\t\t\tbulkActionRunning = false;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\treturn true;\n\t\t\t\t\t}\n\t\t\t\t\trenderProgressPill(data.action || initialAction || '', data.processed || 0, data.total || 0);\n\t\t\t\t\t// Reveal the cancel button only for bulk-actions runs.\n\t\t\t\t\t// The pill is reused by single-artist flows (e.g. the\n\t\t\t\t\t// detail-page run-rules) that do not go through /bulk-\n\t\t\t\t\t// actions/cancel and have no cancel affordance.\n\t\t\t\t\tvar _cancelBtn = document.getElementById('bulk-progress-cancel');\n\t\t\t\t\tif (_cancelBtn) _cancelBtn.classList.remove('hidden');\n\t\t\t\t\tif (data.status === 'completed' || data.status === 'failed' || data.status === 'canceled') {\n\t\t\t\t\t\thideProgressPill();\n\t\t\t\t\t\tbulkActionRunning = false;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\t\t// Re-identify auto breaks out auto_linked/queued/\n\t\t\t\t\t\t// no_match counters so the toast can say \"3 auto-\n\t\t\t\t\t\t// linked, 2 queued, 1 no match\" instead of the\n\t\t\t\t\t\t// generic succeeded/skipped triad. Other actions\n\t\t\t\t\t\t// keep the existing summary text.\n\t\t\t\t\t\tvar msg;\n\t\t\t\t\t\tif ((data.action === 're_identify_auto' || data.action === 're_identify') &&\n\t\t\t\t\t\t\t((data.auto_linked || 0) + (data.queued || 0) + (data.no_match || 0) + (data.failed || 0) > 0)) {\n\t\t\t\t\t\t\tvar rtpl = (pill && pill.getAttribute('data-i18n-reidentify-summary')) ||\n\t\t\t\t\t\t\t\t'{auto_linked} auto-linked, {queued} queued, {no_match} no match';\n\t\t\t\t\t\t\tmsg = rtpl\n\t\t\t\t\t\t\t\t.replace('{auto_linked}', String(data.auto_linked || 0))\n\t\t\t\t\t\t\t\t.replace('{queued}', String(data.queued || 0))\n\t\t\t\t\t\t\t\t.replace('{no_match}', String(data.no_match || 0))\n\t\t\t\t\t\t\t\t.replace('{failed}', String(data.failed || 0));\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tvar tpl = (pill && pill.getAttribute('data-i18n-summary')) || '{succeeded} succeeded, {failed} failed, {skipped} skipped';\n\t\t\t\t\t\t\tmsg = tpl\n\t\t\t\t\t\t\t\t.replace('{succeeded}', String(data.succeeded || 0))\n\t\t\t\t\t\t\t\t.replace('{failed}', String(data.failed || 0))\n\t\t\t\t\t\t\t\t.replace('{skipped}', String(data.skipped || 0));\n\t\t\t\t\t\t}\n\t\t\t\t\t\tif (typeof window.showSuccessToast === 'function' && (data.failed || 0) === 0) {\n\t\t\t\t\t\t\twindow.showSuccessToast(msg);\n\t\t\t\t\t\t} else if (typeof window.showToast === 'function') {\n\t\t\t\t\t\t\twindow.showToast(msg);\n\t\t\t\t\t\t}\n\t\t\t\t\t\treturn true;\n\t\t\t\t\t}\n\t\t\t\t\treturn false;\n\t\t\t\t}\n\n\t\t\t\tfunction startProgressPoll(initialAction) {\n\t\t\t\t\tif (progressPoll) { progressPoll.stop(); progressPoll = null; }\n\t\t\t\t\tbulkActionRunning = true;\n\t\t\t\t\tupdateBar();\n\t\t\t\t\tprogressPoll = pollAsyncStatus(_artistsBp + '/api/v1/artists/bulk-actions/status', {\n\t\t\t\t\t\tonData: function(data) {\n\t\t\t\t\t\t\treturn handleProgressSnapshot(data, initialAction);\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonHTTPError: function() {\n\t\t\t\t\t\t\t// Transport/HTTP errors are non-terminal: the backend\n\t\t\t\t\t\t\t// job may still be running. Keep bulkActionRunning set\n\t\t\t\t\t\t\t// so Apply stays disabled; a later idle/completed/\n\t\t\t\t\t\t\t// failed snapshot from the polling retry will clear\n\t\t\t\t\t\t\t// the lock. Releasing here would reopen the duplicate-\n\t\t\t\t\t\t\t// submit window and reintroduce the 409 loop.\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonNetworkError: function() {\n\t\t\t\t\t\t\t// Same rationale as onHTTPError: the status endpoint\n\t\t\t\t\t\t\t// may be transiently unreachable while the action is\n\t\t\t\t\t\t\t// still running. Do not clear the lock on an unknown\n\t\t\t\t\t\t\t// status.\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t\t// Expose so other controllers (single-artist run-rules on the\n\t\t\t\t// artist detail page) can attach to an in-flight action.\n\t\t\t\twindow.swBulkProgress = {\n\t\t\t\t\tstart: startProgressPoll,\n\t\t\t\t\trender: renderProgressPill,\n\t\t\t\t\thide: hideProgressPill\n\t\t\t\t};\n\n\t\t\t\t// Cancel the in-flight bulk action. The button is wired via\n\t\t\t\t// onclick on the pill; the poll loop picks up the terminal\n\t\t\t\t// \"canceled\" status on the next tick and clears the pill.\n\t\t\t\twindow.swCancelBulkAction = function() {\n\t\t\t\t\tvar btn = document.getElementById('bulk-progress-cancel');\n\t\t\t\t\tif (btn) btn.disabled = true;\n\t\t\t\t\tvar csrfToken = document.cookie.replace(/(?:(?:^|.*;\\s*)csrf_token\\s*\\=\\s*([^;]*).*$)|^.*$/, \"$1\");\n\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/bulk-actions/cancel', {\n\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\tcredentials: 'same-origin',\n\t\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken}\n\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\tif (btn) btn.disabled = false;\n\t\t\t\t\t});\n\t\t\t\t};\n\n\t\t\t\t// Size-aware confirm dialog. <=50: no dialog; >50 and <=500:\n\t\t\t\t// simple confirm with action + count; >500: stronger warning\n\t\t\t\t// that names external API impact for re-identify and\n\t\t\t\t// fetch_images. Returns true when the user confirmed.\n\t\t\t\tfunction confirmBulkAction(action, count) {\n\t\t\t\t\tif (count <= 50) return true;\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\t// Use the action-dropdown's selected option label so the\n\t\t\t\t\t// confirm text reads naturally (e.g. \"Apply Run rules to\n\t\t\t\t\t// 100 artists?\") rather than the progress-verb form.\n\t\t\t\t\tvar selectEl = document.getElementById('bulk-action-select');\n\t\t\t\t\tvar verb = action;\n\t\t\t\t\tif (selectEl && selectEl.selectedOptions && selectEl.selectedOptions[0]) {\n\t\t\t\t\t\tverb = selectEl.selectedOptions[0].textContent || action;\n\t\t\t\t\t}\n\t\t\t\t\t// The large-count copy names external provider APIs, so\n\t\t\t\t\t// only use it for actions that actually hit them. Local\n\t\t\t\t\t// actions (scan, run_rules) get the plain small template\n\t\t\t\t\t// regardless of count to avoid misleading warnings.\n\t\t\t\t\tvar usesExternalProviders = action === 're_identify_auto' || action === 're_identify_review' || action === 'fetch_images';\n\t\t\t\t\tvar tpl;\n\t\t\t\t\tif (count > 500 && usesExternalProviders) {\n\t\t\t\t\t\ttpl = (pill && pill.getAttribute('data-i18n-confirm-large')) || 'You are about to apply {action} to {count} artists. This may take a while and will hit external provider APIs (MusicBrainz, Fanart.tv, etc.). Continue?';\n\t\t\t\t\t} else {\n\t\t\t\t\t\ttpl = (pill && pill.getAttribute('data-i18n-confirm-small')) || 'Apply {action} to {count} artists?';\n\t\t\t\t\t}\n\t\t\t\t\tvar msg = tpl.replace('{action}', verb).replace('{count}', String(count));\n\t\t\t\t\treturn window.confirm(msg);\n\t\t\t\t}\n\n\t\t\t\tdocument.body.addEventListener('click', function(ev) {\n\t\t\t\t\tvar t = ev.target;\n\t\t\t\t\tif (!t || t.id !== 'bulk-action-apply') return;\n\t\t\t\t\tvar selectEl = document.getElementById('bulk-action-select');\n\t\t\t\t\tif (!selectEl || !selectEl.value || selected.size === 0) return;\n\t\t\t\t\tvar action = selectEl.value;\n\t\t\t\t\t// Defensive truncation: the UI cap should already prevent\n\t\t\t\t\t// this, but guard against any drift so we never hit the\n\t\t\t\t\t// backend's hard 1000-ID rejection with a generic toast.\n\t\t\t\t\tvar ids = Array.from(selected).slice(0, MAX_BULK_SELECTION);\n\t\t\t\t\tif (!confirmBulkAction(action, ids.length)) return;\n\t\t\t\t\tvar csrfToken = document.cookie.replace(/(?:(?:^|.*;\\s*)csrf_token\\s*\\=\\s*([^;]*).*$)|^.*$/, \"$1\");\n\t\t\t\t\tt.disabled = true;\n\t\t\t\t\t// Re-identify (review) dispatches to the wizard flow\n\t\t\t\t\t// rather than the bulk-actions endpoint: the wizard is\n\t\t\t\t\t// interactive and owns its own session state, so routing\n\t\t\t\t\t// it through the singleton bulk-action slot would be\n\t\t\t\t\t// misleading. Start the wizard then redirect the user to\n\t\t\t\t\t// its first step.\n\t\t\t\t\tif (action === 're_identify_review') {\n\t\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/re-identify/wizard', {\n\t\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},\n\t\t\t\t\t\t\tbody: JSON.stringify({ids: ids})\n\t\t\t\t\t\t}).then(function(r) {\n\t\t\t\t\t\t\tif (!r.ok) {\n\t\t\t\t\t\t\t\tvar bar3 = document.getElementById('bulk-action-bar');\n\t\t\t\t\t\t\t\talert((bar3 && bar3.getAttribute('data-i18n-failed')) || 'Bulk action failed to start.');\n\t\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\treturn r.json();\n\t\t\t\t\t\t}).then(function(data) {\n\t\t\t\t\t\t\tif (!data || !data.session_id) return;\n\t\t\t\t\t\t\twindow.location.href = _artistsBp + '/artists/re-identify/wizard/' + data.session_id + '/step/0';\n\t\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t});\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/bulk-actions', {\n\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},\n\t\t\t\t\t\tbody: JSON.stringify({action: action, ids: ids})\n\t\t\t\t\t}).then(function(r) {\n\t\t\t\t\t\tvar bar = document.getElementById('bulk-action-bar');\n\t\t\t\t\t\tvar i18nBusy = (bar && bar.getAttribute('data-i18n-busy')) || 'A bulk action is already running. Please wait for it to finish.';\n\t\t\t\t\t\tvar i18nFailed = (bar && bar.getAttribute('data-i18n-failed')) || 'Bulk action failed to start.';\n\t\t\t\t\t\tif (r.status === 409) {\n\t\t\t\t\t\t\talert(i18nBusy);\n\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t} else if (!r.ok) {\n\t\t\t\t\t\t\talert(i18nFailed);\n\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t// Render an immediate 0-of-total pill so the user sees\n\t\t\t\t\t\t\t// feedback before the first poll tick lands, then\n\t\t\t\t\t\t\t// start polling. Apply-disabled stays true until the\n\t\t\t\t\t\t\t// poll observes a terminal status.\n\t\t\t\t\t\t\trenderProgressPill(action, 0, ids.length);\n\t\t\t\t\t\t\tselected.clear();\n\t\t\t\t\t\t\tcapWarned = false;\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t\tstartProgressPoll(action);\n\t\t\t\t\t\t}\n\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\tvar bar2 = document.getElementById('bulk-action-bar');\n\t\t\t\t\t\talert((bar2 && bar2.getAttribute('data-i18n-failed')) || 'Bulk action failed to start.');\n\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t});\n\t\t\t\t});\n\n\t\t\t\t// Scope token: filter-identifying params only. If any of\n\t\t\t\t// these change across an htmx swap, the user is looking\n\t\t\t\t// at a different result set and the previous selection is\n\t\t\t\t// no longer meaningful. Pagination, sort, order, and view\n\t\t\t\t// do NOT reset selection so the user can re-sort, paginate,\n\t\t\t\t// or switch table/grid while preserving their selection.\n\t\t\t\t//\n\t\t\t\t// Prefer the explicit URLSearchParams source over\n\t\t\t\t// window.location.search so the same routine works whether\n\t\t\t\t// we are reacting to an htmx swap (where the URL has\n\t\t\t\t// already been updated by the listener at line 638) or\n\t\t\t\t// computing the initial token at IIFE init.\n\t\t\t\tfunction tokenFromParams(p) {\n\t\t\t\t\tvar keys = [];\n\t\t\t\t\tp.forEach(function(_v, k) {\n\t\t\t\t\t\tif (k === 'search' || k === 'library_id' || k === 'filter' || k.indexOf('filter_') === 0) {\n\t\t\t\t\t\t\tkeys.push(k);\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t\tkeys.sort();\n\t\t\t\t\treturn keys.map(function(k) { return k + '=' + p.get(k); }).join('&');\n\t\t\t\t}\n\t\t\t\tfunction currentScopeToken() {\n\t\t\t\t\treturn tokenFromParams(new URLSearchParams(window.location.search));\n\t\t\t\t}\n\t\t\t\t// Compute the scope token from an htmx request URL. Used in\n\t\t\t\t// the afterSwap handler to derive the new scope without\n\t\t\t\t// depending on whether the URL-update listener has run yet.\n\t\t\t\t// htmx 2.x exposes the request URL on evt.detail.pathInfo\n\t\t\t\t// (requestPath / finalRequestPath); both are checked because\n\t\t\t\t// hx-vals can rewrite the path between them. Falls through\n\t\t\t\t// to the current window.location URL if neither is present.\n\t\t\t\tfunction scopeTokenFromRequest(evt) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tvar pi = evt && evt.detail && evt.detail.pathInfo;\n\t\t\t\t\t\tvar path = pi && (pi.finalRequestPath || pi.requestPath);\n\t\t\t\t\t\tif (path) {\n\t\t\t\t\t\t\tvar u = new URL(path, window.location.origin);\n\t\t\t\t\t\t\treturn tokenFromParams(u.searchParams);\n\t\t\t\t\t\t}\n\t\t\t\t\t} catch (e) { /* fall through */ }\n\t\t\t\t\treturn currentScopeToken();\n\t\t\t\t}\n\t\t\t\tvar lastScopeToken = currentScopeToken();\n\n\t\t\t\t// Re-sync on initial load and after every HTMX swap of the\n\t\t\t\t// artist content (pagination, filter change, etc.). Also\n\t\t\t\t// probe the bulk-actions/status endpoint on load so a page\n\t\t\t\t// reload mid-action re-attaches the progress pill.\n\t\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\t\tupdateBar();\n\t\t\t\t\t// Fire-and-forget status probe. If an action is in flight\n\t\t\t\t\t// the poll attaches; otherwise the pill stays hidden.\n\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/bulk-actions/status', {credentials: 'same-origin'})\n\t\t\t\t\t\t.then(function(r) { return r.ok ? r.json() : null; })\n\t\t\t\t\t\t.then(function(data) {\n\t\t\t\t\t\t\t// Terminal snapshots (completed/failed/idle) are\n\t\t\t\t\t\t\t// handled in-place so the summary toast is not\n\t\t\t\t\t\t\t// dropped on reload-near-end. Non-terminal returns\n\t\t\t\t\t\t\t// false and we start the normal poll.\n\t\t\t\t\t\t\tif (!data) return;\n\t\t\t\t\t\t\tif (handleProgressSnapshot(data, data.action || '')) return;\n\t\t\t\t\t\t\tstartProgressPoll(data.action || '');\n\t\t\t\t\t\t})\n\t\t\t\t\t\t.catch(function(){ /* ignore */ });\n\t\t\t\t});\n\t\t\t\tdocument.body.addEventListener('htmx:afterSwap', function(evt) {\n\t\t\t\t\tif (evt.detail.target && evt.detail.target.id === 'artist-content') {\n\t\t\t\t\t\t// Derive the new scope from the htmx request URL so\n\t\t\t\t\t\t// the comparison does not depend on the URL-update\n\t\t\t\t\t\t// listener (line 638) having fired first. This keeps\n\t\t\t\t\t\t// selection stable across sort/order/page/view swaps\n\t\t\t\t\t\t// (issue #1081 F1) regardless of listener ordering.\n\t\t\t\t\t\tvar currentToken = scopeTokenFromRequest(evt);\n\t\t\t\t\t\tif (currentToken !== lastScopeToken) {\n\t\t\t\t\t\t\tselected.clear();\n\t\t\t\t\t\t\tcapWarned = false;\n\t\t\t\t\t\t\tlastScopeToken = currentToken;\n\t\t\t\t\t\t}\n\t\t\t\t\t\t// Reset the shift-click anchor on every swap: after\n\t\t\t\t\t\t// pagination or sort the prior DOM ordering no longer\n\t\t\t\t\t\t// applies, so an old anchor could select an unintended\n\t\t\t\t\t\t// range on the next shift-click.\n\t\t\t\t\t\tlastClickedId = null;\n\t\t\t\t\t\t// Re-derive every checkbox's checked state from the\n\t\t\t\t\t\t// `selected` Set. The freshly-swapped HTML never\n\t\t\t\t\t\t// includes a `checked` attribute, so this is what\n\t\t\t\t\t\t// keeps checkmarks attached to artist IDs (not row\n\t\t\t\t\t\t// positions) across sort changes (issue #1081 F2).\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t})();\n\t\t</script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, " <script>\n\t\t\tvar _artistsBp = (document.querySelector('meta[name=\"htmx-base-path\"]') || {content: ''}).content;\n\t\t\t// Inject flyout filter params from the URL into HTMX requests that\n\t\t\t// target #artist-content. The flyout stores state in the URL only\n\t\t\t// (not in named form elements), so hx-include cannot pick it up.\n\t\t\tdocument.body.addEventListener('htmx:configRequest', function(evt) {\n\t\t\t\tif (evt.detail.target && evt.detail.target.id === 'artist-content') {\n\t\t\t\t\tvar urlParams = new URLSearchParams(window.location.search);\n\t\t\t\t\turlParams.forEach(function(val, key) {\n\t\t\t\t\t\tif (key.indexOf('filter_') === 0 && !(key in evt.detail.parameters)) {\n\t\t\t\t\t\t\tevt.detail.parameters[key] = val;\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t});\n\n\t\t\tvar _sortActiveClass = 'w-full text-left px-4 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 font-semibold text-blue-600 dark:text-blue-400';\n\t\t\tvar _sortInactiveClass = 'w-full text-left px-4 py-1.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200';\n\n\t\t\tfunction updateSortUI(sort, order) {\n\t\t\t\tvar fieldLabel = document.getElementById('sort-field-label');\n\t\t\t\tvar orderLabel = document.getElementById('sort-order-label');\n\t\t\t\tif (fieldLabel) {\n\t\t\t\t\tvar activeBtn = document.querySelector('#sort-dropdown button[onclick=\"setSort(\\'' + sort + '\\')\"]');\n\t\t\t\t\tfieldLabel.textContent = activeBtn ? activeBtn.textContent.trim() : sort;\n\t\t\t\t}\n\t\t\t\tif (orderLabel) {\n\t\t\t\t\tvar activeOrder = document.querySelector('#sort-dropdown button[onclick=\"setOrder(\\'' + order + '\\')\"]');\n\t\t\t\t\torderLabel.textContent = activeOrder ? activeOrder.textContent.trim() : order;\n\t\t\t\t}\n\t\t\t\t['name', 'sort_name', 'health_score', 'updated_at', 'created_at'].forEach(function(f) {\n\t\t\t\t\tvar btn = document.querySelector('#sort-dropdown button[onclick=\"setSort(\\'' + f + '\\')\"]');\n\t\t\t\t\tif (btn) btn.className = f === sort ? _sortActiveClass : _sortInactiveClass;\n\t\t\t\t});\n\t\t\t\t['asc', 'desc'].forEach(function(d) {\n\t\t\t\t\tvar btn = document.querySelector('#sort-dropdown button[onclick=\"setOrder(\\'' + d + '\\')\"]');\n\t\t\t\t\tif (btn) btn.className = d === order ? _sortActiveClass : _sortInactiveClass;\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction setSort(field) {\n\t\t\t\tvar sortInput = document.getElementById('artist-sort-input');\n\t\t\t\tvar orderInput = document.getElementById('artist-order-input');\n\t\t\t\tif (!sortInput || !orderInput) return;\n\t\t\t\tif (sortInput.value === field) {\n\t\t\t\t\torderInput.value = (orderInput.value === 'asc') ? 'desc' : 'asc';\n\t\t\t\t} else {\n\t\t\t\t\tsortInput.value = field;\n\t\t\t\t\torderInput.value = 'asc';\n\t\t\t\t}\n\t\t\t\tupdateSortUI(sortInput.value, orderInput.value);\n\t\t\t\tcloseSortDropdown();\n\t\t\t\thtmx.ajax('GET', '/artists', {\n\t\t\t\t\ttarget: '#artist-content',\n\t\t\t\t\tswap: 'outerHTML',\n\t\t\t\t\tvalues: buildArtistParams({page: '1'})\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction setOrder(dir) {\n\t\t\t\tvar sortInput = document.getElementById('artist-sort-input');\n\t\t\t\tvar orderInput = document.getElementById('artist-order-input');\n\t\t\t\tif (!orderInput) return;\n\t\t\t\torderInput.value = dir;\n\t\t\t\tupdateSortUI(sortInput ? sortInput.value : '', dir);\n\t\t\t\tcloseSortDropdown();\n\t\t\t\thtmx.ajax('GET', '/artists', {\n\t\t\t\t\ttarget: '#artist-content',\n\t\t\t\t\tswap: 'outerHTML',\n\t\t\t\t\tvalues: buildArtistParams({page: '1'})\n\t\t\t\t});\n\t\t\t}\n\n\t\t\tfunction closeSortDropdown() {\n\t\t\t\tvar d = document.getElementById('sort-dropdown');\n\t\t\t\tif (d) d.removeAttribute('open');\n\t\t\t}\n\n\t\t\tfunction buildArtistParams(overrides) {\n\t\t\t\tvar params = {};\n\t\t\t\t// Collect form-based params from named elements.\n\t\t\t\t['search', 'library_id', 'view', 'sort', 'order'].forEach(function(name) {\n\t\t\t\t\tvar el = document.querySelector('[name=\"' + name + '\"]');\n\t\t\t\t\tif (el) params[name] = el.value;\n\t\t\t\t});\n\t\t\t\t// Carry all flyout filter params from the current URL dynamically.\n\t\t\t\tvar urlParams = new URLSearchParams(window.location.search);\n\t\t\t\turlParams.forEach(function(val, key) {\n\t\t\t\t\tif (key.indexOf('filter_') === 0) {\n\t\t\t\t\t\tparams[key] = val;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\treturn Object.assign(params, overrides);\n\t\t\t}\n\n\t\t\t// Update view toggle button classes to reflect the active view.\n\t\t\t// Mirrors the server-side templ.KV classes on the #view-toggle buttons.\n\t\t\tvar _viewActiveClass = 'p-2 transition-colors bg-blue-600 text-white';\n\t\t\tvar _viewInactiveClass = 'p-2 transition-colors bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700';\n\t\t\tfunction updateViewToggleUI(view) {\n\t\t\t\tvar toggle = document.getElementById('view-toggle');\n\t\t\t\tif (!toggle) return;\n\t\t\t\tvar tableBtn = toggle.querySelector('button[onclick=\"setView(\\'table\\')\"]');\n\t\t\t\tvar gridBtn = toggle.querySelector('button[onclick=\"setView(\\'grid\\')\"]');\n\t\t\t\tif (tableBtn) tableBtn.className = view === 'table' ? _viewActiveClass : _viewInactiveClass;\n\t\t\t\tif (gridBtn) gridBtn.className = view === 'grid' ? _viewActiveClass : _viewInactiveClass;\n\t\t\t}\n\n\t\t\tfunction setView(view) {\n\t\t\t\tvar input = document.getElementById('artist-view-input');\n\t\t\t\tif (input) input.value = view;\n\t\t\t\tupdateViewToggleUI(view);\n\t\t\t\t// Show/hide column toggle based on view\n\t\t\t\tvar colToggle = document.getElementById('col-toggle-wrapper');\n\t\t\t\tif (colToggle) {\n\t\t\t\t\tif (view === 'table') {\n\t\t\t\t\t\tcolToggle.classList.remove('hidden');\n\t\t\t\t\t} else {\n\t\t\t\t\t\tcolToggle.classList.add('hidden');\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\t// Fire-and-forget save preference\n\t\t\t\tvar csrfToken = document.cookie.replace(/(?:(?:^|.*;\\s*)csrf_token\\s*\\=\\s*([^;]*).*$)|^.*$/, \"$1\");\n\t\t\t\tfetch(_artistsBp + '/api/v1/settings', {\n\t\t\t\t\tmethod: 'PUT',\n\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},\n\t\t\t\t\tbody: JSON.stringify({\"ui.artists_view\": view})\n\t\t\t\t}).catch(function() {});\n\t\t\t}\n\n\t\t\t// After HTMX swaps artist content, push the current filter/sort state\n\t\t\t// into the URL so browser back-navigation restores the correct view.\n\t\t\t// Uses window.location.pathname (not hardcoded '/artists') for basePath\n\t\t\t// support, and carries over the page param from the HTMX request URL.\n\t\t\tdocument.body.addEventListener('htmx:afterSwap', function(evt) {\n\t\t\t\tif (evt.detail.target && evt.detail.target.id === 'artist-content') {\n\t\t\t\t\t// Re-sync flyout state from URL after any swap (including chip dismissals\n\t\t\t\t\t// via DismissFilterChip, which bypass the sw:filter-applied event).\n\t\t\t\t\tif (window.swFilterFlyout) {\n\t\t\t\t\t\tswFilterFlyout.initFromURL('artist-filters-flyout');\n\t\t\t\t\t}\n\n\t\t\t\t\tvar params = buildArtistParams({});\n\t\t\t\t\t// Extract page from the HTMX request URL if present.\n\t\t\t\t\ttry {\n\t\t\t\t\t\tvar reqUrl = new URL(evt.detail.requestInfo.path, window.location.origin);\n\t\t\t\t\t\tvar page = reqUrl.searchParams.get('page');\n\t\t\t\t\t\tif (page && page !== '1') params.page = page;\n\t\t\t\t\t\tvar pageSize = reqUrl.searchParams.get('page_size');\n\t\t\t\t\t\tif (pageSize) params.page_size = pageSize;\n\t\t\t\t\t} catch(e) { /* ignore parse errors */ }\n\t\t\t\t\tvar qs = Object.keys(params).filter(function(k) { return params[k]; }).map(function(k) {\n\t\t\t\t\t\treturn encodeURIComponent(k) + '=' + encodeURIComponent(params[k]);\n\t\t\t\t\t}).join('&');\n\t\t\t\t\thistory.replaceState(null, '', window.location.pathname + (qs ? '?' + qs : ''));\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Reload artist content when the filter flyout applies filters.\n\t\t\tdocument.body.addEventListener('sw:filter-applied', function(evt) {\n\t\t\t\tif (evt.target && evt.target.id === 'artist-content') {\n\t\t\t\t\t// Strip the base path from location.pathname before passing to htmx.ajax\n\t\t\t\t\t// to avoid a double-prefix from the htmx:configRequest hook.\n\t\t\t\t\tvar bpMeta = document.querySelector('meta[name=\"htmx-base-path\"]');\n\t\t\t\t\tvar bp = bpMeta ? bpMeta.content : '';\n\t\t\t\t\tvar path = window.location.pathname;\n\t\t\t\t\tif (bp && path.startsWith(bp)) {\n\t\t\t\t\t\tpath = path.slice(bp.length) || '/';\n\t\t\t\t\t}\n\t\t\t\t\thtmx.ajax('GET', path + window.location.search, {target: '#artist-content', swap: 'outerHTML'});\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Initialise the flyout from URL params on first page load.\n\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\tif (window.swFilterFlyout) {\n\t\t\t\t\tswFilterFlyout.initFromURL('artist-filters-flyout');\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// restoreStateFromURL syncs all filter controls, hidden inputs,\n\t\t\t// sort labels, and view toggle from the current URL query params,\n\t\t\t// then triggers an HTMX content reload so the artist list matches\n\t\t\t// the URL state. Used by both pageshow (bfcache) and popstate\n\t\t\t// (history back/forward) handlers.\n\t\t\t//\n\t\t\t// A debounce guard prevents duplicate calls when bfcache restore\n\t\t\t// fires both pageshow and popstate in quick succession.\n\t\t\tvar _restoreLastRun = 0;\n\t\t\tvar _restoreLastHref = '';\n\t\t\tfunction restoreStateFromURL() {\n\t\t\t\tvar now = Date.now();\n\t\t\t\tvar href = window.location.href;\n\t\t\t\tif (href === _restoreLastHref && now - _restoreLastRun < 100) return;\n\t\t\t\t_restoreLastHref = href;\n\t\t\t\t_restoreLastRun = now;\n\t\t\t\tvar params = new URLSearchParams(window.location.search);\n\t\t\t\t// Re-sync flyout chip states from URL.\n\t\t\t\tif (window.swFilterFlyout) {\n\t\t\t\t\tswFilterFlyout.initFromURL('artist-filters-flyout');\n\t\t\t\t}\n\t\t\t\t// Sync the search input from URL params.\n\t\t\t\tvar searchEl = document.getElementById('artist-search');\n\t\t\t\tif (searchEl) searchEl.value = params.get('search') || '';\n\t\t\t\t// Sync select elements from URL params.\n\t\t\t\t['library_id'].forEach(function(name) {\n\t\t\t\t\tvar val = params.get(name);\n\t\t\t\t\tvar el = document.querySelector('select[name=\"' + name + '\"]');\n\t\t\t\t\tif (el) el.value = (val !== null) ? val : '';\n\t\t\t\t});\n\t\t\t\t// Sync hidden inputs from URL params, resetting to markup\n\t\t\t\t// defaults when a param is absent so browser history\n\t\t\t\t// restoration cannot retain stale values from a newer state.\n\t\t\t\t['view', 'sort', 'order'].forEach(function(name) {\n\t\t\t\t\tvar val = params.get(name);\n\t\t\t\t\tvar el = document.getElementById('artist-' + name + '-input');\n\t\t\t\t\tif (el) el.value = (val !== null) ? val : el.defaultValue;\n\t\t\t\t});\n\t\t\t\t// Update visible sort labels and view toggle to match restored state.\n\t\t\t\tvar sortInput = document.getElementById('artist-sort-input');\n\t\t\t\tvar orderInput = document.getElementById('artist-order-input');\n\t\t\t\tif (sortInput && orderInput) updateSortUI(sortInput.value, orderInput.value);\n\t\t\t\tvar viewInput = document.getElementById('artist-view-input');\n\t\t\t\tif (viewInput) {\n\t\t\t\t\tupdateViewToggleUI(viewInput.value);\n\t\t\t\t\tvar colToggle = document.getElementById('col-toggle-wrapper');\n\t\t\t\t\tif (colToggle) colToggle.classList.toggle('hidden', viewInput.value !== 'table');\n\t\t\t\t}\n\t\t\t\tvar _rsMeta = document.querySelector('meta[name=\"htmx-base-path\"]');\n\t\t\t\tvar _rsBp = _rsMeta ? _rsMeta.content : '';\n\t\t\t\tvar _rsPath = window.location.pathname;\n\t\t\t\tif (_rsBp && _rsPath.startsWith(_rsBp)) { _rsPath = _rsPath.slice(_rsBp.length) || '/'; }\n\t\t\t\thtmx.ajax('GET', _rsPath + window.location.search, {target: '#artist-content', swap: 'outerHTML'});\n\t\t\t}\n\n\t\t\t// When the page is restored from bfcache (browser back/forward navigation),\n\t\t\t// sync filter controls from the URL query params and reload content so\n\t\t\t// status badges reflect the latest state.\n\t\t\twindow.addEventListener('pageshow', function(evt) {\n\t\t\t\tif (evt.persisted) {\n\t\t\t\t\trestoreStateFromURL();\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Handle browser back/forward navigation between pushState entries\n\t\t\t// (e.g. filter changes, pagination). Without this, pressing back after\n\t\t\t// applying filters and navigating away would show stale content even\n\t\t\t// though the URL contains the correct filter params. Works in Firefox\n\t\t\t// and all major browsers.\n\t\t\twindow.addEventListener('popstate', function() {\n\t\t\t\trestoreStateFromURL();\n\t\t\t});\n\n\t\t\t(function() {\n\t\t\t\tvar btn = document.getElementById('scan-btn');\n\t\t\t\tif (!btn) return;\n\n\t\t\t\tdocument.body.addEventListener('htmx:afterRequest', function(evt) {\n\t\t\t\t\tif (evt.detail.elt !== btn) return;\n\t\t\t\t\tif (!evt.detail.successful) return;\n\n\t\t\t\t\tvar spinner = document.getElementById('scan-spinner');\n\t\t\t\t\tvar label = document.getElementById('scan-label');\n\t\t\t\t\tbtn.disabled = true;\n\t\t\t\t\tspinner.classList.remove('hidden');\n\t\t\t\t\tlabel.textContent = btn.dataset.labelScanning || 'Scanning...';\n\n\t\t\t\t\tfunction resetScanUI() {\n\t\t\t\t\t\tbtn.disabled = false;\n\t\t\t\t\t\tspinner.classList.add('hidden');\n\t\t\t\t\t\tlabel.textContent = btn.dataset.labelScan || 'Scan Library';\n\t\t\t\t\t}\n\t\t\t\t\tpollAsyncStatus(_artistsBp + '/api/v1/scanner/status', {\n\t\t\t\t\t\tonData: function(data) {\n\t\t\t\t\t\t\tif (data.status === 'completed' || data.status === 'failed' || data.status === 'canceled') {\n\t\t\t\t\t\t\t\tresetScanUI();\n\t\t\t\t\t\t\t\tvar _scMeta = document.querySelector('meta[name=\"htmx-base-path\"]');\n\t\t\t\t\t\t\t\tvar _scBp = _scMeta ? _scMeta.content : '';\n\t\t\t\t\t\t\t\tvar _scPath = window.location.pathname;\n\t\t\t\t\t\t\t\tif (_scBp && _scPath.startsWith(_scBp)) { _scPath = _scPath.slice(_scBp.length) || '/'; }\n\t\t\t\t\t\t\t\thtmx.ajax('GET', _scPath + window.location.search, {target: '#artist-content', swap: 'outerHTML'});\n\t\t\t\t\t\t\t\treturn true;\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\treturn false;\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonHTTPError: function() {\n\t\t\t\t\t\t\tresetScanUI();\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonNetworkError: function() {\n\t\t\t\t\t\t\tresetScanUI();\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t});\n\t\t\t})();\n\n\t\t\t// Bulk-action controller. Wires the Select-All checkbox, per-row\n\t\t\t// checkboxes, the \"N selected\" indicator, and the action dropdown\n\t\t\t// to the /api/v1/artists/bulk-actions endpoint. The controller is\n\t\t\t// idempotent: it attaches listeners via event delegation so it\n\t\t\t// works across HTMX swaps of #artist-content without re-binding.\n\t\t\t(function() {\n\t\t\t\t// Selection state persists across HTMX swaps of the list so\n\t\t\t\t// the user can paginate while keeping earlier selections.\n\t\t\t\tvar selected = new Set();\n\t\t\t\t// Matches the backend cap in handlers_bulk_actions.go; keeps\n\t\t\t\t// the UI in sync so we never POST a payload the server will\n\t\t\t\t// reject with a generic \"failed to start\" toast.\n\t\t\t\tvar MAX_BULK_SELECTION = 1000;\n\t\t\t\tvar capWarned = false;\n\t\t\t\t// Tracks the last checkbox clicked for shift-click range\n\t\t\t\t// selection (Gmail/GitHub-style). Reset on scope change.\n\t\t\t\tvar lastClickedId = null;\n\t\t\t\t// Polling handle for the in-flight bulk action status. Non-null\n\t\t\t\t// while a bulk or single-artist run-rules action is running.\n\t\t\t\tvar progressPoll = null;\n\t\t\t\t// Tracks whether a bulk action is running end-to-end. Gates the\n\t\t\t\t// Apply button so checkbox/dropdown changes cannot re-enable it\n\t\t\t\t// mid-flight and queue a second POST (which would 409-loop).\n\t\t\t\tvar bulkActionRunning = false;\n\n\t\t\t\tfunction warnCap() {\n\t\t\t\t\tif (capWarned) return;\n\t\t\t\t\tcapWarned = true;\n\t\t\t\t\tvar bar = document.getElementById('bulk-action-bar');\n\t\t\t\t\tvar tpl = (bar && bar.getAttribute('data-i18n-selection-cap')) || 'You can select up to {count} artists at a time.';\n\t\t\t\t\talert(tpl.replace('{count}', String(MAX_BULK_SELECTION)));\n\t\t\t\t}\n\n\t\t\t\tfunction tryAdd(id) {\n\t\t\t\t\tif (selected.has(id)) return true;\n\t\t\t\t\tif (selected.size >= MAX_BULK_SELECTION) {\n\t\t\t\t\t\twarnCap();\n\t\t\t\t\t\treturn false;\n\t\t\t\t\t}\n\t\t\t\t\tselected.add(id);\n\t\t\t\t\treturn true;\n\t\t\t\t}\n\n\t\t\t\tfunction updateBar() {\n\t\t\t\t\tvar bar = document.getElementById('bulk-action-bar');\n\t\t\t\t\tif (!bar) return;\n\t\t\t\t\tvar countEl = document.getElementById('bulk-selected-count');\n\t\t\t\t\tvar applyBtn = document.getElementById('bulk-action-apply');\n\t\t\t\t\tvar selectEl = document.getElementById('bulk-action-select');\n\t\t\t\t\tvar selectAll = document.getElementById('bulk-select-all');\n\t\t\t\t\tvar boxes = document.querySelectorAll('#artist-content .sw-bulk-select');\n\t\t\t\t\tvar i18nNone = bar.getAttribute('data-i18n-none') || 'None selected';\n\t\t\t\t\tvar i18nSelectedOne = bar.getAttribute('data-i18n-selected-one') || '1 selected';\n\t\t\t\t\tvar i18nSelectedOther = bar.getAttribute('data-i18n-selected-other') || '{count} selected';\n\t\t\t\t\tif (countEl) {\n\t\t\t\t\t\tif (selected.size === 0) {\n\t\t\t\t\t\t\tcountEl.textContent = i18nNone;\n\t\t\t\t\t\t} else if (selected.size === 1) {\n\t\t\t\t\t\t\tcountEl.textContent = i18nSelectedOne;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tcountEl.textContent = i18nSelectedOther.replace('{count}', String(selected.size));\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\tif (applyBtn) applyBtn.disabled = bulkActionRunning || selected.size === 0 || !selectEl || !selectEl.value;\n\t\t\t\t\tif (selectEl) selectEl.disabled = bulkActionRunning || selected.size === 0;\n\t\t\t\t\t// Sync per-row checkboxes with persisted selection state.\n\t\t\t\t\tvar visibleChecked = 0;\n\t\t\t\t\tboxes.forEach(function(cb) {\n\t\t\t\t\t\tvar id = cb.getAttribute('data-artist-id');\n\t\t\t\t\t\tcb.checked = selected.has(id);\n\t\t\t\t\t\tif (cb.checked) visibleChecked++;\n\t\t\t\t\t});\n\t\t\t\t\t// Select-All indeterminate state.\n\t\t\t\t\tvar allChecked = false;\n\t\t\t\t\tif (selectAll) {\n\t\t\t\t\t\tif (boxes.length === 0) {\n\t\t\t\t\t\t\tselectAll.checked = false;\n\t\t\t\t\t\t\tselectAll.indeterminate = false;\n\t\t\t\t\t\t} else if (visibleChecked === 0) {\n\t\t\t\t\t\t\tselectAll.checked = false;\n\t\t\t\t\t\t\tselectAll.indeterminate = false;\n\t\t\t\t\t\t} else if (visibleChecked === boxes.length) {\n\t\t\t\t\t\t\tselectAll.checked = true;\n\t\t\t\t\t\t\tselectAll.indeterminate = false;\n\t\t\t\t\t\t\tallChecked = true;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tselectAll.checked = false;\n\t\t\t\t\t\t\tselectAll.indeterminate = true;\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\t// Swap the checkbox label between Select all / Deselect all\n\t\t\t\t\t// so screen readers and sighted users both see the action\n\t\t\t\t\t// that a click will perform next.\n\t\t\t\t\tvar labelEl = document.getElementById('bulk-select-all-label');\n\t\t\t\t\tif (labelEl) {\n\t\t\t\t\t\tvar i18nSelectAll = bar.getAttribute('data-i18n-select-all') || 'Select all on page';\n\t\t\t\t\t\tvar i18nDeselectAll = bar.getAttribute('data-i18n-deselect-all') || 'Deselect all on page';\n\t\t\t\t\t\tlabelEl.textContent = allChecked ? i18nDeselectAll : i18nSelectAll;\n\t\t\t\t\t}\n\t\t\t\t\tif (selectAll) {\n\t\t\t\t\t\tvar i18nSelectAllAria = bar.getAttribute('data-i18n-select-all') || 'Select all on page';\n\t\t\t\t\t\tvar i18nDeselectAllAria = bar.getAttribute('data-i18n-deselect-all') || 'Deselect all on page';\n\t\t\t\t\t\tselectAll.setAttribute('aria-label', allChecked ? i18nDeselectAllAria : i18nSelectAllAria);\n\t\t\t\t\t}\n\t\t\t\t}\n\n\t\t\t\t// Shift-click range selection: capture on click (before the\n\t\t\t\t// change event) so we can see event.shiftKey. If shift is\n\t\t\t\t// held and we have a prior lastClickedId, select/deselect\n\t\t\t\t// every checkbox between the two anchors in DOM order.\n\t\t\t\tdocument.body.addEventListener('click', function(ev) {\n\t\t\t\t\tvar t = ev.target;\n\t\t\t\t\tif (!t || !t.classList || !t.classList.contains('sw-bulk-select')) return;\n\t\t\t\t\tvar id = t.getAttribute('data-artist-id');\n\t\t\t\t\tif (!id) return;\n\t\t\t\t\t// Keyboard Shift+Space triggers a click with shiftKey.\n\t\t\t\t\tif (ev.shiftKey && lastClickedId && lastClickedId !== id) {\n\t\t\t\t\t\tvar boxes = Array.prototype.slice.call(\n\t\t\t\t\t\t\tdocument.querySelectorAll('#artist-content .sw-bulk-select')\n\t\t\t\t\t\t);\n\t\t\t\t\t\tvar idx1 = -1, idx2 = -1;\n\t\t\t\t\t\tfor (var i = 0; i < boxes.length; i++) {\n\t\t\t\t\t\t\tvar bid = boxes[i].getAttribute('data-artist-id');\n\t\t\t\t\t\t\tif (bid === lastClickedId) idx1 = i;\n\t\t\t\t\t\t\tif (bid === id) idx2 = i;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tif (idx1 >= 0 && idx2 >= 0) {\n\t\t\t\t\t\t\tvar lo = Math.min(idx1, idx2), hi = Math.max(idx1, idx2);\n\t\t\t\t\t\t\t// Target state follows the just-clicked checkbox's\n\t\t\t\t\t\t\t// post-click state (which the browser has already\n\t\t\t\t\t\t\t// set by the time this click handler runs).\n\t\t\t\t\t\t\tvar target = t.checked;\n\t\t\t\t\t\t\tfor (var j = lo; j <= hi; j++) {\n\t\t\t\t\t\t\t\tvar cb = boxes[j];\n\t\t\t\t\t\t\t\tvar cid = cb.getAttribute('data-artist-id');\n\t\t\t\t\t\t\t\tif (!cid) continue;\n\t\t\t\t\t\t\t\tif (target) {\n\t\t\t\t\t\t\t\t\tif (!tryAdd(cid)) { cb.checked = false; continue; }\n\t\t\t\t\t\t\t\t\tcb.checked = true;\n\t\t\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t\t\tselected.delete(cid);\n\t\t\t\t\t\t\t\t\tcb.checked = false;\n\t\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\tif (!target) capWarned = false;\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\tlastClickedId = id;\n\t\t\t\t}, true);\n\n\t\t\t\tdocument.body.addEventListener('change', function(ev) {\n\t\t\t\t\tvar t = ev.target;\n\t\t\t\t\tif (!t) return;\n\t\t\t\t\tif (t.classList && t.classList.contains('sw-bulk-select')) {\n\t\t\t\t\t\tvar id = t.getAttribute('data-artist-id');\n\t\t\t\t\t\tif (!id) return;\n\t\t\t\t\t\tif (t.checked) {\n\t\t\t\t\t\t\tif (!tryAdd(id)) { t.checked = false; }\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tselected.delete(id);\n\t\t\t\t\t\t\tcapWarned = false;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t} else if (t.id === 'bulk-select-all') {\n\t\t\t\t\t\tvar boxes = document.querySelectorAll('#artist-content .sw-bulk-select');\n\t\t\t\t\t\tboxes.forEach(function(cb) {\n\t\t\t\t\t\t\tvar id = cb.getAttribute('data-artist-id');\n\t\t\t\t\t\t\tif (!id) return;\n\t\t\t\t\t\t\tif (t.checked) {\n\t\t\t\t\t\t\t\tcb.checked = tryAdd(id);\n\t\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t\tcb.checked = false;\n\t\t\t\t\t\t\t\tselected.delete(id);\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t});\n\t\t\t\t\t\tif (!t.checked) capWarned = false;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t} else if (t.id === 'bulk-action-select') {\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t}\n\t\t\t\t});\n\n\t\t\t\t// Build the localized verb label for a bulk action from the\n\t\t\t\t// data attributes on the progress pill. Falls back to the\n\t\t\t\t// raw action key if a verb is missing.\n\t\t\t\tfunction actionVerb(action) {\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\tif (!pill) return action;\n\t\t\t\t\tvar key = 'data-i18n-verb-' + action.replace(/_/g, '-');\n\t\t\t\t\treturn pill.getAttribute(key) || action;\n\t\t\t\t}\n\n\t\t\t\t// Render the progress pill with the current snapshot. Called\n\t\t\t\t// from both the initial 202 response and the poll callback.\n\t\t\t\tfunction renderProgressPill(action, processed, total) {\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\tvar txt = document.getElementById('bulk-progress-text');\n\t\t\t\t\tif (!pill || !txt) return;\n\t\t\t\t\tvar tpl = pill.getAttribute('data-i18n-template') || '{verb}: {processed} of {total} artists';\n\t\t\t\t\tvar verb = actionVerb(action);\n\t\t\t\t\ttxt.textContent = tpl\n\t\t\t\t\t\t.replace('{verb}', verb)\n\t\t\t\t\t\t.replace('{processed}', String(processed))\n\t\t\t\t\t\t.replace('{total}', String(total));\n\t\t\t\t\tpill.classList.remove('hidden');\n\t\t\t\t\t// Re-enable the cancel button each render tick so a prior\n\t\t\t\t\t// canceled run does not leave the button disabled on the\n\t\t\t\t\t// next action.\n\t\t\t\t\tvar cancelBtn = document.getElementById('bulk-progress-cancel');\n\t\t\t\t\tif (cancelBtn) cancelBtn.disabled = false;\n\t\t\t\t}\n\n\t\t\t\tfunction hideProgressPill() {\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\tif (pill) pill.classList.add('hidden');\n\t\t\t\t}\n\n\t\t\t\t// Start polling bulk-actions/status every 2s. Stops on terminal\n\t\t\t\t// status and surfaces an outcome-breakdown toast. Page reloads\n\t\t\t\t// mid-action re-attach by calling this on DOMContentLoaded.\n\t\t\t\t// Process one /status snapshot. Returns true when the status\n\t\t\t\t// is terminal (idle/completed/failed) so callers know to stop\n\t\t\t\t// polling and do not need to start one. Shared between the\n\t\t\t\t// active poll callback and the DOMContentLoaded recovery\n\t\t\t\t// path so a page reload near the end of a bulk job still\n\t\t\t\t// surfaces the summary toast from the terminal snapshot.\n\t\t\t\tfunction handleProgressSnapshot(data, initialAction) {\n\t\t\t\t\tif (!data || data.status === 'idle') {\n\t\t\t\t\t\thideProgressPill();\n\t\t\t\t\t\tbulkActionRunning = false;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\treturn true;\n\t\t\t\t\t}\n\t\t\t\t\trenderProgressPill(data.action || initialAction || '', data.processed || 0, data.total || 0);\n\t\t\t\t\t// Reveal the cancel button only for bulk-actions runs.\n\t\t\t\t\t// The pill is reused by single-artist flows (e.g. the\n\t\t\t\t\t// detail-page run-rules) that do not go through /bulk-\n\t\t\t\t\t// actions/cancel and have no cancel affordance.\n\t\t\t\t\tvar _cancelBtn = document.getElementById('bulk-progress-cancel');\n\t\t\t\t\tif (_cancelBtn) _cancelBtn.classList.remove('hidden');\n\t\t\t\t\tif (data.status === 'completed' || data.status === 'failed' || data.status === 'canceled') {\n\t\t\t\t\t\thideProgressPill();\n\t\t\t\t\t\tbulkActionRunning = false;\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\t\t// Re-identify auto breaks out auto_linked/queued/\n\t\t\t\t\t\t// no_match counters so the toast can say \"3 auto-\n\t\t\t\t\t\t// linked, 2 queued, 1 no match\" instead of the\n\t\t\t\t\t\t// generic succeeded/skipped triad. Other actions\n\t\t\t\t\t\t// keep the existing summary text.\n\t\t\t\t\t\tvar msg;\n\t\t\t\t\t\tif ((data.action === 're_identify_auto' || data.action === 're_identify') &&\n\t\t\t\t\t\t\t((data.auto_linked || 0) + (data.queued || 0) + (data.no_match || 0) + (data.failed || 0) > 0)) {\n\t\t\t\t\t\t\tvar rtpl = (pill && pill.getAttribute('data-i18n-reidentify-summary')) ||\n\t\t\t\t\t\t\t\t'{auto_linked} auto-linked, {queued} queued, {no_match} no match';\n\t\t\t\t\t\t\tmsg = rtpl\n\t\t\t\t\t\t\t\t.replace('{auto_linked}', String(data.auto_linked || 0))\n\t\t\t\t\t\t\t\t.replace('{queued}', String(data.queued || 0))\n\t\t\t\t\t\t\t\t.replace('{no_match}', String(data.no_match || 0))\n\t\t\t\t\t\t\t\t.replace('{failed}', String(data.failed || 0));\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tvar tpl = (pill && pill.getAttribute('data-i18n-summary')) || '{succeeded} succeeded, {failed} failed, {skipped} skipped';\n\t\t\t\t\t\t\tmsg = tpl\n\t\t\t\t\t\t\t\t.replace('{succeeded}', String(data.succeeded || 0))\n\t\t\t\t\t\t\t\t.replace('{failed}', String(data.failed || 0))\n\t\t\t\t\t\t\t\t.replace('{skipped}', String(data.skipped || 0));\n\t\t\t\t\t\t}\n\t\t\t\t\t\tif (typeof window.showSuccessToast === 'function' && (data.failed || 0) === 0) {\n\t\t\t\t\t\t\twindow.showSuccessToast(msg);\n\t\t\t\t\t\t} else if (typeof window.showToast === 'function') {\n\t\t\t\t\t\t\twindow.showToast(msg);\n\t\t\t\t\t\t}\n\t\t\t\t\t\treturn true;\n\t\t\t\t\t}\n\t\t\t\t\treturn false;\n\t\t\t\t}\n\n\t\t\t\tfunction startProgressPoll(initialAction) {\n\t\t\t\t\tif (progressPoll) { progressPoll.stop(); progressPoll = null; }\n\t\t\t\t\tbulkActionRunning = true;\n\t\t\t\t\tupdateBar();\n\t\t\t\t\tprogressPoll = pollAsyncStatus(_artistsBp + '/api/v1/artists/bulk-actions/status', {\n\t\t\t\t\t\tonData: function(data) {\n\t\t\t\t\t\t\treturn handleProgressSnapshot(data, initialAction);\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonHTTPError: function() {\n\t\t\t\t\t\t\t// Transport/HTTP errors are non-terminal: the backend\n\t\t\t\t\t\t\t// job may still be running. Keep bulkActionRunning set\n\t\t\t\t\t\t\t// so Apply stays disabled; a later idle/completed/\n\t\t\t\t\t\t\t// failed snapshot from the polling retry will clear\n\t\t\t\t\t\t\t// the lock. Releasing here would reopen the duplicate-\n\t\t\t\t\t\t\t// submit window and reintroduce the 409 loop.\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t},\n\t\t\t\t\t\tonNetworkError: function() {\n\t\t\t\t\t\t\t// Same rationale as onHTTPError: the status endpoint\n\t\t\t\t\t\t\t// may be transiently unreachable while the action is\n\t\t\t\t\t\t\t// still running. Do not clear the lock on an unknown\n\t\t\t\t\t\t\t// status.\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t\t// Expose so other controllers (single-artist run-rules on the\n\t\t\t\t// artist detail page) can attach to an in-flight action.\n\t\t\t\twindow.swBulkProgress = {\n\t\t\t\t\tstart: startProgressPoll,\n\t\t\t\t\trender: renderProgressPill,\n\t\t\t\t\thide: hideProgressPill\n\t\t\t\t};\n\n\t\t\t\t// Cancel the in-flight bulk action. The button is wired via\n\t\t\t\t// onclick on the pill; the poll loop picks up the terminal\n\t\t\t\t// \"canceled\" status on the next tick and clears the pill.\n\t\t\t\twindow.swCancelBulkAction = function() {\n\t\t\t\t\tvar btn = document.getElementById('bulk-progress-cancel');\n\t\t\t\t\tif (btn) btn.disabled = true;\n\t\t\t\t\tvar csrfToken = document.cookie.replace(/(?:(?:^|.*;\\s*)csrf_token\\s*\\=\\s*([^;]*).*$)|^.*$/, \"$1\");\n\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/bulk-actions/cancel', {\n\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\tcredentials: 'same-origin',\n\t\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken}\n\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\tif (btn) btn.disabled = false;\n\t\t\t\t\t});\n\t\t\t\t};\n\n\t\t\t\t// Size-aware confirm dialog. <=50: no dialog; >50 and <=500:\n\t\t\t\t// simple confirm with action + count; >500: stronger warning\n\t\t\t\t// that names external API impact for re-identify and\n\t\t\t\t// fetch_images. Returns true when the user confirmed.\n\t\t\t\tfunction confirmBulkAction(action, count) {\n\t\t\t\t\tif (count <= 50) return true;\n\t\t\t\t\tvar pill = document.getElementById('bulk-progress-pill');\n\t\t\t\t\t// Use the action-dropdown's selected option label so the\n\t\t\t\t\t// confirm text reads naturally (e.g. \"Apply Run rules to\n\t\t\t\t\t// 100 artists?\") rather than the progress-verb form.\n\t\t\t\t\tvar selectEl = document.getElementById('bulk-action-select');\n\t\t\t\t\tvar verb = action;\n\t\t\t\t\tif (selectEl && selectEl.selectedOptions && selectEl.selectedOptions[0]) {\n\t\t\t\t\t\tverb = selectEl.selectedOptions[0].textContent || action;\n\t\t\t\t\t}\n\t\t\t\t\t// The large-count copy names external provider APIs, so\n\t\t\t\t\t// only use it for actions that actually hit them. Local\n\t\t\t\t\t// actions (scan, run_rules) get the plain small template\n\t\t\t\t\t// regardless of count to avoid misleading warnings.\n\t\t\t\t\tvar usesExternalProviders = action === 're_identify_auto' || action === 're_identify_review' || action === 'fetch_images';\n\t\t\t\t\tvar tpl;\n\t\t\t\t\tif (count > 500 && usesExternalProviders) {\n\t\t\t\t\t\ttpl = (pill && pill.getAttribute('data-i18n-confirm-large')) || 'You are about to apply {action} to {count} artists. This may take a while and will hit external provider APIs (MusicBrainz, Fanart.tv, etc.). Continue?';\n\t\t\t\t\t} else {\n\t\t\t\t\t\ttpl = (pill && pill.getAttribute('data-i18n-confirm-small')) || 'Apply {action} to {count} artists?';\n\t\t\t\t\t}\n\t\t\t\t\tvar msg = tpl.replace('{action}', verb).replace('{count}', String(count));\n\t\t\t\t\treturn window.confirm(msg);\n\t\t\t\t}\n\n\t\t\t\tdocument.body.addEventListener('click', function(ev) {\n\t\t\t\t\tvar t = ev.target;\n\t\t\t\t\tif (!t || t.id !== 'bulk-action-apply') return;\n\t\t\t\t\tvar selectEl = document.getElementById('bulk-action-select');\n\t\t\t\t\tif (!selectEl || !selectEl.value || selected.size === 0) return;\n\t\t\t\t\tvar action = selectEl.value;\n\t\t\t\t\t// Defensive truncation: the UI cap should already prevent\n\t\t\t\t\t// this, but guard against any drift so we never hit the\n\t\t\t\t\t// backend's hard 1000-ID rejection with a generic toast.\n\t\t\t\t\tvar ids = Array.from(selected).slice(0, MAX_BULK_SELECTION);\n\t\t\t\t\tif (!confirmBulkAction(action, ids.length)) return;\n\t\t\t\t\tvar csrfToken = document.cookie.replace(/(?:(?:^|.*;\\s*)csrf_token\\s*\\=\\s*([^;]*).*$)|^.*$/, \"$1\");\n\t\t\t\t\tt.disabled = true;\n\t\t\t\t\t// Re-identify (review) dispatches to the wizard flow\n\t\t\t\t\t// rather than the bulk-actions endpoint: the wizard is\n\t\t\t\t\t// interactive and owns its own session state, so routing\n\t\t\t\t\t// it through the singleton bulk-action slot would be\n\t\t\t\t\t// misleading. Start the wizard then redirect the user to\n\t\t\t\t\t// its first step.\n\t\t\t\t\tif (action === 're_identify_review') {\n\t\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/re-identify/wizard', {\n\t\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},\n\t\t\t\t\t\t\tbody: JSON.stringify({ids: ids})\n\t\t\t\t\t\t}).then(function(r) {\n\t\t\t\t\t\t\tif (!r.ok) {\n\t\t\t\t\t\t\t\tvar bar3 = document.getElementById('bulk-action-bar');\n\t\t\t\t\t\t\t\talert((bar3 && bar3.getAttribute('data-i18n-failed')) || 'Bulk action failed to start.');\n\t\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t\t\treturn;\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t\treturn r.json();\n\t\t\t\t\t\t}).then(function(data) {\n\t\t\t\t\t\t\tif (!data || !data.session_id) return;\n\t\t\t\t\t\t\twindow.location.href = _artistsBp + '/artists/re-identify/wizard/' + data.session_id + '/step/0';\n\t\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t});\n\t\t\t\t\t\treturn;\n\t\t\t\t\t}\n\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/bulk-actions', {\n\t\t\t\t\t\tmethod: 'POST',\n\t\t\t\t\t\theaders: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},\n\t\t\t\t\t\tbody: JSON.stringify({action: action, ids: ids})\n\t\t\t\t\t}).then(function(r) {\n\t\t\t\t\t\tvar bar = document.getElementById('bulk-action-bar');\n\t\t\t\t\t\tvar i18nBusy = (bar && bar.getAttribute('data-i18n-busy')) || 'A bulk action is already running. Please wait for it to finish.';\n\t\t\t\t\t\tvar i18nFailed = (bar && bar.getAttribute('data-i18n-failed')) || 'Bulk action failed to start.';\n\t\t\t\t\t\tif (r.status === 409) {\n\t\t\t\t\t\t\talert(i18nBusy);\n\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t} else if (!r.ok) {\n\t\t\t\t\t\t\talert(i18nFailed);\n\t\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\t// Render an immediate 0-of-total pill so the user sees\n\t\t\t\t\t\t\t// feedback before the first poll tick lands, then\n\t\t\t\t\t\t\t// start polling. Apply-disabled stays true until the\n\t\t\t\t\t\t\t// poll observes a terminal status.\n\t\t\t\t\t\t\trenderProgressPill(action, 0, ids.length);\n\t\t\t\t\t\t\tselected.clear();\n\t\t\t\t\t\t\tcapWarned = false;\n\t\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t\t\tstartProgressPoll(action);\n\t\t\t\t\t\t}\n\t\t\t\t\t}).catch(function() {\n\t\t\t\t\t\tvar bar2 = document.getElementById('bulk-action-bar');\n\t\t\t\t\t\talert((bar2 && bar2.getAttribute('data-i18n-failed')) || 'Bulk action failed to start.');\n\t\t\t\t\t\tt.disabled = false;\n\t\t\t\t\t});\n\t\t\t\t});\n\n\t\t\t\t// Scope token: filter-identifying params only. If any of\n\t\t\t\t// these change across an htmx swap, the user is looking\n\t\t\t\t// at a different result set and the previous selection is\n\t\t\t\t// no longer meaningful. Pagination, sort, order, and view\n\t\t\t\t// do NOT reset selection so the user can re-sort, paginate,\n\t\t\t\t// or switch table/grid while preserving their selection.\n\t\t\t\t//\n\t\t\t\t// Prefer the explicit URLSearchParams source over\n\t\t\t\t// window.location.search so the same routine works whether\n\t\t\t\t// we are reacting to an htmx swap (where the URL has\n\t\t\t\t// already been updated by the listener at line 638) or\n\t\t\t\t// computing the initial token at IIFE init.\n\t\t\t\tfunction tokenFromParams(p) {\n\t\t\t\t\tvar keys = [];\n\t\t\t\t\tp.forEach(function(_v, k) {\n\t\t\t\t\t\tif (k === 'search' || k === 'library_id' || k === 'filter' || k.indexOf('filter_') === 0) {\n\t\t\t\t\t\t\tkeys.push(k);\n\t\t\t\t\t\t}\n\t\t\t\t\t});\n\t\t\t\t\tkeys.sort();\n\t\t\t\t\treturn keys.map(function(k) { return k + '=' + p.get(k); }).join('&');\n\t\t\t\t}\n\t\t\t\tfunction currentScopeToken() {\n\t\t\t\t\treturn tokenFromParams(new URLSearchParams(window.location.search));\n\t\t\t\t}\n\t\t\t\t// Compute the scope token from an htmx request URL. Used in\n\t\t\t\t// the afterSwap handler to derive the new scope without\n\t\t\t\t// depending on whether the URL-update listener has run yet.\n\t\t\t\t// htmx 2.0.8 exposes the request configuration on\n\t\t\t\t// evt.detail.requestConfig.path (the path htmx issued the\n\t\t\t\t// request to) and the resolved URL on evt.detail.xhr.responseURL\n\t\t\t\t// (post-redirect). We try requestConfig.path first because it\n\t\t\t\t// reflects what htmx asked for, fall back to xhr.responseURL,\n\t\t\t\t// then finally to window.location if neither is present.\n\t\t\t\tfunction scopeTokenFromRequest(evt) {\n\t\t\t\t\ttry {\n\t\t\t\t\t\tvar rc = evt && evt.detail && evt.detail.requestConfig;\n\t\t\t\t\t\tvar xhr = evt && evt.detail && evt.detail.xhr;\n\t\t\t\t\t\tvar path = (rc && rc.path) || (xhr && xhr.responseURL);\n\t\t\t\t\t\tif (path) {\n\t\t\t\t\t\t\tvar u = new URL(path, window.location.origin);\n\t\t\t\t\t\t\treturn tokenFromParams(u.searchParams);\n\t\t\t\t\t\t}\n\t\t\t\t\t} catch (e) { /* fall through */ }\n\t\t\t\t\treturn currentScopeToken();\n\t\t\t\t}\n\t\t\t\tvar lastScopeToken = currentScopeToken();\n\n\t\t\t\t// Re-sync on initial load and after every HTMX swap of the\n\t\t\t\t// artist content (pagination, filter change, etc.). Also\n\t\t\t\t// probe the bulk-actions/status endpoint on load so a page\n\t\t\t\t// reload mid-action re-attaches the progress pill.\n\t\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\t\tupdateBar();\n\t\t\t\t\t// Fire-and-forget status probe. If an action is in flight\n\t\t\t\t\t// the poll attaches; otherwise the pill stays hidden.\n\t\t\t\t\tfetch(_artistsBp + '/api/v1/artists/bulk-actions/status', {credentials: 'same-origin'})\n\t\t\t\t\t\t.then(function(r) { return r.ok ? r.json() : null; })\n\t\t\t\t\t\t.then(function(data) {\n\t\t\t\t\t\t\t// Terminal snapshots (completed/failed/idle) are\n\t\t\t\t\t\t\t// handled in-place so the summary toast is not\n\t\t\t\t\t\t\t// dropped on reload-near-end. Non-terminal returns\n\t\t\t\t\t\t\t// false and we start the normal poll.\n\t\t\t\t\t\t\tif (!data) return;\n\t\t\t\t\t\t\tif (handleProgressSnapshot(data, data.action || '')) return;\n\t\t\t\t\t\t\tstartProgressPoll(data.action || '');\n\t\t\t\t\t\t})\n\t\t\t\t\t\t.catch(function(){ /* ignore */ });\n\t\t\t\t});\n\t\t\t\tdocument.body.addEventListener('htmx:afterSwap', function(evt) {\n\t\t\t\t\tif (evt.detail.target && evt.detail.target.id === 'artist-content') {\n\t\t\t\t\t\t// Derive the new scope from the htmx request URL so\n\t\t\t\t\t\t// the comparison does not depend on the URL-update\n\t\t\t\t\t\t// listener (line 638) having fired first. This keeps\n\t\t\t\t\t\t// selection stable across sort/order/page/view swaps\n\t\t\t\t\t\t// (issue #1081 F1) regardless of listener ordering.\n\t\t\t\t\t\tvar currentToken = scopeTokenFromRequest(evt);\n\t\t\t\t\t\tif (currentToken !== lastScopeToken) {\n\t\t\t\t\t\t\tselected.clear();\n\t\t\t\t\t\t\tcapWarned = false;\n\t\t\t\t\t\t\tlastScopeToken = currentToken;\n\t\t\t\t\t\t}\n\t\t\t\t\t\t// Reset the shift-click anchor on every swap: after\n\t\t\t\t\t\t// pagination or sort the prior DOM ordering no longer\n\t\t\t\t\t\t// applies, so an old anchor could select an unintended\n\t\t\t\t\t\t// range on the next shift-click.\n\t\t\t\t\t\tlastClickedId = null;\n\t\t\t\t\t\t// Re-derive every checkbox's checked state from the\n\t\t\t\t\t\t// `selected` Set. The freshly-swapped HTML never\n\t\t\t\t\t\t// includes a `checked` attribute, so this is what\n\t\t\t\t\t\t// keeps checkmarks attached to artist IDs (not row\n\t\t\t\t\t\t// positions) across sort changes (issue #1081 F2).\n\t\t\t\t\t\tupdateBar();\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t})();\n\t\t</script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1443,7 +1443,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var73 string
 		templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.toolbar"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1338, Col: 45}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1341, Col: 45}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
 		if templ_7745c5c3_Err != nil {
@@ -1456,7 +1456,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var74 string
 		templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.none_selected"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1339, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1342, Col: 55}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
 		if templ_7745c5c3_Err != nil {
@@ -1469,7 +1469,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var75 string
 		templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.selected.one"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1340, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1343, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
 		if templ_7745c5c3_Err != nil {
@@ -1482,7 +1482,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var76 string
 		templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.selected.other"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1341, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1344, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
 		if templ_7745c5c3_Err != nil {
@@ -1495,7 +1495,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var77 string
 		templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.busy"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1342, Col: 46}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1345, Col: 46}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
 		if templ_7745c5c3_Err != nil {
@@ -1508,7 +1508,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var78 string
 		templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.failed"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1343, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1346, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
 		if templ_7745c5c3_Err != nil {
@@ -1521,7 +1521,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var79 string
 		templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.select_all"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1344, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1347, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
 		if templ_7745c5c3_Err != nil {
@@ -1534,7 +1534,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var80 string
 		templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.deselect_all"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1345, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1348, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
 		if templ_7745c5c3_Err != nil {
@@ -1547,7 +1547,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var81 string
 		templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.selection_cap"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1346, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1349, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var81))
 		if templ_7745c5c3_Err != nil {
@@ -1560,7 +1560,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var82 string
 		templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.select_all"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1354, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1357, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 		if templ_7745c5c3_Err != nil {
@@ -1573,7 +1573,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var83 string
 		templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.select_all"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1356, Col: 71}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1359, Col: 71}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
 		if templ_7745c5c3_Err != nil {
@@ -1586,7 +1586,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var84 string
 		templ_7745c5c3_Var84, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.none_selected"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1359, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1362, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var84))
 		if templ_7745c5c3_Err != nil {
@@ -1599,7 +1599,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var85 string
 		templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action_label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1366, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1369, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
 		if templ_7745c5c3_Err != nil {
@@ -1612,7 +1612,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var86 string
 		templ_7745c5c3_Var86, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.choose_action"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1368, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1371, Col: 59}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var86))
 		if templ_7745c5c3_Err != nil {
@@ -1625,7 +1625,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var87 string
 		templ_7745c5c3_Var87, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.run_rules"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1369, Col: 71}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1372, Col: 71}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var87))
 		if templ_7745c5c3_Err != nil {
@@ -1638,7 +1638,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var88 string
 		templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.re_identify_auto"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1370, Col: 85}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1373, Col: 85}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
 		if templ_7745c5c3_Err != nil {
@@ -1651,7 +1651,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var89 string
 		templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.re_identify_review"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1371, Col: 89}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1374, Col: 89}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
 		if templ_7745c5c3_Err != nil {
@@ -1664,7 +1664,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var90 string
 		templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.scan"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1372, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1375, Col: 61}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
 		if templ_7745c5c3_Err != nil {
@@ -1677,7 +1677,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var91 string
 		templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.action.fetch_images"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1373, Col: 77}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1376, Col: 77}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
 		if templ_7745c5c3_Err != nil {
@@ -1690,7 +1690,7 @@ func BulkActionBar(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var92 string
 		templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.apply"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1381, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1384, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
 		if templ_7745c5c3_Err != nil {
@@ -1755,7 +1755,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var94 string
 			templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.active_filters"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1392, Col: 99}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1395, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var94))
 			if templ_7745c5c3_Err != nil {
@@ -1792,7 +1792,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var97 string
 					templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(filterChipLabelFromData(ctx, key, data.Filters[key], data.Libraries, data.LibrarySources))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1396, Col: 98}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1399, Col: 98}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
 					if templ_7745c5c3_Err != nil {
@@ -1813,7 +1813,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var98 string
 					templ_7745c5c3_Var98, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "common.remove_filter", filterChipLabelFromData(ctx, key, data.Filters[key], data.Libraries, data.LibrarySources)))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1400, Col: 143}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1403, Col: 143}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var98))
 					if templ_7745c5c3_Err != nil {
@@ -1846,7 +1846,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var100 string
 		templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.select_column"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1417, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1420, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
 		if templ_7745c5c3_Err != nil {
@@ -1859,7 +1859,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var101 string
 		templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.sort_by_name"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1424, Col: 46}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1427, Col: 46}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
 		if templ_7745c5c3_Err != nil {
@@ -1872,7 +1872,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var102 string
 		templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.col.name"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1426, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1429, Col: 36}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var102))
 		if templ_7745c5c3_Err != nil {
@@ -1902,7 +1902,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var103 string
 		templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.col.metadata"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1437, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1440, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
 		if templ_7745c5c3_Err != nil {
@@ -1915,7 +1915,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var104 string
 		templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(img.ImageTermFor("thumb", data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1440, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1443, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var104))
 		if templ_7745c5c3_Err != nil {
@@ -1928,7 +1928,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var105 string
 		templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(img.ImageTermFor("fanart", data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1443, Col: 53}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1446, Col: 53}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
 		if templ_7745c5c3_Err != nil {
@@ -1941,7 +1941,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var106 string
 		templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(img.ImageTermFor("logo", data.ProfileName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1446, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1449, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
 		if templ_7745c5c3_Err != nil {
@@ -1954,7 +1954,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 		var templ_7745c5c3_Var107 string
 		templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.col.mbid"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1449, Col: 35}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1452, Col: 35}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
 		if templ_7745c5c3_Err != nil {
@@ -1972,7 +1972,7 @@ func ArtistTable(data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var108 string
 			templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.empty_state"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1457, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1460, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
 			if templ_7745c5c3_Err != nil {
@@ -2056,7 +2056,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var112 string
 			templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(a.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1478, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1481, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
 			if templ_7745c5c3_Err != nil {
@@ -2069,7 +2069,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var113 string
 			templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "artists.bulk.select_artist", a.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1479, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1482, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var113))
 			if templ_7745c5c3_Err != nil {
@@ -2110,7 +2110,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var116 string
 			templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs(complianceDotTitle(ctx, artistCompliance(a.ID, compliance)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1488, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1491, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var116))
 			if templ_7745c5c3_Err != nil {
@@ -2123,7 +2123,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var117 string
 			templ_7745c5c3_Var117, templ_7745c5c3_Err = templ.JoinStringErrs(complianceDotTitle(ctx, artistCompliance(a.ID, compliance)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1489, Col: 78}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1492, Col: 78}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var117))
 			if templ_7745c5c3_Err != nil {
@@ -2145,7 +2145,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 		var templ_7745c5c3_Var118 templ.SafeURL
 		templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath() + "/artists/" + a.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1495, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1498, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var118))
 		if templ_7745c5c3_Err != nil {
@@ -2158,7 +2158,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 		var templ_7745c5c3_Var119 string
 		templ_7745c5c3_Var119, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1498, Col: 13}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1501, Col: 13}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var119))
 		if templ_7745c5c3_Err != nil {
@@ -2176,7 +2176,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var120 string
 			templ_7745c5c3_Var120, templ_7745c5c3_Err = templ.JoinStringErrs(a.SortName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1501, Col: 59}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1504, Col: 59}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var120))
 			if templ_7745c5c3_Err != nil {
@@ -2195,7 +2195,7 @@ func ArtistRow(a artist.Artist, sources map[string]LibrarySourceInfo, compliance
 			var templ_7745c5c3_Var121 string
 			templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.excluded"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1504, Col: 184}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1507, Col: 184}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var121))
 			if templ_7745c5c3_Err != nil {
@@ -2306,7 +2306,7 @@ func ArtistGrid(data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var123 string
 			templ_7745c5c3_Var123, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.active_filters"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1532, Col: 99}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1535, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var123))
 			if templ_7745c5c3_Err != nil {
@@ -2343,7 +2343,7 @@ func ArtistGrid(data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var126 string
 					templ_7745c5c3_Var126, templ_7745c5c3_Err = templ.JoinStringErrs(filterChipLabelFromData(ctx, key, data.Filters[key], data.Libraries, data.LibrarySources))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1536, Col: 98}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1539, Col: 98}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var126))
 					if templ_7745c5c3_Err != nil {
@@ -2364,7 +2364,7 @@ func ArtistGrid(data ArtistListData) templ.Component {
 					var templ_7745c5c3_Var127 string
 					templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "common.remove_filter", filterChipLabelFromData(ctx, key, data.Filters[key], data.Libraries, data.LibrarySources)))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1540, Col: 143}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1543, Col: 143}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var127))
 					if templ_7745c5c3_Err != nil {
@@ -2398,7 +2398,7 @@ func ArtistGrid(data ArtistListData) templ.Component {
 			var templ_7745c5c3_Var129 string
 			templ_7745c5c3_Var129, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.empty_state"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1554, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1557, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var129))
 			if templ_7745c5c3_Err != nil {
@@ -2469,7 +2469,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var131 string
 			templ_7745c5c3_Var131, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "artists.bulk.select_artist", a.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1573, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1576, Col: 62}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var131))
 			if templ_7745c5c3_Err != nil {
@@ -2482,7 +2482,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var132 string
 			templ_7745c5c3_Var132, templ_7745c5c3_Err = templ.JoinStringErrs(a.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1578, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1581, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var132))
 			if templ_7745c5c3_Err != nil {
@@ -2495,7 +2495,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var133 string
 			templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "artists.bulk.select_artist", a.Name))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1580, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1583, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var133))
 			if templ_7745c5c3_Err != nil {
@@ -2518,7 +2518,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 		var templ_7745c5c3_Var135 templ.SafeURL
 		templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath() + "/artists/" + a.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1585, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1588, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var135))
 		if templ_7745c5c3_Err != nil {
@@ -2550,7 +2550,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 				var templ_7745c5c3_Var137 string
 				templ_7745c5c3_Var137, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(templ.SafeCSS("background-image:url('" + a.ThumbPlaceholder + "')"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1591, Col: 111}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1594, Col: 111}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var137))
 				if templ_7745c5c3_Err != nil {
@@ -2568,7 +2568,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var138 string
 			templ_7745c5c3_Var138, templ_7745c5c3_Err = templ.JoinStringErrs(basePath() + "/api/v1/artists/" + a.ID + "/images/thumb/file")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1594, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1597, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var138))
 			if templ_7745c5c3_Err != nil {
@@ -2581,7 +2581,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var139 string
 			templ_7745c5c3_Var139, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1595, Col: 18}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1598, Col: 18}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var139))
 			if templ_7745c5c3_Err != nil {
@@ -2599,7 +2599,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var140 string
 			templ_7745c5c3_Var140, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(templ.SafeCSS("background-image:url('" + a.ThumbPlaceholder + "')"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1601, Col: 110}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1604, Col: 110}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var140))
 			if templ_7745c5c3_Err != nil {
@@ -2641,7 +2641,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var143 string
 			templ_7745c5c3_Var143, templ_7745c5c3_Err = templ.JoinStringErrs(complianceDotTitle(ctx, artistCompliance(a.ID, compliance)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1612, Col: 73}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1615, Col: 73}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var143))
 			if templ_7745c5c3_Err != nil {
@@ -2654,7 +2654,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 			var templ_7745c5c3_Var144 string
 			templ_7745c5c3_Var144, templ_7745c5c3_Err = templ.JoinStringErrs(complianceDotTitle(ctx, artistCompliance(a.ID, compliance)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1613, Col: 78}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1616, Col: 78}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var144))
 			if templ_7745c5c3_Err != nil {
@@ -2676,7 +2676,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 		var templ_7745c5c3_Var145 string
 		templ_7745c5c3_Var145, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1620, Col: 91}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1623, Col: 91}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var145))
 		if templ_7745c5c3_Err != nil {
@@ -2689,7 +2689,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 		var templ_7745c5c3_Var146 string
 		templ_7745c5c3_Var146, templ_7745c5c3_Err = templ.JoinStringErrs(a.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1621, Col: 13}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1624, Col: 13}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var146))
 		if templ_7745c5c3_Err != nil {
@@ -2724,7 +2724,7 @@ func ArtistCard(a artist.Artist, sources map[string]LibrarySourceInfo, complianc
 		var templ_7745c5c3_Var149 string
 		templ_7745c5c3_Var149, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("%.0f%%", a.HealthScore))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1624, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1627, Col: 43}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var149))
 		if templ_7745c5c3_Err != nil {
@@ -2865,7 +2865,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var153 string
 		templ_7745c5c3_Var153, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.run_rules"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1668, Col: 70}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1671, Col: 70}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var153))
 		if templ_7745c5c3_Err != nil {
@@ -2878,7 +2878,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var154 string
 		templ_7745c5c3_Var154, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.re_identify"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1669, Col: 74}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1672, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var154))
 		if templ_7745c5c3_Err != nil {
@@ -2891,7 +2891,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var155 string
 		templ_7745c5c3_Var155, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.re_identify_auto"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1670, Col: 84}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1673, Col: 84}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var155))
 		if templ_7745c5c3_Err != nil {
@@ -2904,7 +2904,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var156 string
 		templ_7745c5c3_Var156, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.re_identify_review"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1671, Col: 88}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1674, Col: 88}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var156))
 		if templ_7745c5c3_Err != nil {
@@ -2917,7 +2917,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var157 string
 		templ_7745c5c3_Var157, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.scan"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1672, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1675, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var157))
 		if templ_7745c5c3_Err != nil {
@@ -2930,7 +2930,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var158 string
 		templ_7745c5c3_Var158, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.fetch_images"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1673, Col: 76}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1676, Col: 76}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var158))
 		if templ_7745c5c3_Err != nil {
@@ -2943,7 +2943,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var159 string
 		templ_7745c5c3_Var159, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.template"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1674, Col: 63}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1677, Col: 63}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var159))
 		if templ_7745c5c3_Err != nil {
@@ -2956,7 +2956,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var160 string
 		templ_7745c5c3_Var160, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.progress.single"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1675, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1678, Col: 59}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var160))
 		if templ_7745c5c3_Err != nil {
@@ -2969,7 +2969,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var161 string
 		templ_7745c5c3_Var161, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.summary"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1676, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1679, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var161))
 		if templ_7745c5c3_Err != nil {
@@ -2982,7 +2982,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var162 string
 		templ_7745c5c3_Var162, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.summary"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1677, Col: 74}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1680, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var162))
 		if templ_7745c5c3_Err != nil {
@@ -2995,7 +2995,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var163 string
 		templ_7745c5c3_Var163, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.confirm.small"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1678, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1681, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var163))
 		if templ_7745c5c3_Err != nil {
@@ -3008,7 +3008,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var164 string
 		templ_7745c5c3_Var164, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.confirm.large"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1679, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1682, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var164))
 		if templ_7745c5c3_Err != nil {
@@ -3021,7 +3021,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var165 string
 		templ_7745c5c3_Var165, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.cancel"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1690, Col: 45}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1693, Col: 45}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var165))
 		if templ_7745c5c3_Err != nil {
@@ -3034,7 +3034,7 @@ func BulkProgressPill() templ.Component {
 		var templ_7745c5c3_Var166 string
 		templ_7745c5c3_Var166, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.cancel"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1693, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artists.templ`, Line: 1696, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var166))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

- Bulk selection on `/artists` now survives sort, order, page, and view swaps regardless of the order in which `htmx:afterSwap` listeners fire. The selection-controller previously read the new scope from `window.location.search`, which depended on the URL-update listener (registered earlier in the same script) running first; if that order ever changed, sort would silently clear selection (F1, gallery) or appear positional (F2, table).
- The new `scopeTokenFromRequest` helper reads the request URL straight from `evt.detail.pathInfo.finalRequestPath` / `requestPath` (the htmx 2.x event payload), with a fallback to the URL-based token. The set of scope-defining params is unchanged: `search`, `library_id`, `filter`, `filter_*` reset selection; `sort`, `order`, `page`, `page_size`, `view` do not.
- Adds `TestArtistsPage_BulkSelectionSurvivesSort` (table + grid) to pin the markup contract: every row carries its own `data-artist-id`, no baked-in `checked` attribute, and the scope-token allowlist only includes filter-identifying keys.

## Test plan

- [x] `go test -race -timeout 120s -run TestArtistsPage ./internal/api/` green
- [x] `bash scripts/pre-push-gate.sh` green (tests, OpenAPI, generated files)
- [x] `make lint` 0 issues
- [x] UAT: filtered single-page subset on /artists, bulk-selected 3 artists at varied positions, changed sort -> selection preserved by ID. Cross-page case (>500 artists, 2 pages) is a follow-up; the agent's fix targets in-page sort persistence specifically.

## Follow-ups

- #1227 -- bulk selection appears lost when sort moves selected artists off-page (UAT discovered)
- #1228 -- pagination URL listener at artists.templ:649 reads non-existent htmx 2.x event property (agent discovered)

Closes #1081

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test ensuring bulk-selection survives sorting for both table and grid views.

* **Bug Fixes**
  * Improved bulk-selection handling so selection state is driven by the actual HTMX request that produced the content swap, correctly clearing and repopulating selections when scope changes and avoiding pre-checked inputs in server-rendered markup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->