### PR TITLE
feat(docs): codegen Supported Providers matrix from registry (#1251)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate migrate favicon hooks check-openapi hadolint scan
+.PHONY: build run test test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks check-openapi hadolint scan
 
 # Binary name
 BINARY=stillwater
@@ -68,6 +68,10 @@ tailwind:
 
 ## generate: Run all code generation (templ + tailwind)
 generate: templ tailwind
+
+## generate-docs: Regenerate docs site content from code (provider matrix)
+generate-docs:
+	go run ./cmd/gen-provider-matrix
 
 ## tailwind-watch: Watch and rebuild Tailwind CSS
 tailwind-watch:

--- a/cmd/gen-provider-matrix/main.go
+++ b/cmd/gen-provider-matrix/main.go
@@ -10,8 +10,10 @@
 //	go run ./cmd/gen-provider-matrix -check       # exit non-zero if regen needed
 //	go run ./cmd/gen-provider-matrix -output FILE # write to a different file
 //
-// AllMusic is intentionally skipped: the adapter exists but is not currently
-// part of AllProviderNames(), so the matrix only reflects in-use providers.
+// AllMusic is intentionally excluded: the adapter exists in
+// internal/provider/allmusic but is not part of AllProviderNames() in normal
+// builds. The renderer also filters it defensively in case the registry order
+// changes; see project_allmusic_cleanup / issue #1275.
 package main
 
 import (
@@ -176,25 +178,24 @@ func renderYesNo(b bool) string {
 	return "No"
 }
 
+// renderFields joins the provider's declared metadata fields with commas.
+// Declaration order is preserved so registries can group related fields
+// (born/formed/died/disbanded) for readability. Returns "Image only" when no
+// metadata fields are declared (e.g., Fanart.tv).
 func renderFields(fields []string) string {
 	if len(fields) == 0 {
 		return "Image only"
 	}
-	// Preserve declaration order so providers can group related fields
-	// (born/formed/died/disbanded) for readability. Defensive copy avoids
-	// mutating the registry slice.
-	out := make([]string, len(fields))
-	copy(out, fields)
-	return strings.Join(out, ", ")
+	return strings.Join(fields, ", ")
 }
 
+// renderImages joins the provider's declared image types. Returns "None" for
+// metadata-only providers.
 func renderImages(images []string) string {
 	if len(images) == 0 {
 		return "None"
 	}
-	out := make([]string, len(images))
-	copy(out, images)
-	return strings.Join(out, ", ")
+	return strings.Join(images, ", ")
 }
 
 // replaceBetweenMarkers returns src with the region between begin and end

--- a/cmd/gen-provider-matrix/main.go
+++ b/cmd/gen-provider-matrix/main.go
@@ -181,21 +181,41 @@ func renderYesNo(b bool) string {
 // renderFields joins the provider's declared metadata fields with commas.
 // Declaration order is preserved so registries can group related fields
 // (born/formed/died/disbanded) for readability. Returns "Image only" when no
-// metadata fields are declared (e.g., Fanart.tv).
+// metadata fields are declared (e.g., Fanart.tv). Field names are emitted in
+// user-facing form: snake_case identifiers are detokenized into space-separated
+// words with sentence-case capitalization (e.g., sort_name -> Sort name).
 func renderFields(fields []string) string {
 	if len(fields) == 0 {
 		return "Image only"
 	}
-	return strings.Join(fields, ", ")
+	out := make([]string, len(fields))
+	for i, f := range fields {
+		out[i] = friendlyFieldName(f)
+	}
+	return strings.Join(out, ", ")
 }
 
 // renderImages joins the provider's declared image types. Returns "None" for
-// metadata-only providers.
+// metadata-only providers. Image type identifiers are emitted as-is (lowercase,
+// matching the convention used elsewhere in user docs: thumb, fanart, hdlogo,
+// widethumb, etc.).
 func renderImages(images []string) string {
 	if len(images) == 0 {
 		return "None"
 	}
 	return strings.Join(images, ", ")
+}
+
+// friendlyFieldName converts a snake_case metadata-field identifier into the
+// sentence-case user-facing form used in docs prose (sort_name -> "Sort name",
+// years_active -> "Years active"). Identifiers without underscores are returned
+// with only the first letter capitalized (name -> "Name").
+func friendlyFieldName(s string) string {
+	if s == "" {
+		return s
+	}
+	spaced := strings.ReplaceAll(s, "_", " ")
+	return strings.ToUpper(spaced[:1]) + spaced[1:]
 }
 
 // replaceBetweenMarkers returns src with the region between begin and end

--- a/cmd/gen-provider-matrix/main.go
+++ b/cmd/gen-provider-matrix/main.go
@@ -1,0 +1,229 @@
+// Command gen-provider-matrix renders the "Supported Providers" capability
+// matrix in docs/site/src/reference/providers.md from the live provider
+// registry. It walks AllProviderNames() in display order, reads each
+// provider's ProviderCapability, and writes a Markdown table between the
+// well-known BEGIN/END markers in the docs file.
+//
+// Usage:
+//
+//	go run ./cmd/gen-provider-matrix              # rewrite the file in place
+//	go run ./cmd/gen-provider-matrix -check       # exit non-zero if regen needed
+//	go run ./cmd/gen-provider-matrix -output FILE # write to a different file
+//
+// AllMusic is intentionally skipped: the adapter exists but is not currently
+// part of AllProviderNames(), so the matrix only reflects in-use providers.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+const (
+	beginMarker = "<!-- BEGIN GENERATED: provider-matrix -->"
+	endMarker   = "<!-- END GENERATED: provider-matrix -->"
+)
+
+// defaultOutputPath is the docs file the generator writes to. It is a
+// repo-relative path resolved from the current working directory.
+const defaultOutputPath = "docs/site/src/reference/providers.md"
+
+func main() {
+	var (
+		checkOnly bool
+		outPath   string
+	)
+	flag.BoolVar(&checkOnly, "check", false, "exit non-zero if the matrix needs to be regenerated")
+	flag.StringVar(&outPath, "output", defaultOutputPath, "path to the docs file to update")
+	flag.Parse()
+
+	if err := run(outPath, checkOnly); err != nil {
+		fmt.Fprintln(os.Stderr, "gen-provider-matrix:", err)
+		os.Exit(1)
+	}
+}
+
+func run(outPath string, checkOnly bool) error {
+	// outPath comes from the -output flag (or the default docs path); this
+	// is a developer-only build-time tool, so a configurable path is intended.
+	existing, err := os.ReadFile(outPath) //nolint:gosec // G304: developer CLI, path is intentionally configurable
+	if err != nil {
+		return fmt.Errorf("read %s: %w", outPath, err)
+	}
+
+	rendered := renderMatrix(provider.AllProviderNames(), provider.ProviderCapabilities())
+	updated, err := replaceBetweenMarkers(existing, beginMarker, endMarker, rendered)
+	if err != nil {
+		return fmt.Errorf("update %s: %w", outPath, err)
+	}
+
+	if checkOnly {
+		if !bytes.Equal(existing, updated) {
+			return fmt.Errorf("%s is stale; run `make generate-docs` to regenerate", filepath.ToSlash(outPath))
+		}
+		return nil
+	}
+
+	if bytes.Equal(existing, updated) {
+		return nil
+	}
+	if err := os.WriteFile(outPath, updated, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", outPath, err)
+	}
+	return nil
+}
+
+// renderMatrix returns the Markdown table body (without surrounding markers)
+// for the providers in names, looked up in caps. Providers absent from caps
+// are skipped, as is the AllMusic adapter (not part of AllProviderNames in
+// practice, but defensively skipped here).
+func renderMatrix(names []provider.ProviderName, caps map[provider.ProviderName]provider.ProviderCapability) string {
+	var b strings.Builder
+	b.WriteString("| Provider | Tier | Sign-up | Rate limit | Mirror | Metadata fields | Image types |\n")
+	b.WriteString("|---|---|---|---|---|---|---|\n")
+	for _, name := range names {
+		if name == provider.NameAllMusic {
+			continue
+		}
+		c, ok := caps[name]
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s | %s |\n",
+			name.DisplayName(),
+			renderTier(c.Tier),
+			renderSignup(c.HelpURL),
+			renderRateLimit(c.RateLimit),
+			renderYesNo(c.SupportsBaseURL),
+			renderFields(c.SupportedFields),
+			renderImages(c.SupportedImages),
+		)
+	}
+	return b.String()
+}
+
+func renderTier(t provider.AccessTier) string {
+	switch t {
+	case provider.TierFree:
+		return "Free"
+	case provider.TierFreeKey:
+		return "Free key"
+	case provider.TierFreemium:
+		return "Freemium"
+	case provider.TierPaid:
+		return "Paid"
+	default:
+		return string(t)
+	}
+}
+
+func renderSignup(helpURL string) string {
+	if helpURL == "" {
+		return "Not required"
+	}
+	return fmt.Sprintf("[Sign up](%s)", helpURL)
+}
+
+func renderRateLimit(rl *provider.RateLimitInfo) string {
+	if rl == nil {
+		return "Unknown"
+	}
+	var parts []string
+	if rl.RequestsPerSecond > 0 {
+		parts = append(parts, formatPerSecond(rl.RequestsPerSecond))
+	}
+	if rl.RequestsPerDay > 0 {
+		parts = append(parts, fmt.Sprintf("%d/day", rl.RequestsPerDay))
+	}
+	if rl.RequestsPerMonth > 0 {
+		parts = append(parts, fmt.Sprintf("%d/month", rl.RequestsPerMonth))
+	}
+	if len(parts) == 0 {
+		return "Unknown"
+	}
+	return strings.Join(parts, ", ")
+}
+
+// formatPerSecond renders requests-per-second as a compact human label.
+// Whole-number rates (1, 3, 5) render as "N/sec"; sub-second rates render in
+// per-minute terms ("30/min" for 0.5 rps) so the matrix doesn't display
+// "0.5/sec".
+func formatPerSecond(rps float64) string {
+	if rps >= 1 {
+		// Trim a trailing ".0" if the value is integral.
+		if rps == float64(int(rps)) {
+			return fmt.Sprintf("%d/sec", int(rps))
+		}
+		return fmt.Sprintf("%.1f/sec", rps)
+	}
+	perMin := rps * 60
+	if perMin == float64(int(perMin)) {
+		return fmt.Sprintf("%d/min", int(perMin))
+	}
+	return fmt.Sprintf("%.1f/min", perMin)
+}
+
+func renderYesNo(b bool) string {
+	if b {
+		return "Yes"
+	}
+	return "No"
+}
+
+func renderFields(fields []string) string {
+	if len(fields) == 0 {
+		return "Image only"
+	}
+	// Preserve declaration order so providers can group related fields
+	// (born/formed/died/disbanded) for readability. Defensive copy avoids
+	// mutating the registry slice.
+	out := make([]string, len(fields))
+	copy(out, fields)
+	return strings.Join(out, ", ")
+}
+
+func renderImages(images []string) string {
+	if len(images) == 0 {
+		return "None"
+	}
+	out := make([]string, len(images))
+	copy(out, images)
+	return strings.Join(out, ", ")
+}
+
+// replaceBetweenMarkers returns src with the region between begin and end
+// replaced by body. The markers themselves are preserved. body is sandwiched
+// in newlines so the rendered table has clean blank-line separation from the
+// markers; trailing newlines on body are normalized.
+//
+// begin and end are parameters (not constants) so the helper can be exercised
+// with bespoke markers in tests.
+func replaceBetweenMarkers(src []byte, begin, end, body string) ([]byte, error) { //nolint:unparam // begin/end are exposed as parameters for testability
+	beginIdx := bytes.Index(src, []byte(begin))
+	if beginIdx < 0 {
+		return nil, fmt.Errorf("begin marker %q not found", begin)
+	}
+	endIdx := bytes.Index(src, []byte(end))
+	if endIdx < 0 {
+		return nil, fmt.Errorf("end marker %q not found", end)
+	}
+	if endIdx < beginIdx {
+		return nil, fmt.Errorf("end marker appears before begin marker")
+	}
+
+	body = strings.TrimRight(body, "\n")
+	var out bytes.Buffer
+	out.Write(src[:beginIdx])
+	out.WriteString(begin)
+	out.WriteString("\n")
+	out.WriteString(body)
+	out.WriteString("\n")
+	out.Write(src[endIdx:])
+	return out.Bytes(), nil
+}

--- a/cmd/gen-provider-matrix/main.go
+++ b/cmd/gen-provider-matrix/main.go
@@ -61,7 +61,10 @@ func run(outPath string, checkOnly bool) error {
 		return fmt.Errorf("read %s: %w", outPath, err)
 	}
 
-	rendered := renderMatrix(provider.AllProviderNames(), provider.ProviderCapabilities())
+	rendered, err := renderMatrix(provider.AllProviderNames(), provider.ProviderCapabilities())
+	if err != nil {
+		return fmt.Errorf("render matrix: %w", err)
+	}
 	updated, err := replaceBetweenMarkers(existing, beginMarker, endMarker, rendered)
 	if err != nil {
 		return fmt.Errorf("update %s: %w", outPath, err)
@@ -84,10 +87,14 @@ func run(outPath string, checkOnly bool) error {
 }
 
 // renderMatrix returns the Markdown table body (without surrounding markers)
-// for the providers in names, looked up in caps. Providers absent from caps
-// are skipped, as is the AllMusic adapter (not part of AllProviderNames in
-// practice, but defensively skipped here).
-func renderMatrix(names []provider.ProviderName, caps map[provider.ProviderName]provider.ProviderCapability) string {
+// for the providers in names, looked up in caps. The AllMusic adapter is
+// defensively skipped (it is not part of AllProviderNames in normal builds;
+// see project_allmusic_cleanup / issue #1275). A provider that appears in
+// names but lacks a capability declaration in caps is treated as a hard error
+// so drift between AllProviderNames() and ProviderCapabilities() fails the
+// `make generate-docs` / `-check` pipeline loudly instead of silently dropping
+// the row from docs.
+func renderMatrix(names []provider.ProviderName, caps map[provider.ProviderName]provider.ProviderCapability) (string, error) {
 	var b strings.Builder
 	b.WriteString("| Provider | Tier | Sign-up | Rate limit | Mirror | Metadata fields | Image types |\n")
 	b.WriteString("|---|---|---|---|---|---|---|\n")
@@ -97,7 +104,7 @@ func renderMatrix(names []provider.ProviderName, caps map[provider.ProviderName]
 		}
 		c, ok := caps[name]
 		if !ok {
-			continue
+			return "", fmt.Errorf("missing capability declaration for provider %q in ProviderCapabilities()", name)
 		}
 		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s | %s |\n",
 			name.DisplayName(),
@@ -109,7 +116,7 @@ func renderMatrix(names []provider.ProviderName, caps map[provider.ProviderName]
 			renderImages(c.SupportedImages),
 		)
 	}
-	return b.String()
+	return b.String(), nil
 }
 
 func renderTier(t provider.AccessTier) string {

--- a/cmd/gen-provider-matrix/main.go
+++ b/cmd/gen-provider-matrix/main.go
@@ -1,8 +1,9 @@
 // Command gen-provider-matrix renders the "Supported Providers" capability
-// matrix in docs/site/src/reference/providers.md from the live provider
-// registry. It walks AllProviderNames() in display order, reads each
-// provider's ProviderCapability, and writes a Markdown table between the
-// well-known BEGIN/END markers in the docs file.
+// matrix in docs/site/src/reference/providers.md from the static provider
+// declarations in internal/provider (provider.AllProviderNames() for display
+// order and provider.ProviderCapabilities() for per-provider capability data).
+// It does not introspect the runtime provider.Registry. It writes a Markdown
+// table between the well-known BEGIN/END markers in the docs file.
 //
 // Usage:
 //
@@ -24,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sydlexius/stillwater/internal/filesystem"
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
@@ -75,7 +77,7 @@ func run(outPath string, checkOnly bool) error {
 	if bytes.Equal(existing, updated) {
 		return nil
 	}
-	if err := os.WriteFile(outPath, updated, 0o600); err != nil {
+	if err := filesystem.WriteFileAtomic(outPath, updated, 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", outPath, err)
 	}
 	return nil
@@ -199,11 +201,15 @@ func renderFields(fields []string) string {
 // metadata-only providers. Image type identifiers are emitted as-is (lowercase,
 // matching the convention used elsewhere in user docs: thumb, fanart, hdlogo,
 // widethumb, etc.).
-func renderImages(images []string) string {
+func renderImages(images []provider.ImageType) string {
 	if len(images) == 0 {
 		return "None"
 	}
-	return strings.Join(images, ", ")
+	parts := make([]string, len(images))
+	for i, img := range images {
+		parts[i] = string(img)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // friendlyFieldName converts a snake_case metadata-field identifier into the
@@ -230,13 +236,15 @@ func replaceBetweenMarkers(src []byte, begin, end, body string) ([]byte, error) 
 	if beginIdx < 0 {
 		return nil, fmt.Errorf("begin marker %q not found", begin)
 	}
-	endIdx := bytes.Index(src, []byte(end))
-	if endIdx < 0 {
-		return nil, fmt.Errorf("end marker %q not found", end)
+	// Search for the end marker only after the begin marker so an incidental
+	// occurrence of the end marker text earlier in the file (for example, in a
+	// fenced code block illustrating the convention) cannot be mistaken for
+	// the closing marker.
+	relEndIdx := bytes.Index(src[beginIdx:], []byte(end))
+	if relEndIdx < 0 {
+		return nil, fmt.Errorf("end marker %q not found after begin marker", end)
 	}
-	if endIdx < beginIdx {
-		return nil, fmt.Errorf("end marker appears before begin marker")
-	}
+	endIdx := beginIdx + relEndIdx
 
 	body = strings.TrimRight(body, "\n")
 	var out bytes.Buffer

--- a/cmd/gen-provider-matrix/main_test.go
+++ b/cmd/gen-provider-matrix/main_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+func TestRenderMatrix_HappyPath(t *testing.T) {
+	got := renderMatrix(provider.AllProviderNames(), provider.ProviderCapabilities())
+
+	// Header is fixed.
+	wantHeader := "| Provider | Tier | Sign-up | Rate limit | Mirror | Metadata fields | Image types |\n|---|---|---|---|---|---|---|\n"
+	if !strings.HasPrefix(got, wantHeader) {
+		t.Fatalf("missing or wrong header.\ngot:\n%s", got)
+	}
+
+	// Every in-use provider gets a row keyed by its DisplayName.
+	for _, name := range provider.AllProviderNames() {
+		if name == provider.NameAllMusic {
+			continue
+		}
+		needle := "| " + name.DisplayName() + " |"
+		if !strings.Contains(got, needle) {
+			t.Errorf("expected row for %s; output was:\n%s", name.DisplayName(), got)
+		}
+	}
+
+	// AllMusic must never appear (skip-entirely policy from the spec).
+	if strings.Contains(got, "AllMusic") {
+		t.Errorf("AllMusic should be excluded from generated matrix; got:\n%s", got)
+	}
+
+	// Spot-check a few representative renderings.
+	if !strings.Contains(got, "MusicBrainz | Free | Not required | 1/sec | Yes |") {
+		t.Errorf("MusicBrainz row not rendered as expected; got:\n%s", got)
+	}
+	if !strings.Contains(got, "Fanart.tv | Free key |") || !strings.Contains(got, "Image only") {
+		t.Errorf("Fanart.tv row missing expected fragments; got:\n%s", got)
+	}
+	if !strings.Contains(got, "TheAudioDB | Freemium |") || !strings.Contains(got, "30/min") {
+		t.Errorf("TheAudioDB row should render Freemium with 30/min rate limit; got:\n%s", got)
+	}
+	if !strings.Contains(got, "Discogs |") || !strings.Contains(got, "1/sec, 1000/day") {
+		t.Errorf("Discogs row should render combined rate limits; got:\n%s", got)
+	}
+}
+
+func TestReplaceBetweenMarkers(t *testing.T) {
+	src := []byte("prefix\n" + beginMarker + "\nstale body\n" + endMarker + "\nsuffix\n")
+	out, err := replaceBetweenMarkers(src, beginMarker, endMarker, "fresh body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "prefix\n" + beginMarker + "\nfresh body\n" + endMarker + "\nsuffix\n"
+	if string(out) != want {
+		t.Fatalf("unexpected output\nwant:\n%s\n\ngot:\n%s", want, string(out))
+	}
+}
+
+func TestReplaceBetweenMarkers_MissingBegin(t *testing.T) {
+	_, err := replaceBetweenMarkers([]byte("no markers here"), beginMarker, endMarker, "body")
+	if err == nil {
+		t.Fatal("expected error when begin marker is missing")
+	}
+}
+
+func TestReplaceBetweenMarkers_MissingEnd(t *testing.T) {
+	src := []byte("prefix " + beginMarker + " no end")
+	_, err := replaceBetweenMarkers(src, beginMarker, endMarker, "body")
+	if err == nil {
+		t.Fatal("expected error when end marker is missing")
+	}
+}
+
+func TestRenderTier(t *testing.T) {
+	cases := map[provider.AccessTier]string{
+		provider.TierFree:     "Free",
+		provider.TierFreeKey:  "Free key",
+		provider.TierFreemium: "Freemium",
+		provider.TierPaid:     "Paid",
+	}
+	for tier, want := range cases {
+		if got := renderTier(tier); got != want {
+			t.Errorf("renderTier(%q) = %q, want %q", tier, got, want)
+		}
+	}
+}
+
+func TestFormatPerSecond(t *testing.T) {
+	cases := []struct {
+		rps  float64
+		want string
+	}{
+		{1, "1/sec"},
+		{3, "3/sec"},
+		{5, "5/sec"},
+		{0.5, "30/min"},
+		{2.5, "2.5/sec"},
+	}
+	for _, c := range cases {
+		if got := formatPerSecond(c.rps); got != c.want {
+			t.Errorf("formatPerSecond(%v) = %q, want %q", c.rps, got, c.want)
+		}
+	}
+}
+
+func TestRenderRateLimit_Nil(t *testing.T) {
+	if got := renderRateLimit(nil); got != "Unknown" {
+		t.Errorf("renderRateLimit(nil) = %q, want %q", got, "Unknown")
+	}
+}
+
+func TestRenderSignup(t *testing.T) {
+	if got := renderSignup(""); got != "Not required" {
+		t.Errorf("empty helpURL should render as Not required; got %q", got)
+	}
+	if got := renderSignup("https://example.com/key"); got != "[Sign up](https://example.com/key)" {
+		t.Errorf("unexpected sign-up rendering: %q", got)
+	}
+}

--- a/cmd/gen-provider-matrix/main_test.go
+++ b/cmd/gen-provider-matrix/main_test.go
@@ -8,7 +8,10 @@ import (
 )
 
 func TestRenderMatrix_HappyPath(t *testing.T) {
-	got := renderMatrix(provider.AllProviderNames(), provider.ProviderCapabilities())
+	got, err := renderMatrix(provider.AllProviderNames(), provider.ProviderCapabilities())
+	if err != nil {
+		t.Fatalf("renderMatrix: %v", err)
+	}
 
 	// Header is fixed.
 	wantHeader := "| Provider | Tier | Sign-up | Rate limit | Mirror | Metadata fields | Image types |\n|---|---|---|---|---|---|---|\n"
@@ -118,5 +121,21 @@ func TestRenderSignup(t *testing.T) {
 	}
 	if got := renderSignup("https://example.com/key"); got != "[Sign up](https://example.com/key)" {
 		t.Errorf("unexpected sign-up rendering: %q", got)
+	}
+}
+
+func TestRenderMatrix_MissingCapabilityIsError(t *testing.T) {
+	// Drift between AllProviderNames() and ProviderCapabilities() must fail
+	// generation loudly rather than silently dropping the provider's row.
+	names := []provider.ProviderName{provider.NameMusicBrainz, "ghost-provider"}
+	caps := map[provider.ProviderName]provider.ProviderCapability{
+		provider.NameMusicBrainz: provider.ProviderCapabilities()[provider.NameMusicBrainz],
+	}
+	_, err := renderMatrix(names, caps)
+	if err == nil {
+		t.Fatal("expected error when a name has no capability declaration")
+	}
+	if !strings.Contains(err.Error(), "ghost-provider") {
+		t.Errorf("error should name the missing provider; got %v", err)
 	}
 }

--- a/docs/site/src/reference/index.md
+++ b/docs/site/src/reference/index.md
@@ -28,7 +28,7 @@ The map for "where do I find the exact list of X?" Each page is a deep enumerati
 
     ---
 
-    The capability matrix (generated from the live registry), the fallback chain semantics, per-field aggregation, and the auth tiers.
+    The capability matrix (generated from the provider definitions in the codebase), the fallback chain semantics, per-field aggregation, and the auth tiers.
 
     [Read more](providers.md)
 

--- a/docs/site/src/reference/providers.md
+++ b/docs/site/src/reference/providers.md
@@ -10,7 +10,7 @@ A **provider** is an external metadata source Stillwater queries for an artist's
 
 ## Capability matrix
 
-The table below is generated from the live provider registry. Don't edit it directly -- regenerate with `make generate-docs` after changes to the registry or any provider package.
+The table below is generated from the provider definitions in the codebase. Don't edit it directly -- regenerate with `make generate-docs` after changes to the registry or any provider package.
 
 <!-- BEGIN GENERATED: provider-matrix -->
 | Provider | Tier | Sign-up | Rate limit | Mirror | Metadata fields | Image types |

--- a/docs/site/src/reference/providers.md
+++ b/docs/site/src/reference/providers.md
@@ -15,16 +15,16 @@ The table below is generated from the live provider registry. Don't edit it dire
 <!-- BEGIN GENERATED: provider-matrix -->
 | Provider | Tier | Sign-up | Rate limit | Mirror | Metadata fields | Image types |
 |---|---|---|---|---|---|---|
-| MusicBrainz | Free | Not required | 1/sec | Yes | name, sort_name, type, gender, disambiguation, origin, born, formed, died, disbanded, years_active, genres, styles, moods, members, aliases | None |
-| Wikipedia | Free | Not required | 5/sec | No | name, biography, years_active, origin, genres, members | None |
+| MusicBrainz | Free | Not required | 1/sec | Yes | Name, Sort name, Type, Gender, Disambiguation, Origin, Born, Formed, Died, Disbanded, Years active, Genres, Styles, Moods, Members, Aliases | None |
+| Wikipedia | Free | Not required | 5/sec | No | Name, Biography, Years active, Origin, Genres, Members | None |
 | Fanart.tv | Free key | [Sign up](https://fanart.tv/get-an-api-key/) | 3/sec | No | Image only | thumb, fanart, logo, hdlogo, banner |
-| TheAudioDB | Freemium | [Sign up](https://www.theaudiodb.com/pricing) | 30/min | No | name, gender, origin, biography, genres, styles, moods, born, formed, died, disbanded, aliases | thumb, logo, widethumb, banner, fanart |
-| Discogs | Free key | [Sign up](https://www.discogs.com/settings/developers) | 1/sec, 1000/day | No | name, biography, aliases, members | thumb |
-| Last.fm | Free key | [Sign up](https://www.last.fm/api/account/create) | 5/sec | No | name, biography, genres, styles, moods, similar_artists | None |
-| Wikidata | Free | Not required | 5/sec | No | name, formed, disbanded, origin, genres | thumb, logo |
-| Deezer | Free | Not required | 5/sec | No | name | thumb |
-| Genius | Free key | [Sign up](https://genius.com/api-clients) | 5/sec | No | name, biography, aliases | None |
-| Spotify | Paid | [Sign up](https://developer.spotify.com/dashboard) | 5/sec | No | name, genres | thumb |
+| TheAudioDB | Freemium | [Sign up](https://www.theaudiodb.com/pricing) | 30/min | No | Name, Gender, Origin, Biography, Genres, Styles, Moods, Born, Formed, Died, Disbanded, Aliases | thumb, logo, widethumb, banner, fanart |
+| Discogs | Free key | [Sign up](https://www.discogs.com/settings/developers) | 1/sec, 1000/day | No | Name, Biography, Aliases, Members | thumb |
+| Last.fm | Free key | [Sign up](https://www.last.fm/api/account/create) | 5/sec | No | Name, Biography, Genres, Styles, Moods, Similar artists | None |
+| Wikidata | Free | Not required | 5/sec | No | Name, Formed, Disbanded, Origin, Genres | thumb, logo |
+| Deezer | Free | Not required | 5/sec | No | Name | thumb |
+| Genius | Free key | [Sign up](https://genius.com/api-clients) | 5/sec | No | Name, Biography, Aliases | None |
+| Spotify | Paid | [Sign up](https://developer.spotify.com/dashboard) | 5/sec | No | Name, Genres | thumb |
 <!-- END GENERATED: provider-matrix -->
 
 ## How the fallback chain works

--- a/docs/site/src/reference/providers.md
+++ b/docs/site/src/reference/providers.md
@@ -13,7 +13,18 @@ A **provider** is an external metadata source Stillwater queries for an artist's
 The table below is generated from the live provider registry. Don't edit it directly -- regenerate with `make generate-docs` after changes to the registry or any provider package.
 
 <!-- BEGIN GENERATED: provider-matrix -->
-*The provider matrix is generated at build time. To preview without running the generator, see [providers in core concepts](../core-concepts/providers.md) for the high-level list.*
+| Provider | Tier | Sign-up | Rate limit | Mirror | Metadata fields | Image types |
+|---|---|---|---|---|---|---|
+| MusicBrainz | Free | Not required | 1/sec | Yes | name, sort_name, type, gender, disambiguation, origin, born, formed, died, disbanded, years_active, genres, styles, moods, members, aliases | None |
+| Wikipedia | Free | Not required | 5/sec | No | name, biography, years_active, origin, genres, members | None |
+| Fanart.tv | Free key | [Sign up](https://fanart.tv/get-an-api-key/) | 3/sec | No | Image only | thumb, fanart, logo, hdlogo, banner |
+| TheAudioDB | Freemium | [Sign up](https://www.theaudiodb.com/pricing) | 30/min | No | name, gender, origin, biography, genres, styles, moods, born, formed, died, disbanded, aliases | thumb, logo, widethumb, banner, fanart |
+| Discogs | Free key | [Sign up](https://www.discogs.com/settings/developers) | 1/sec, 1000/day | No | name, biography, aliases, members | thumb |
+| Last.fm | Free key | [Sign up](https://www.last.fm/api/account/create) | 5/sec | No | name, biography, genres, styles, moods, similar_artists | None |
+| Wikidata | Free | Not required | 5/sec | No | name, formed, disbanded, origin, genres | thumb, logo |
+| Deezer | Free | Not required | 5/sec | No | name | thumb |
+| Genius | Free key | [Sign up](https://genius.com/api-clients) | 5/sec | No | name, biography, aliases | None |
+| Spotify | Paid | [Sign up](https://developer.spotify.com/dashboard) | 5/sec | No | name, genres | thumb |
 <!-- END GENERATED: provider-matrix -->
 
 ## How the fallback chain works

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -39,9 +39,11 @@ type ProviderCapability struct {
 	SupportedFields []string `json:"supported_fields,omitempty"`
 
 	// SupportedImages lists the image types this provider's GetImages can
-	// return. Values use the ImageType constants ("thumb", "fanart", "logo",
-	// "hdlogo", "banner", "widethumb"). Empty for metadata-only providers.
-	SupportedImages []string `json:"supported_images,omitempty"`
+	// return, drawn from the ImageType constants below (ImageThumb, ImageFanart,
+	// ImageLogo, ImageHDLogo, ImageBanner, ImageWideThumb, ImageBackground).
+	// Typed as []ImageType so capability declarations cannot drift from the
+	// canonical set. Empty for metadata-only providers.
+	SupportedImages []ImageType `json:"supported_images,omitempty"`
 }
 
 // ProviderCapabilities returns the known capability metadata for each provider.
@@ -66,7 +68,7 @@ func ProviderCapabilities() map[ProviderName]ProviderCapability {
 			Tier:            TierFreeKey,
 			HelpURL:         "https://fanart.tv/get-an-api-key/",
 			RateLimit:       &RateLimitInfo{RequestsPerSecond: 3},
-			SupportedImages: []string{"thumb", "fanart", "logo", "hdlogo", "banner"},
+			SupportedImages: []ImageType{ImageThumb, ImageFanart, ImageLogo, ImageHDLogo, ImageBanner},
 		},
 		NameAudioDB: {
 			Tier:      TierFreemium,
@@ -77,14 +79,14 @@ func ProviderCapabilities() map[ProviderName]ProviderCapability {
 				"genres", "styles", "moods",
 				"born", "formed", "died", "disbanded", "aliases",
 			},
-			SupportedImages: []string{"thumb", "logo", "widethumb", "banner", "fanart"},
+			SupportedImages: []ImageType{ImageThumb, ImageLogo, ImageWideThumb, ImageBanner, ImageFanart},
 		},
 		NameDiscogs: {
 			Tier:            TierFreeKey,
 			HelpURL:         "https://www.discogs.com/settings/developers",
 			RateLimit:       &RateLimitInfo{RequestsPerSecond: 1, RequestsPerDay: 1000},
 			SupportedFields: []string{"name", "biography", "aliases", "members"},
-			SupportedImages: []string{"thumb"},
+			SupportedImages: []ImageType{ImageThumb},
 		},
 		NameLastFM: {
 			Tier:      TierFreeKey,
@@ -98,7 +100,7 @@ func ProviderCapabilities() map[ProviderName]ProviderCapability {
 			Tier:            TierFree,
 			RateLimit:       &RateLimitInfo{RequestsPerSecond: 5},
 			SupportedFields: []string{"name", "formed", "disbanded", "origin", "genres"},
-			SupportedImages: []string{"thumb", "logo"},
+			SupportedImages: []ImageType{ImageThumb, ImageLogo},
 		},
 		NameDuckDuckGo: {
 			Tier:      TierFree,
@@ -108,7 +110,7 @@ func ProviderCapabilities() map[ProviderName]ProviderCapability {
 			Tier:            TierFree,
 			RateLimit:       &RateLimitInfo{RequestsPerSecond: 5},
 			SupportedFields: []string{"name"},
-			SupportedImages: []string{"thumb"},
+			SupportedImages: []ImageType{ImageThumb},
 		},
 		NameGenius: {
 			Tier:            TierFreeKey,
@@ -126,7 +128,7 @@ func ProviderCapabilities() map[ProviderName]ProviderCapability {
 			HelpURL:         "https://developer.spotify.com/dashboard",
 			RateLimit:       &RateLimitInfo{RequestsPerSecond: 5},
 			SupportedFields: []string{"name", "genres"},
-			SupportedImages: []string{"thumb"},
+			SupportedImages: []ImageType{ImageThumb},
 		},
 	}
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -31,61 +31,102 @@ type ProviderCapability struct {
 	HelpURL         string         `json:"help_url,omitempty"`
 	RateLimit       *RateLimitInfo `json:"rate_limit,omitempty"`
 	SupportsBaseURL bool           `json:"supports_base_url,omitempty"`
+
+	// SupportedFields lists the ArtistMetadata fields this provider's GetArtist
+	// populates. Field names use the same JSON tag values as ArtistMetadata
+	// (lowercase snake_case); for example "biography", "sort_name", "genres".
+	// Used by cmd/gen-provider-matrix to render the docs capability matrix.
+	SupportedFields []string `json:"supported_fields,omitempty"`
+
+	// SupportedImages lists the image types this provider's GetImages can
+	// return. Values use the ImageType constants ("thumb", "fanart", "logo",
+	// "hdlogo", "banner", "widethumb"). Empty for metadata-only providers.
+	SupportedImages []string `json:"supported_images,omitempty"`
 }
 
 // ProviderCapabilities returns the known capability metadata for each provider.
+//
+// SupportedFields and SupportedImages are static declarations of what each
+// provider's GetArtist and GetImages return. They are read by
+// cmd/gen-provider-matrix to render the docs capability matrix. When a provider
+// changes its coverage, update the declaration here and run `make generate-docs`.
 func ProviderCapabilities() map[ProviderName]ProviderCapability {
 	return map[ProviderName]ProviderCapability{
 		NameMusicBrainz: {
 			Tier:            TierFree,
 			RateLimit:       &RateLimitInfo{RequestsPerSecond: 1},
 			SupportsBaseURL: true,
+			SupportedFields: []string{
+				"name", "sort_name", "type", "gender", "disambiguation", "origin",
+				"born", "formed", "died", "disbanded", "years_active",
+				"genres", "styles", "moods", "members", "aliases",
+			},
 		},
 		NameFanartTV: {
-			Tier:      TierFreeKey,
-			HelpURL:   "https://fanart.tv/get-an-api-key/",
-			RateLimit: &RateLimitInfo{RequestsPerSecond: 3},
+			Tier:            TierFreeKey,
+			HelpURL:         "https://fanart.tv/get-an-api-key/",
+			RateLimit:       &RateLimitInfo{RequestsPerSecond: 3},
+			SupportedImages: []string{"thumb", "fanart", "logo", "hdlogo", "banner"},
 		},
 		NameAudioDB: {
 			Tier:      TierFreemium,
 			HelpURL:   "https://www.theaudiodb.com/pricing",
 			RateLimit: &RateLimitInfo{RequestsPerSecond: 0.5}, // free tier: 30 req/min
+			SupportedFields: []string{
+				"name", "gender", "origin", "biography",
+				"genres", "styles", "moods",
+				"born", "formed", "died", "disbanded", "aliases",
+			},
+			SupportedImages: []string{"thumb", "logo", "widethumb", "banner", "fanart"},
 		},
 		NameDiscogs: {
-			Tier:      TierFreeKey,
-			HelpURL:   "https://www.discogs.com/settings/developers",
-			RateLimit: &RateLimitInfo{RequestsPerSecond: 1, RequestsPerDay: 1000},
+			Tier:            TierFreeKey,
+			HelpURL:         "https://www.discogs.com/settings/developers",
+			RateLimit:       &RateLimitInfo{RequestsPerSecond: 1, RequestsPerDay: 1000},
+			SupportedFields: []string{"name", "biography", "aliases", "members"},
+			SupportedImages: []string{"thumb"},
 		},
 		NameLastFM: {
 			Tier:      TierFreeKey,
 			HelpURL:   "https://www.last.fm/api/account/create",
 			RateLimit: &RateLimitInfo{RequestsPerSecond: 5},
+			SupportedFields: []string{
+				"name", "biography", "genres", "styles", "moods", "similar_artists",
+			},
 		},
 		NameWikidata: {
-			Tier:      TierFree,
-			RateLimit: &RateLimitInfo{RequestsPerSecond: 5},
+			Tier:            TierFree,
+			RateLimit:       &RateLimitInfo{RequestsPerSecond: 5},
+			SupportedFields: []string{"name", "formed", "disbanded", "origin", "genres"},
+			SupportedImages: []string{"thumb", "logo"},
 		},
 		NameDuckDuckGo: {
 			Tier:      TierFree,
 			RateLimit: &RateLimitInfo{RequestsPerSecond: 1},
 		},
 		NameDeezer: {
-			Tier:      TierFree,
-			RateLimit: &RateLimitInfo{RequestsPerSecond: 5},
+			Tier:            TierFree,
+			RateLimit:       &RateLimitInfo{RequestsPerSecond: 5},
+			SupportedFields: []string{"name"},
+			SupportedImages: []string{"thumb"},
 		},
 		NameGenius: {
-			Tier:      TierFreeKey,
-			HelpURL:   "https://genius.com/api-clients",
-			RateLimit: &RateLimitInfo{RequestsPerSecond: 5},
+			Tier:            TierFreeKey,
+			HelpURL:         "https://genius.com/api-clients",
+			RateLimit:       &RateLimitInfo{RequestsPerSecond: 5},
+			SupportedFields: []string{"name", "biography", "aliases"},
 		},
 		NameWikipedia: {
-			Tier:      TierFree,
-			RateLimit: &RateLimitInfo{RequestsPerSecond: 5},
+			Tier:            TierFree,
+			RateLimit:       &RateLimitInfo{RequestsPerSecond: 5},
+			SupportedFields: []string{"name", "biography", "years_active", "origin", "genres", "members"},
 		},
 		NameSpotify: {
-			Tier:      TierPaid,
-			HelpURL:   "https://developer.spotify.com/dashboard",
-			RateLimit: &RateLimitInfo{RequestsPerSecond: 5},
+			Tier:            TierPaid,
+			HelpURL:         "https://developer.spotify.com/dashboard",
+			RateLimit:       &RateLimitInfo{RequestsPerSecond: 5},
+			SupportedFields: []string{"name", "genres"},
+			SupportedImages: []string{"thumb"},
 		},
 	}
 }

--- a/scripts/check-generated.sh
+++ b/scripts/check-generated.sh
@@ -22,4 +22,14 @@ if [ -n "$missing" ]; then
   exit 1
 fi
 
+# Verify the docs provider matrix is in sync with the live registry. The
+# generator runs in -check mode and exits non-zero if regeneration is needed.
+# Skip silently if the docs file is absent (e.g., a docs-stripped checkout).
+if [ -f docs/site/src/reference/providers.md ]; then
+  if ! go run ./cmd/gen-provider-matrix -check; then
+    echo "ERROR: docs/site/src/reference/providers.md is stale. Run: make generate-docs"
+    exit 1
+  fi
+fi
+
 echo "Generated files: OK"


### PR DESCRIPTION
## Summary
- Adds `cmd/gen-provider-matrix` Go tool that emits a capability matrix into `docs/site/src/reference/providers.md` between the BEGIN/END markers.
- Extends `ProviderCapability` with `SupportedFields` / `SupportedImages` populated per-provider.
- Adds `make generate-docs` target and extends `scripts/check-generated.sh` to fail on stale matrix.
- AllMusic excluded per project_allmusic_cleanup.md / #1275.

Closes #1251.

## Test plan
- [ ] `make generate-docs` regenerates the matrix without diff after a clean run
- [ ] `bash scripts/check-generated.sh` fails when the matrix is stale
- [ ] Visual check of the rendered table in MkDocs preview
- [ ] All 10 in-use providers appear in the table; AllMusic is absent

DRAFT until UAT complete.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic generation/regeneration of the provider capability matrix (tiers, sign-up, rate limits, metadata fields, image types).

* **Documentation**
  * Reference docs updated with a fully enumerated provider capability table and note that it’s generated from provider definitions.

* **Chores**
  * Added a generator CLI, a Makefile target to run it, and a script check to verify docs are in sync.

* **Tests**
  * Added unit tests covering generation, formatting, and marker-based insertion/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->