### PR TITLE
chore(release): bump dev-fallback version to 1.0.1

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // These variables are set at build time via -ldflags.
 var (
-	Version = "1.0.0"
+	Version = "1.0.1"
 	Commit  = "unknown"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

Aligns the dev-fallback `Version` constant in `internal/version/version.go` with the released `v1.0.1` tag so `go run` shows the correct version when ldflags aren't injected.

The tag itself was pushed first (server-side branch protection blocks direct pushes to main). Production builds inject the version via `-ldflags "-X version.Version=..."`, so this is a dev-only fix.

## Test plan

- [x] CI on main HEAD (5ad86134) was already green when v1.0.1 was tagged
- [ ] Confirm CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.0.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->