### PR TITLE
feat(activity): emit recent-activity entries for rule auto-fixes (#1106)

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -320,6 +320,10 @@ func run() error {
 		rule.NewBackdropSequencingFixer(platformService, fsCheck, logger),
 	}
 	pipeline := rule.NewPipeline(ruleEngine, artistService, ruleService, fixers, publisher, logger)
+	// Wire the history service so successful auto-fixes appear in the
+	// Recent Activity feed (issue #1106). Setter form keeps NewPipeline's
+	// signature stable for the wide set of test call sites.
+	pipeline.SetHistoryService(historyService)
 
 	// Initialize bulk operations
 	bulkService := rule.NewBulkService(db)

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -458,6 +458,7 @@
   "field.moods": "Moods",
   "field.musicbrainz_id": "MusicBrainz ID",
   "field.name": "Name",
+  "field.rule_fix": "Rule auto-fix",
   "field.sort_name": "Sort Name",
   "field.spotify_id": "Spotify ID",
   "field.styles": "Styles",

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -142,6 +142,13 @@ type Pipeline struct {
 	writeGateMu sync.RWMutex
 	writeGate   WriteGate
 
+	// historyServiceMu guards historyService for the same reason as
+	// writeGateMu: SetHistoryService can be called after construction so
+	// the auto-fix history-recording read path on every successful fix
+	// must lock against a concurrent setter. Issue #1106.
+	historyServiceMu sync.RWMutex
+	historyService   *artist.HistoryService
+
 	ruleCacheMu sync.RWMutex
 	ruleCache   map[string]*Rule
 }
@@ -163,6 +170,58 @@ func (p *Pipeline) getWriteGate() WriteGate {
 	p.writeGateMu.RLock()
 	defer p.writeGateMu.RUnlock()
 	return p.writeGate
+}
+
+// SetHistoryService installs (or replaces) the artist history service the
+// pipeline uses to emit a Recent Activity entry on every successful auto-fix.
+// Passing nil disables history recording -- callers that never configure a
+// history service behave exactly as before. Issue #1106.
+//
+// Setter form (rather than a NewPipeline parameter) keeps the existing
+// constructor signature stable for the wide set of test call sites.
+func (p *Pipeline) SetHistoryService(h *artist.HistoryService) {
+	p.historyServiceMu.Lock()
+	p.historyService = h
+	p.historyServiceMu.Unlock()
+}
+
+// getHistoryService returns the currently installed HistoryService under the
+// historyServiceMu read lock so the auto-fix recorder can read it safely
+// without racing a concurrent SetHistoryService.
+func (p *Pipeline) getHistoryService() *artist.HistoryService {
+	p.historyServiceMu.RLock()
+	defer p.historyServiceMu.RUnlock()
+	return p.historyService
+}
+
+// recordRuleFixHistory emits a single Recent Activity entry for a successful
+// auto-fix. The entry uses the canonical "rule:<rule_id>" source and a
+// dedicated "rule_fix" pseudo-field name so the existing activity feed UI:
+//
+//   - Renders the source label as "Rule: <rule_id>" (history.source.rule_named).
+//   - Hides the Revert button (artist.IsTrackableField returns false for
+//     "rule_fix"), which is intentional: most rule auto-fixes mutate the
+//     filesystem (NFO file, image file, directory rename, extraneous-file
+//     delete) and cannot be safely undone via the field-revert path. The
+//     dedicated FixViolation undo flow (W4.B) handles single-violation
+//     reverts where supported.
+//
+// Errors are warn-logged and never propagated: the history entry is
+// supplementary audit data and must not fail the actual fix.
+//
+// Issue #1106.
+func (p *Pipeline) recordRuleFixHistory(ctx context.Context, artistID string, fr *FixResult) {
+	if fr == nil || !fr.Fixed {
+		return
+	}
+	h := p.getHistoryService()
+	if h == nil {
+		return
+	}
+	if err := h.Record(ctx, artistID, "rule_fix", "", fr.Message, "rule:"+fr.RuleID); err != nil {
+		p.logger.Warn("recording rule auto-fix history",
+			"rule_id", fr.RuleID, "artist_id", artistID, "error", err)
+	}
 }
 
 // NewPipeline creates a new fix pipeline.
@@ -325,6 +384,11 @@ func (p *Pipeline) RunRuleScoped(ctx context.Context, ruleID string, scope RunSc
 				} else {
 					perRuleMetadata = true
 				}
+				// Issue #1106: emit a Recent Activity entry so users see
+				// what the rule engine just did on their behalf. Best-effort;
+				// recordRuleFixHistory warn-logs on failure and never fails
+				// the surrounding fix flow.
+				p.recordRuleFixHistory(ctx, a.ID, fr)
 				resolvedRows = append(resolvedRows, &RuleViolation{
 					RuleID:     v.RuleID,
 					ArtistID:   a.ID,
@@ -573,6 +637,10 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 			} else {
 				metadataFixed = true
 			}
+			// Issue #1106: emit a Recent Activity entry. See the
+			// matching comment + helper docstring in
+			// RunRuleScoped.processArtist.
+			p.recordRuleFixHistory(ctx, a.ID, fr)
 			resolvedRows = append(resolvedRows, &RuleViolation{
 				RuleID:     v.RuleID,
 				ArtistID:   a.ID,
@@ -834,6 +902,10 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 				} else {
 					perArtistMetadata = true
 				}
+				// Issue #1106: emit a Recent Activity entry. See the
+				// matching comment + helper docstring in
+				// RunRuleScoped.processArtist.
+				p.recordRuleFixHistory(ctx, a.ID, fr)
 				resolvedRows = append(resolvedRows, &RuleViolation{
 					RuleID:     v.RuleID,
 					ArtistID:   a.ID,

--- a/internal/rule/fixer_test.go
+++ b/internal/rule/fixer_test.go
@@ -2191,3 +2191,342 @@ func TestAttemptFix_GateAllowsOtherCategories(t *testing.T) {
 		t.Errorf("fixer should have run once for metadata category, calls=%d", fixer.calls)
 	}
 }
+
+// candidateDiscoveryFixer is a scoped mock that also implements
+// CandidateDiscoverer so the manual-mode pipeline branch will actually invoke
+// it (and route through DiscoveryOnly). Without this, the pipeline's
+// supportsCandidateDiscovery gate would skip the fixer in manual mode and the
+// test could never reach the recorder. Issue #1106.
+type candidateDiscoveryFixer struct {
+	canFixRuleID string
+	result       *FixResult
+}
+
+func (c *candidateDiscoveryFixer) CanFix(v *Violation) bool {
+	return v.RuleID == c.canFixRuleID
+}
+
+func (c *candidateDiscoveryFixer) Fix(_ context.Context, _ *artist.Artist, v *Violation) (*FixResult, error) {
+	if c.result != nil {
+		out := *c.result
+		out.RuleID = v.RuleID
+		return &out, nil
+	}
+	return &FixResult{RuleID: v.RuleID, Fixed: false, Message: "candidate-discovery noop"}, nil
+}
+
+func (c *candidateDiscoveryFixer) SupportsCandidateDiscovery() bool { return true }
+
+// scopedMockFixer narrows the canFix predicate to a single rule ID and lets
+// the test pin the FixResult for assertions about rule-fix history entries.
+// Unlike mockFixer (which claims every violation), this fixer only handles a
+// targeted rule so the surrounding test can assert "exactly N entries for
+// the rule under test" without bleed-through from peer rules that run in
+// the same pipeline pass. Issue #1106.
+type scopedMockFixer struct {
+	canFixRuleID string
+	result       *FixResult
+	calls        int
+}
+
+func (s *scopedMockFixer) CanFix(v *Violation) bool {
+	return v.RuleID == s.canFixRuleID
+}
+
+func (s *scopedMockFixer) Fix(_ context.Context, _ *artist.Artist, v *Violation) (*FixResult, error) {
+	s.calls++
+	if s.result != nil {
+		// Always reflect the violation's RuleID so a result reused across
+		// multiple rules still records the right rule_id in source.
+		out := *s.result
+		out.RuleID = v.RuleID
+		return &out, nil
+	}
+	return &FixResult{RuleID: v.RuleID, Fixed: true, Message: "scoped mock fixed"}, nil
+}
+
+// setupAutoFixHistoryHarness builds a Pipeline + HistoryService wired against
+// a shared test DB and seeds RuleNFOExists in auto mode so the runner
+// exercised by the test will attempt a fix. The fixer narrowly claims
+// RuleNFOExists only, so the test can assert "one rule_fix entry per
+// successful fix of THIS rule" without peer rules contributing extra entries.
+// Issue #1106.
+func setupAutoFixHistoryHarness(t *testing.T, fr *FixResult) (*Pipeline, *artist.HistoryService, *artist.Artist) {
+	t.Helper()
+	db := setupTestDB(t)
+	artistSvc := artist.NewService(db)
+	historySvc := artist.NewHistoryService(db)
+	artistSvc.SetHistoryService(historySvc)
+
+	ruleSvc := NewService(db)
+	ctx := context.Background()
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	// Force RuleNFOExists into auto mode so the pipeline auto-fix path
+	// (where the new history hook lives) is exercised. Default is auto
+	// already because the rule definition omits AutomationMode, but the
+	// test pins the mode so a future default-mode change cannot silently
+	// disable this assertion.
+	r, err := ruleSvc.GetByID(ctx, RuleNFOExists)
+	if err != nil {
+		t.Fatalf("getting nfo_exists rule: %v", err)
+	}
+	r.AutomationMode = AutomationModeAuto
+	if err := ruleSvc.Update(ctx, r); err != nil {
+		t.Fatalf("updating rule: %v", err)
+	}
+
+	a := &artist.Artist{
+		Name:     "Auto-fix Activity Artist",
+		SortName: "Auto-fix Activity Artist",
+		Path:     t.TempDir(),
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	fixer := &scopedMockFixer{canFixRuleID: RuleNFOExists, result: fr}
+	logger := testLogger()
+	engine := NewEngine(ruleSvc, db, nil, nil, logger)
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{fixer}, nil, logger)
+	pipeline.SetHistoryService(historySvc)
+	return pipeline, historySvc, a
+}
+
+// TestPipeline_RunForArtist_RecordsAutoFixHistory verifies that a successful
+// auto-fix produces a single Recent Activity entry tagged with the synthetic
+// "rule_fix" field and the canonical "rule:<rule_id>" source so the activity
+// feed surfaces filesystem/image/NFO repairs the engine performed on the
+// user's behalf. Issue #1106.
+func TestPipeline_RunForArtist_RecordsAutoFixHistory(t *testing.T) {
+	pipeline, historySvc, a := setupAutoFixHistoryHarness(t, &FixResult{
+		RuleID:  RuleNFOExists,
+		Fixed:   true,
+		Message: "created artist.nfo for Auto-fix Activity Artist",
+	})
+
+	if _, err := pipeline.RunForArtist(context.Background(), a); err != nil {
+		t.Fatalf("RunForArtist: %v", err)
+	}
+
+	// Filter to rule_fix entries. The pre-Update health-score path may also
+	// record other diffs (e.g. biography changes) for fixers that mutate
+	// trackable fields, so we narrow the assertion to the new entry type
+	// rather than asserting "exactly one history row total".
+	changes, _, err := historySvc.ListGlobal(context.Background(), artist.GlobalHistoryFilter{
+		ArtistID: a.ID,
+		Fields:   []string{"rule_fix"},
+	})
+	if err != nil {
+		t.Fatalf("ListGlobal: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("rule_fix history rows = %d, want 1; got: %#v", len(changes), changes)
+	}
+	got := changes[0]
+	if got.Field != "rule_fix" {
+		t.Errorf("Field = %q, want %q", got.Field, "rule_fix")
+	}
+	if got.Source != "rule:"+RuleNFOExists {
+		t.Errorf("Source = %q, want %q", got.Source, "rule:"+RuleNFOExists)
+	}
+	if got.NewValue != "created artist.nfo for Auto-fix Activity Artist" {
+		t.Errorf("NewValue = %q, want the fixer message", got.NewValue)
+	}
+	// rule_fix is intentionally NOT a trackable field, so the activity
+	// feed UI hides the Revert button. Pin the contract here so a future
+	// well-meaning addition to trackableFields cannot silently introduce
+	// a broken Revert affordance for filesystem-mutating auto-fixes.
+	if artist.IsTrackableField("rule_fix") {
+		t.Error("rule_fix must not be a trackable field; the activity feed renders Revert only for trackable fields and rule auto-fixes write to disk")
+	}
+}
+
+// TestPipeline_RunForArtist_NoHistoryWhenFixFails verifies that a failed fix
+// (Fixed=false) does NOT produce a Recent Activity entry. Issue #1106.
+func TestPipeline_RunForArtist_NoHistoryWhenFixFails(t *testing.T) {
+	pipeline, historySvc, a := setupAutoFixHistoryHarness(t, &FixResult{
+		RuleID:  RuleNFOExists,
+		Fixed:   false,
+		Message: "no fixer available",
+	})
+
+	if _, err := pipeline.RunForArtist(context.Background(), a); err != nil {
+		t.Fatalf("RunForArtist: %v", err)
+	}
+
+	changes, _, err := historySvc.ListGlobal(context.Background(), artist.GlobalHistoryFilter{
+		ArtistID: a.ID,
+		Fields:   []string{"rule_fix"},
+	})
+	if err != nil {
+		t.Fatalf("ListGlobal: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("rule_fix history rows = %d, want 0 for failed fix; got: %#v", len(changes), changes)
+	}
+}
+
+// TestPipeline_NoHistoryWithoutHistoryService verifies that the pipeline
+// continues to work when SetHistoryService has not been called -- the audit
+// trail is best-effort and must not be a wiring requirement that breaks
+// existing test harnesses that omit it. Issue #1106.
+func TestPipeline_NoHistoryWithoutHistoryService(t *testing.T) {
+	db := setupTestDB(t)
+	artistSvc := artist.NewService(db)
+	ruleSvc := NewService(db)
+	ctx := context.Background()
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	r, err := ruleSvc.GetByID(ctx, RuleNFOExists)
+	if err != nil {
+		t.Fatalf("GetByID rule: %v", err)
+	}
+	r.AutomationMode = AutomationModeAuto
+	if err := ruleSvc.Update(ctx, r); err != nil {
+		t.Fatalf("Update rule: %v", err)
+	}
+
+	a := &artist.Artist{Name: "No-History Artist", SortName: "No-History Artist", Path: t.TempDir()}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("Create artist: %v", err)
+	}
+
+	fixer := &scopedMockFixer{canFixRuleID: RuleNFOExists, result: &FixResult{Fixed: true, Message: "fake"}}
+	logger := testLogger()
+	engine := NewEngine(ruleSvc, db, nil, nil, logger)
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{fixer}, nil, logger)
+	// Intentionally do NOT call pipeline.SetHistoryService. The recorder
+	// must short-circuit cleanly on a nil service.
+
+	if _, err := pipeline.RunForArtist(ctx, a); err != nil {
+		t.Fatalf("RunForArtist with no history service: %v", err)
+	}
+}
+
+// TestPipeline_ManualMode_NoAutoFixHistory verifies that manual-mode
+// candidate discovery does NOT emit a rule_fix history entry. Manual-mode
+// fixers run in DiscoveryOnly mode and return Fixed=false plus a candidate
+// list; the recorder gates on Fixed=true so it must skip these. Issue #1106.
+func TestPipeline_ManualMode_NoAutoFixHistory(t *testing.T) {
+	db := setupTestDB(t)
+	artistSvc := artist.NewService(db)
+	historySvc := artist.NewHistoryService(db)
+	artistSvc.SetHistoryService(historySvc)
+
+	ruleSvc := NewService(db)
+	ctx := context.Background()
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	// RuleFanartExists in manual mode -> candidate discovery, no auto-apply.
+	r, err := ruleSvc.GetByID(ctx, RuleFanartExists)
+	if err != nil {
+		t.Fatalf("GetByID rule: %v", err)
+	}
+	r.AutomationMode = AutomationModeManual
+	if err := ruleSvc.Update(ctx, r); err != nil {
+		t.Fatalf("Update rule: %v", err)
+	}
+
+	a := &artist.Artist{
+		Name:          "Manual-mode Artist",
+		SortName:      "Manual-mode Artist",
+		Path:          t.TempDir(),
+		MusicBrainzID: "mbid-manual-mode",
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("Create artist: %v", err)
+	}
+
+	candidates := []ImageCandidate{
+		{URL: "http://example/img.jpg", Width: 1920, Height: 1080, Source: "prov", ImageType: "fanart"},
+		{URL: "http://example/img2.jpg", Width: 3840, Height: 2160, Source: "prov", ImageType: "fanart"},
+	}
+	// Returns Fixed=false plus a candidate list, exactly mirroring how a real
+	// manual-mode fixer signals "I have suggestions but did not write".
+	// Manual-mode also requires the fixer to advertise CandidateDiscovery
+	// support; without it the pipeline would skip invocation entirely and
+	// short-circuit before ever reaching the recorder under test.
+	fixer := &candidateDiscoveryFixer{canFixRuleID: RuleFanartExists, result: &FixResult{
+		Fixed:      false,
+		Message:    "found 2 fanart candidates; awaiting user selection",
+		Candidates: candidates,
+	}}
+
+	logger := testLogger()
+	engine := NewEngine(ruleSvc, db, nil, nil, logger)
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{fixer}, nil, logger)
+	pipeline.SetHistoryService(historySvc)
+
+	if _, err := pipeline.RunRule(ctx, RuleFanartExists); err != nil {
+		t.Fatalf("RunRule: %v", err)
+	}
+
+	changes, _, err := historySvc.ListGlobal(ctx, artist.GlobalHistoryFilter{
+		ArtistID: a.ID,
+		Fields:   []string{"rule_fix"},
+	})
+	if err != nil {
+		t.Fatalf("ListGlobal: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("rule_fix history rows = %d, want 0 for manual-mode discovery; got: %#v", len(changes), changes)
+	}
+}
+
+// TestPipeline_RunAll_RecordsAutoFixHistory verifies the same recording path
+// fires for the multi-rule walker (the user-facing "Run Rules" button).
+// Issue #1106.
+func TestPipeline_RunAll_RecordsAutoFixHistory(t *testing.T) {
+	pipeline, historySvc, a := setupAutoFixHistoryHarness(t, &FixResult{
+		RuleID:  RuleNFOExists,
+		Fixed:   true,
+		Message: "fix-all path",
+	})
+
+	if _, err := pipeline.RunAll(context.Background()); err != nil {
+		t.Fatalf("RunAll: %v", err)
+	}
+
+	changes, _, err := historySvc.ListGlobal(context.Background(), artist.GlobalHistoryFilter{
+		ArtistID: a.ID,
+		Fields:   []string{"rule_fix"},
+	})
+	if err != nil {
+		t.Fatalf("ListGlobal: %v", err)
+	}
+	if len(changes) == 0 {
+		t.Fatal("expected at least one rule_fix entry after RunAll, got none")
+	}
+	if changes[0].Source != "rule:"+RuleNFOExists {
+		t.Errorf("Source = %q, want %q", changes[0].Source, "rule:"+RuleNFOExists)
+	}
+}
+
+// TestPipeline_RunRule_RecordsAutoFixHistory verifies the recording path also
+// fires for the single-rule walker. Issue #1106.
+func TestPipeline_RunRule_RecordsAutoFixHistory(t *testing.T) {
+	pipeline, historySvc, a := setupAutoFixHistoryHarness(t, &FixResult{
+		RuleID:  RuleNFOExists,
+		Fixed:   true,
+		Message: "single-rule path",
+	})
+
+	if _, err := pipeline.RunRule(context.Background(), RuleNFOExists); err != nil {
+		t.Fatalf("RunRule: %v", err)
+	}
+
+	changes, _, err := historySvc.ListGlobal(context.Background(), artist.GlobalHistoryFilter{
+		ArtistID: a.ID,
+		Fields:   []string{"rule_fix"},
+	})
+	if err != nil {
+		t.Fatalf("ListGlobal: %v", err)
+	}
+	if len(changes) == 0 {
+		t.Fatal("expected at least one rule_fix entry after RunRule, got none")
+	}
+}

--- a/web/templates/activity.templ
+++ b/web/templates/activity.templ
@@ -139,6 +139,11 @@ templ ActivityPage(assets AssetPaths, data ActivityPageData) {
 				@components.FilterItem("activity-filters-flyout", "field", "years_active", t(ctx, "field.years_active"), "neutral")
 				@components.FilterItem("activity-filters-flyout", "field", "type", t(ctx, "field.type"), "neutral")
 				@components.FilterItem("activity-filters-flyout", "field", "gender", t(ctx, "field.gender"), "neutral")
+				// Rule auto-fix entries use the synthetic "rule_fix" field so
+				// the activity feed surfaces filesystem/image/NFO repairs the
+				// engine performed automatically (issue #1106). The same
+				// entries also match the existing "rule:*" source filter.
+				@components.FilterItem("activity-filters-flyout", "field", "rule_fix", t(ctx, "field.rule_fix"), "neutral")
 			}
 			@components.FilterSection(t(ctx, "activity.filter_section.trigger_source")) {
 				@components.FilterItem("activity-filters-flyout", "source", "manual", t(ctx, "history.source.manual"), "neutral")

--- a/web/templates/activity_templ.go
+++ b/web/templates/activity_templ.go
@@ -541,13 +541,21 @@ func ActivityPage(assets AssetPaths, data ActivityPageData) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "     ")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = components.FilterItem("activity-filters-flyout", "field", "rule_fix", t(ctx, "field.rule_fix"), "neutral").Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
 					return nil
 				})
 				templ_7745c5c3_Err = components.FilterSection(t(ctx, "activity.filter_section.change_type")).Render(templ.WithChildren(ctx, templ_7745c5c3_Var30), templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -567,7 +575,7 @@ func ActivityPage(assets AssetPaths, data ActivityPageData) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -575,7 +583,7 @@ func ActivityPage(assets AssetPaths, data ActivityPageData) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -583,7 +591,7 @@ func ActivityPage(assets AssetPaths, data ActivityPageData) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -591,7 +599,7 @@ func ActivityPage(assets AssetPaths, data ActivityPageData) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -599,7 +607,7 @@ func ActivityPage(assets AssetPaths, data ActivityPageData) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -619,7 +627,7 @@ func ActivityPage(assets AssetPaths, data ActivityPageData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, " <script>\n\t\t\t// Reload activity content when the filter flyout applies filters.\n\t\t\t// The shared htmx:configRequest hook prepends the base path automatically,\n\t\t\t// so we use the root-relative path here to avoid double-prefixing.\n\t\t\tdocument.body.addEventListener('sw:filter-applied', function(evt) {\n\t\t\t\tif (evt.target && evt.target.id === 'activity-content') {\n\t\t\t\t\thtmx.ajax('GET', '/activity/content' + window.location.search, {target: '#activity-content', swap: 'innerHTML'});\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Initialise the flyout from URL params on first page load.\n\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\tif (typeof swFilterFlyout !== 'undefined') {\n\t\t\t\t\tswFilterFlyout.initFromURL('activity-filters-flyout');\n\t\t\t\t} else {\n\t\t\t\t\tconsole.warn('[activity] swFilterFlyout not loaded; filter UI will not sync from URL params');\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Date range filter: apply button updates URL params and reloads content.\n\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\tvar applyBtn = document.getElementById('activity-date-apply');\n\t\t\t\tvar clearBtn = document.getElementById('activity-date-clear');\n\t\t\t\tvar fromInput = document.getElementById('activity-date-from');\n\t\t\t\tvar toInput = document.getElementById('activity-date-to');\n\n\t\t\t\t// Show or hide the Clear button based on whether either date input has a value.\n\t\t\t\tfunction updateClearVisibility() {\n\t\t\t\t\tif (!clearBtn) return;\n\t\t\t\t\tvar hasValue = (fromInput && fromInput.value) || (toInput && toInput.value);\n\t\t\t\t\tclearBtn.classList.toggle('hidden', !hasValue);\n\t\t\t\t}\n\n\t\t\t\t// Sync visibility on page load (handles server-rendered initial state).\n\t\t\t\tupdateClearVisibility();\n\n\t\t\t\t// Keep Clear button in sync when inputs change.\n\t\t\t\tif (fromInput) fromInput.addEventListener('change', updateClearVisibility);\n\t\t\t\tif (toInput) toInput.addEventListener('change', updateClearVisibility);\n\n\t\t\t\tif (applyBtn) {\n\t\t\t\t\tapplyBtn.addEventListener('click', function() {\n\t\t\t\t\t\tvar params = new URLSearchParams(window.location.search);\n\n\t\t\t\t\t\tif (fromInput && fromInput.value) {\n\t\t\t\t\t\t\t// Send the raw YYYY-MM-DD value so the server interprets it\n\t\t\t\t\t\t\t// as UTC midnight without any timezone drift.\n\t\t\t\t\t\t\tparams.set('from', fromInput.value);\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tparams.delete('from');\n\t\t\t\t\t\t}\n\n\t\t\t\t\t\tif (toInput && toInput.value) {\n\t\t\t\t\t\t\t// Send the raw YYYY-MM-DD value; the server treats plain-date\n\t\t\t\t\t\t\t// \"to\" values as end-of-day UTC so the full day is included.\n\t\t\t\t\t\t\tparams.set('to', toInput.value);\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tparams.delete('to');\n\t\t\t\t\t\t}\n\n\t\t\t\t\t\tvar qs = params.toString();\n\t\t\t\t\t\tvar newURL = window.location.pathname;\n\t\t\t\t\t\tif (qs) newURL += '?' + qs;\n\t\t\t\t\t\twindow.history.replaceState({}, '', newURL);\n\t\t\t\t\t\tupdateClearVisibility();\n\t\t\t\t\t\thtmx.ajax('GET', '/activity/content' + (qs ? '?' + qs : ''), {target: '#activity-content', swap: 'innerHTML'});\n\t\t\t\t\t});\n\t\t\t\t}\n\n\t\t\t\tif (clearBtn) {\n\t\t\t\t\tclearBtn.addEventListener('click', function() {\n\t\t\t\t\t\tif (fromInput) fromInput.value = '';\n\t\t\t\t\t\tif (toInput) toInput.value = '';\n\t\t\t\t\t\tvar params = new URLSearchParams(window.location.search);\n\t\t\t\t\t\tparams.delete('from');\n\t\t\t\t\t\tparams.delete('to');\n\t\t\t\t\t\tvar newURL = window.location.pathname;\n\t\t\t\t\t\tvar qs = params.toString();\n\t\t\t\t\t\tif (qs) newURL += '?' + qs;\n\t\t\t\t\t\twindow.history.replaceState({}, '', newURL);\n\t\t\t\t\t\tupdateClearVisibility();\n\t\t\t\t\t\thtmx.ajax('GET', '/activity/content' + (qs ? '?' + qs : ''), {target: '#activity-content', swap: 'innerHTML'});\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t});\n\t\t</script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, " <script>\n\t\t\t// Reload activity content when the filter flyout applies filters.\n\t\t\t// The shared htmx:configRequest hook prepends the base path automatically,\n\t\t\t// so we use the root-relative path here to avoid double-prefixing.\n\t\t\tdocument.body.addEventListener('sw:filter-applied', function(evt) {\n\t\t\t\tif (evt.target && evt.target.id === 'activity-content') {\n\t\t\t\t\thtmx.ajax('GET', '/activity/content' + window.location.search, {target: '#activity-content', swap: 'innerHTML'});\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Initialise the flyout from URL params on first page load.\n\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\tif (typeof swFilterFlyout !== 'undefined') {\n\t\t\t\t\tswFilterFlyout.initFromURL('activity-filters-flyout');\n\t\t\t\t} else {\n\t\t\t\t\tconsole.warn('[activity] swFilterFlyout not loaded; filter UI will not sync from URL params');\n\t\t\t\t}\n\t\t\t});\n\n\t\t\t// Date range filter: apply button updates URL params and reloads content.\n\t\t\tdocument.addEventListener('DOMContentLoaded', function() {\n\t\t\t\tvar applyBtn = document.getElementById('activity-date-apply');\n\t\t\t\tvar clearBtn = document.getElementById('activity-date-clear');\n\t\t\t\tvar fromInput = document.getElementById('activity-date-from');\n\t\t\t\tvar toInput = document.getElementById('activity-date-to');\n\n\t\t\t\t// Show or hide the Clear button based on whether either date input has a value.\n\t\t\t\tfunction updateClearVisibility() {\n\t\t\t\t\tif (!clearBtn) return;\n\t\t\t\t\tvar hasValue = (fromInput && fromInput.value) || (toInput && toInput.value);\n\t\t\t\t\tclearBtn.classList.toggle('hidden', !hasValue);\n\t\t\t\t}\n\n\t\t\t\t// Sync visibility on page load (handles server-rendered initial state).\n\t\t\t\tupdateClearVisibility();\n\n\t\t\t\t// Keep Clear button in sync when inputs change.\n\t\t\t\tif (fromInput) fromInput.addEventListener('change', updateClearVisibility);\n\t\t\t\tif (toInput) toInput.addEventListener('change', updateClearVisibility);\n\n\t\t\t\tif (applyBtn) {\n\t\t\t\t\tapplyBtn.addEventListener('click', function() {\n\t\t\t\t\t\tvar params = new URLSearchParams(window.location.search);\n\n\t\t\t\t\t\tif (fromInput && fromInput.value) {\n\t\t\t\t\t\t\t// Send the raw YYYY-MM-DD value so the server interprets it\n\t\t\t\t\t\t\t// as UTC midnight without any timezone drift.\n\t\t\t\t\t\t\tparams.set('from', fromInput.value);\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tparams.delete('from');\n\t\t\t\t\t\t}\n\n\t\t\t\t\t\tif (toInput && toInput.value) {\n\t\t\t\t\t\t\t// Send the raw YYYY-MM-DD value; the server treats plain-date\n\t\t\t\t\t\t\t// \"to\" values as end-of-day UTC so the full day is included.\n\t\t\t\t\t\t\tparams.set('to', toInput.value);\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tparams.delete('to');\n\t\t\t\t\t\t}\n\n\t\t\t\t\t\tvar qs = params.toString();\n\t\t\t\t\t\tvar newURL = window.location.pathname;\n\t\t\t\t\t\tif (qs) newURL += '?' + qs;\n\t\t\t\t\t\twindow.history.replaceState({}, '', newURL);\n\t\t\t\t\t\tupdateClearVisibility();\n\t\t\t\t\t\thtmx.ajax('GET', '/activity/content' + (qs ? '?' + qs : ''), {target: '#activity-content', swap: 'innerHTML'});\n\t\t\t\t\t});\n\t\t\t\t}\n\n\t\t\t\tif (clearBtn) {\n\t\t\t\t\tclearBtn.addEventListener('click', function() {\n\t\t\t\t\t\tif (fromInput) fromInput.value = '';\n\t\t\t\t\t\tif (toInput) toInput.value = '';\n\t\t\t\t\t\tvar params = new URLSearchParams(window.location.search);\n\t\t\t\t\t\tparams.delete('from');\n\t\t\t\t\t\tparams.delete('to');\n\t\t\t\t\t\tvar newURL = window.location.pathname;\n\t\t\t\t\t\tvar qs = params.toString();\n\t\t\t\t\t\tif (qs) newURL += '?' + qs;\n\t\t\t\t\t\twindow.history.replaceState({}, '', newURL);\n\t\t\t\t\t\tupdateClearVisibility();\n\t\t\t\t\t\thtmx.ajax('GET', '/activity/content' + (qs ? '?' + qs : ''), {target: '#activity-content', swap: 'innerHTML'});\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t});\n\t\t</script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -656,25 +664,25 @@ func ActivityContent(data ActivityPageData) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		if len(data.Changes) == 0 && data.Offset == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<div class=\"sw-card rounded-lg p-8 text-center\"><p class=\"text-sm text-gray-500 dark:text-gray-400 italic\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<div class=\"sw-card rounded-lg p-8 text-center\"><p class=\"text-sm text-gray-500 dark:text-gray-400 italic\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var33 string
 			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "activity.empty_state"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 245, Col: 94}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 250, Col: 94}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</p></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</p></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<div class=\"space-y-2\" id=\"activity-entries\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<div class=\"space-y-2\" id=\"activity-entries\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -684,7 +692,7 @@ func ActivityContent(data ActivityPageData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -694,25 +702,25 @@ func ActivityContent(data ActivityPageData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if data.Total > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<p id=\"activity-showing-counter\" class=\"text-xs text-gray-400 dark:text-gray-500 text-right mt-2\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<p id=\"activity-showing-counter\" class=\"text-xs text-gray-400 dark:text-gray-500 text-right mt-2\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var34 string
 				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "common.showing_of", min(data.Offset+len(data.Changes), data.Total), data.Total))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 258, Col: 94}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 263, Col: 94}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -746,46 +754,46 @@ func activityLoadMoreButton(data ActivityPageData) templ.Component {
 			templ_7745c5c3_Var35 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<div id=\"activity-load-more\" class=\"flex justify-center mt-4\"><button type=\"button\" aria-label=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<div id=\"activity-load-more\" class=\"flex justify-center mt-4\"><button type=\"button\" aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var36 string
 		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "activity.load_more_aria"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 271, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 276, Col: 49}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\" class=\"px-4 py-2 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors\" hx-get=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\" class=\"px-4 py-2 text-sm rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors\" hx-get=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var37 string
 		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(activityLoadMoreURL(data))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 273, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 278, Col: 37}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\" hx-target=\"#activity-load-more\" hx-swap=\"outerHTML\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "\" hx-target=\"#activity-load-more\" hx-swap=\"outerHTML\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var38 string
 		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.load_more"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 277, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 282, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</button></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "</button></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -824,12 +832,12 @@ func ActivityMoreRows(data ActivityPageData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "<div id=\"activity-load-more\"></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<div id=\"activity-load-more\"></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<div id=\"activity-entries\" hx-swap-oob=\"beforeend\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "<div id=\"activity-entries\" hx-swap-oob=\"beforeend\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -839,25 +847,25 @@ func ActivityMoreRows(data ActivityPageData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if data.Total > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<p id=\"activity-showing-counter\" hx-swap-oob=\"true\" class=\"text-xs text-gray-400 dark:text-gray-500 text-right mt-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "<p id=\"activity-showing-counter\" hx-swap-oob=\"true\" class=\"text-xs text-gray-400 dark:text-gray-500 text-right mt-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var40 string
 			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "common.showing_of", min(data.Offset+len(data.Changes), data.Total), data.Total))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 299, Col: 93}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 304, Col: 93}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -922,20 +930,20 @@ func ActivityRevertFragment(revertedID string, newChange artist.MetadataChangeWi
 			templ_7745c5c3_Var42 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "<div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "<div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var43 string
 		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs("activity-revert-placeholder-" + revertedID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 320, Col: 54}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 325, Col: 54}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "\" class=\"hidden\"></div><div id=\"activity-entries\" hx-swap-oob=\"afterbegin\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "\" class=\"hidden\"></div><div id=\"activity-entries\" hx-swap-oob=\"afterbegin\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -943,25 +951,25 @@ func ActivityRevertFragment(revertedID string, newChange artist.MetadataChangeWi
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if total > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<p id=\"activity-showing-counter\" hx-swap-oob=\"true\" class=\"text-xs text-gray-400 dark:text-gray-500 text-right mt-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "<p id=\"activity-showing-counter\" hx-swap-oob=\"true\" class=\"text-xs text-gray-400 dark:text-gray-500 text-right mt-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var44 string
 			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "common.showing_of", showing, total))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 327, Col: 49}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 332, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -992,46 +1000,46 @@ func activityRow(c artist.MetadataChangeWithArtist, basePath string) templ.Compo
 			templ_7745c5c3_Var45 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "<div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "<div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var46 string
 		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs("activity-change-" + c.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 334, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 339, Col: 36}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "\" class=\"sw-card rounded-lg p-4\"><div class=\"flex items-center justify-between\"><div class=\"flex items-center gap-3\"><a href=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\" class=\"sw-card rounded-lg p-4\"><div class=\"flex items-center justify-between\"><div class=\"flex items-center gap-3\"><a href=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var47 templ.SafeURL
 		templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath + "/artists/" + c.ArtistID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 338, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 343, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\" class=\"font-medium text-sm text-blue-600 dark:text-blue-400 hover:underline\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "\" class=\"font-medium text-sm text-blue-600 dark:text-blue-400 hover:underline\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var48 string
 		templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(c.ArtistName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 341, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 346, Col: 19}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "</a> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</a> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1040,7 +1048,7 @@ func activityRow(c artist.MetadataChangeWithArtist, basePath string) templ.Compo
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "<span class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "<span class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1053,305 +1061,305 @@ func activityRow(c artist.MetadataChangeWithArtist, basePath string) templ.Compo
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var51 string
 		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(historySourceLabel(ctx, c.Source))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 344, Col: 40}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 349, Col: 40}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "</span> <time datetime=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "</span> <time datetime=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var52 string
 		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(c.CreatedAt.Format(time.RFC3339))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 347, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 352, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "\" title=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "\" title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var53 string
 		templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(c.CreatedAt.Format("2006-01-02 15:04:05 UTC"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 348, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 353, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "\" class=\"text-xs text-gray-500 dark:text-gray-400\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "\" class=\"text-xs text-gray-500 dark:text-gray-400\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var54 string
 		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(historyTimeAgo(ctx, c.CreatedAt))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 351, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 356, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "</time></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "</time></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if artist.IsTrackableField(c.Field) && c.Source != "revert" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "<button type=\"button\" hx-post=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "<button type=\"button\" hx-post=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var55 string
 			templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs("/api/v1/history/" + c.ID + "/revert")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 357, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 362, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "\" hx-target=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "\" hx-target=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var56 string
 			templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs("#activity-change-" + c.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 358, Col: 43}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 363, Col: 43}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "\" hx-swap=\"outerHTML\" hx-disabled-elt=\"this\" hx-confirm=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "\" hx-swap=\"outerHTML\" hx-disabled-elt=\"this\" hx-confirm=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var57 string
 			templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "history.undo_confirm", historyFieldLabel(ctx, c.Field)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 361, Col: 82}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 366, Col: 82}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "\" hx-vals=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "\" hx-vals=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var58 string
 			templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(`js:{"showing": document.querySelectorAll("#activity-entries > [id^='activity-change-']").length}`)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 362, Col: 113}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 367, Col: 113}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "\" class=\"text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "\" class=\"text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var59 string
 			templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "history.undo_title"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 364, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 369, Col: 41}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var60 string
 			templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "history.undo"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 366, Col: 29}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 371, Col: 29}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</button>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "</button>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "</div><details class=\"mt-2\"><summary class=\"text-sm cursor-pointer text-gray-700 dark:text-gray-300\"><span class=\"font-medium\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</div><details class=\"mt-2\"><summary class=\"text-sm cursor-pointer text-gray-700 dark:text-gray-300\"><span class=\"font-medium\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var61 string
 		templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(historyFieldLabel(ctx, c.Field))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 372, Col: 63}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 377, Col: 63}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</span> <span class=\"mx-1 text-gray-400\">--</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "</span> <span class=\"mx-1 text-gray-400\">--</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if c.OldValue == "" && c.NewValue != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<span class=\"text-green-600 dark:text-green-400\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "<span class=\"text-green-600 dark:text-green-400\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var62 string
 			templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "history.set_to", historyTruncate(c.NewValue, 80)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 375, Col: 114}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 380, Col: 114}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else if c.OldValue != "" && c.NewValue == "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "<span class=\"text-red-500 dark:text-red-400\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "<span class=\"text-red-500 dark:text-red-400\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var63 string
 			templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "history.cleared"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 377, Col: 77}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 382, Col: 77}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else if c.OldValue != "" && c.NewValue != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "<span class=\"text-gray-500 dark:text-gray-400\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "<span class=\"text-gray-500 dark:text-gray-400\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var64 string
 			templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "history.changed"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 379, Col: 79}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 384, Col: 79}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "<span class=\"text-gray-400 italic\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "<span class=\"text-gray-400 italic\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var65 string
 			templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "history.no_value"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 381, Col: 68}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 386, Col: 68}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "</summary><div class=\"mt-2 pl-4 border-l-2 border-gray-200 dark:border-gray-700 space-y-1 text-sm\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "</summary><div class=\"mt-2 pl-4 border-l-2 border-gray-200 dark:border-gray-700 space-y-1 text-sm\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if c.OldValue != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "<div><span class=\"text-xs font-medium text-gray-500 dark:text-gray-400 uppercase\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "<div><span class=\"text-xs font-medium text-gray-500 dark:text-gray-400 uppercase\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var66 string
 			templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "history.previous"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 387, Col: 111}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 392, Col: 111}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "</span><p class=\"text-red-500 dark:text-red-400 line-through break-words whitespace-pre-wrap\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "</span><p class=\"text-red-500 dark:text-red-400 line-through break-words whitespace-pre-wrap\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var67 string
 			templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(c.OldValue)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 388, Col: 105}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 393, Col: 105}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "</p></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "</p></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if c.NewValue != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "<div><span class=\"text-xs font-medium text-gray-500 dark:text-gray-400 uppercase\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "<div><span class=\"text-xs font-medium text-gray-500 dark:text-gray-400 uppercase\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var68 string
 			templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "history.current"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 393, Col: 110}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 398, Col: 110}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "</span><p class=\"text-green-600 dark:text-green-400 break-words whitespace-pre-wrap\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "</span><p class=\"text-green-600 dark:text-green-400 break-words whitespace-pre-wrap\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var69 string
 			templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(c.NewValue)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 394, Col: 96}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/activity.templ`, Line: 399, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "</p></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "</p></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "</div></details></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "</div></details></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/templates/activity_test.go
+++ b/web/templates/activity_test.go
@@ -1,0 +1,109 @@
+package templates
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+)
+
+// TestActivityRow_RuleFixSourceHidesRevert pins the contract that rule
+// auto-fix entries (field "rule_fix", source "rule:<rule_id>") render in the
+// activity feed without a Revert button. The feed shows Revert only for
+// trackable fields, and rule auto-fixes mutate disk state (NFO files, image
+// files, directory renames) that cannot be safely undone via the field-revert
+// path. A future addition of "rule_fix" to trackableFields would silently
+// introduce a broken Revert affordance, and this test guards against that
+// regression. Issue #1106.
+func TestActivityRow_RuleFixSourceHidesRevert(t *testing.T) {
+	c := artist.MetadataChangeWithArtist{
+		MetadataChange: artist.MetadataChange{
+			ID:        "rule-fix-1",
+			ArtistID:  "a-1",
+			Field:     "rule_fix",
+			OldValue:  "",
+			NewValue:  "created artist.nfo for Test Artist",
+			Source:    "rule:nfo_exists",
+			CreatedAt: time.Now().UTC(),
+		},
+		ArtistName: "Test Artist",
+	}
+
+	var buf bytes.Buffer
+	if err := ActivityChangeRowFragment(c, "").Render(testCtx(t), &buf); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := buf.String()
+
+	// The fragment must mark the row with the activity-change- id prefix so
+	// the feed's load-more / counter logic finds it.
+	if !strings.Contains(body, `id="activity-change-rule-fix-1"`) {
+		t.Errorf("rendered row missing activity-change-<id> wrapper; body:\n%s", body)
+	}
+
+	// The source label must surface the rule ID so users can tell which
+	// rule produced the entry. The historySourceLabel helper formats
+	// "rule:<id>" as "Rule: <id>".
+	if !strings.Contains(body, "Rule: nfo_exists") {
+		t.Errorf("rendered row missing rule source label; body:\n%s", body)
+	}
+
+	// Critical: the Revert button must NOT render for rule_fix entries. The
+	// button is the htmx POST against /api/v1/history/<id>/revert; if the
+	// trackableFields gate ever leaks rule_fix, this assertion catches it.
+	if strings.Contains(body, "/api/v1/history/rule-fix-1/revert") {
+		t.Errorf("rule_fix activity row rendered a Revert button; rule auto-fixes mutate disk state and cannot be reverted via the field-revert path. Body:\n%s", body)
+	}
+
+	// The fixer's human-readable message must surface in the row body so
+	// the user sees what changed without expanding the details panel.
+	if !strings.Contains(body, "created artist.nfo for Test Artist") {
+		t.Errorf("rendered row missing fixer message in NewValue display; body:\n%s", body)
+	}
+}
+
+// TestActivityPage_RenderRuleFixFilterChip verifies that the activity page
+// surfaces a "Rule auto-fix" filter chip in the change-type filter section
+// so users can scope the feed to engine-driven repairs. Issue #1106.
+func TestActivityPage_RenderRuleFixFilterChip(t *testing.T) {
+	data := ActivityPageData{
+		Limit:    50,
+		BasePath: "",
+	}
+	var buf bytes.Buffer
+	if err := ActivityPage(AssetPaths{}, data).Render(testCtx(t), &buf); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := buf.String()
+
+	// FilterItem renders an option with value="rule_fix" inside the
+	// activity-filters-flyout filter group so users can include/exclude
+	// rule auto-fix entries from the feed view.
+	if !strings.Contains(body, `value="rule_fix"`) {
+		t.Errorf("activity page missing rule_fix filter chip; body excerpt:\n%s", excerpt(body, "rule_fix", 200))
+	}
+	if !strings.Contains(body, "Rule auto-fix") {
+		t.Errorf("activity page missing Rule auto-fix filter label; the i18n key field.rule_fix is expected. Body excerpt:\n%s", excerpt(body, "rule_fix", 200))
+	}
+}
+
+// excerpt returns up to ctx characters around the first occurrence of needle
+// in body, or the full body if needle is missing. Used to keep failure logs
+// readable when a large rendered template is involved.
+func excerpt(body, needle string, ctx int) string {
+	idx := strings.Index(body, needle)
+	if idx < 0 {
+		return body
+	}
+	start := idx - ctx
+	if start < 0 {
+		start = 0
+	}
+	end := idx + len(needle) + ctx
+	if end > len(body) {
+		end = len(body)
+	}
+	return body[start:end]
+}


### PR DESCRIPTION
## Summary

- When the rule engine auto-fixes a violation, emit a Recent Activity entry so users see what the engine did on their behalf. Closes #1106.
- Uses a synthetic `rule_fix` field with canonical `rule:<rule_id>` source so the existing activity feed surfaces the entry with the "Rule: <id>" label.
- History service is wired in via `Pipeline.SetHistoryService` to keep the constructor signature stable for the wide set of test call sites; nil short-circuits cleanly.
- Revert is intentionally NOT rendered for `rule_fix` entries: filesystem mutations cannot be safely undone via the field-revert path. The dedicated FixViolation undo flow handles single-violation reverts where supported. Pinned by `IsTrackableField("rule_fix") == false` test.

## Test plan

- [x] `bash scripts/pre-push-gate.sh` passes (full -race suite, OpenAPI, generated, raw error leak, patch coverage 100%).
- [x] New fixer tests pass under -race: success, failure no-record, no-service no-record, manual mode no-record, RunAll, RunRule.
- [x] Templ test pins `rule_fix` row hides Revert and filter chip renders.
- [ ] Optional manual: trigger an auto-fix rule, verify entry shows on `/activity` with the rule id label.

Closes #1106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rule auto-fix executions now automatically appear in the Recent Activity feed for visibility and tracking.
  * Added "Rule auto-fix" field filter option in the activity filters flyout for easy discovery and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->