### PR TITLE
fix(violations): show error on fix failure and guard against double-submit (#1026, #1110)

### DIFF
--- a/internal/api/handlers_fix_test.go
+++ b/internal/api/handlers_fix_test.go
@@ -565,6 +565,50 @@ func TestHandleFixViolation_ReturnsUndoID(t *testing.T) {
 	}
 }
 
+// TestHandleFixViolation_HTMX_FailureCarriesMessage pins the user-facing
+// error contract: when a fix attempt does not resolve the violation, the
+// HTMX response must be 422 with the rule-fixer's message in the body so
+// the global htmx:responseError listener (in layout.templ) can surface it
+// as a toast. Without this guard a future refactor could silently regress
+// to status-only errors and the dashboard card would fail without
+// explanation.
+func TestHandleFixViolation_HTMX_FailureCarriesMessage(t *testing.T) {
+	const failureMsg = "no image found from any configured provider"
+	stub := &stubPipeline{
+		fixViolationFn: func(_ context.Context, _ string) (*rule.FixResult, error) {
+			// Fixed=false and Dismissed=false drives the failure branch.
+			return &rule.FixResult{RuleID: "thumb_exists", Fixed: false, Message: failureMsg}, nil
+		},
+	}
+	r, _ := testRouterWithStubPipeline(t, stub)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/notifications/test-id/fix", nil)
+	req.SetPathValue("id", "test-id")
+	req.Header.Set("HX-Request", "true")
+	w := httptest.NewRecorder()
+
+	r.handleFixViolation(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d (Unprocessable Entity); body: %s", w.Code, http.StatusUnprocessableEntity, w.Body.String())
+	}
+	// Body must contain the user-visible rule-fixer message so the global
+	// toast surface in layout.templ has something to display. We compare
+	// against the HTML-escaped form because handleFixViolation runs the
+	// message through html.EscapeString to stop a malicious provider name
+	// from breaking out of the error toast. The message we picked has no
+	// special characters, so the escaped form equals the raw text.
+	if got := w.Body.String(); got != failureMsg {
+		t.Errorf("body = %q, want %q (the rule-fixer's reason must be the response body verbatim so the global htmx:responseError handler can render it)", got, failureMsg)
+	}
+	// HX-Trigger MUST NOT be set on the failure path: a queue refresh would
+	// destroy the action card before the user could read the toast and
+	// retry, defeating the user-facing error contract.
+	if trigger := w.Header().Get("HX-Trigger"); trigger != "" {
+		t.Errorf("HX-Trigger = %q, want empty on fix-failure path", trigger)
+	}
+}
+
 // TestHandleFixViolation_HTMX_WithUndo verifies that when a fix is applied
 // via HTMX and an undo entry exists, the response contains UndoToast HTML
 // and does NOT set the HX-Trigger header (to avoid destroying the toast).

--- a/web/templates/artist_violations_tab.templ
+++ b/web/templates/artist_violations_tab.templ
@@ -108,7 +108,7 @@ templ artistViolationRow(v rule.RuleViolation, artistID string) {
 						data-artist-id={ artistID }
 						onclick={ artistViolationFix(v.ID, artistID) }
 						aria-label={ fmt.Sprintf(t(ctx, "artist.fix_action_aria"), fixButtonLabel(v.RuleID)) }
-						class="font-semibold text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-300"
+						class="font-semibold text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-300 disabled:opacity-60 disabled:cursor-not-allowed"
 					>
 						{ fixButtonLabel(v.RuleID) }
 					</button>
@@ -119,7 +119,7 @@ templ artistViolationRow(v rule.RuleViolation, artistID string) {
 					data-artist-id={ artistID }
 					data-confirm={ t(ctx, "notifications.dismiss_confirm") }
 					onclick={ artistViolationDismiss(v.ID, artistID) }
-					class="font-semibold text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300"
+					class="font-semibold text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 disabled:opacity-60 disabled:cursor-not-allowed"
 				>
 					{ t(ctx, "common.dismiss") }
 				</button>
@@ -138,6 +138,14 @@ script artistViolationFix(violationID string, artistID string) {
 	var row = document.getElementById('artist-violation-' + violationID);
 	var fixFailedTpl = (row && row.dataset.fixFailed) || 'Fix failed: %s';
 	var fixNetworkTpl = (row && row.dataset.fixNetwork) || 'Network error applying fix.';
+	// Disable both action buttons in this row for the duration of the
+	// fetch so a rapid second click cannot queue a duplicate POST. The
+	// finally() block re-enables them on every settled outcome (success,
+	// HTTP error, network error) so a transient failure never leaves the
+	// row permanently inert. The dashboard cards use htmx's hx-disabled-elt
+	// attribute to achieve the same guard via the htmx swap pipeline.
+	var actionBtns = row ? row.querySelectorAll('button[data-violation-id="' + violationID + '"][data-artist-id="' + artistID + '"]') : [];
+	for (var i = 0; i < actionBtns.length; i++) { actionBtns[i].disabled = true; }
 	var bp = (document.querySelector('meta[name="htmx-base-path"]') || {content: ''}).content;
 	var csrfToken = document.cookie.replace(/(?:(?:^|.*;\s*)csrf_token\s*=\s*([^;]*).*$)|^.*$/, '$1');
 	fetch(bp + '/api/v1/notifications/' + violationID + '/fix', {
@@ -155,10 +163,19 @@ script artistViolationFix(violationID string, artistID string) {
 			// would fire two identical GETs back-to-back.
 			document.body.dispatchEvent(new CustomEvent('dashboard:action-resolved'));
 		} else {
-			alert(fixFailedTpl.replace('%s', data.message || ''));
+			// Surface the rule-fixer's reason via the global toast pipeline
+			// (window.showToast in layout.templ) so the user sees the same
+			// styling as every other action error. Falls back to alert()
+			// only when the toast helper is unavailable (e.g. the layout
+			// script failed to load).
+			var failMsg = fixFailedTpl.replace('%s', data.message || '');
+			if (typeof window.showToast === 'function') { window.showToast(failMsg); } else { alert(failMsg); }
 		}
 	}).catch(function(err) {
-		alert(fixNetworkTpl + ' ' + err.message);
+		var netMsg = fixNetworkTpl + ' ' + err.message;
+		if (typeof window.showToast === 'function') { window.showToast(netMsg); } else { alert(netMsg); }
+	}).finally(function() {
+		for (var j = 0; j < actionBtns.length; j++) { actionBtns[j].disabled = false; }
 	});
 }
 
@@ -179,6 +196,11 @@ script artistViolationDismiss(violationID string, artistID string) {
 	var row = document.getElementById('artist-violation-' + violationID);
 	var dismissFailed = (row && row.dataset.dismissFailed) || 'Failed to dismiss violation.';
 	var dismissNetwork = (row && row.dataset.dismissNetwork) || 'Network error dismissing violation.';
+	// Disable both action buttons in the row while the dismiss request is
+	// in flight; finally() re-enables them so an error path never leaves
+	// the row inert. See artistViolationFix for the same pattern.
+	var actionBtns = row ? row.querySelectorAll('button[data-violation-id="' + violationID + '"][data-artist-id="' + artistID + '"]') : [];
+	for (var i = 0; i < actionBtns.length; i++) { actionBtns[i].disabled = true; }
 	var bp = (document.querySelector('meta[name="htmx-base-path"]') || {content: ''}).content;
 	var csrfToken = document.cookie.replace(/(?:(?:^|.*;\s*)csrf_token\s*=\s*([^;]*).*$)|^.*$/, '$1');
 	fetch(bp + '/api/v1/notifications/' + violationID + '/dismiss', {
@@ -190,9 +212,11 @@ script artistViolationDismiss(violationID string, artistID string) {
 			// Refresh handled by the page-level listener -- see artistViolationFix above.
 			document.body.dispatchEvent(new CustomEvent('dashboard:action-resolved'));
 		} else {
-			alert(dismissFailed);
+			if (typeof window.showToast === 'function') { window.showToast(dismissFailed); } else { alert(dismissFailed); }
 		}
 	}).catch(function() {
-		alert(dismissNetwork);
+		if (typeof window.showToast === 'function') { window.showToast(dismissNetwork); } else { alert(dismissNetwork); }
+	}).finally(function() {
+		for (var j = 0; j < actionBtns.length; j++) { actionBtns[j].disabled = false; }
 	});
 }

--- a/web/templates/artist_violations_tab_templ.go
+++ b/web/templates/artist_violations_tab_templ.go
@@ -482,7 +482,7 @@ func artistViolationRow(v rule.RuleViolation, artistID string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\" class=\"font-semibold text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-300\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\" class=\"font-semibold text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-300 disabled:opacity-60 disabled:cursor-not-allowed\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -552,7 +552,7 @@ func artistViolationRow(v rule.RuleViolation, artistID string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\" class=\"font-semibold text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\" class=\"font-semibold text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 disabled:opacity-60 disabled:cursor-not-allowed\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -576,14 +576,22 @@ func artistViolationRow(v rule.RuleViolation, artistID string) templ.Component {
 // artistViolationFix triggers a fix for a violation and refreshes the violations tab.
 func artistViolationFix(violationID string, artistID string) templ.ComponentScript {
 	return templ.ComponentScript{
-		Name: `__templ_artistViolationFix_cbd3`,
-		Function: `function __templ_artistViolationFix_cbd3(violationID, artistID){// Localized error strings sourced from data-* on the row, with English
+		Name: `__templ_artistViolationFix_511b`,
+		Function: `function __templ_artistViolationFix_511b(violationID, artistID){// Localized error strings sourced from data-* on the row, with English
 	// fallback as defense-in-depth (matches the established pattern from
 	// the retired notifications.templ). %s in fix_failed is substituted
 	// with the server-supplied error message.
 	var row = document.getElementById('artist-violation-' + violationID);
 	var fixFailedTpl = (row && row.dataset.fixFailed) || 'Fix failed: %s';
 	var fixNetworkTpl = (row && row.dataset.fixNetwork) || 'Network error applying fix.';
+	// Disable both action buttons in this row for the duration of the
+	// fetch so a rapid second click cannot queue a duplicate POST. The
+	// finally() block re-enables them on every settled outcome (success,
+	// HTTP error, network error) so a transient failure never leaves the
+	// row permanently inert. The dashboard cards use htmx's hx-disabled-elt
+	// attribute to achieve the same guard via the htmx swap pipeline.
+	var actionBtns = row ? row.querySelectorAll('button[data-violation-id="' + violationID + '"][data-artist-id="' + artistID + '"]') : [];
+	for (var i = 0; i < actionBtns.length; i++) { actionBtns[i].disabled = true; }
 	var bp = (document.querySelector('meta[name="htmx-base-path"]') || {content: ''}).content;
 	var csrfToken = document.cookie.replace(/(?:(?:^|.*;\s*)csrf_token\s*=\s*([^;]*).*$)|^.*$/, '$1');
 	fetch(bp + '/api/v1/notifications/' + violationID + '/fix', {
@@ -601,22 +609,31 @@ func artistViolationFix(violationID string, artistID string) templ.ComponentScri
 			// would fire two identical GETs back-to-back.
 			document.body.dispatchEvent(new CustomEvent('dashboard:action-resolved'));
 		} else {
-			alert(fixFailedTpl.replace('%s', data.message || ''));
+			// Surface the rule-fixer's reason via the global toast pipeline
+			// (window.showToast in layout.templ) so the user sees the same
+			// styling as every other action error. Falls back to alert()
+			// only when the toast helper is unavailable (e.g. the layout
+			// script failed to load).
+			var failMsg = fixFailedTpl.replace('%s', data.message || '');
+			if (typeof window.showToast === 'function') { window.showToast(failMsg); } else { alert(failMsg); }
 		}
 	}).catch(function(err) {
-		alert(fixNetworkTpl + ' ' + err.message);
+		var netMsg = fixNetworkTpl + ' ' + err.message;
+		if (typeof window.showToast === 'function') { window.showToast(netMsg); } else { alert(netMsg); }
+	}).finally(function() {
+		for (var j = 0; j < actionBtns.length; j++) { actionBtns[j].disabled = false; }
 	});
 }`,
-		Call:       templ.SafeScript(`__templ_artistViolationFix_cbd3`, violationID, artistID),
-		CallInline: templ.SafeScriptInline(`__templ_artistViolationFix_cbd3`, violationID, artistID),
+		Call:       templ.SafeScript(`__templ_artistViolationFix_511b`, violationID, artistID),
+		CallInline: templ.SafeScriptInline(`__templ_artistViolationFix_511b`, violationID, artistID),
 	}
 }
 
 // artistViolationDismiss dismisses a violation and refreshes the violations tab.
 func artistViolationDismiss(violationID string, artistID string) templ.ComponentScript {
 	return templ.ComponentScript{
-		Name: `__templ_artistViolationDismiss_e8c8`,
-		Function: `function __templ_artistViolationDismiss_e8c8(violationID, artistID){// Localized prompt sourced from the dismiss button's data-confirm attribute
+		Name: `__templ_artistViolationDismiss_fd9a`,
+		Function: `function __templ_artistViolationDismiss_fd9a(violationID, artistID){// Localized prompt sourced from the dismiss button's data-confirm attribute
 	// (set in artistViolationRow). The [data-confirm] filter is required: the
 	// Fix and Dismiss buttons on a fixable/open row share data-violation-id and
 	// data-artist-id, so a selector without it would return the Fix button
@@ -630,6 +647,11 @@ func artistViolationDismiss(violationID string, artistID string) templ.Component
 	var row = document.getElementById('artist-violation-' + violationID);
 	var dismissFailed = (row && row.dataset.dismissFailed) || 'Failed to dismiss violation.';
 	var dismissNetwork = (row && row.dataset.dismissNetwork) || 'Network error dismissing violation.';
+	// Disable both action buttons in the row while the dismiss request is
+	// in flight; finally() re-enables them so an error path never leaves
+	// the row inert. See artistViolationFix for the same pattern.
+	var actionBtns = row ? row.querySelectorAll('button[data-violation-id="' + violationID + '"][data-artist-id="' + artistID + '"]') : [];
+	for (var i = 0; i < actionBtns.length; i++) { actionBtns[i].disabled = true; }
 	var bp = (document.querySelector('meta[name="htmx-base-path"]') || {content: ''}).content;
 	var csrfToken = document.cookie.replace(/(?:(?:^|.*;\s*)csrf_token\s*=\s*([^;]*).*$)|^.*$/, '$1');
 	fetch(bp + '/api/v1/notifications/' + violationID + '/dismiss', {
@@ -641,14 +663,16 @@ func artistViolationDismiss(violationID string, artistID string) templ.Component
 			// Refresh handled by the page-level listener -- see artistViolationFix above.
 			document.body.dispatchEvent(new CustomEvent('dashboard:action-resolved'));
 		} else {
-			alert(dismissFailed);
+			if (typeof window.showToast === 'function') { window.showToast(dismissFailed); } else { alert(dismissFailed); }
 		}
 	}).catch(function() {
-		alert(dismissNetwork);
+		if (typeof window.showToast === 'function') { window.showToast(dismissNetwork); } else { alert(dismissNetwork); }
+	}).finally(function() {
+		for (var j = 0; j < actionBtns.length; j++) { actionBtns[j].disabled = false; }
 	});
 }`,
-		Call:       templ.SafeScript(`__templ_artistViolationDismiss_e8c8`, violationID, artistID),
-		CallInline: templ.SafeScriptInline(`__templ_artistViolationDismiss_e8c8`, violationID, artistID),
+		Call:       templ.SafeScript(`__templ_artistViolationDismiss_fd9a`, violationID, artistID),
+		CallInline: templ.SafeScriptInline(`__templ_artistViolationDismiss_fd9a`, violationID, artistID),
 	}
 }
 

--- a/web/templates/artist_violations_tab_test.go
+++ b/web/templates/artist_violations_tab_test.go
@@ -1,0 +1,79 @@
+package templates
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/stillwater/internal/rule"
+)
+
+// TestArtistViolationsTab_DoubleSubmitGuard pins the per-row double-submit
+// guard. The artist-detail violations tab uses raw fetch() rather than
+// htmx, so the guard lives in the templ script function: both onclick
+// handlers must disable the row's action buttons before issuing the POST
+// and re-enable them in finally(). We assert the rendered tab contains
+// the disable code so a future refactor cannot quietly drop it.
+//
+// We also assert finally() and window.showToast appear in the rendered
+// script: finally guarantees re-enable on every settled outcome (success,
+// HTTP error, network error) and showToast is the user-facing failure
+// surface that replaces the prior native alert() dialog.
+func TestArtistViolationsTab_DoubleSubmitGuard(t *testing.T) {
+	data := ArtistViolationsTabData{
+		ArtistID: "a-1110",
+		Violations: []rule.RuleViolation{
+			{
+				ID:         "v-1110",
+				RuleID:     rule.RuleNFOExists,
+				ArtistID:   "a-1110",
+				ArtistName: "Tab Test Artist",
+				Severity:   "error",
+				Message:    "missing nfo",
+				Fixable:    true,
+				Status:     rule.ViolationStatusOpen,
+				CreatedAt:  time.Now().UTC(),
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := ArtistViolationsTab(data).Render(testCtx(t), &buf); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := buf.String()
+
+	// The Fix and Dismiss buttons render their JS via templ script blocks,
+	// which the templ runtime may emit either inline or in a hoisted
+	// <script> tag. Either way the function bodies appear in the rendered
+	// HTML for the tab, so substring assertions are stable across both
+	// emission modes.
+
+	// Disable-on-click: every settled outcome must re-enable, so the
+	// finally() block is required. Without it a network error would leave
+	// the row's buttons stuck in the disabled state.
+	if !strings.Contains(body, "actionBtns[i].disabled = true") {
+		t.Errorf("artist-tab fix/dismiss script missing the in-flight disable assignment; got:\n%s", body)
+	}
+	if !strings.Contains(body, "actionBtns[j].disabled = false") {
+		t.Errorf("artist-tab fix/dismiss script missing the finally() re-enable assignment; got:\n%s", body)
+	}
+	if !strings.Contains(body, ".finally(function()") {
+		t.Errorf("artist-tab fix/dismiss script missing finally() block; got:\n%s", body)
+	}
+
+	// User-facing failure surface: the script must route failures through
+	// window.showToast so the artist tab matches the dashboard toast
+	// styling instead of using a native browser alert dialog.
+	if !strings.Contains(body, "window.showToast") {
+		t.Errorf("artist-tab fix/dismiss script missing window.showToast routing; got:\n%s", body)
+	}
+
+	// Disabled-state styling so the visual feedback matches user expectation
+	// while the request is in flight. Without this the buttons stay clickable-
+	// looking even though the disabled property suppresses the click.
+	if !strings.Contains(body, "disabled:opacity-60") {
+		t.Errorf("artist-tab action buttons missing disabled:opacity-60 styling; got:\n%s", body)
+	}
+}

--- a/web/templates/dashboard.templ
+++ b/web/templates/dashboard.templ
@@ -720,7 +720,8 @@ templ DashboardActionCard(v rule.RuleViolation, basePath string) {
 						hx-post={ "/api/v1/notifications/" + v.ID + "/fix" }
 						hx-target={ "#action-card-" + v.ID }
 						hx-swap="outerHTML"
-						class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 shadow-sm transition-colors"
+						hx-disabled-elt="this"
+						class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 shadow-sm transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
 					>
 						{ dashboardFixLabel(ctx, v.RuleID) }
 					</button>
@@ -739,7 +740,8 @@ templ DashboardActionCard(v rule.RuleViolation, basePath string) {
 					hx-post={ "/api/v1/notifications/" + v.ID + "/dismiss" }
 					hx-target={ "#action-card-" + v.ID }
 					hx-swap="outerHTML"
-					class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+					hx-disabled-elt="this"
+					class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
 				>
 					{ t(ctx, "dashboard.dismiss") }
 				</button>

--- a/web/templates/dashboard_action_card_test.go
+++ b/web/templates/dashboard_action_card_test.go
@@ -1,0 +1,72 @@
+package templates
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/stillwater/internal/rule"
+)
+
+// TestDashboardActionCard_DoubleSubmitGuard pins the htmx-native double-click
+// guard on the dashboard violation cards. Both the Fix and Dismiss buttons
+// must render hx-disabled-elt="this" so htmx disables the element while
+// the request is in flight and re-enables it on settled (success or
+// error). Without this pin a future refactor that splits the button
+// rendering could silently drop the guard and reintroduce the duplicate-
+// POST regression. We do NOT exercise the click suppression itself --
+// htmx owns that semantics.
+func TestDashboardActionCard_DoubleSubmitGuard(t *testing.T) {
+	v := rule.RuleViolation{
+		ID:         "v-test-1110",
+		RuleID:     rule.RuleNFOExists,
+		ArtistID:   "a-1",
+		ArtistName: "Test Artist",
+		Severity:   "error",
+		Message:    "missing nfo",
+		Fixable:    true,
+		Status:     rule.ViolationStatusOpen,
+		CreatedAt:  time.Now().UTC(),
+	}
+
+	var buf bytes.Buffer
+	if err := DashboardActionCard(v, "").Render(testCtx(t), &buf); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := buf.String()
+
+	// The Fix button is the htmx POST against /fix. It must carry the
+	// disable attribute so a rapid second click cannot queue a second
+	// fix attempt against an already-resolving violation.
+	if !strings.Contains(body, `hx-post="/api/v1/notifications/v-test-1110/fix"`) {
+		t.Fatalf("rendered card missing fix hx-post attribute; got:\n%s", body)
+	}
+	fixIdx := strings.Index(body, `hx-post="/api/v1/notifications/v-test-1110/fix"`)
+	// Find the closing > of the Fix button starting from the hx-post.
+	fixCloseIdx := strings.Index(body[fixIdx:], ">")
+	if fixCloseIdx < 0 {
+		t.Fatalf("could not find end of Fix button tag")
+	}
+	fixTag := body[fixIdx : fixIdx+fixCloseIdx]
+	if !strings.Contains(fixTag, `hx-disabled-elt="this"`) {
+		t.Errorf("Fix button missing hx-disabled-elt=\"this\"; tag was:\n%s", fixTag)
+	}
+
+	// Same guard required on the Dismiss button: even though dismiss is
+	// idempotent server-side, the UX requirement is no double-submit
+	// during in-flight, and dropping the attribute would leave a visible
+	// "second click goes through" regression.
+	if !strings.Contains(body, `hx-post="/api/v1/notifications/v-test-1110/dismiss"`) {
+		t.Fatalf("rendered card missing dismiss hx-post attribute; got:\n%s", body)
+	}
+	dismissIdx := strings.Index(body, `hx-post="/api/v1/notifications/v-test-1110/dismiss"`)
+	dismissCloseIdx := strings.Index(body[dismissIdx:], ">")
+	if dismissCloseIdx < 0 {
+		t.Fatalf("could not find end of Dismiss button tag")
+	}
+	dismissTag := body[dismissIdx : dismissIdx+dismissCloseIdx]
+	if !strings.Contains(dismissTag, `hx-disabled-elt="this"`) {
+		t.Errorf("Dismiss button missing hx-disabled-elt=\"this\"; tag was:\n%s", dismissTag)
+	}
+}

--- a/web/templates/dashboard_templ.go
+++ b/web/templates/dashboard_templ.go
@@ -1699,14 +1699,14 @@ func DashboardActionCard(v rule.RuleViolation, basePath string) templ.Component 
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "\" hx-swap=\"outerHTML\" class=\"inline-flex items-center rounded-md px-2 py-1 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 shadow-sm transition-colors\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "\" hx-swap=\"outerHTML\" hx-disabled-elt=\"this\" class=\"inline-flex items-center rounded-md px-2 py-1 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 shadow-sm transition-colors disabled:opacity-60 disabled:cursor-not-allowed\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var77 string
 			templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(dashboardFixLabel(ctx, v.RuleID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 725, Col: 40}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 726, Col: 40}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
 			if templ_7745c5c3_Err != nil {
@@ -1724,7 +1724,7 @@ func DashboardActionCard(v rule.RuleViolation, basePath string) templ.Component 
 			var templ_7745c5c3_Var78 templ.SafeURL
 			templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath + "/artists/" + v.ArtistID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 731, Col: 63}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 732, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
 			if templ_7745c5c3_Err != nil {
@@ -1737,7 +1737,7 @@ func DashboardActionCard(v rule.RuleViolation, basePath string) templ.Component 
 			var templ_7745c5c3_Var79 string
 			templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.re_identify"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 734, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 735, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
 			if templ_7745c5c3_Err != nil {
@@ -1755,7 +1755,7 @@ func DashboardActionCard(v rule.RuleViolation, basePath string) templ.Component 
 		var templ_7745c5c3_Var80 string
 		templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs("/api/v1/notifications/" + v.ID + "/dismiss")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 739, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 740, Col: 59}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
 		if templ_7745c5c3_Err != nil {
@@ -1768,20 +1768,20 @@ func DashboardActionCard(v rule.RuleViolation, basePath string) templ.Component 
 		var templ_7745c5c3_Var81 string
 		templ_7745c5c3_Var81, templ_7745c5c3_Err = templ.JoinStringErrs("#action-card-" + v.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 740, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 741, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var81))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "\" hx-swap=\"outerHTML\" class=\"inline-flex items-center rounded-md px-2 py-1 text-xs font-medium text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "\" hx-swap=\"outerHTML\" hx-disabled-elt=\"this\" class=\"inline-flex items-center rounded-md px-2 py-1 text-xs font-medium text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var82 string
 		templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.dismiss"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 744, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 746, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 		if templ_7745c5c3_Err != nil {
@@ -1794,7 +1794,7 @@ func DashboardActionCard(v rule.RuleViolation, basePath string) templ.Component 
 		var templ_7745c5c3_Var83 templ.SafeURL
 		templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath + "/artists/" + v.ArtistID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 747, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 749, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
 		if templ_7745c5c3_Err != nil {
@@ -1807,7 +1807,7 @@ func DashboardActionCard(v rule.RuleViolation, basePath string) templ.Component 
 		var templ_7745c5c3_Var84 string
 		templ_7745c5c3_Var84, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.view_artist"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 749, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 751, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var84))
 		if templ_7745c5c3_Err != nil {
@@ -1850,7 +1850,7 @@ func DashboardActivityFeed(data ActivityFeedData) templ.Component {
 		var templ_7745c5c3_Var86 string
 		templ_7745c5c3_Var86, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.recent_activity"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 763, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 765, Col: 80}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var86))
 		if templ_7745c5c3_Err != nil {
@@ -1868,7 +1868,7 @@ func DashboardActivityFeed(data ActivityFeedData) templ.Component {
 			var templ_7745c5c3_Var87 string
 			templ_7745c5c3_Var87, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.no_recent_activity"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 769, Col: 96}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 771, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var87))
 			if templ_7745c5c3_Err != nil {
@@ -1896,7 +1896,7 @@ func DashboardActivityFeed(data ActivityFeedData) templ.Component {
 			var templ_7745c5c3_Var88 templ.SafeURL
 			templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.BasePath + "/activity"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 779, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 781, Col: 54}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
 			if templ_7745c5c3_Err != nil {
@@ -1909,7 +1909,7 @@ func DashboardActivityFeed(data ActivityFeedData) templ.Component {
 			var templ_7745c5c3_Var89 string
 			templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.view_all_activity"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 782, Col: 44}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 784, Col: 44}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
 			if templ_7745c5c3_Err != nil {
@@ -1957,7 +1957,7 @@ func DashboardActivityRow(c artist.MetadataChangeWithArtist, basePath string) te
 		var templ_7745c5c3_Var91 templ.SafeURL
 		templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath + "/artists/" + c.ArtistID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 798, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 800, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
 		if templ_7745c5c3_Err != nil {
@@ -1970,7 +1970,7 @@ func DashboardActivityRow(c artist.MetadataChangeWithArtist, basePath string) te
 		var templ_7745c5c3_Var92 string
 		templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(c.ArtistName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 801, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 803, Col: 19}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
 		if templ_7745c5c3_Err != nil {
@@ -1983,7 +1983,7 @@ func DashboardActivityRow(c artist.MetadataChangeWithArtist, basePath string) te
 		var templ_7745c5c3_Var93 string
 		templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(historyFieldLabel(ctx, c.Field))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 804, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 806, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
 		if templ_7745c5c3_Err != nil {
@@ -2001,7 +2001,7 @@ func DashboardActivityRow(c artist.MetadataChangeWithArtist, basePath string) te
 			var templ_7745c5c3_Var94 string
 			templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.activity_set"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 807, Col: 89}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 809, Col: 89}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var94))
 			if templ_7745c5c3_Err != nil {
@@ -2019,7 +2019,7 @@ func DashboardActivityRow(c artist.MetadataChangeWithArtist, basePath string) te
 			var templ_7745c5c3_Var95 string
 			templ_7745c5c3_Var95, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.activity_cleared"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 809, Col: 89}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 811, Col: 89}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var95))
 			if templ_7745c5c3_Err != nil {
@@ -2037,7 +2037,7 @@ func DashboardActivityRow(c artist.MetadataChangeWithArtist, basePath string) te
 			var templ_7745c5c3_Var96 string
 			templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.activity_changed"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 811, Col: 91}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 813, Col: 91}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var96))
 			if templ_7745c5c3_Err != nil {
@@ -2077,7 +2077,7 @@ func DashboardActivityRow(c artist.MetadataChangeWithArtist, basePath string) te
 		var templ_7745c5c3_Var99 string
 		templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.JoinStringErrs(historySourceLabel(ctx, c.Source))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 817, Col: 40}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 819, Col: 40}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var99))
 		if templ_7745c5c3_Err != nil {
@@ -2090,7 +2090,7 @@ func DashboardActivityRow(c artist.MetadataChangeWithArtist, basePath string) te
 		var templ_7745c5c3_Var100 string
 		templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(c.CreatedAt.Format(time.RFC3339))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 820, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 822, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
 		if templ_7745c5c3_Err != nil {
@@ -2103,7 +2103,7 @@ func DashboardActivityRow(c artist.MetadataChangeWithArtist, basePath string) te
 		var templ_7745c5c3_Var101 string
 		templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs(c.CreatedAt.Format("2006-01-02 15:04:05 UTC"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 821, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 823, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
 		if templ_7745c5c3_Err != nil {
@@ -2116,7 +2116,7 @@ func DashboardActivityRow(c artist.MetadataChangeWithArtist, basePath string) te
 		var templ_7745c5c3_Var102 string
 		templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(dashboardTimeAgo(ctx, c.CreatedAt))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 824, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 826, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var102))
 		if templ_7745c5c3_Err != nil {
@@ -2161,7 +2161,7 @@ func DashboardEmptyState(score float64, healthStatsError bool) templ.Component {
 		var templ_7745c5c3_Var104 string
 		templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.all_clear"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 841, Col: 100}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 843, Col: 100}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var104))
 		if templ_7745c5c3_Err != nil {
@@ -2179,7 +2179,7 @@ func DashboardEmptyState(score float64, healthStatsError bool) templ.Component {
 			var templ_7745c5c3_Var105 string
 			templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.stats_unavailable"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 843, Col: 116}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 845, Col: 116}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
 			if templ_7745c5c3_Err != nil {
@@ -2192,7 +2192,7 @@ func DashboardEmptyState(score float64, healthStatsError bool) templ.Component {
 			var templ_7745c5c3_Var106 string
 			templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.stats_unavailable"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 843, Col: 169}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 845, Col: 169}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
 			if templ_7745c5c3_Err != nil {
@@ -2232,7 +2232,7 @@ func DashboardEmptyState(score float64, healthStatsError bool) templ.Component {
 			var templ_7745c5c3_Var109 string
 			templ_7745c5c3_Var109, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "dashboard.health_compliant_score", score))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 855, Col: 56}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 857, Col: 56}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var109))
 			if templ_7745c5c3_Err != nil {
@@ -2286,7 +2286,7 @@ func UndoToast(undoID string, expiresIn int) templ.Component {
 		var templ_7745c5c3_Var111 string
 		templ_7745c5c3_Var111, templ_7745c5c3_Err = templ.JoinStringErrs("undo-toast-" + undoID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 870, Col: 29}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 872, Col: 29}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var111))
 		if templ_7745c5c3_Err != nil {
@@ -2299,7 +2299,7 @@ func UndoToast(undoID string, expiresIn int) templ.Component {
 		var templ_7745c5c3_Var112 string
 		templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(undoID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 871, Col: 23}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 873, Col: 23}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
 		if templ_7745c5c3_Err != nil {
@@ -2312,7 +2312,7 @@ func UndoToast(undoID string, expiresIn int) templ.Component {
 		var templ_7745c5c3_Var113 string
 		templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(expiresIn))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 872, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 874, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var113))
 		if templ_7745c5c3_Err != nil {
@@ -2325,7 +2325,7 @@ func UndoToast(undoID string, expiresIn int) templ.Component {
 		var templ_7745c5c3_Var114 string
 		templ_7745c5c3_Var114, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.fix_applied"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 880, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 882, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var114))
 		if templ_7745c5c3_Err != nil {
@@ -2338,7 +2338,7 @@ func UndoToast(undoID string, expiresIn int) templ.Component {
 		var templ_7745c5c3_Var115 string
 		templ_7745c5c3_Var115, templ_7745c5c3_Err = templ.JoinStringErrs("/api/v1/fix-undo/" + undoID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 883, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 885, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var115))
 		if templ_7745c5c3_Err != nil {
@@ -2351,7 +2351,7 @@ func UndoToast(undoID string, expiresIn int) templ.Component {
 		var templ_7745c5c3_Var116 string
 		templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs("#undo-toast-" + undoID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 884, Col: 38}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 886, Col: 38}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var116))
 		if templ_7745c5c3_Err != nil {
@@ -2364,7 +2364,7 @@ func UndoToast(undoID string, expiresIn int) templ.Component {
 		var templ_7745c5c3_Var117 string
 		templ_7745c5c3_Var117, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.undo_fix"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 887, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 889, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var117))
 		if templ_7745c5c3_Err != nil {
@@ -2377,7 +2377,7 @@ func UndoToast(undoID string, expiresIn int) templ.Component {
 		var templ_7745c5c3_Var118 string
 		templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "dashboard.undo"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 890, Col: 29}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/dashboard.templ`, Line: 892, Col: 29}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var118))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary
- Dashboard violation cards now use htmx-native `hx-disabled-elt="this"` on the Fix and Dismiss buttons; the global `htmx:responseError` listener in layout.templ already routes 422 bodies through `window.showToast`, so failures surface visibly instead of leaving the card silently in place.
- Artist-detail Violations tab (raw fetch path) disables both row buttons on click and re-enables them in `finally()` so an error path never leaves the row inert; failure branches route through `window.showToast` with an `alert()` fallback so the toast styling matches the dashboard.
- New handler test pins the 422 body contract; new templ tests pin the disable attribute on dashboard cards and the disable / showToast pattern in the artist-tab scripts.

## Test plan
- [x] `/violations` -> click Fix on a failing violation -> visible toast with the fixer's reason (UAT confirmed)
- [x] `/violations` -> rapidly double-click Fix on a fixable violation -> guarded; only one POST fires (UAT confirmed)
- [x] Artist-detail Violations tab raw-fetch path covered by `TestArtistViolationsTab_DoubleSubmitGuard` (unit; not UAT-driven)
- [x] `bash scripts/pre-push-gate.sh` clean

Closes #1026
Closes #1110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented double-submit protection to prevent duplicate submissions while requests are in flight.
  * Replaced alert-based error notifications with toast messages for improved feedback.

* **Bug Fixes**
  * Improved error response handling with proper status codes.
  * Added visual feedback (disabled styling) for action buttons during processing.

* **Tests**
  * Added regression test for error handling in violation-fix operations.
  * Added test coverage for double-submit guard behavior across UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->