### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // These variables are set at build time via -ldflags.
 var (
-	Version = "0.9.6"
+	Version = "1.0.0"
 	Commit  = "unknown"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

Bump `internal/version/version.go` from 0.9.6 to 1.0.0.

The v1.0.0 tag was already pushed at `057a9e2f` and triggered the Release workflow; this PR brings main in sync with the tag's content.

## Test plan

- [x] `bash scripts/pre-push-gate.sh` clean before tag
- [x] `grype dir:.` clean before tag
- [x] CI on main HEAD (ed450af) all green pre-tag
- [x] Release workflow building v1.0.0 from the tag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version bumped to 1.0.0, marking a major release milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->