### PR TITLE
test(smoke): add --writeback-audit FS audit + per-worktree run-paths

### DIFF
--- a/scripts/dev-restart.sh
+++ b/scripts/dev-restart.sh
@@ -6,6 +6,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+# Per-worktree run-artifact directory. The dev log defaults to
+# $SW_RUN_DIR/dev.log unless SW_DEV_LOG is set, so each worktree's dev
+# server writes to its own log path without collision.
+. "$(dirname "$0")/lib/run-paths.sh"
+
 echo "==> Building..."
 make build
 
@@ -35,7 +40,7 @@ else
 fi
 
 echo "==> Launching Stillwater..."
-LOG_FILE="${SW_DEV_LOG:-/tmp/stillwater.log}"
+LOG_FILE="${SW_DEV_LOG:-$SW_RUN_DIR/dev.log}"
 mkdir -p "$(dirname "$LOG_FILE")"
 ./stillwater >"$LOG_FILE" 2>&1 &
 SWPID=$!

--- a/scripts/lib/run-paths.sh
+++ b/scripts/lib/run-paths.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/lib/run-paths.sh
+#
+# Deterministic, per-worktree run-artifact paths. Sourced by pre-push-gate.sh,
+# smoke.sh, and dev-restart.sh so every script writes coverage profiles, log
+# files, and similar transient artifacts under a single predictable directory.
+#
+# Why not /tmp:
+#   - A stray `rm -f /tmp/stillwater-*` from any agent improvisation can wipe
+#     a sibling worktree's in-flight artifacts. Cache-dir paths (defaulting to
+#     ~/.cache/stillwater-run/<worktree>) are out of that blast radius.
+#   - macOS rotates /tmp aggressively; ~/.cache survives reboots.
+#
+# Why deterministic (no mktemp XXXXXX):
+#   - Same worktree always writes the same path -- trivial to inspect, diff
+#     across runs, and clean up (`rm -rf $SW_RUN_DIR`).
+#   - Same-worktree concurrent runs WOULD clobber each other, but
+#     `feedback_no_parallel_heavy_gates` already bans that; the scope of
+#     "multi-agent safe" we want is ACROSS worktrees, which this delivers.
+#
+# Why source instead of inline:
+#   - Single place to evolve the convention. Future scripts get the same
+#     behaviour by sourcing this file; reviewers grep one location to find
+#     every script that participates.
+#
+# Exports:
+#   SW_RUN_ROOT  -- ${XDG_CACHE_HOME:-$HOME/.cache}/stillwater-run
+#   SW_RUN_DIR   -- $SW_RUN_ROOT/<worktree-basename>, mkdir -p applied
+#
+# Worktree basename:
+#   - Uses `git rev-parse --show-toplevel` so a script invoked from a
+#     subdirectory still writes to the worktree-root-keyed path.
+#   - Falls back to $PWD when not inside a git repo (e.g. one-off invocations
+#     against a checkout of the scripts directory). The fallback is not a
+#     failure mode -- the scripts are expected to run from a worktree.
+
+# Resolve the worktree root. `git rev-parse` is preferred so cd'ing into a
+# subdirectory still yields the worktree root, but fall back to $PWD for the
+# rare case where this is sourced outside a git checkout.
+sw_worktree_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+sw_worktree_basename="$(basename "$sw_worktree_root")"
+
+# Guard against an empty basename. `basename /` returns "/" which would make
+# the run dir `$SW_RUN_ROOT//` and silently merge artifacts from any "root"
+# invocation into the same bucket. Surface the misconfiguration loudly.
+if [ -z "$sw_worktree_basename" ] || [ "$sw_worktree_basename" = "/" ]; then
+  echo "scripts/lib/run-paths.sh: cannot derive worktree basename from '$sw_worktree_root'" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+SW_RUN_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/stillwater-run"
+SW_RUN_DIR="$SW_RUN_ROOT/$sw_worktree_basename"
+mkdir -p "$SW_RUN_DIR"
+
+unset sw_worktree_root sw_worktree_basename
+
+export SW_RUN_ROOT SW_RUN_DIR

--- a/scripts/lib/run-paths.sh
+++ b/scripts/lib/run-paths.sh
@@ -48,10 +48,16 @@ if [ -z "$sw_worktree_basename" ] || [ "$sw_worktree_basename" = "/" ]; then
   return 1 2>/dev/null || exit 1
 fi
 
+# Append a short hash of the absolute worktree path so two checkouts that
+# happen to share a basename (e.g. `stillwater` checked out in two parent
+# directories) do not collide on the same SW_RUN_DIR. The hash keeps the
+# basename for human readability while making the path component unique.
+sw_worktree_id="$(printf '%s' "$sw_worktree_root" | shasum -a 256 | awk '{print substr($1,1,12)}')"
+
 SW_RUN_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/stillwater-run"
-SW_RUN_DIR="$SW_RUN_ROOT/$sw_worktree_basename"
+SW_RUN_DIR="$SW_RUN_ROOT/${sw_worktree_basename}-${sw_worktree_id}"
 mkdir -p "$SW_RUN_DIR"
 
-unset sw_worktree_root sw_worktree_basename
+unset sw_worktree_root sw_worktree_basename sw_worktree_id
 
 export SW_RUN_ROOT SW_RUN_DIR

--- a/scripts/lib/run-paths.sh
+++ b/scripts/lib/run-paths.sh
@@ -57,6 +57,11 @@ sw_worktree_id="$(printf '%s' "$sw_worktree_root" | shasum -a 256 | awk '{print 
 SW_RUN_ROOT="${XDG_CACHE_HOME:-$HOME/.cache}/stillwater-run"
 SW_RUN_DIR="$SW_RUN_ROOT/${sw_worktree_basename}-${sw_worktree_id}"
 mkdir -p "$SW_RUN_DIR"
+# Lock the dir to 0700 before any caller writes secrets (cookie jars from
+# smoke.sh, coverage profiles, future log dumps). mkdir -p inherits the
+# caller's umask, typically 0755, which would leave these artifacts
+# readable by other local users on permissive home directories.
+chmod 700 "$SW_RUN_DIR"
 
 unset sw_worktree_root sw_worktree_basename sw_worktree_id
 

--- a/scripts/lib/run-paths.sh
+++ b/scripts/lib/run-paths.sh
@@ -25,7 +25,10 @@
 #
 # Exports:
 #   SW_RUN_ROOT  -- ${XDG_CACHE_HOME:-$HOME/.cache}/stillwater-run
-#   SW_RUN_DIR   -- $SW_RUN_ROOT/<worktree-basename>, mkdir -p applied
+#   SW_RUN_DIR   -- $SW_RUN_ROOT/<worktree-basename>-<id>, mkdir -p applied
+#                   and chmod 700 applied. <id> is a 12-char sha256 prefix
+#                   of the absolute worktree path so checkouts that share
+#                   a basename do not collide on the same artifact dir.
 #
 # Worktree basename:
 #   - Uses `git rev-parse --show-toplevel` so a script invoked from a

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -6,10 +6,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BASE=$(git merge-base main HEAD 2>/dev/null || echo "HEAD~1")
 
-WORKTREE_BASENAME=$(basename "$(git rev-parse --show-toplevel)")
-GATE_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/stillwater-gate/${WORKTREE_BASENAME}"
-mkdir -p "$GATE_CACHE"
-COVER_OUT=$(mktemp "$GATE_CACHE/cover.XXXXXX.out")
+# Source the per-worktree run-path helper. Provides $SW_RUN_DIR keyed by the
+# worktree basename so concurrent gate runs in different worktrees write to
+# disjoint paths and can never clobber each other's coverage profiles. See
+# scripts/lib/run-paths.sh for the full rationale.
+. "$SCRIPT_DIR/lib/run-paths.sh"
+
+COVER_OUT="$SW_RUN_DIR/cover.out"
 tmp_openapi=""
 cleanup() {
   rm -f "${COVER_OUT:-}" "${tmp_openapi:-}"
@@ -45,7 +48,7 @@ echo "OK"
 echo ""
 echo "=== OpenAPI breaking changes ==="
 if command -v oasdiff &>/dev/null; then
-  tmp_openapi=$(mktemp "$GATE_CACHE/openapi-base.XXXXXX.yaml")
+  tmp_openapi="$SW_RUN_DIR/openapi-base.yaml"
   if git show main:internal/api/openapi.yaml > "$tmp_openapi" 2>/dev/null; then
     breaking=$(oasdiff breaking "$tmp_openapi" internal/api/openapi.yaml 2>&1 || true)
     if [ -n "$breaking" ]; then

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1690,9 +1690,21 @@ if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
         audit_skip=1
       fi
 
+      # Strict response validation: a 200 with a missing or non-array .saved
+      # is a contract break, not "no expected files". Collapsing it into an
+      # empty set would let a broken handler PASS audit because there'd be
+      # no expectation to fail against. jq -e exits non-zero when the path
+      # selector matches nothing, which is exactly the signal we want.
       if [[ "${audit_skip:-0}" -ne 1 ]]; then
+        if ! audit_saved_thumb=$(echo "$audit_fetch_body" | jq -er '.saved | arrays | .[]' 2>/dev/null); then
+          FAIL=$((FAIL + 1))
+          FAILURES+=("Writeback audit -- fetch response missing valid .saved array")
+          echo "[FAIL] Writeback audit -- fetch response missing valid .saved array"
+          audit_skip=1
+        fi
+      fi
 
-      audit_saved_thumb=$(echo "$audit_fetch_body" | jq -r '.saved[]? // empty' 2>/dev/null || true)
+      if [[ "${audit_skip:-0}" -ne 1 ]]; then
 
       # Settle window: peer write-back observed in #1180 arrived within
       # 550ms; the configurable default of 5s is a generous ceiling.
@@ -1718,13 +1730,17 @@ if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
       printf '%s\n' "$post_snapshot" | awk -F'\t' 'NF==2{print $2}' | sort -u > "$post_files_file"
 
       # actual_added = post \ pre. unexpected_added = actual_added \ expected_added.
-      # missing_expected = expected_added \ actual_added: files the API said
-      # it saved but that are not actually on disk after the settle window.
-      # This is the symmetric guarantee that "actual equals expected exactly".
+      # missing_expected = expected_added \ post: files the API said it
+      # saved but that are not present on disk after the settle window.
+      # We diff against the FULL post-snapshot (not actual_added) because
+      # a fetch may legitimately rewrite an existing file -- e.g. Tier 4
+      # already wrote thumb.jpg, the audit re-fetches the same URL, and
+      # the file's basename is in .saved while actual_added is empty.
+      # Treating that as missing would false-FAIL the audit.
       actual_added=$(comm -23 "$post_files_file" "$pre_files_file")
       printf '%s\n' "$actual_added" | sed '/^$/d' | sort -u > "$post_files_file.actual"
       unexpected_added=$(comm -23 "$post_files_file.actual" "$expected_added_file")
-      missing_expected=$(comm -23 "$expected_added_file" "$post_files_file.actual")
+      missing_expected=$(comm -23 "$expected_added_file" "$post_files_file")
 
       # Silent overwrite check: any file present in BOTH pre and post whose
       # sha256 changed and which is not in the expected_added set has been

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -348,15 +348,24 @@ get_mtime() {
 # files in this set, so widening the pattern would only add false positives.
 AUDIT_IMAGE_PATTERN='^(backdrop|fanart|poster|logo|banner|thumb|clearart|disc|landscape)[0-9]*\.(jpg|jpeg|png)$'
 
-# audit_dir_snapshot DIR -> stdout: lines of "<sha256>\t<filename>" for every
-# image-pattern file in DIR. Returns 0 even when DIR is empty so the caller
-# can diff snapshots without special-casing first-run.
+# audit_dir_snapshot DIR -> stdout: lines of "<mtime>\t<size>\t<sha256>\t<filename>"
+# for every image-pattern file in DIR. The four fields match the evidence
+# objective in #1183: mtime + size + sha256 are the inputs needed to detect
+# silent rewrites (sha changes) AND mismatched-mtime spoofing (peer write
+# back leaves a fresh mtime on a copied file). Returns 0 even when DIR is
+# empty so the caller can diff snapshots without special-casing first-run.
 audit_dir_snapshot() {
   local dir="$1"
   if [[ ! -d "$dir" ]]; then
     return 0
   fi
-  local f base hash
+  # Portable stat: BSD/macOS uses -f, GNU uses -c.
+  local stat_mtime_fmt='-f %m' stat_size_fmt='-f %z'
+  if stat --version &>/dev/null; then
+    stat_mtime_fmt='-c %Y'
+    stat_size_fmt='-c %s'
+  fi
+  local f base hash mtime size
   for f in "$dir"/*; do
     [[ -f "$f" ]] || continue
     base=$(basename "$f")
@@ -365,7 +374,12 @@ audit_dir_snapshot() {
     fi
     hash=$(shasum -a 256 "$f" 2>/dev/null | awk '{print $1}')
     [[ -n "$hash" ]] || continue
-    printf '%s\t%s\n' "$hash" "$base"
+    # shellcheck disable=SC2086
+    mtime=$(stat $stat_mtime_fmt "$f" 2>/dev/null)
+    # shellcheck disable=SC2086
+    size=$(stat $stat_size_fmt "$f" 2>/dev/null)
+    [[ -n "$mtime" && -n "$size" ]] || continue
+    printf '%s\t%s\t%s\t%s\n' "$mtime" "$size" "$hash" "$base"
   done
 }
 
@@ -1667,14 +1681,22 @@ if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
     else
       echo "  Audit path: $audit_path"
       settle="${SW_WRITEBACK_SETTLE:-5}"
+      # Validate the tunable before sleep consumes it. Non-numeric input
+      # (typo, accidental shell expansion) would otherwise crash the script
+      # under set -e and turn a bad env var into a hard stop.
+      if ! [[ "$settle" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+        echo "[WARN] SW_WRITEBACK_SETTLE='$settle' is not numeric; falling back to default 5"
+        settle=5
+      fi
 
       pre_snapshot=$(audit_dir_snapshot "$audit_path")
 
-      # Fetch a single thumb. Same URL the Tier 4 fetch already exercises so
-      # the audit produces a deterministic write set even on first run.
-      # Capture the HTTP code: a curl/server failure must SKIP the audit,
-      # not fall through with an empty expected set (which would otherwise
-      # let any post-fetch state PASS as "no unexpected files" -- the
+      # Trigger deterministic writes on BOTH the single-image fetch path
+      # and the multi-URL fanart batch path. #1180's write-back duplication
+      # was observed on fanart, so a thumb-only audit would miss the actual
+      # regression class. Capture HTTP codes so transport failures SKIP
+      # cleanly rather than collapsing into an empty expected set (which
+      # would let any post-fetch state PASS as "no unexpected files" -- the
       # opposite of what an audit must guarantee).
       audit_fetch_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
         -X POST "$SW_BASE/api/v1/artists/$ARTIST_ID/images/fetch" \
@@ -1683,10 +1705,26 @@ if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
       audit_fetch_body=$(echo "$audit_fetch_resp" | sed '$d')
       audit_fetch_code=$(echo "$audit_fetch_resp" | tail -n 1)
 
+      audit_batch_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
+        -X POST "$SW_BASE/api/v1/artists/$ARTIST_ID/images/fanart/fetch-batch" \
+        -H "Content-Type: application/json" \
+        -d '{"urls":[
+          "https://upload.wikimedia.org/wikipedia/en/a/aa/A-ha_band_2015.jpg",
+          "https://upload.wikimedia.org/wikipedia/commons/c/c1/A-ha_in_2010.jpg",
+          "https://upload.wikimedia.org/wikipedia/commons/8/89/A-ha_in_Sopot_2018.jpg",
+          "https://upload.wikimedia.org/wikipedia/en/3/30/A-ha_-_Hunting_High_and_Low.png"
+        ]}') || audit_batch_resp=$'\n000'
+      audit_batch_body=$(echo "$audit_batch_resp" | sed '$d')
+      audit_batch_code=$(echo "$audit_batch_resp" | tail -n 1)
+
       if [[ "$audit_fetch_code" != "200" ]]; then
-        echo "[SKIP] Writeback audit -- fetch failed (HTTP $audit_fetch_code)"
+        echo "[SKIP] Writeback audit -- thumb fetch failed (HTTP $audit_fetch_code)"
         echo ""
         # Skip the rest of the audit body without exiting the script.
+        audit_skip=1
+      elif [[ "$audit_batch_code" != "200" ]]; then
+        echo "[SKIP] Writeback audit -- fanart batch fetch failed (HTTP $audit_batch_code)"
+        echo ""
         audit_skip=1
       fi
 
@@ -1698,8 +1736,16 @@ if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
       if [[ "${audit_skip:-0}" -ne 1 ]]; then
         if ! audit_saved_thumb=$(echo "$audit_fetch_body" | jq -er '.saved | arrays | .[]' 2>/dev/null); then
           FAIL=$((FAIL + 1))
-          FAILURES+=("Writeback audit -- fetch response missing valid .saved array")
-          echo "[FAIL] Writeback audit -- fetch response missing valid .saved array"
+          FAILURES+=("Writeback audit -- thumb fetch response missing valid .saved array")
+          echo "[FAIL] Writeback audit -- thumb fetch response missing valid .saved array"
+          audit_skip=1
+        fi
+      fi
+      if [[ "${audit_skip:-0}" -ne 1 ]]; then
+        if ! audit_saved_batch=$(echo "$audit_batch_body" | jq -er '.saved | arrays | .[]' 2>/dev/null); then
+          FAIL=$((FAIL + 1))
+          FAILURES+=("Writeback audit -- fanart batch fetch response missing valid .saved array")
+          echo "[FAIL] Writeback audit -- fanart batch fetch response missing valid .saved array"
           audit_skip=1
         fi
       fi
@@ -1712,22 +1758,23 @@ if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
 
       post_snapshot=$(audit_dir_snapshot "$audit_path")
 
-      # Build the expected-added set from the API responses. Filenames only;
-      # snapshot lines are "<sha256>\t<filename>" so cut on \t. Normalize
-      # any path-shaped .saved entries (current handlers return basenames,
-      # but the OpenAPI contract is loose -- "Filenames of images saved" --
-      # and a future change to dest paths must not turn every legitimate
-      # save into an unexpected_added entry).
+      # Build the expected-added set from the union of both fetch responses.
+      # Snapshot lines are "<mtime>\t<size>\t<sha256>\t<filename>" so the
+      # filename column is field 4 (see the awk parses below). Normalize any
+      # path-shaped .saved entries (current handlers return basenames, but
+      # the OpenAPI contract is loose - "Filenames of images saved" - and a
+      # future change to dest paths must not turn every legitimate save
+      # into an unexpected_added entry).
       expected_added_file=$(mktemp "$SW_RUN_DIR/audit-expected.XXXXXX")
       pre_files_file=$(mktemp "$SW_RUN_DIR/audit-pre.XXXXXX")
       post_files_file=$(mktemp "$SW_RUN_DIR/audit-post.XXXXXX")
 
-      printf '%s\n' "$audit_saved_thumb" \
+      { printf '%s\n' "$audit_saved_thumb"; printf '%s\n' "$audit_saved_batch"; } \
         | sed '/^$/d' \
         | awk -F/ '{print $NF}' \
         | sort -u > "$expected_added_file"
-      printf '%s\n' "$pre_snapshot"  | awk -F'\t' 'NF==2{print $2}' | sort -u > "$pre_files_file"
-      printf '%s\n' "$post_snapshot" | awk -F'\t' 'NF==2{print $2}' | sort -u > "$post_files_file"
+      printf '%s\n' "$pre_snapshot"  | awk -F'\t' 'NF==4{print $4}' | sort -u > "$pre_files_file"
+      printf '%s\n' "$post_snapshot" | awk -F'\t' 'NF==4{print $4}' | sort -u > "$post_files_file"
 
       # actual_added = post \ pre. unexpected_added = actual_added \ expected_added.
       # missing_expected = expected_added \ post: files the API said it
@@ -1748,9 +1795,9 @@ if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
       # server overwrites a Stillwater-placed file in addition to the
       # additive duplication case the directory-delta catches.
       silent_rewrites=""
-      while IFS=$'\t' read -r post_hash post_name; do
+      while IFS=$'\t' read -r _post_mtime _post_size post_hash post_name; do
         [[ -z "$post_name" ]] && continue
-        pre_hash=$(printf '%s\n' "$pre_snapshot" | awk -F'\t' -v n="$post_name" '$2==n{print $1; exit}')
+        pre_hash=$(printf '%s\n' "$pre_snapshot" | awk -F'\t' -v n="$post_name" '$4==n{print $3; exit}')
         if [[ -n "$pre_hash" && "$pre_hash" != "$post_hash" ]]; then
           if ! grep -Fxq "$post_name" "$expected_added_file"; then
             silent_rewrites+="$post_name"$'\n'
@@ -1766,14 +1813,14 @@ if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
         echo "[FAIL] $audit_label -- unexpected files appeared:"
         while IFS= read -r u; do
           [[ -z "$u" ]] && continue
-          u_hash=$(printf '%s\n' "$post_snapshot" | awk -F'\t' -v n="$u" '$2==n{print $1; exit}')
+          u_hash=$(printf '%s\n' "$post_snapshot" | awk -F'\t' -v n="$u" '$4==n{print $3; exit}')
           # Cross-reference: is this file byte-identical to anything we asked
           # for? That match is the #1180 fingerprint -- the peer wrote a
           # rename of our file, not a different image.
           dup_of=""
           while IFS= read -r exp; do
             [[ -z "$exp" ]] && continue
-            exp_hash=$(printf '%s\n' "$post_snapshot" | awk -F'\t' -v n="$exp" '$2==n{print $1; exit}')
+            exp_hash=$(printf '%s\n' "$post_snapshot" | awk -F'\t' -v n="$exp" '$4==n{print $3; exit}')
             if [[ -n "$exp_hash" && "$exp_hash" == "$u_hash" ]]; then
               dup_of="$exp"
               break

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -374,13 +374,15 @@ audit_dir_snapshot() {
 # WriteProvenance, exit 1 otherwise. Used to classify unexpected files:
 # present means Stillwater wrote it (internal bug -- renumbering, race);
 # absent means a peer server wrote it (peer write-back, the #1180 signature).
-# Pure bash plus xxd so the audit has no Go-helper or exiftool dependency.
+# Uses raw-byte grep (LC_ALL=C grep -aFq) rather than xxd|grep because xxd
+# wraps output every 16 bytes; a marker that straddles a wrap boundary would
+# be split across lines and missed.
 audit_has_sw_provenance() {
   local f="$1"
   if [[ ! -f "$f" ]]; then
     return 1
   fi
-  xxd "$f" 2>/dev/null | grep -q 'stillwater:v1'
+  LC_ALL=C grep -aFq 'stillwater:v1' "$f"
 }
 
 # Poll for an NFO file's mtime to change (indicates platform wrote it).
@@ -1670,12 +1672,27 @@ if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
 
       # Fetch a single thumb. Same URL the Tier 4 fetch already exercises so
       # the audit produces a deterministic write set even on first run.
-      audit_fetch_resp=$(curl -s "${AUTH[@]}" \
+      # Capture the HTTP code: a curl/server failure must SKIP the audit,
+      # not fall through with an empty expected set (which would otherwise
+      # let any post-fetch state PASS as "no unexpected files" -- the
+      # opposite of what an audit must guarantee).
+      audit_fetch_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
         -X POST "$SW_BASE/api/v1/artists/$ARTIST_ID/images/fetch" \
         -H "Content-Type: application/json" \
-        -d '{"url":"https://upload.wikimedia.org/wikipedia/en/a/aa/A-ha_band_2015.jpg","type":"thumb"}') || audit_fetch_resp=""
+        -d '{"url":"https://upload.wikimedia.org/wikipedia/en/a/aa/A-ha_band_2015.jpg","type":"thumb"}') || audit_fetch_resp=$'\n000'
+      audit_fetch_body=$(echo "$audit_fetch_resp" | sed '$d')
+      audit_fetch_code=$(echo "$audit_fetch_resp" | tail -n 1)
 
-      audit_saved_thumb=$(echo "$audit_fetch_resp" | jq -r '.saved[]? // empty' 2>/dev/null || true)
+      if [[ "$audit_fetch_code" != "200" ]]; then
+        echo "[SKIP] Writeback audit -- fetch failed (HTTP $audit_fetch_code)"
+        echo ""
+        # Skip the rest of the audit body without exiting the script.
+        audit_skip=1
+      fi
+
+      if [[ "${audit_skip:-0}" -ne 1 ]]; then
+
+      audit_saved_thumb=$(echo "$audit_fetch_body" | jq -r '.saved[]? // empty' 2>/dev/null || true)
 
       # Settle window: peer write-back observed in #1180 arrived within
       # 550ms; the configurable default of 5s is a generous ceiling.
@@ -1684,20 +1701,30 @@ if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
       post_snapshot=$(audit_dir_snapshot "$audit_path")
 
       # Build the expected-added set from the API responses. Filenames only;
-      # snapshot lines are "<sha256>\t<filename>" so cut on \t.
+      # snapshot lines are "<sha256>\t<filename>" so cut on \t. Normalize
+      # any path-shaped .saved entries (current handlers return basenames,
+      # but the OpenAPI contract is loose -- "Filenames of images saved" --
+      # and a future change to dest paths must not turn every legitimate
+      # save into an unexpected_added entry).
       expected_added_file=$(mktemp "$SW_RUN_DIR/audit-expected.XXXXXX")
       pre_files_file=$(mktemp "$SW_RUN_DIR/audit-pre.XXXXXX")
       post_files_file=$(mktemp "$SW_RUN_DIR/audit-post.XXXXXX")
 
-      # The endpoint emits one filename per line via jq above; just copy.
-      printf '%s\n' "$audit_saved_thumb" | sed '/^$/d' | sort -u > "$expected_added_file"
+      printf '%s\n' "$audit_saved_thumb" \
+        | sed '/^$/d' \
+        | awk -F/ '{print $NF}' \
+        | sort -u > "$expected_added_file"
       printf '%s\n' "$pre_snapshot"  | awk -F'\t' 'NF==2{print $2}' | sort -u > "$pre_files_file"
       printf '%s\n' "$post_snapshot" | awk -F'\t' 'NF==2{print $2}' | sort -u > "$post_files_file"
 
       # actual_added = post \ pre. unexpected_added = actual_added \ expected_added.
+      # missing_expected = expected_added \ actual_added: files the API said
+      # it saved but that are not actually on disk after the settle window.
+      # This is the symmetric guarantee that "actual equals expected exactly".
       actual_added=$(comm -23 "$post_files_file" "$pre_files_file")
       printf '%s\n' "$actual_added" | sed '/^$/d' | sort -u > "$post_files_file.actual"
       unexpected_added=$(comm -23 "$post_files_file.actual" "$expected_added_file")
+      missing_expected=$(comm -23 "$expected_added_file" "$post_files_file.actual")
 
       # Silent overwrite check: any file present in BOTH pre and post whose
       # sha256 changed and which is not in the expected_added set has been
@@ -1758,13 +1785,25 @@ if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
         done <<< "$silent_rewrites"
       fi
 
-      if [[ -z "$unexpected_added" && -z "$silent_rewrites" ]]; then
+      if [[ -n "$missing_expected" ]]; then
+        FAIL=$((FAIL + 1))
+        FAILURES+=("$audit_label -- API reported saved files that did not appear on disk")
+        echo "[FAIL] $audit_label -- expected files missing on disk:"
+        while IFS= read -r m; do
+          [[ -z "$m" ]] && continue
+          echo "         $m"
+        done <<< "$missing_expected"
+      fi
+
+      if [[ -z "$unexpected_added" && -z "$silent_rewrites" && -z "$missing_expected" ]]; then
         expected_count=$(grep -c . "$expected_added_file" 2>/dev/null || echo 0)
-        echo "[PASS] $audit_label -- $expected_count expected files, 0 unexpected, 0 silent rewrites"
+        echo "[PASS] $audit_label -- $expected_count expected files, 0 unexpected, 0 silent rewrites, 0 missing"
         PASS=$((PASS + 1))
       fi
 
       rm -f "$expected_added_file" "$pre_files_file" "$post_files_file" "$post_files_file.actual"
+
+      fi  # audit_skip guard
     fi
   fi
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -14,9 +14,21 @@
 #   JELLYFIN_URL   -- Jellyfin server URL (used by --roundtrip)
 #   JELLYFIN_API_KEY -- Jellyfin API key  (used by --roundtrip)
 #
-# --full        enables Tier 4 destructive/stateful checks (off by default)
-# --roundtrip   enables Tier 5 NFO roundtrip checks (off by default)
-# --music-path  music directory for roundtrip artist discovery (repeatable)
+# --full              enables Tier 4 destructive/stateful checks (off by default)
+# --roundtrip         enables Tier 5 NFO roundtrip checks (off by default)
+# --writeback-audit   enables Tier 6 post-fetch filesystem audit (off by default;
+#                     requires --full because the audit relies on Tier 4 fetches
+#                     to produce a write to inspect). Detects peer write-back
+#                     duplication (#1180) by snapshotting the artist directory
+#                     before and after an image fetch and asserting the delta
+#                     matches the API-reported saved set exactly.
+# --music-path        music directory for roundtrip artist discovery (repeatable)
+#
+# Environment for --writeback-audit:
+#   SW_WRITEBACK_SETTLE  -- seconds to wait between fetch and post-snapshot for
+#                           any peer write-back to land. Default 5. The #1180
+#                           Caro Emerald repro had write-back arrive within
+#                           550 ms; 5 s is a generous ceiling.
 #
 # Music path precedence (for roundtrip artist filtering):
 #   1. --music-path CLI arguments (highest)
@@ -25,17 +37,25 @@
 
 set -euo pipefail
 
+# Per-worktree run-artifact directory (cookie jar lives here). See
+# scripts/lib/run-paths.sh -- keeps concurrent smoke runs in different
+# worktrees from sharing a cookie file.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/lib/run-paths.sh"
+
 SW_USER="${SW_USER:-admin}"
 SW_PASS="${SW_PASS:-admin}"
 SW_BASE="${SW_BASE:-http://localhost:1973}"
 
 FULL=0
 ROUNDTRIP=0
+WRITEBACK_AUDIT=0
 MUSIC_PATHS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --full) FULL=1; shift ;;
     --roundtrip) ROUNDTRIP=1; shift ;;
+    --writeback-audit) WRITEBACK_AUDIT=1; shift ;;
     --music-path)
       if [[ -z "${2:-}" ]]; then
         echo "ERROR: --music-path requires a value"
@@ -50,7 +70,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     *)
       echo "ERROR: unknown argument: $1"
-      echo "Usage: bash scripts/smoke.sh [--full] [--roundtrip] [--music-path PATH ...]"
+      echo "Usage: bash scripts/smoke.sh [--full] [--roundtrip] [--writeback-audit] [--music-path PATH ...]"
       exit 1
       ;;
   esac
@@ -321,6 +341,48 @@ get_mtime() {
   echo "$mtime"
 }
 
+# Pattern allowlist for the writeback audit (Tier 6). Stillwater and known
+# media servers all write image files matching one of these stems; restricting
+# the snapshot keeps user-placed extras (album metadata, .DS_Store) from
+# polluting the delta. Peer write-back observed in #1180 only ever produced
+# files in this set, so widening the pattern would only add false positives.
+AUDIT_IMAGE_PATTERN='^(backdrop|fanart|poster|logo|banner|thumb|clearart|disc|landscape)[0-9]*\.(jpg|jpeg|png)$'
+
+# audit_dir_snapshot DIR -> stdout: lines of "<sha256>\t<filename>" for every
+# image-pattern file in DIR. Returns 0 even when DIR is empty so the caller
+# can diff snapshots without special-casing first-run.
+audit_dir_snapshot() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    return 0
+  fi
+  local f base hash
+  for f in "$dir"/*; do
+    [[ -f "$f" ]] || continue
+    base=$(basename "$f")
+    if [[ ! "$base" =~ $AUDIT_IMAGE_PATTERN ]]; then
+      continue
+    fi
+    hash=$(shasum -a 256 "$f" 2>/dev/null | awk '{print $1}')
+    [[ -n "$hash" ]] || continue
+    printf '%s\t%s\n' "$hash" "$base"
+  done
+}
+
+# audit_has_sw_provenance FILE -> exit 0 if the file contains the
+# "stillwater:v1" byte signature embedded by internal/image/exif.go's
+# WriteProvenance, exit 1 otherwise. Used to classify unexpected files:
+# present means Stillwater wrote it (internal bug -- renumbering, race);
+# absent means a peer server wrote it (peer write-back, the #1180 signature).
+# Pure bash plus xxd so the audit has no Go-helper or exiftool dependency.
+audit_has_sw_provenance() {
+  local f="$1"
+  if [[ ! -f "$f" ]]; then
+    return 1
+  fi
+  xxd "$f" 2>/dev/null | grep -q 'stillwater:v1'
+}
+
 # Poll for an NFO file's mtime to change (indicates platform wrote it).
 # Returns 0 if mtime changed within the timeout, 1 if it did not.
 # When original_mtime is "MISSING", any file creation counts as a change.
@@ -378,8 +440,11 @@ echo ""
 echo "--- Tier 1: Core ---"
 echo ""
 
-# Create cookie jar early so the health GET can receive the csrf_token cookie
-COOKIE_JAR=$(mktemp /tmp/smoke-cookies-XXXXXX)
+# Create cookie jar early so the health GET can receive the csrf_token cookie.
+# Deterministic per-worktree path (see scripts/lib/run-paths.sh) -- truncate
+# any leftover from a prior run rather than appending to it.
+COOKIE_JAR="$SW_RUN_DIR/smoke-cookies.jar"
+: > "$COOKIE_JAR"
 
 # Health (public, no auth) -- also seeds the csrf_token cookie
 resp=$(curl -s -c "$COOKIE_JAR" -w "\n%{http_code}" "$SW_BASE/api/v1/health")
@@ -1548,6 +1613,162 @@ if [[ "$ROUNDTRIP" -eq 1 ]]; then
 
     fi  # RT_SETUP_OK guard
   fi
+fi
+
+# ---------------------------------------------------------------------------
+# Tier 6: Writeback audit (opt-in with --writeback-audit; requires --full)
+# ---------------------------------------------------------------------------
+#
+# Detects peer write-back duplication (#1180) and silent overwrites by
+# snapshotting the artist directory before and after a deterministic image
+# fetch. Any file appearing post-fetch that the API did not report as saved
+# is a regression: either Stillwater renumbered behind our back (internal
+# bug) or a peer media server wrote files we did not ask for (the #1180
+# signature). Each unexpected file is classified by checking for the
+# stillwater:v1 EXIF/PNG provenance string written by internal/image/exif.go.
+#
+# CI does not run smoke today (live-server requirement), so this is an
+# operator-driven gate. Recipe:
+#   bash scripts/smoke.sh --full --writeback-audit \
+#     --music-path /path/to/music
+#
+# The audit is skipped (not failed) when:
+#   - --full was not passed (no fetch was issued, nothing to audit)
+#   - the discovered artist has no filesystem path or is not under any
+#     configured --music-path
+#   - the network fetch itself fails (transport errors are not regressions)
+#
+# Tunables: SW_WRITEBACK_SETTLE seconds (default 5).
+
+if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
+  echo "--- Tier 6: Writeback Audit (--writeback-audit) ---"
+  echo ""
+
+  if [[ "$FULL" -ne 1 ]]; then
+    echo "[SKIP] Writeback audit -- requires --full to issue the fetch under audit"
+  elif [[ -z "$ARTIST_ID" || "$ARTIST_ID" == "unknown" ]]; then
+    echo "[SKIP] Writeback audit -- no test artist available"
+  else
+    # Resolve the artist's filesystem path. The audit refuses to run unless
+    # the path is under a configured --music-path so that an operator running
+    # the audit on a stale or unintended directory cannot accidentally have
+    # the assertion pass against the wrong tree.
+    audit_detail=$(curl -s "${AUTH[@]}" "$SW_BASE/api/v1/artists/$ARTIST_ID") || audit_detail=""
+    audit_path=$(echo "$audit_detail" | jq -r '.artist.path // empty' 2>/dev/null || true)
+
+    if [[ -z "$audit_path" ]]; then
+      echo "[SKIP] Writeback audit -- artist $ARTIST_ID has no filesystem path"
+    elif ! path_under_music_dirs "$audit_path"; then
+      echo "[SKIP] Writeback audit -- artist path not under configured --music-path"
+    elif [[ ! -d "$audit_path" ]]; then
+      echo "[SKIP] Writeback audit -- artist path $audit_path does not exist on this host"
+    else
+      echo "  Audit path: $audit_path"
+      settle="${SW_WRITEBACK_SETTLE:-5}"
+
+      pre_snapshot=$(audit_dir_snapshot "$audit_path")
+
+      # Fetch a single thumb. Same URL the Tier 4 fetch already exercises so
+      # the audit produces a deterministic write set even on first run.
+      audit_fetch_resp=$(curl -s "${AUTH[@]}" \
+        -X POST "$SW_BASE/api/v1/artists/$ARTIST_ID/images/fetch" \
+        -H "Content-Type: application/json" \
+        -d '{"url":"https://upload.wikimedia.org/wikipedia/en/a/aa/A-ha_band_2015.jpg","type":"thumb"}') || audit_fetch_resp=""
+
+      audit_saved_thumb=$(echo "$audit_fetch_resp" | jq -r '.saved[]? // empty' 2>/dev/null || true)
+
+      # Settle window: peer write-back observed in #1180 arrived within
+      # 550ms; the configurable default of 5s is a generous ceiling.
+      sleep "$settle"
+
+      post_snapshot=$(audit_dir_snapshot "$audit_path")
+
+      # Build the expected-added set from the API responses. Filenames only;
+      # snapshot lines are "<sha256>\t<filename>" so cut on \t.
+      expected_added_file=$(mktemp "$SW_RUN_DIR/audit-expected.XXXXXX")
+      pre_files_file=$(mktemp "$SW_RUN_DIR/audit-pre.XXXXXX")
+      post_files_file=$(mktemp "$SW_RUN_DIR/audit-post.XXXXXX")
+
+      # The endpoint emits one filename per line via jq above; just copy.
+      printf '%s\n' "$audit_saved_thumb" | sed '/^$/d' | sort -u > "$expected_added_file"
+      printf '%s\n' "$pre_snapshot"  | awk -F'\t' 'NF==2{print $2}' | sort -u > "$pre_files_file"
+      printf '%s\n' "$post_snapshot" | awk -F'\t' 'NF==2{print $2}' | sort -u > "$post_files_file"
+
+      # actual_added = post \ pre. unexpected_added = actual_added \ expected_added.
+      actual_added=$(comm -23 "$post_files_file" "$pre_files_file")
+      printf '%s\n' "$actual_added" | sed '/^$/d' | sort -u > "$post_files_file.actual"
+      unexpected_added=$(comm -23 "$post_files_file.actual" "$expected_added_file")
+
+      # Silent overwrite check: any file present in BOTH pre and post whose
+      # sha256 changed and which is not in the expected_added set has been
+      # rewritten without us asking. This catches the #1180 case where a peer
+      # server overwrites a Stillwater-placed file in addition to the
+      # additive duplication case the directory-delta catches.
+      silent_rewrites=""
+      while IFS=$'\t' read -r post_hash post_name; do
+        [[ -z "$post_name" ]] && continue
+        pre_hash=$(printf '%s\n' "$pre_snapshot" | awk -F'\t' -v n="$post_name" '$2==n{print $1; exit}')
+        if [[ -n "$pre_hash" && "$pre_hash" != "$post_hash" ]]; then
+          if ! grep -Fxq "$post_name" "$expected_added_file"; then
+            silent_rewrites+="$post_name"$'\n'
+          fi
+        fi
+      done <<< "$post_snapshot"
+
+      audit_label="writeback audit on $audit_path"
+
+      if [[ -n "$unexpected_added" ]]; then
+        FAIL=$((FAIL + 1))
+        FAILURES+=("$audit_label -- unexpected files appeared after fetch")
+        echo "[FAIL] $audit_label -- unexpected files appeared:"
+        while IFS= read -r u; do
+          [[ -z "$u" ]] && continue
+          u_hash=$(printf '%s\n' "$post_snapshot" | awk -F'\t' -v n="$u" '$2==n{print $1; exit}')
+          # Cross-reference: is this file byte-identical to anything we asked
+          # for? That match is the #1180 fingerprint -- the peer wrote a
+          # rename of our file, not a different image.
+          dup_of=""
+          while IFS= read -r exp; do
+            [[ -z "$exp" ]] && continue
+            exp_hash=$(printf '%s\n' "$post_snapshot" | awk -F'\t' -v n="$exp" '$2==n{print $1; exit}')
+            if [[ -n "$exp_hash" && "$exp_hash" == "$u_hash" ]]; then
+              dup_of="$exp"
+              break
+            fi
+          done < "$expected_added_file"
+          provenance="no-stillwater-provenance"
+          if audit_has_sw_provenance "$audit_path/$u"; then
+            provenance="stillwater-provenance-present"
+          fi
+          if [[ -n "$dup_of" ]]; then
+            echo "         $u  sha256=$u_hash  byte-identical-to=$dup_of  $provenance"
+          else
+            echo "         $u  sha256=$u_hash  $provenance"
+          fi
+        done <<< "$unexpected_added"
+      fi
+
+      if [[ -n "$silent_rewrites" ]]; then
+        FAIL=$((FAIL + 1))
+        FAILURES+=("$audit_label -- pre-existing files silently overwritten")
+        echo "[FAIL] $audit_label -- pre-existing files silently overwritten:"
+        while IFS= read -r r; do
+          [[ -z "$r" ]] && continue
+          echo "         $r"
+        done <<< "$silent_rewrites"
+      fi
+
+      if [[ -z "$unexpected_added" && -z "$silent_rewrites" ]]; then
+        expected_count=$(grep -c . "$expected_added_file" 2>/dev/null || echo 0)
+        echo "[PASS] $audit_label -- $expected_count expected files, 0 unexpected, 0 silent rewrites"
+        PASS=$((PASS + 1))
+      fi
+
+      rm -f "$expected_added_file" "$pre_files_file" "$post_files_file" "$post_files_file.actual"
+    fi
+  fi
+
+  echo ""
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1674,6 +1674,13 @@ if [[ "$WRITEBACK_AUDIT" -eq 1 ]]; then
 
     if [[ -z "$audit_path" ]]; then
       echo "[SKIP] Writeback audit -- artist $ARTIST_ID has no filesystem path"
+    elif [[ ${#MUSIC_PATHS[@]} -eq 0 ]]; then
+      # path_under_music_dirs returns true (allow) when MUSIC_PATHS is empty,
+      # which would otherwise bypass the safety contract that forbids
+      # auditing whatever directory the operator's instance happens to expose.
+      # Tier 6 explicitly refuses to touch the filesystem without an
+      # operator-supplied music-path scope.
+      echo "[SKIP] Writeback audit -- requires --music-path or SW_MUSIC_PATH to scope the filesystem check"
     elif ! path_under_music_dirs "$audit_path"; then
       echo "[SKIP] Writeback audit -- artist path not under configured --music-path"
     elif [[ ! -d "$audit_path" ]]; then


### PR DESCRIPTION
Closes #1183.

Adds a Tier 6 writeback audit (`--writeback-audit`) to `scripts/smoke.sh`
that catches peer write-back duplication (#1180) and silent overwrites
that the existing tiers miss because they only check HTTP response codes.
Bundled with the per-worktree run-paths refactor that smoke.sh,
pre-push-gate.sh, and dev-restart.sh now share so concurrent gate runs
across worktrees write to disjoint artifact paths.

## Summary

- New `scripts/lib/run-paths.sh` helper: exports `$SW_RUN_DIR` keyed on
  worktree basename, replacing the BSD-mktemp pattern that left literal
  `cover.XXXXXX.out` files on macOS and the `/tmp` cookie-jar collisions
  across worktrees.
- `scripts/smoke.sh --writeback-audit` (requires `--full`):
  - Pre-fetch snapshot: sha256 + filename for every image-pattern file
    (`backdrop|fanart|poster|logo|banner|thumb|clearart|disc|landscape`)
    in the test artist's directory.
  - Triggers the deterministic Tier 4 thumb fetch.
  - Settles `SW_WRITEBACK_SETTLE` seconds (default 5; the #1180 repro
    saw write-back arrive within 550 ms).
  - Post-fetch snapshot, then asserts:
    - `unexpected_added == empty`. Each unexpected file is reported with
      its sha256, byte-identity cross-reference against the expected set
      (the #1180 fingerprint), and `stillwater:v1` provenance status to
      classify the bug as internal vs. peer.
    - No silent overwrites: any pre-existing file whose sha256 changed
      without being in the expected-saved set is a regression.
- Skips (does not fail) when `--full` is absent, when the artist has no
  filesystem path, when the path is not under any configured
  `--music-path`, or when the path is not accessible on this host.

## Why this lives in smoke

CI does not run smoke today (live-server requirement) so this is an
operator-driven gate. The audit is opt-in alongside `--full` so default
runs stay non-destructive.

## Test plan

- [x] `bash -n scripts/smoke.sh` passes
- [x] `bash scripts/pre-push-gate.sh` green
- [ ] Operator UAT: run `bash scripts/smoke.sh --full --writeback-audit
      --music-path <path>` against a healthy instance, see
      `[PASS] writeback audit: N expected files, 0 unexpected, 0 silent
      rewrites`
- [ ] Operator UAT: same against an instance with peer write-back enabled
      (Emby `SaveLocalMetadata=true`), see `[FAIL]` listing the duplicated
      filenames with their sha256 byte-identity callout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in Tier‑6 writeback audit for smoke tests (requires full run): verifies saved images, detects unexpected additions/overwrites, and fails on mismatches; includes a post‑fetch settle window and provenance checks.

* **Chores**
  * Route logs, cookie jars, coverage and OpenAPI artifacts into deterministic per‑checkout run directories to isolate dev output.
  * Ensure per‑run directories are uniquely namespaced and created with restrictive permissions for safer, consistent temporary artifact handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->