### PR TITLE
chore(pre-commit): add markdownlint-cli2 hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,11 @@ repos:
     hooks:
       - id: actionlint
 
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.22.1
+    hooks:
+      - id: markdownlint-cli2
+
   - repo: local
     hooks:
       - id: templ-generate


### PR DESCRIPTION
## Summary

Close the local-validation gap that let PR #1259's MD025 failure ship to CI. The Markdown Lint workflow (`docs.yml`) was the only gate enforcing markdown style, which meant errors only surfaced ~10 minutes after push.

- Adds `DavidAnson/markdownlint-cli2` to `.pre-commit-config.yaml`.
- Pinned to **v0.22.1** -- one patch ahead of the CI action's bundled v0.22.0, so pre-commit is at least as strict as CI.
- Both consume the same `.markdownlint-cli2.yaml` config, so rules are identical.

## Test plan

- [x] `pre-commit run markdownlint-cli2 --all-files` passes on the current tree.
- [ ] Commit a deliberate MD025 violation to a scratch branch; pre-commit refuses the commit.

## Why patch-ahead instead of exact-match

CI is locked to v0.22.0 via the action's bundle; pre-commit is at v0.22.1 (latest available tag). Strictness can only grow with newer versions of markdownlint-cli2 (it does not loosen rules). Erring slightly stricter locally means a commit that fails pre-commit would have failed CI; the reverse is not always true.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added markdown linting to pre-commit hooks to ensure consistent documentation quality and formatting standards during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->