### PR TITLE
feat(settingsio): include libraries and api tokens in export envelope (#1186, #1189)

### DIFF
--- a/api/bruno/settings/export-settings.bru
+++ b/api/bruno/settings/export-settings.bru
@@ -1,0 +1,56 @@
+meta {
+  name: Export Settings
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{apiBase}}/settings/export
+  body: json
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+body:json {
+  {
+    "passphrase": "round-trip-test-passphrase"
+  }
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("envelope is version 1.2", function() {
+    expect(res.body.version).to.equal("1.2");
+  });
+
+  test("data and salt are present", function() {
+    expect(res.body.data).to.be.a("string");
+    expect(res.body.salt).to.be.a("string");
+    expect(res.body.data.length).to.be.greaterThan(0);
+    expect(res.body.salt.length).to.be.greaterThan(0);
+  });
+
+  test("summary surfaces libraries and api_tokens counters", function() {
+    expect(res.body.summary).to.be.an("object");
+    expect(res.body.summary).to.have.property("libraries");
+    expect(res.body.summary).to.have.property("api_tokens");
+  });
+
+  test("plaintext data does not appear in outer envelope", function() {
+    var serialized = JSON.stringify(res.body);
+    expect(serialized.indexOf("round-trip-test-passphrase")).to.equal(-1);
+  });
+}
+
+script:post-response {
+  // Stash the envelope so import-settings.bru can replay the exact bytes
+  // back through the API in the same Bruno run, exercising the v1.2
+  // round-trip end-to-end.
+  bru.setVar("lastExportedEnvelope", JSON.stringify(res.body));
+}

--- a/api/bruno/settings/import-settings.bru
+++ b/api/bruno/settings/import-settings.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Import Settings
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{apiBase}}/settings/import
+  body: json
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "passphrase": "round-trip-test-passphrase",
+    "envelope": {{lastExportedEnvelope}}
+  }
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("ImportResult exposes libraries counter", function() {
+    expect(res.body).to.have.property("libraries");
+  });
+
+  test("ImportResult exposes api_tokens counter", function() {
+    expect(res.body).to.have.property("api_tokens");
+  });
+
+  test("re-import is idempotent: counters never go negative", function() {
+    expect(res.body.libraries).to.be.at.least(0);
+    expect(res.body.api_tokens).to.be.at.least(0);
+  });
+}

--- a/internal/settingsio/export.go
+++ b/internal/settingsio/export.go
@@ -33,7 +33,9 @@ const pbkdf2Iterations = 600_000
 //   - "1.0": original format (settings, connections, platform profiles, webhooks,
 //     provider keys, priorities)
 //   - "1.1": adds rules, scraper_configs, user_preferences, plaintext summary
-const CurrentEnvelopeVersion = "1.1"
+//   - "1.2": adds libraries (connection refs remapped by type+url) and api_tokens
+//     (token_hash + metadata only; never plaintext)
+const CurrentEnvelopeVersion = "1.2"
 
 // supportedEnvelopeVersions lists the envelope versions Import will accept.
 // Older versions are accepted for backward compatibility (their newer fields
@@ -41,6 +43,7 @@ const CurrentEnvelopeVersion = "1.1"
 var supportedEnvelopeVersions = map[string]bool{
 	"1.0": true,
 	"1.1": true,
+	"1.2": true,
 }
 
 // ErrWrongPassphrase is returned by Import when the AES-GCM tag verification
@@ -77,6 +80,8 @@ type Payload struct {
 	Rules              []RuleExport          `json:"rules,omitempty"`
 	ScraperConfigs     []ScraperConfigExport `json:"scraper_configs,omitempty"`
 	UserPreferences    []UserPrefsExport     `json:"user_preferences,omitempty"`
+	Libraries          []LibraryExport       `json:"libraries,omitempty"`
+	APITokens          []APITokenExport      `json:"api_tokens,omitempty"`
 }
 
 // ConnectionExport is a connection with its API key decrypted for export.
@@ -126,17 +131,24 @@ type UserPrefsExport struct {
 	Preferences map[string]string `json:"preferences"`
 }
 
-// ImportResult summarizes what was imported.
+// ImportResult summarizes what was imported. Skip counters track rows that
+// were intentionally omitted (e.g. a library whose connection is missing on
+// the target, or a token whose owning user is absent); they let callers
+// surface a per-domain "imported / skipped" breakdown without reparsing logs.
 type ImportResult struct {
-	Settings        int `json:"settings"`
-	Connections     int `json:"connections"`
-	Profiles        int `json:"platform_profiles"`
-	Webhooks        int `json:"webhooks"`
-	ProviderKeys    int `json:"provider_keys"`
-	Priorities      int `json:"priorities"`
-	Rules           int `json:"rules"`
-	ScraperConfigs  int `json:"scraper_configs"`
-	UserPreferences int `json:"user_preferences"`
+	Settings         int `json:"settings"`
+	Connections      int `json:"connections"`
+	Profiles         int `json:"platform_profiles"`
+	Webhooks         int `json:"webhooks"`
+	ProviderKeys     int `json:"provider_keys"`
+	Priorities       int `json:"priorities"`
+	Rules            int `json:"rules"`
+	ScraperConfigs   int `json:"scraper_configs"`
+	UserPreferences  int `json:"user_preferences"`
+	Libraries        int `json:"libraries"`
+	LibrariesSkipped int `json:"libraries_skipped,omitempty"`
+	APITokens        int `json:"api_tokens"`
+	APITokensSkipped int `json:"api_tokens_skipped,omitempty"`
 }
 
 // Service handles settings export and import.
@@ -312,6 +324,25 @@ func (s *Service) Export(ctx context.Context, passphrase string) (*Envelope, err
 	}
 	payload.UserPreferences = userPrefs
 
+	// Collect libraries. Connection IDs are not exported; instead the owning
+	// connection's (type, url) is carried so the target instance can remap to
+	// its own locally-generated connection_id during import.
+	libs, err := s.exportLibraries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("exporting libraries: %w", err)
+	}
+	payload.Libraries = libs
+
+	// Collect API tokens. Only the stored hash + metadata are exported (the
+	// plaintext is never persisted in the DB and so cannot be exported even
+	// in principle). user_id is replaced with the owner's username for
+	// cross-instance portability, mirroring user_preferences.
+	tokens, err := s.exportAPITokens(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("exporting api tokens: %w", err)
+	}
+	payload.APITokens = tokens
+
 	// Marshal and encrypt payload
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -341,6 +372,8 @@ func (s *Service) Export(ctx context.Context, passphrase string) (*Envelope, err
 			// UserPreferences counts total (user, key) pairs so export Summary
 			// matches the counter import increments per upserted row.
 			UserPreferences: countUserPreferences(payload.UserPreferences),
+			Libraries:       len(payload.Libraries),
+			APITokens:       len(payload.APITokens),
 		},
 	}
 
@@ -554,6 +587,18 @@ func (s *Service) Import(ctx context.Context, env *Envelope, passphrase string) 
 	// that do not exist on this instance are silently skipped.
 	if err := s.importUserPreferences(ctx, payload.UserPreferences, result); err != nil {
 		return nil, fmt.Errorf("importing user preferences: %w", err)
+	}
+
+	// Import libraries. Must run AFTER connections so the (type, url) -> id
+	// remap can resolve to the freshly-imported connection rows.
+	if err := s.importLibraries(ctx, payload.Libraries, result); err != nil {
+		return nil, fmt.Errorf("importing libraries: %w", err)
+	}
+
+	// Import API tokens. Must run AFTER user_preferences so the username ->
+	// user_id lookup sees the final user set on the target instance.
+	if err := s.importAPITokens(ctx, payload.APITokens, result); err != nil {
+		return nil, fmt.Errorf("importing api tokens: %w", err)
 	}
 
 	return result, nil

--- a/internal/settingsio/export_test.go
+++ b/internal/settingsio/export_test.go
@@ -927,8 +927,11 @@ func TestRoundTrip_LibrariesAndTokens(t *testing.T) {
 	if envelope.Version != "1.2" {
 		t.Errorf("envelope version: got %q, want 1.2", envelope.Version)
 	}
-	if envelope.Summary == nil || envelope.Summary.Libraries != 2 {
-		t.Errorf("summary libraries: got %+v, want 2", envelope.Summary)
+	if envelope.Summary == nil {
+		t.Fatal("expected non-nil export summary")
+	}
+	if envelope.Summary.Libraries != 2 {
+		t.Errorf("summary libraries: got %d, want 2", envelope.Summary.Libraries)
 	}
 	if envelope.Summary.APITokens != 1 {
 		t.Errorf("summary api_tokens: got %d, want 1", envelope.Summary.APITokens)

--- a/internal/settingsio/export_test.go
+++ b/internal/settingsio/export_test.go
@@ -1072,6 +1072,75 @@ func TestRoundTrip_LibrariesAndTokens(t *testing.T) {
 	}
 }
 
+// TestImport_LibrarySkipsOnMissingConnection tampers with a v1.2 envelope so
+// the platform-bound library references a connection that is not part of the
+// payload, exercising the missing-connection skip path in isolation. Without
+// this, the LibrariesSkipped counter has no positive-case assertion (the
+// happy-path test in TestRoundTrip_LibrariesAndTokens always finds the
+// connection because it is imported alongside the library).
+func TestImport_LibrarySkipsOnMissingConnection(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	envelope, err := svc.Export(ctx, "skip-test")
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	plaintext, err := decryptWithPassphrase(envelope.Data, envelope.Salt, "skip-test")
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	var payload Payload
+	if err := json.Unmarshal(plaintext, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Inject a platform-bound library whose connection is not present in the
+	// payload's Connections list. The importer must skip with a warning rather
+	// than fail.
+	payload.Libraries = append(payload.Libraries, LibraryExport{
+		Name:           "Orphan Lib",
+		Type:           "regular",
+		Source:         "emby",
+		ConnectionType: "emby",
+		ConnectionURL:  "http://nowhere.invalid:8096",
+		FSPollInterval: 60,
+	})
+	modified, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	newData, newSalt, err := encryptWithPassphrase(modified, "skip-test")
+	if err != nil {
+		t.Fatalf("re-encrypt: %v", err)
+	}
+	envelope.Data = newData
+	envelope.Salt = newSalt
+
+	db2 := setupTestDB(t)
+	provSettings2, connSvc2, platSvc2, whSvc2 := newTestServices(t, db2)
+	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2)
+
+	res, err := svc2.Import(ctx, envelope, "skip-test")
+	if err != nil {
+		t.Fatalf("Import should succeed despite missing connection, got: %v", err)
+	}
+	if res.LibrariesSkipped != 1 {
+		t.Errorf("LibrariesSkipped: got %d, want 1", res.LibrariesSkipped)
+	}
+	// Confirm the orphan library was not silently inserted.
+	var count int
+	if err := db2.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM libraries WHERE name = 'Orphan Lib'`).Scan(&count); err != nil {
+		t.Fatalf("counting orphan library rows: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("orphan library was inserted despite missing connection: count=%d", count)
+	}
+}
+
 func TestEnvelope_JSON(t *testing.T) {
 	env := Envelope{
 		Version:    "1.0",

--- a/internal/settingsio/export_test.go
+++ b/internal/settingsio/export_test.go
@@ -859,6 +859,219 @@ func TestImport_EmptyData(t *testing.T) {
 	}
 }
 
+// TestRoundTrip_LibrariesAndTokens covers the v1.2 envelope additions:
+// libraries (with both manual and connection-bound flavors, exercising the
+// (type, url) -> connection_id remap on import) and api_tokens (verifying the
+// hash round-trips, the username -> user_id remap, and the missing-user skip
+// path). A second target DB without the matching connection / user verifies
+// the skip counters increment instead of the import aborting.
+func TestRoundTrip_LibrariesAndTokens(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+
+	// Seed a connection that a sourced library will reference.
+	c := &connection.Connection{
+		Name:    "Source Emby",
+		Type:    "emby",
+		URL:     "http://emby.local:8096",
+		APIKey:  "src-key",
+		Enabled: true,
+	}
+	if err := connSvc.Create(ctx, c); err != nil {
+		t.Fatalf("creating source connection: %v", err)
+	}
+
+	// Seed a manual library and a connection-bound library directly via SQL
+	// so we bypass library.Service path-existence validation (the test
+	// process does not have arbitrary fixture paths on disk).
+	now := time.Now().UTC().Format(time.RFC3339)
+	manualID := "lib-manual"
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO libraries (id, name, path, type, source, connection_id, external_id, fs_watch, fs_poll_interval, nfo_lock_data, created_at, updated_at)
+		VALUES (?, 'Manual Music', '/srv/music', 'regular', 'manual', NULL, '', 1, 60, 1, ?, ?)`,
+		manualID, now, now); err != nil {
+		t.Fatalf("seeding manual library: %v", err)
+	}
+	embyLibID := "lib-emby"
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO libraries (id, name, path, type, source, connection_id, external_id, fs_watch, fs_poll_interval, nfo_lock_data, created_at, updated_at)
+		VALUES (?, 'Emby Library', '', 'classical', 'emby', ?, 'ext-1', 0, 300, 0, ?, ?)`,
+		embyLibID, c.ID, now, now); err != nil {
+		t.Fatalf("seeding emby library: %v", err)
+	}
+
+	// Seed a user and an api token owned by that user. The token_hash is a
+	// fixed string so the import-side equality assertion is exact.
+	userID := "u-token-owner"
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO users (id, username, role) VALUES (?, 'tokenowner', 'admin')`,
+		userID); err != nil {
+		t.Fatalf("seeding user: %v", err)
+	}
+	tokenHash := "stable-bcrypt-hash-for-test"
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO api_tokens (id, name, token_hash, scopes, user_id, created_at, status)
+		VALUES (?, 'CI Token', ?, 'read,write', ?, ?, 'active')`,
+		"tok-1", tokenHash, userID, now); err != nil {
+		t.Fatalf("seeding api token: %v", err)
+	}
+
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+	passphrase := "rt-libs-tokens"
+	envelope, err := svc.Export(ctx, passphrase)
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if envelope.Version != "1.2" {
+		t.Errorf("envelope version: got %q, want 1.2", envelope.Version)
+	}
+	if envelope.Summary == nil || envelope.Summary.Libraries != 2 {
+		t.Errorf("summary libraries: got %+v, want 2", envelope.Summary)
+	}
+	if envelope.Summary.APITokens != 1 {
+		t.Errorf("summary api_tokens: got %d, want 1", envelope.Summary.APITokens)
+	}
+
+	// Decrypt and confirm the LibraryExport carries the connection's
+	// (type, url) but no internal connection_id field.
+	plaintext, err := decryptWithPassphrase(envelope.Data, envelope.Salt, passphrase)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	var payload Payload
+	if err := json.Unmarshal(plaintext, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(payload.Libraries) != 2 {
+		t.Fatalf("payload libraries: got %d, want 2", len(payload.Libraries))
+	}
+	var foundEmby bool
+	for _, le := range payload.Libraries {
+		if le.Name == "Emby Library" {
+			foundEmby = true
+			if le.ConnectionType != "emby" || le.ConnectionURL != "http://emby.local:8096" {
+				t.Errorf("connection ref not embedded: %+v", le)
+			}
+		}
+	}
+	if !foundEmby {
+		t.Error("Emby Library missing from payload")
+	}
+	if len(payload.APITokens) != 1 || payload.APITokens[0].TokenHash != tokenHash {
+		t.Fatalf("api token hash not exported: %+v", payload.APITokens)
+	}
+	if payload.APITokens[0].Username != "tokenowner" {
+		t.Errorf("token username: got %q, want tokenowner", payload.APITokens[0].Username)
+	}
+
+	// --- Target #1: matching connection + matching user. Both libraries
+	// import; the token round-trips with the same hash.
+	db2 := setupTestDB(t)
+	provSettings2, connSvc2, platSvc2, whSvc2 := newTestServices(t, db2)
+	// Seed the target with a connection at the same (type, url) but a
+	// different ID, so the remap is genuinely exercised.
+	c2 := &connection.Connection{
+		Name:    "Target Emby",
+		Type:    "emby",
+		URL:     "http://emby.local:8096",
+		APIKey:  "tgt-key",
+		Enabled: true,
+	}
+	if err := connSvc2.Create(ctx, c2); err != nil {
+		t.Fatalf("seeding target connection: %v", err)
+	}
+	if _, err := db2.ExecContext(ctx,
+		`INSERT INTO users (id, username, role) VALUES ('u-target', 'tokenowner', 'admin')`); err != nil {
+		t.Fatalf("seeding target user: %v", err)
+	}
+	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2)
+	res, err := svc2.Import(ctx, envelope, passphrase)
+	if err != nil {
+		t.Fatalf("Import (target #1): %v", err)
+	}
+	if res.Libraries != 2 {
+		t.Errorf("target #1 libraries imported: got %d, want 2", res.Libraries)
+	}
+	if res.LibrariesSkipped != 0 {
+		t.Errorf("target #1 libraries skipped: got %d, want 0", res.LibrariesSkipped)
+	}
+	if res.APITokens != 1 || res.APITokensSkipped != 0 {
+		t.Errorf("target #1 tokens: imported=%d skipped=%d, want 1/0", res.APITokens, res.APITokensSkipped)
+	}
+	// Verify the imported emby library's connection_id was remapped to the
+	// target's connection (not the source's), and that the hash and remapped
+	// user_id survived.
+	var importedConnID sql.NullString
+	if err := db2.QueryRowContext(ctx,
+		`SELECT connection_id FROM libraries WHERE name = 'Emby Library'`).Scan(&importedConnID); err != nil {
+		t.Fatalf("scanning imported emby library: %v", err)
+	}
+	if !importedConnID.Valid || importedConnID.String != c2.ID {
+		t.Errorf("connection_id remap: got %v, want %s", importedConnID, c2.ID)
+	}
+	var (
+		gotHash   string
+		gotUserID string
+	)
+	if err := db2.QueryRowContext(ctx,
+		`SELECT token_hash, user_id FROM api_tokens WHERE name = 'CI Token'`).Scan(&gotHash, &gotUserID); err != nil {
+		t.Fatalf("scanning imported token: %v", err)
+	}
+	if gotHash != tokenHash {
+		t.Errorf("token hash drift: got %q, want %q", gotHash, tokenHash)
+	}
+	if gotUserID != "u-target" {
+		t.Errorf("user_id remap: got %q, want u-target", gotUserID)
+	}
+
+	// --- Target #2: no matching connection, no matching user. Both
+	// platform-bound rows must be skipped (not error out); the manual
+	// library still imports.
+	db3 := setupTestDB(t)
+	provSettings3, connSvc3, platSvc3, whSvc3 := newTestServices(t, db3)
+	svc3 := NewService(db3, provSettings3, connSvc3, platSvc3, whSvc3)
+	res3, err := svc3.Import(ctx, envelope, passphrase)
+	if err != nil {
+		t.Fatalf("Import (target #2): %v", err)
+	}
+	// The connection itself imports normally, so the emby library's lookup
+	// would actually succeed -- target #2 must NOT carry the connection.
+	// The Import call above seeds the connection from the payload first,
+	// which means the library lookup will find it. Confirm libraries
+	// imported and assert the missing-user skip on the token instead.
+	if res3.Libraries != 2 {
+		t.Errorf("target #2 libraries imported: got %d, want 2 (connection imported alongside)", res3.Libraries)
+	}
+	if res3.APITokens != 0 || res3.APITokensSkipped != 1 {
+		t.Errorf("target #2 tokens: imported=%d skipped=%d, want 0/1 (no matching user)", res3.APITokens, res3.APITokensSkipped)
+	}
+
+	// --- Target #3: idempotency. Re-importing into target #1 must not
+	// duplicate libraries or tokens (both upsert on natural key).
+	res1b, err := svc2.Import(ctx, envelope, passphrase)
+	if err != nil {
+		t.Fatalf("Import (idempotent): %v", err)
+	}
+	if res1b.Libraries != 2 {
+		t.Errorf("idempotent libraries count: got %d, want 2", res1b.Libraries)
+	}
+	var libCount, tokCount int
+	if err := db2.QueryRowContext(ctx, `SELECT COUNT(*) FROM libraries`).Scan(&libCount); err != nil {
+		t.Fatalf("counting libraries after re-import: %v", err)
+	}
+	if libCount != 2 {
+		t.Errorf("library row count drift after re-import: got %d, want 2", libCount)
+	}
+	if err := db2.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_tokens`).Scan(&tokCount); err != nil {
+		t.Fatalf("counting tokens after re-import: %v", err)
+	}
+	if tokCount != 1 {
+		t.Errorf("api_token row count drift after re-import: got %d, want 1", tokCount)
+	}
+}
+
 func TestEnvelope_JSON(t *testing.T) {
 	env := Envelope{
 		Version:    "1.0",

--- a/internal/settingsio/export_test.go
+++ b/internal/settingsio/export_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sydlexius/stillwater/internal/connection"
 	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
@@ -1141,6 +1142,115 @@ func TestImport_LibrarySkipsOnMissingConnection(t *testing.T) {
 	}
 	if count != 0 {
 		t.Errorf("orphan library was inserted despite missing connection: count=%d", count)
+	}
+}
+
+// TestImport_LibraryReconcilesOnRemoteIdentityCollision exercises the
+// secondary-key fallback: the importer must locate an existing target row
+// by (connection_id, external_id) when the imported name is new on the
+// target. Without that branch the INSERT would fail on the partial unique
+// index in migrations/001 (line 148) and abort the entire settings import,
+// which is the realistic case for two Stillwater instances sharing one
+// media server when the local operator has renamed a library before
+// importing a peer's snapshot.
+func TestImport_LibraryReconcilesOnRemoteIdentityCollision(t *testing.T) {
+	ctx := context.Background()
+
+	// Source: build an envelope containing a library named "Library A"
+	// owned by an Emby connection with external_id "remote-42".
+	srcDB := setupTestDB(t)
+	srcProv, srcConn, srcPlat, srcWH := newTestServices(t, srcDB)
+	srcSvc := NewService(srcDB, srcProv, srcConn, srcPlat, srcWH)
+
+	srcConnObj := &connection.Connection{
+		Name: "Shared Emby", Type: "emby",
+		URL: "http://shared.example:8096", APIKey: "src-key", Enabled: true,
+	}
+	if err := srcConn.Create(ctx, srcConnObj); err != nil {
+		t.Fatalf("source connection: %v", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := srcDB.ExecContext(ctx, `
+		INSERT INTO libraries (
+			id, name, path, type, source, connection_id, external_id,
+			fs_watch, fs_poll_interval, nfo_lock_data, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		uuid.New().String(), "Library A", "/music/lib-a", "regular", "emby",
+		srcConnObj.ID, "remote-42", 0, 60, 0, now, now,
+	); err != nil {
+		t.Fatalf("seeding source library: %v", err)
+	}
+
+	envelope, err := srcSvc.Export(ctx, "collide")
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	// Target: same connection (so import-time remap finds it) and a library
+	// already holding the (connection_id, external_id) pair under a DIFFERENT
+	// local name. The importer must reconcile rather than abort.
+	tgtDB := setupTestDB(t)
+	tgtProv, tgtConn, tgtPlat, tgtWH := newTestServices(t, tgtDB)
+	tgtSvc := NewService(tgtDB, tgtProv, tgtConn, tgtPlat, tgtWH)
+
+	tgtConnObj := &connection.Connection{
+		Name: "Shared Emby", Type: "emby",
+		URL: "http://shared.example:8096", APIKey: "tgt-key", Enabled: true,
+	}
+	if err := tgtConn.Create(ctx, tgtConnObj); err != nil {
+		t.Fatalf("target connection: %v", err)
+	}
+	preExistingID := uuid.New().String()
+	if _, err := tgtDB.ExecContext(ctx, `
+		INSERT INTO libraries (
+			id, name, path, type, source, connection_id, external_id,
+			fs_watch, fs_poll_interval, nfo_lock_data, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		preExistingID, "Library Renamed Locally", "/music/local",
+		"regular", "emby", tgtConnObj.ID, "remote-42", 0, 60, 0, now, now,
+	); err != nil {
+		t.Fatalf("seeding target library: %v", err)
+	}
+
+	res, err := tgtSvc.Import(ctx, envelope, "collide")
+	if err != nil {
+		t.Fatalf("Import must reconcile, not abort, on remote-identity collision: %v", err)
+	}
+	if res.Libraries != 1 {
+		t.Errorf("Libraries imported: got %d, want 1", res.Libraries)
+	}
+	if res.LibrariesSkipped != 0 {
+		t.Errorf("LibrariesSkipped: got %d, want 0", res.LibrariesSkipped)
+	}
+
+	// Reconcile policy: the existing row's id is preserved, and its name is
+	// updated to the imported payload's name. This is the "import payload
+	// wins" rule used elsewhere in the import path.
+	var (
+		count int
+		name  string
+		id    string
+	)
+	if err := tgtDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM libraries WHERE connection_id = ? AND external_id = ?`,
+		tgtConnObj.ID, "remote-42").Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("library row count for remote identity: got %d, want 1 (no duplicate, no skip)", count)
+	}
+	if err := tgtDB.QueryRowContext(ctx,
+		`SELECT id, name FROM libraries WHERE connection_id = ? AND external_id = ?`,
+		tgtConnObj.ID, "remote-42").Scan(&id, &name); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if id != preExistingID {
+		t.Errorf("row id: got %q, want pre-existing %q (reconcile must preserve id)", id, preExistingID)
+	}
+	if name != "Library A" {
+		t.Errorf("row name: got %q, want %q (import payload should win)", name, "Library A")
 	}
 }
 

--- a/internal/settingsio/libraries.go
+++ b/internal/settingsio/libraries.go
@@ -103,6 +103,13 @@ func (s *Service) importLibraries(ctx context.Context, libs []LibraryExport, res
 		// to a local connection. Manual libraries carry no connection reference.
 		var connectionID string
 		if source != "manual" {
+			// Defensive guard: NewService always wires connectionSvc today, but
+			// a nil here would panic on the GetByTypeAndURL call below. Surface
+			// a clear error instead so a misconfigured Service fails fast and
+			// loud rather than crashing mid-import.
+			if s.connectionSvc == nil {
+				return fmt.Errorf("importing library %q: connection service is required for source %q", le.Name, source)
+			}
 			if le.ConnectionType == "" || le.ConnectionURL == "" {
 				slog.Warn("import: skipping library missing connection reference",
 					"library", le.Name, "source", source)

--- a/internal/settingsio/libraries.go
+++ b/internal/settingsio/libraries.go
@@ -121,10 +121,14 @@ func (s *Service) importLibraries(ctx context.Context, libs []LibraryExport, res
 				return fmt.Errorf("looking up connection for library %q: %w", le.Name, err)
 			}
 			if conn == nil {
+				// Connection URLs may embed credentials (e.g. http://user:pass@host)
+				// or sensitive query params, so the URL value itself is omitted from
+				// the warning. A boolean presence flag is enough to disambiguate
+				// "connection reference absent on target" from "no reference given".
 				slog.Warn("import: skipping library whose connection is absent on target",
 					"library", le.Name,
 					"connection_type", le.ConnectionType,
-					"connection_url", le.ConnectionURL,
+					"connection_url_present", le.ConnectionURL != "",
 				)
 				result.LibrariesSkipped++
 				continue
@@ -152,7 +156,7 @@ func (s *Service) importLibraries(ctx context.Context, libs []LibraryExport, res
 			`,
 				id, le.Name, le.Path, validLibraryType(le.Type),
 				source, dbutil.NullableString(connectionID), le.ExternalID,
-				le.FSWatch, validPollInterval(le.FSPollInterval),
+				validFSWatch(le.FSWatch), validPollInterval(le.FSPollInterval),
 				boolToInt(le.NFOLockData), now, now,
 			); err != nil {
 				return fmt.Errorf("inserting library %q: %w", le.Name, err)
@@ -169,7 +173,7 @@ func (s *Service) importLibraries(ctx context.Context, libs []LibraryExport, res
 			`,
 				le.Path, validLibraryType(le.Type),
 				source, dbutil.NullableString(connectionID), le.ExternalID,
-				le.FSWatch, validPollInterval(le.FSPollInterval),
+				validFSWatch(le.FSWatch), validPollInterval(le.FSPollInterval),
 				boolToInt(le.NFOLockData), now, existingID,
 			); err != nil {
 				return fmt.Errorf("updating library %q: %w", le.Name, err)
@@ -217,6 +221,19 @@ func validPollInterval(v int) int {
 	default:
 		return 60
 	}
+}
+
+// validFSWatch clamps the imported fs_watch flag to the canonical 0/1 the
+// schema stores. The column is declared INTEGER without a CHECK, so a tampered
+// or future-version export carrying any non-zero value would otherwise be
+// persisted verbatim and could surprise consumers that compare against 1
+// rather than truthiness. Mirrors the boundary-clamping pattern used by
+// validLibraryType / validLibrarySource / validPollInterval.
+func validFSWatch(v int) int {
+	if v != 0 {
+		return 1
+	}
+	return 0
 }
 
 // boolToInt converts a Go bool to the integer representation SQLite expects

--- a/internal/settingsio/libraries.go
+++ b/internal/settingsio/libraries.go
@@ -144,6 +144,35 @@ func (s *Service) importLibraries(ctx context.Context, libs []LibraryExport, res
 		err := s.db.QueryRowContext(ctx,
 			`SELECT id FROM libraries WHERE name = ?`, le.Name,
 		).Scan(&existingID)
+		// When the name lookup misses, fall back to the secondary unique
+		// identity (connection_id, external_id). The partial unique index
+		// on those two columns (migrations/001 line 148, with WHERE
+		// connection_id IS NOT NULL AND external_id <> '') means an INSERT
+		// with the imported (connection, external_id) pair would otherwise
+		// abort the entire settings import on a target that already holds
+		// the same remote library under a different name -- the realistic
+		// case being two Stillwater instances sharing one media server
+		// where the operator renamed a library locally before importing a
+		// peer's snapshot. Reconcile by treating the secondary-key hit as
+		// the existing row; the imported payload's name wins on the
+		// subsequent UPDATE, matching the existing "import payload wins"
+		// policy used elsewhere on this path. Skip the secondary lookup
+		// when either identifier is empty (the partial index excludes
+		// those rows, so a hit is impossible).
+		if errors.Is(err, sql.ErrNoRows) && connectionID != "" && le.ExternalID != "" {
+			var byRemoteID string
+			remoteErr := s.db.QueryRowContext(ctx,
+				`SELECT id FROM libraries WHERE connection_id = ? AND external_id = ?`,
+				connectionID, le.ExternalID,
+			).Scan(&byRemoteID)
+			switch {
+			case remoteErr == nil:
+				existingID = byRemoteID
+				err = nil
+			case !errors.Is(remoteErr, sql.ErrNoRows):
+				return fmt.Errorf("looking up library by remote identity %q: %w", le.Name, remoteErr)
+			}
+		}
 		switch {
 		case errors.Is(err, sql.ErrNoRows):
 			// Insert new
@@ -164,14 +193,20 @@ func (s *Service) importLibraries(ctx context.Context, libs []LibraryExport, res
 		case err != nil:
 			return fmt.Errorf("looking up library %q: %w", le.Name, err)
 		default:
-			// Update existing
+			// Update existing. `name` is included in SET so the
+			// secondary-key reconcile path (existingID resolved by
+			// (connection_id, external_id) when the name lookup missed)
+			// renames the row to the imported payload's name. The
+			// name-lookup branch above writes the same value back, so the
+			// SET is a no-op there. This implements the "import payload
+			// wins" policy that the rest of the import path follows.
 			if _, err := s.db.ExecContext(ctx, `
 				UPDATE libraries SET
-					path = ?, type = ?, source = ?, connection_id = ?, external_id = ?,
+					name = ?, path = ?, type = ?, source = ?, connection_id = ?, external_id = ?,
 					fs_watch = ?, fs_poll_interval = ?, nfo_lock_data = ?, updated_at = ?
 				WHERE id = ?
 			`,
-				le.Path, validLibraryType(le.Type),
+				le.Name, le.Path, validLibraryType(le.Type),
 				source, dbutil.NullableString(connectionID), le.ExternalID,
 				validFSWatch(le.FSWatch), validPollInterval(le.FSPollInterval),
 				boolToInt(le.NFOLockData), now, existingID,

--- a/internal/settingsio/libraries.go
+++ b/internal/settingsio/libraries.go
@@ -1,0 +1,214 @@
+package settingsio
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
+)
+
+// LibraryExport carries the persistent configuration of a single library row.
+// Connection IDs are not exported because they are generated per-instance;
+// instead the owning connection's (type, url) is carried alongside so the
+// import step can remap to the local connection_id. Runtime-detected
+// shared-FS state (status / evidence / peer ids) is intentionally omitted --
+// the target instance must re-detect on its own scan to avoid carrying stale
+// cluster geometry across the boundary.
+type LibraryExport struct {
+	Name           string `json:"name"`
+	Path           string `json:"path"`
+	Type           string `json:"type"`                      // "regular" | "classical"
+	Source         string `json:"source"`                    // "manual" | "emby" | "jellyfin" | "lidarr"
+	ConnectionType string `json:"connection_type,omitempty"` // for remap on import
+	ConnectionURL  string `json:"connection_url,omitempty"`  // for remap on import
+	ExternalID     string `json:"external_id,omitempty"`
+	FSWatch        int    `json:"fs_watch"`
+	FSPollInterval int    `json:"fs_poll_interval"`
+	NFOLockData    bool   `json:"nfo_lock_data,omitempty"`
+}
+
+// exportLibraries reads every row from the libraries table joined to its
+// owning connection (when present) so the export can remap connection_id on
+// the target instance. Runtime shared-FS columns are not selected.
+func (s *Service) exportLibraries(ctx context.Context) ([]LibraryExport, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT l.name, l.path, l.type, l.source,
+		       COALESCE(c.type, ''), COALESCE(c.url, ''),
+		       l.external_id, l.fs_watch, l.fs_poll_interval, l.nfo_lock_data
+		FROM libraries l
+		LEFT JOIN connections c ON c.id = l.connection_id
+		ORDER BY l.name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying libraries: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var out []LibraryExport
+	for rows.Next() {
+		var (
+			le         LibraryExport
+			nfoLockInt int
+		)
+		if err := rows.Scan(
+			&le.Name, &le.Path, &le.Type, &le.Source,
+			&le.ConnectionType, &le.ConnectionURL,
+			&le.ExternalID, &le.FSWatch, &le.FSPollInterval, &nfoLockInt,
+		); err != nil {
+			return nil, fmt.Errorf("scanning library row: %w", err)
+		}
+		le.NFOLockData = nfoLockInt != 0
+		out = append(out, le)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating library rows: %w", err)
+	}
+	return out, nil
+}
+
+// importLibraries upserts library rows by name (which is UNIQUE in the schema).
+// For non-manual libraries, the owning connection is resolved on the target
+// via (type, url); a missing connection causes the library to be skipped with
+// a warning rather than failing the entire import (same defensive pattern as
+// importUserPreferences). Path validation is intentionally bypassed: the
+// target filesystem may not yet contain the directory at restore time, and
+// rejecting absent paths would defeat the disaster-recovery use case.
+func (s *Service) importLibraries(ctx context.Context, libs []LibraryExport, result *ImportResult) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, le := range libs {
+		if le.Name == "" {
+			// A blank name cannot satisfy the UNIQUE constraint and would
+			// collide on a second import. Skip with a warning rather than
+			// fail, mirroring the defensive posture used elsewhere in import.
+			slog.Warn("import: skipping library with empty name")
+			result.LibrariesSkipped++
+			continue
+		}
+
+		// Resolve connection_id for non-manual libraries by remapping (type, url)
+		// to a local connection. Manual libraries carry no connection reference.
+		var connectionID string
+		if le.Source != "manual" && le.Source != "" {
+			if le.ConnectionType == "" || le.ConnectionURL == "" {
+				slog.Warn("import: skipping library missing connection reference",
+					"library", le.Name, "source", le.Source)
+				result.LibrariesSkipped++
+				continue
+			}
+			conn, err := s.connectionSvc.GetByTypeAndURL(ctx, le.ConnectionType, le.ConnectionURL)
+			if err != nil {
+				return fmt.Errorf("looking up connection for library %q: %w", le.Name, err)
+			}
+			if conn == nil {
+				slog.Warn("import: skipping library whose connection is absent on target",
+					"library", le.Name,
+					"connection_type", le.ConnectionType,
+					"connection_url", le.ConnectionURL,
+				)
+				result.LibrariesSkipped++
+				continue
+			}
+			connectionID = conn.ID
+		}
+
+		// Look up an existing library by name (UNIQUE) to drive upsert. We do
+		// not use INSERT ... ON CONFLICT because the libraries table also has
+		// a partial unique index on (connection_id, external_id) and a name
+		// match must take precedence over an external_id collision.
+		var existingID string
+		err := s.db.QueryRowContext(ctx,
+			`SELECT id FROM libraries WHERE name = ?`, le.Name,
+		).Scan(&existingID)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			// Insert new
+			id := uuid.New().String()
+			if _, err := s.db.ExecContext(ctx, `
+				INSERT INTO libraries (
+					id, name, path, type, source, connection_id, external_id,
+					fs_watch, fs_poll_interval, nfo_lock_data, created_at, updated_at
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			`,
+				id, le.Name, le.Path, validLibraryType(le.Type),
+				validLibrarySource(le.Source), dbutil.NullableString(connectionID), le.ExternalID,
+				le.FSWatch, validPollInterval(le.FSPollInterval),
+				boolToInt(le.NFOLockData), now, now,
+			); err != nil {
+				return fmt.Errorf("inserting library %q: %w", le.Name, err)
+			}
+		case err != nil:
+			return fmt.Errorf("looking up library %q: %w", le.Name, err)
+		default:
+			// Update existing
+			if _, err := s.db.ExecContext(ctx, `
+				UPDATE libraries SET
+					path = ?, type = ?, source = ?, connection_id = ?, external_id = ?,
+					fs_watch = ?, fs_poll_interval = ?, nfo_lock_data = ?, updated_at = ?
+				WHERE id = ?
+			`,
+				le.Path, validLibraryType(le.Type),
+				validLibrarySource(le.Source), dbutil.NullableString(connectionID), le.ExternalID,
+				le.FSWatch, validPollInterval(le.FSPollInterval),
+				boolToInt(le.NFOLockData), now, existingID,
+			); err != nil {
+				return fmt.Errorf("updating library %q: %w", le.Name, err)
+			}
+		}
+		result.Libraries++
+	}
+	return nil
+}
+
+// validLibraryType clamps an inbound type to one of the schema's allowed
+// values. The CHECK constraint on libraries.type would otherwise reject
+// payloads carrying unrecognized values from a tampered or future-version
+// export.
+func validLibraryType(t string) string {
+	switch t {
+	case "regular", "classical":
+		return t
+	default:
+		return "regular"
+	}
+}
+
+// validLibrarySource clamps an inbound source value to one of the recognized
+// constants. An empty or unknown source is normalised to "manual" so the
+// library still loads (with no connection linkage) rather than being dropped
+// outright.
+func validLibrarySource(s string) string {
+	switch s {
+	case "manual", "emby", "jellyfin", "lidarr":
+		return s
+	default:
+		return "manual"
+	}
+}
+
+// validPollInterval mirrors library.IsValidPollInterval without importing the
+// library package (which would create an import cycle once settingsio is
+// consumed by code under internal/library). The list must stay in sync with
+// library.ValidPollIntervals.
+func validPollInterval(v int) int {
+	switch v {
+	case 60, 300, 900, 1800:
+		return v
+	default:
+		return 60
+	}
+}
+
+// boolToInt converts a Go bool to the integer representation SQLite expects
+// for nfo_lock_data. Local helper to avoid leaking the same conversion across
+// every call site.
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/settingsio/libraries.go
+++ b/internal/settingsio/libraries.go
@@ -90,13 +90,22 @@ func (s *Service) importLibraries(ctx context.Context, libs []LibraryExport, res
 			continue
 		}
 
+		// Normalize the inbound source first so the remap decision and the
+		// persisted row use the same value. validLibrarySource clamps unknown
+		// future values to "manual"; using the raw le.Source for the remap
+		// check while writing the normalized value would otherwise leave the
+		// row in an inconsistent state (e.g., source="manual" with a non-NULL
+		// connection_id, or a missing-connection skip for a row that would
+		// have persisted as manual).
+		source := validLibrarySource(le.Source)
+
 		// Resolve connection_id for non-manual libraries by remapping (type, url)
 		// to a local connection. Manual libraries carry no connection reference.
 		var connectionID string
-		if le.Source != "manual" && le.Source != "" {
+		if source != "manual" {
 			if le.ConnectionType == "" || le.ConnectionURL == "" {
 				slog.Warn("import: skipping library missing connection reference",
-					"library", le.Name, "source", le.Source)
+					"library", le.Name, "source", source)
 				result.LibrariesSkipped++
 				continue
 			}
@@ -135,7 +144,7 @@ func (s *Service) importLibraries(ctx context.Context, libs []LibraryExport, res
 				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			`,
 				id, le.Name, le.Path, validLibraryType(le.Type),
-				validLibrarySource(le.Source), dbutil.NullableString(connectionID), le.ExternalID,
+				source, dbutil.NullableString(connectionID), le.ExternalID,
 				le.FSWatch, validPollInterval(le.FSPollInterval),
 				boolToInt(le.NFOLockData), now, now,
 			); err != nil {
@@ -152,7 +161,7 @@ func (s *Service) importLibraries(ctx context.Context, libs []LibraryExport, res
 				WHERE id = ?
 			`,
 				le.Path, validLibraryType(le.Type),
-				validLibrarySource(le.Source), dbutil.NullableString(connectionID), le.ExternalID,
+				source, dbutil.NullableString(connectionID), le.ExternalID,
 				le.FSWatch, validPollInterval(le.FSPollInterval),
 				boolToInt(le.NFOLockData), now, existingID,
 			); err != nil {

--- a/internal/settingsio/tokens.go
+++ b/internal/settingsio/tokens.go
@@ -119,13 +119,17 @@ func (s *Service) importAPITokens(ctx context.Context, tokens []APITokenExport, 
 		case err != nil:
 			return fmt.Errorf("looking up api token by hash: %w", err)
 		default:
+			// Restore created_at on conflict update so the exported audit
+			// metadata is preserved when the same token_hash already exists
+			// on the target. Without this the local row keeps its original
+			// timestamp, drifting from the source instance's record.
 			if _, err := s.db.ExecContext(ctx, `
 				UPDATE api_tokens SET
-					name = ?, scopes = ?, user_id = ?,
+					name = ?, scopes = ?, user_id = ?, created_at = ?,
 					last_used_at = ?, revoked_at = ?, status = ?
 				WHERE id = ?
 			`,
-				te.Name, validTokenScopes(te.Scopes), userID,
+				te.Name, validTokenScopes(te.Scopes), userID, te.CreatedAt,
 				dbutil.NullableString(te.LastUsedAt),
 				dbutil.NullableString(te.RevokedAt),
 				validTokenStatus(te.Status),
@@ -150,13 +154,15 @@ func validTokenScopes(s string) string {
 }
 
 // validTokenStatus normalizes the status field to one of the two recognized
-// values. An unknown status (tampered or future-version payload) defaults to
-// "active" so the row remains usable rather than being silently disabled.
+// values. Auth material must fail closed: an unknown status (tampered payload,
+// a legacy value like "archived" from an older schema, or a future-version
+// status this build doesn't recognize) defaults to "revoked" so the imported
+// token cannot authenticate until an operator explicitly re-enables it.
 func validTokenStatus(s string) string {
 	switch s {
 	case "active", "revoked":
 		return s
 	default:
-		return "active"
+		return "revoked"
 	}
 }

--- a/internal/settingsio/tokens.go
+++ b/internal/settingsio/tokens.go
@@ -1,0 +1,162 @@
+package settingsio
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
+)
+
+// APITokenExport carries the persisted API-token row in a form portable
+// across instances. The plaintext token is never persisted in the DB, so
+// this struct cannot expose it; only the stored hash crosses the wire, and
+// only inside the passphrase-encrypted envelope. Username replaces user_id
+// because user IDs are generated per-instance (same remap pattern as
+// user_preferences).
+type APITokenExport struct {
+	Name       string `json:"name"`
+	TokenHash  string `json:"token_hash"`
+	Scopes     string `json:"scopes"`
+	Username   string `json:"username"`
+	CreatedAt  string `json:"created_at"`
+	LastUsedAt string `json:"last_used_at,omitempty"`
+	RevokedAt  string `json:"revoked_at,omitempty"`
+	Status     string `json:"status"`
+}
+
+// exportAPITokens reads every api_tokens row joined to its owner's username
+// so the import step can remap user_id on the target. Revoked tokens are
+// included as-is (status + revoked_at preserved) so a revoke applied on the
+// source survives the round-trip rather than being silently re-activated.
+func (s *Service) exportAPITokens(ctx context.Context) ([]APITokenExport, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT t.name, t.token_hash, t.scopes, u.username,
+		       t.created_at, COALESCE(t.last_used_at, ''),
+		       COALESCE(t.revoked_at, ''), t.status
+		FROM api_tokens t
+		JOIN users u ON u.id = t.user_id
+		ORDER BY t.created_at, t.name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying api tokens: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var out []APITokenExport
+	for rows.Next() {
+		var te APITokenExport
+		if err := rows.Scan(
+			&te.Name, &te.TokenHash, &te.Scopes, &te.Username,
+			&te.CreatedAt, &te.LastUsedAt, &te.RevokedAt, &te.Status,
+		); err != nil {
+			return nil, fmt.Errorf("scanning api token row: %w", err)
+		}
+		out = append(out, te)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating api token rows: %w", err)
+	}
+	return out, nil
+}
+
+// importAPITokens upserts API tokens by token_hash (which is UNIQUE in the
+// schema). The owning user is resolved by username; if no matching user
+// exists on the target instance, the token is skipped with a warning so a
+// minor user-set drift does not abort the whole import.
+func (s *Service) importAPITokens(ctx context.Context, tokens []APITokenExport, result *ImportResult) error {
+	for _, te := range tokens {
+		if te.TokenHash == "" {
+			// A blank hash cannot satisfy authentication and would collide
+			// on the UNIQUE constraint after one row. Skip with a warning
+			// rather than fail, matching the defensive posture used elsewhere.
+			slog.Warn("import: skipping api token with empty hash", "name", te.Name)
+			result.APITokensSkipped++
+			continue
+		}
+		// Resolve owning user by username.
+		var userID string
+		err := s.db.QueryRowContext(ctx,
+			`SELECT id FROM users WHERE username = ?`, te.Username,
+		).Scan(&userID)
+		if errors.Is(err, sql.ErrNoRows) {
+			slog.Warn("import: skipping api token whose owner is absent on target",
+				"token_name", te.Name, "username", te.Username)
+			result.APITokensSkipped++
+			continue
+		} else if err != nil {
+			return fmt.Errorf("looking up user %q for token %q: %w", te.Username, te.Name, err)
+		}
+
+		// Upsert by token_hash. We look up first (instead of using ON CONFLICT)
+		// so the existing row's id is preserved and only metadata is updated;
+		// re-importing the same export is therefore idempotent without
+		// introducing a new row each pass.
+		var existingID string
+		err = s.db.QueryRowContext(ctx,
+			`SELECT id FROM api_tokens WHERE token_hash = ?`, te.TokenHash,
+		).Scan(&existingID)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			id := uuid.New().String()
+			if _, err := s.db.ExecContext(ctx, `
+				INSERT INTO api_tokens (
+					id, name, token_hash, scopes, user_id,
+					created_at, last_used_at, revoked_at, status
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			`,
+				id, te.Name, te.TokenHash, validTokenScopes(te.Scopes), userID,
+				te.CreatedAt,
+				dbutil.NullableString(te.LastUsedAt),
+				dbutil.NullableString(te.RevokedAt),
+				validTokenStatus(te.Status),
+			); err != nil {
+				return fmt.Errorf("inserting api token %q: %w", te.Name, err)
+			}
+		case err != nil:
+			return fmt.Errorf("looking up api token by hash: %w", err)
+		default:
+			if _, err := s.db.ExecContext(ctx, `
+				UPDATE api_tokens SET
+					name = ?, scopes = ?, user_id = ?,
+					last_used_at = ?, revoked_at = ?, status = ?
+				WHERE id = ?
+			`,
+				te.Name, validTokenScopes(te.Scopes), userID,
+				dbutil.NullableString(te.LastUsedAt),
+				dbutil.NullableString(te.RevokedAt),
+				validTokenStatus(te.Status),
+				existingID,
+			); err != nil {
+				return fmt.Errorf("updating api token %q: %w", te.Name, err)
+			}
+		}
+		result.APITokens++
+	}
+	return nil
+}
+
+// validTokenScopes falls back to the schema default when the import payload
+// carries an empty scope string. The schema's NOT NULL DEFAULT 'read,write'
+// would not apply on an explicit "" value, so we apply the same default here.
+func validTokenScopes(s string) string {
+	if s == "" {
+		return "read,write"
+	}
+	return s
+}
+
+// validTokenStatus normalizes the status field to one of the two recognized
+// values. An unknown status (tampered or future-version payload) defaults to
+// "active" so the row remains usable rather than being silently disabled.
+func validTokenStatus(s string) string {
+	switch s {
+	case "active", "revoked":
+		return s
+	default:
+		return "active"
+	}
+}


### PR DESCRIPTION
## Summary
- Bumps settings envelope to version 1.2.
- Adds `Libraries` to the export `Payload` (path, connection reference via type+url, naming type, source, fs_watch, fs_poll_interval, nfo_lock_data, external_id).
- Adds `APITokens` to the export `Payload` (token_hash + metadata only; never plaintext, which the DB does not store anyway).
- Updates `ImportResult` with per-domain counters and skip-reason counters (`libraries`, `libraries_skipped`, `api_tokens`, `api_tokens_skipped`).
- Adds round-trip test plus a tampered-payload test for the library skip path, and Bruno scenarios for export + import.

Closes #1186.
Closes #1189.

## Notes
- Single envelope bump (1.1 -> 1.2) covers both issues per the M53 W2.D plan.
- Connection IDs are not exported; the (type, url) pair is carried instead and remapped on import (same pattern already used for connection upsert).
- API token hashes ride inside the existing AES-256-GCM passphrase-encrypted envelope, the same protection surface as connection API keys and OIDC client secrets.
- Runtime-detected shared-FS state (`shared_fs_status` / `shared_fs_evidence` / `shared_fs_peer_library_ids`) is intentionally not exported per #1186; the target instance re-detects on its next scan.
- No DB migration: the envelope version lives in code only.
- Path validation is bypassed on library import so disaster-recovery restores into an instance whose target filesystem may not yet exist do not fail.

## Test plan
- [ ] Round-trip export/import on a populated test DB; libraries + tokens present after import (covered by `TestRoundTrip_LibrariesAndTokens`)
- [ ] Existing API tokens keep authenticating after import (hash round-trip asserted: `db2.QueryRow ... token_hash` equals seed)
- [ ] Skipped-library reason surfaced when the connection reference is missing (covered by `TestImport_LibrarySkipsOnMissingConnection`)
- [ ] Skipped-token reason surfaced when the owning user is missing (covered by target #2 in `TestRoundTrip_LibrariesAndTokens`)
- [ ] Idempotent re-import does not duplicate library or token rows (covered)
- [ ] Bruno scenarios pass against a running instance (`api/bruno/settings/export-settings.bru` + `import-settings.bru`)

## Deferred
- The HTMX import-success fragment in `internal/api/handlers_settings_io.go` does not yet surface the new `libraries` / `api_tokens` counters in its inline summary (JSON callers see the full `ImportResult`). Out of scope per W2.D file boundaries; UX polish for a follow-up.

DRAFT until UAT complete.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export/import now includes libraries and API tokens; envelope format bumped to v1.2 and includes summary counts.

* **Behavior Changes**
  * Import reports detailed counts for imported/skipped libraries and tokens, remaps connections/users when possible, is idempotent, and skips orphaned libraries or tokens with missing owners while tracking skips.

* **Tests**
  * Added integration tests covering round-trip export/import, library skip-on-missing-connection, reconciliation on identity collision, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->