### PR TITLE
test(rule): pin bio_missing resolution after provider refresh (#1027)

### DIFF
--- a/internal/api/handlers_refresh_test.go
+++ b/internal/api/handlers_refresh_test.go
@@ -451,6 +451,128 @@ func TestApplyMemberRefresh(t *testing.T) {
 	})
 }
 
+// TestExecuteRefreshAndPostHook_ResolvesBioViolation is the issue #1027
+// regression guard. It exercises the full post-refresh pipeline at the
+// HTTP-handler level (not just the rule package): given an artist with an
+// open bio_missing violation, calling executeRefreshCtx with a provider stub
+// that returns a populated biography MUST cause the subsequent
+// runRulesAfterRefresh call to transition the violation row to resolved.
+//
+// The bug as filed reads as a wiring problem (the post-refresh hook
+// "may not be calling re-eval at all"). Inspection shows the wiring is
+// correct on main: handleArtistRefresh / handleRefreshLink both invoke
+// runRulesAfterRefresh after executeRefreshCtx persists provider data.
+// The W2.B (#1208) fix already resolves stale violation rows when a rule
+// re-evaluates as a pass via persistPassResults -> ResolveViolationIfActive.
+//
+// This integration test pins both pieces together so a future change to the
+// refresh handler (or to the rule pipeline's pass-resolution path) that
+// silently breaks the user-visible "violation clears after refresh" behavior
+// surfaces here as a failing test instead of as another reopened bug.
+func TestExecuteRefreshAndPostHook_ResolvesBioViolation(t *testing.T) {
+	r, artistSvc, ruleSvc := testRouterWithPipelineFull(t)
+
+	// Disable every rule except bio_exists so the test is independent of
+	// seed defaults and so unrelated rules cannot mask the assertion by
+	// flipping the persistOK bit on transient FK or fixture issues.
+	ctx := context.Background()
+	rules, err := ruleSvc.List(ctx)
+	if err != nil {
+		t.Fatalf("listing rules: %v", err)
+	}
+	for i := range rules {
+		if rules[i].ID == rule.RuleBioExists {
+			continue
+		}
+		rules[i].Enabled = false
+		if err := ruleSvc.Update(ctx, &rules[i]); err != nil {
+			t.Fatalf("disabling rule %s: %v", rules[i].ID, err)
+		}
+	}
+
+	// Seed an artist with empty biography and a MusicBrainzID so the
+	// refresh handler does not divert to the disambiguation form.
+	a := &artist.Artist{
+		Name:          "Bio Refresh Integration",
+		SortName:      "Bio Refresh Integration",
+		Type:          "person",
+		Path:          "/music/Bio Refresh Integration",
+		MusicBrainzID: "00000000-0000-0000-0000-000000000abc",
+		Biography:     "",
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// Run the pipeline once to seed the open bio_missing violation row.
+	if _, err := r.pipeline.RunForArtist(ctx, a); err != nil {
+		t.Fatalf("seeding violation via RunForArtist: %v", err)
+	}
+	violations, err := ruleSvc.ListViolationsFiltered(ctx, rule.ViolationListParams{ArtistID: a.ID})
+	if err != nil {
+		t.Fatalf("listing violations after seed: %v", err)
+	}
+	var seeded *rule.RuleViolation
+	for i := range violations {
+		if violations[i].RuleID == rule.RuleBioExists {
+			seeded = &violations[i]
+			break
+		}
+	}
+	if seeded == nil {
+		t.Fatalf("expected bio_missing violation seeded by initial pipeline run")
+	}
+	if seeded.Status != rule.ViolationStatusOpen {
+		t.Fatalf("seeded violation status = %q, want %q", seeded.Status, rule.ViolationStatusOpen)
+	}
+
+	// Wire a stub orchestrator that returns a non-empty biography so
+	// executeRefreshCtx applies the field via ApplyMetadata and Update.
+	stub := &stubScraperExecutor{
+		result: &provider.FetchResult{
+			Metadata: &provider.ArtistMetadata{
+				Biography: "Integration test biography long enough to satisfy the minimum length checker.",
+			},
+			AttemptedFields: []string{"biography"},
+			PopulatedFields: []string{"biography"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	orch := provider.NewOrchestrator(nil, nil, logger)
+	orch.SetExecutor(stub)
+	r.orchestrator = orch
+
+	// Execute the same sequence the HTTP handler runs: refresh -> post-hook.
+	if _, err := r.executeRefreshCtx(ctx, a); err != nil {
+		t.Fatalf("executeRefreshCtx: %v", err)
+	}
+	r.runRulesAfterRefresh(ctx, a)
+
+	// The seeded violation row must now be resolved with resolved_at set.
+	got, err := ruleSvc.GetViolationByID(ctx, seeded.ID)
+	if err != nil {
+		t.Fatalf("GetViolationByID: %v", err)
+	}
+	if got.Status != rule.ViolationStatusResolved {
+		t.Errorf("bio violation status after refresh = %q, want %q",
+			got.Status, rule.ViolationStatusResolved)
+	}
+	if got.ResolvedAt == nil {
+		t.Errorf("resolved_at = nil, want populated after refresh resolves the bio violation")
+	}
+
+	// Sanity check: the persisted artist row carries the new biography. If
+	// this fails the assertion above is meaningless because the refresh
+	// itself dropped the data before re-eval ever saw it.
+	reloaded, err := artistSvc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("reloading artist: %v", err)
+	}
+	if reloaded.Biography == "" {
+		t.Errorf("biography empty after refresh; ApplyMetadata or Update lost the value")
+	}
+}
+
 // TestRunRulesAfterRefresh_InvokesPipeline verifies that runRulesAfterRefresh
 // calls the pipeline's RunForArtist method with the re-fetched artist.
 func TestRunRulesAfterRefresh_InvokesPipeline(t *testing.T) {

--- a/internal/rule/lifecycle_test.go
+++ b/internal/rule/lifecycle_test.go
@@ -2,6 +2,8 @@ package rule
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +11,25 @@ import (
 
 	"github.com/sydlexius/stillwater/internal/artist"
 )
+
+// lookupViolationByRuleArtist returns the persisted (id, status) of the
+// rule_violations row keyed by (rule_id, artist_id). The unique index makes
+// this a stable lookup across re-evaluations because UpsertViolation reuses
+// the existing row id on conflict. Returns ("", "", nil) when no row exists.
+func lookupViolationByRuleArtist(ctx context.Context, db *sql.DB, ruleID, artistID string) (string, string, error) {
+	var id, status string
+	err := db.QueryRowContext(ctx,
+		`SELECT id, status FROM rule_violations WHERE rule_id = ? AND artist_id = ?`,
+		ruleID, artistID,
+	).Scan(&id, &status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", "", nil
+	}
+	if err != nil {
+		return "", "", err
+	}
+	return id, status, nil
+}
 
 // TestPipeline_ReEvalPassResolvesStaleViolation exercises issue #1105: when a
 // rule that previously violated now passes (because the underlying condition
@@ -266,6 +287,101 @@ func TestService_DisablingRuleSoftResolvesViolations(t *testing.T) {
 	}
 	if resultsCount != 0 {
 		t.Errorf("rule_results rows for %s = %d, want 0 after manual disable", RuleNFOExists, resultsCount)
+	}
+}
+
+// TestPipeline_BioViolationResolvedAfterBiographyPopulated exercises issue
+// #1027: the post-refresh hook in handlers_refresh.go runs RunForArtist after
+// a successful provider fetch populates Biography. The bio_exists rule should
+// then evaluate as a pass for that artist, and the previously-open
+// rule_violations row must transition to status='resolved'. This test bypasses
+// the HTTP layer and simulates the same sequence directly: seed an open
+// bio_missing violation against an artist with no biography, persist a
+// biography update through the artist service, then run the pipeline and
+// assert the row is resolved with resolved_at populated.
+//
+// Without the W2.B (#1105) resolve-on-pass fix this test would still fail,
+// because the pipeline only resolves rows it produced inline (via the
+// resolvedRows path) and not stale rows whose underlying condition was
+// corrected out-of-band. The test also guards against future regressions in
+// the post-refresh wiring: any change that prevents the pipeline from seeing
+// the persisted Biography (e.g. the post-refresh handler reading a stale
+// in-memory copy instead of GetByID-ing fresh state) would surface here as a
+// re-evaluation that still reports bio_missing and never resolves the row.
+func TestPipeline_BioViolationResolvedAfterBiographyPopulated(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	artistSvc := artist.NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	disableAllRulesExcept(t, db, RuleBioExists)
+
+	// Step 1: insert an artist with empty biography. checkBioExists fires.
+	a := &artist.Artist{
+		Name:      "Bio Refresh",
+		SortName:  "Bio Refresh",
+		Path:      t.TempDir(),
+		Biography: "",
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, nil, nil, testLogger())
+
+	// Step 2: first eval -- bio_missing violation row must exist as 'open'.
+	if _, err := pipeline.RunForArtist(ctx, a); err != nil {
+		t.Fatalf("first RunForArtist: %v", err)
+	}
+	violationID, openStatus, err := lookupViolationByRuleArtist(ctx, db, RuleBioExists, a.ID)
+	if err != nil {
+		t.Fatalf("looking up bio violation after first eval: %v", err)
+	}
+	if violationID == "" {
+		t.Fatalf("expected bio_missing violation row after first eval, got none")
+	}
+	if openStatus != ViolationStatusOpen {
+		t.Fatalf("violation status after first eval = %q, want %q", openStatus, ViolationStatusOpen)
+	}
+
+	// Step 3: simulate provider refresh populating the biography. The
+	// production path is internal/api/handlers_refresh.go executeRefreshCtx,
+	// which calls artist.Service.Update with Biography filled in. We
+	// reproduce the persisted side-effect directly.
+	a.Biography = "Bio Refresh is a rock band formed for testing in 2026."
+	if err := artistSvc.Update(ctx, a); err != nil {
+		t.Fatalf("Update with populated biography: %v", err)
+	}
+
+	// Step 4: re-run the pipeline against the freshly-loaded artist, the
+	// same way runRulesAfterRefresh does (GetByID then RunForArtist). The
+	// bio_exists rule now passes, so persistPassResults must call
+	// ResolveViolationIfActive and transition the row to resolved.
+	fresh, err := artistSvc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID after Update: %v", err)
+	}
+	if fresh.Biography == "" {
+		t.Fatalf("biography did not persist; reloaded artist has empty Biography")
+	}
+	if _, err := pipeline.RunForArtist(ctx, fresh); err != nil {
+		t.Fatalf("post-refresh RunForArtist: %v", err)
+	}
+
+	rv, err := ruleSvc.GetViolationByID(ctx, violationID)
+	if err != nil {
+		t.Fatalf("GetViolationByID: %v", err)
+	}
+	if rv.Status != ViolationStatusResolved {
+		t.Errorf("bio violation status after post-refresh eval = %q, want %q",
+			rv.Status, ViolationStatusResolved)
+	}
+	if rv.ResolvedAt == nil {
+		t.Errorf("resolved_at = nil, want populated after post-refresh eval")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds end-to-end regression coverage that the `bio_missing` violation clears after a successful provider refresh populates the biography. This pins together the W2.B (#1208) resolve-on-pass fix and the existing post-refresh hook in `handlers_refresh.go` so the user-reported behavior in #1027 cannot regress without a failing test.
- No production code change. Investigation showed the wiring is already correct on `main`: `handleArtistRefresh` and `handleRefreshLink` both invoke `runRulesAfterRefresh` after `executeRefreshCtx`, and the W2.B fix added `ResolveViolationIfActive` to `persistPassResults` so any rule that re-evaluates as a pass clears its stale violation row.
- Two new tests: a rule-package unit test driving the pipeline directly, and an HTTP-handler integration test driving `executeRefreshCtx` + `runRulesAfterRefresh` through the same path the production handler runs.

## Test plan

- [x] `go test -race -run TestPipeline_BioViolationResolvedAfterBiographyPopulated ./internal/rule -v` passes.
- [x] `go test -race -run TestExecuteRefreshAndPostHook_ResolvesBioViolation ./internal/api -v` passes.
- [x] `bash scripts/pre-push-gate.sh` passes (full -race suite + OpenAPI + generated + coverage; patch coverage 100% on application lines).

Closes #1027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression tests for biography refresh behavior to ensure violations are properly resolved during post-hook execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->