### PR TITLE
ci(docs): add docs-drift PR guard + CodeRabbit instructions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -72,6 +72,11 @@ reviews:
         - Descriptions accurately reflect code behavior (not "empty when X" if code
           also makes it non-empty when Y)
         - $ref schemas match the actual response shape
+        The API reference at https://sydlexius.github.io/stillwater/api/
+        auto-builds from this spec, so spec correctness is user-visible. Every
+        new response field, enum value, or schema change should have a
+        corresponding handler edit in the same PR; flag any drift between
+        schema and handler signatures.
     - path: "**/*.go"
       instructions: |
         Check for null/empty edge cases:
@@ -116,13 +121,6 @@ reviews:
         write-back semantics). If user-visible behavior changes, flag the PR
         if neither `docs/site/src/getting-started/connect-*.md` nor
         `docs/site/src/troubleshooting/platform-auth.md` is updated.
-    - path: "internal/api/openapi.yaml"
-      instructions: |
-        Confirm spec/handler consistency in this PR. The API reference at
-        `https://sydlexius.github.io/stillwater/api/` auto-builds from this
-        spec, so spec correctness is user-visible. Every new response field,
-        enum value, or schema change should have a corresponding handler edit
-        in the same PR; flag any drift between schema and handler signatures.
   tools:
     golangci-lint:
       enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -99,6 +99,30 @@ reviews:
           test goroutine must be synchronized (data race)
         - Engine/rule tests should assert relative properties rather than exact
           counts that break when new rules are added
+    - path: "internal/provider/**/*.go"
+      instructions: |
+        Watch for changes that should be reflected on the user-facing docs site
+        (https://sydlexius.github.io/stillwater/). Flag the PR if the change
+        adds, modifies, or removes a provider, capability flag, supported
+        field, or default value AND `docs/site/src/reference/providers.md` is
+        unchanged in the same PR. The provider matrix between
+        `<!-- BEGIN GENERATED: provider-matrix -->` and
+        `<!-- END GENERATED: provider-matrix -->` is auto-generated; narrative
+        prose around it is manual.
+    - path: "internal/connection/**/*.go"
+      instructions: |
+        Check whether the change affects platform connector behavior visible
+        to the user (Emby, Jellyfin, or Lidarr auth, library scan, or
+        write-back semantics). If user-visible behavior changes, flag the PR
+        if neither `docs/site/src/getting-started/connect-*.md` nor
+        `docs/site/src/troubleshooting/platform-auth.md` is updated.
+    - path: "internal/api/openapi.yaml"
+      instructions: |
+        Confirm spec/handler consistency in this PR. The API reference at
+        `https://sydlexius.github.io/stillwater/api/` auto-builds from this
+        spec, so spec correctness is user-visible. Every new response field,
+        enum value, or schema change should have a corresponding handler edit
+        in the same PR; flag any drift between schema and handler signatures.
   tools:
     golangci-lint:
       enabled: true

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -1,0 +1,149 @@
+name: Docs Drift
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - 'internal/provider/**'
+      - 'internal/connection/**'
+      - 'internal/scraper/**'
+      - 'internal/api/openapi.yaml'
+      - 'internal/api/handlers_*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    name: Check docs drift
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+        with:
+          filters: |
+            code:
+              - 'internal/provider/**'
+              - 'internal/connection/**'
+              - 'internal/scraper/**'
+              - 'internal/api/openapi.yaml'
+              - 'internal/api/handlers_*'
+            docs:
+              - 'docs/**'
+
+      - name: Apply or clear docs-drift advisory
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CODE_CHANGED: ${{ steps.filter.outputs.code }}
+          DOCS_CHANGED: ${{ steps.filter.outputs.docs }}
+        with:
+          script: |
+            const MARKER = '<!-- docs-drift-bot -->';
+            const NEEDS_LABEL = 'needs-docs-review';
+            const OPT_OUT_LABEL = 'docs: not-required';
+
+            const codeChanged = process.env.CODE_CHANGED === 'true';
+            const docsChanged = process.env.DOCS_CHANGED === 'true';
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = pr.number;
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (err) {
+                if (err.status === 404) {
+                  await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                } else {
+                  throw err;
+                }
+              }
+            }
+
+            async function findMarkerComment() {
+              const iter = github.paginate.iterator(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number, per_page: 100 }
+              );
+              for await (const { data: comments } of iter) {
+                for (const c of comments) {
+                  if (c.body && c.body.includes(MARKER)) return c;
+                }
+              }
+              return null;
+            }
+
+            async function setLabel(name, present) {
+              const labels = pr.labels.map(l => l.name);
+              const has = labels.includes(name);
+              if (present && !has) {
+                await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [name] });
+              } else if (!present && has) {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+              }
+            }
+
+            await ensureLabel(NEEDS_LABEL, 'fbca04', 'Code changed but docs were not updated; please review docs surface');
+            await ensureLabel(OPT_OUT_LABEL, 'c5def5', 'Override the docs-drift advisory; this PR does not need docs changes');
+
+            const optedOut = pr.labels.some(l => l.name === OPT_OUT_LABEL);
+            const driftDetected = codeChanged && !docsChanged && !optedOut;
+            const existing = await findMarkerComment();
+
+            if (driftDetected) {
+              const body = [
+                MARKER,
+                '## Docs drift advisory',
+                '',
+                'This PR touches code surfaces whose user-visible behavior is documented at',
+                '<https://sydlexius.github.io/stillwater/>, but no `docs/` files changed.',
+                'Consider whether any of the following pages need an update:',
+                '',
+                '- Provider list and capabilities (`docs/site/src/reference/providers.md`)',
+                '- Settings reference (`docs/site/src/reference/settings-by-tab.md`)',
+                '- Connect-platform guides (`docs/site/src/getting-started/connect-*.md`)',
+                '- Troubleshooting (`docs/site/src/troubleshooting/platform-auth.md`)',
+                '- API reference auto-built from `internal/api/openapi.yaml`',
+                '',
+                'If no docs change is needed, apply the `docs: not-required` label and this',
+                'advisory will clear on the next workflow run.',
+                '',
+                '_This is a soft advisory and never blocks merge._',
+              ].join('\n');
+
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number, body });
+              }
+              await setLabel(NEEDS_LABEL, true);
+            } else {
+              if (existing) {
+                const cleared = [
+                  MARKER,
+                  '## Docs drift advisory',
+                  '',
+                  optedOut
+                    ? 'Cleared: `docs: not-required` label is set on this PR.'
+                    : (docsChanged
+                        ? 'Cleared: this PR updates `docs/` alongside the code changes.'
+                        : 'Cleared: no docs-sensitive code paths are modified.'),
+                  '',
+                  '_This is a soft advisory and never blocks merge._',
+                ].join('\n');
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: cleared });
+              }
+              await setLabel(NEEDS_LABEL, false);
+            }

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -22,6 +22,7 @@ jobs:
     name: Check docs drift
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
       issues: write
     steps:
@@ -65,7 +66,11 @@ jobs:
                 await github.rest.issues.getLabel({ owner, repo, name });
               } catch (err) {
                 if (err.status === 404) {
-                  await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                  try {
+                    await github.rest.issues.createLabel({ owner, repo, name, color, description });
+                  } catch (createErr) {
+                    if (createErr.status !== 422) throw createErr;
+                  }
                 } else {
                   throw err;
                 }
@@ -91,7 +96,11 @@ jobs:
               if (present && !has) {
                 await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [name] });
               } else if (!present && has) {
-                await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+                try {
+                  await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+                } catch (err) {
+                  if (err.status !== 404) throw err;
+                }
               }
             }
 


### PR DESCRIPTION
## Summary

Two-layer docs-drift detection: a deterministic CI advisory plus judgment-driven CodeRabbit feedback. **Neither blocks merge** -- both surface the smell so docs and code can stay in sync as the project grows.

- `.github/workflows/docs-drift.yml` triggers on PRs touching `internal/provider/`, `internal/connection/`, `internal/scraper/`, `internal/api/openapi.yaml`, or `internal/api/handlers_*`. When code changes without a corresponding `docs/` edit, the workflow upserts a marked advisory comment and adds the `needs-docs-review` label. Authors override with the `docs: not-required` label and the next run clears the advisory. Both labels are auto-created at runtime if absent.
- `.coderabbit.yaml` gains three `path_instructions` entries (provider, connection, openapi).

## Important

**The workflow must NOT be added as a required status check.** It is informational by design.

Closes #1252
Closes #1255

## Test plan

- [x] `actionlint .github/workflows/docs-drift.yml` passes.
- [x] Both YAML files parse cleanly (`yaml.safe_load`).
- [ ] After merge, open a draft PR touching `internal/provider/musicbrainz/adapter.go` without `docs/` -- confirm the workflow comments + labels.
- [ ] Apply the `docs: not-required` label -- next run clears the advisory.
- [ ] Open a draft PR touching both code and `docs/` -- no advisory.

## Notes

- Both labels (`needs-docs-review` color `fbca04`, `docs: not-required` color `c5def5`) are created on first run if missing.
- Comment is keyed by an HTML marker (`<!-- docs-drift-bot -->`) so re-runs update in place rather than spam.
- Concurrency group is per-PR with `cancel-in-progress: true`, so superseded runs are dropped.

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened PR review guidance to require corresponding documentation updates when changes affect user-facing APIs, provider references, or connector auth/behavior.
  * Added an automated CI check that detects documentation drift, posts a checklist/marker on PRs, and applies or clears a docs-review label based on whether docs were updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->