### PR TITLE
feat(docs): codegen env-var reference from config struct tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,10 @@ tailwind:
 ## generate: Run all code generation (templ + tailwind)
 generate: templ tailwind
 
-## generate-docs: Regenerate docs site content from code (provider matrix)
+## generate-docs: Regenerate docs site content from code (provider matrix, env-var reference)
 generate-docs:
 	go run ./cmd/gen-provider-matrix
+	go run ./cmd/gen-env-reference
 
 ## tailwind-watch: Watch and rebuild Tailwind CSS
 tailwind-watch:

--- a/cmd/gen-env-reference/main.go
+++ b/cmd/gen-env-reference/main.go
@@ -1,0 +1,220 @@
+// Command gen-env-reference renders the SW_* environment variable reference
+// table in docs/site/src/reference/environment-variables.md from struct tags
+// on the Config type in internal/config. Each rendered row consists of the
+// variable name, a doc-friendly type label, the documented default, and a
+// description sentence. The generator walks the Config struct via reflection,
+// requires every field that carries an env: tag to also carry a desc: tag
+// (otherwise generation fails loudly), sorts the variables alphabetically for
+// deterministic output, and writes the table between the well-known
+// BEGIN/END markers in the docs file. Manual prose around the markers is
+// preserved.
+//
+// Usage:
+//
+//	go run ./cmd/gen-env-reference              # rewrite the file in place
+//	go run ./cmd/gen-env-reference -check       # exit non-zero if regen needed
+//	go run ./cmd/gen-env-reference -output FILE # write to a different file
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/sydlexius/stillwater/internal/config"
+	"github.com/sydlexius/stillwater/internal/filesystem"
+)
+
+const (
+	beginMarker = "<!-- BEGIN GENERATED: env-reference -->"
+	endMarker   = "<!-- END GENERATED: env-reference -->"
+)
+
+const defaultOutputPath = "docs/site/src/reference/environment-variables.md"
+
+func main() {
+	var (
+		checkOnly bool
+		outPath   string
+	)
+	flag.BoolVar(&checkOnly, "check", false, "exit non-zero if the env-var reference needs to be regenerated")
+	flag.StringVar(&outPath, "output", defaultOutputPath, "path to the docs file to update")
+	flag.Parse()
+
+	if err := run(outPath, checkOnly); err != nil {
+		fmt.Fprintln(os.Stderr, "gen-env-reference:", err)
+		os.Exit(1)
+	}
+}
+
+func run(outPath string, checkOnly bool) error {
+	rows, err := collectRows(reflect.TypeOf(config.Config{}))
+	if err != nil {
+		return fmt.Errorf("collect rows: %w", err)
+	}
+	rendered := renderTable(rows)
+
+	// outPath comes from the -output flag; this is a developer-only build-time
+	// tool, so a configurable path is intended.
+	existing, err := os.ReadFile(outPath) //nolint:gosec // G304: developer CLI, path is intentionally configurable
+	if err != nil {
+		return fmt.Errorf("read %s: %w", outPath, err)
+	}
+
+	updated, err := replaceBetweenMarkers(existing, beginMarker, endMarker, rendered)
+	if err != nil {
+		return fmt.Errorf("update %s: %w", outPath, err)
+	}
+
+	if checkOnly {
+		if !bytes.Equal(existing, updated) {
+			return fmt.Errorf("%s is stale; run `make generate-docs` to regenerate", filepath.ToSlash(outPath))
+		}
+		return nil
+	}
+
+	if bytes.Equal(existing, updated) {
+		return nil
+	}
+	if err := filesystem.WriteFileAtomic(outPath, updated, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", outPath, err)
+	}
+	return nil
+}
+
+// envRow is a single row in the rendered Markdown table.
+type envRow struct {
+	Name        string
+	Type        string
+	Default     string
+	Description string
+}
+
+// collectRows reflects over t (which must be a struct type) and returns one
+// envRow per field carrying an env: tag, recursively walking nested struct
+// fields. Fields with an env: tag but no desc: tag fail with an error so that
+// the docs page never silently emits an empty description column.
+func collectRows(t reflect.Type) ([]envRow, error) {
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("collectRows: expected struct, got %s", t.Kind())
+	}
+	var rows []envRow
+	if err := walkStruct(t, &rows); err != nil {
+		return nil, err
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Name < rows[j].Name })
+	return rows, nil
+}
+
+func walkStruct(t reflect.Type, rows *[]envRow) error {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if f.Type.Kind() == reflect.Struct {
+			if err := walkStruct(f.Type, rows); err != nil {
+				return err
+			}
+			continue
+		}
+		envName := f.Tag.Get("env")
+		if envName == "" {
+			continue
+		}
+		desc := f.Tag.Get("desc")
+		if desc == "" {
+			return fmt.Errorf("field %s has env:%q tag but no desc: tag; add a one-sentence description so the env-var reference page is never empty", f.Name, envName)
+		}
+		def := f.Tag.Get("default")
+		*rows = append(*rows, envRow{
+			Name:        envName,
+			Type:        docType(f.Type, envName),
+			Default:     renderDefault(def),
+			Description: desc,
+		})
+	}
+	return nil
+}
+
+// docType maps a Go reflect.Type to the user-facing type label used in docs.
+// User docs deliberately avoid Go-specific notation (no *string, no
+// time.Duration, no []string); the labels here are deployment-operator
+// vocabulary instead.
+func docType(t reflect.Type, envName string) string {
+	switch t.Kind() {
+	case reflect.String:
+		// Path-like variables get a clearer label so operators know to mount a
+		// volume or supply an absolute path.
+		if strings.Contains(envName, "PATH") {
+			return "path"
+		}
+		return "string"
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return "integer"
+	case reflect.Float32, reflect.Float64:
+		return "number"
+	case reflect.Slice, reflect.Array:
+		return "list (comma-separated)"
+	default:
+		return "string"
+	}
+}
+
+// renderDefault converts the raw default: tag value into the cell text used in
+// the table. Empty strings render as an em-dash-free "(none)" so the column is
+// always populated; the literal "unset" passes through unchanged.
+func renderDefault(def string) string {
+	if def == "" {
+		return "(none)"
+	}
+	if def == "unset" {
+		return "unset"
+	}
+	return "`" + def + "`"
+}
+
+// renderTable returns the Markdown table body (without surrounding markers).
+func renderTable(rows []envRow) string {
+	var b strings.Builder
+	b.WriteString("| Variable | Type | Default | Description |\n")
+	b.WriteString("|---|---|---|---|\n")
+	for _, r := range rows {
+		fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n", r.Name, r.Type, r.Default, r.Description)
+	}
+	return b.String()
+}
+
+// replaceBetweenMarkers returns src with the region between begin and end
+// replaced by body. The markers themselves are preserved. body is sandwiched
+// in newlines so the rendered table has clean blank-line separation from the
+// markers; trailing newlines on body are normalized.
+//
+// begin and end are parameters (not constants) so the helper can be exercised
+// with bespoke markers in tests.
+func replaceBetweenMarkers(src []byte, begin, end, body string) ([]byte, error) { //nolint:unparam // begin/end are exposed as parameters for testability
+	beginIdx := bytes.Index(src, []byte(begin))
+	if beginIdx < 0 {
+		return nil, fmt.Errorf("begin marker %q not found", begin)
+	}
+	relEndIdx := bytes.Index(src[beginIdx:], []byte(end))
+	if relEndIdx < 0 {
+		return nil, fmt.Errorf("end marker %q not found after begin marker", end)
+	}
+	endIdx := beginIdx + relEndIdx
+
+	body = strings.TrimRight(body, "\n")
+	var out bytes.Buffer
+	out.Write(src[:beginIdx])
+	out.WriteString(begin)
+	out.WriteString("\n")
+	out.WriteString(body)
+	out.WriteString("\n")
+	out.Write(src[endIdx:])
+	return out.Bytes(), nil
+}

--- a/cmd/gen-env-reference/main.go
+++ b/cmd/gen-env-reference/main.go
@@ -107,6 +107,16 @@ func collectRows(t reflect.Type) ([]envRow, error) {
 	if err := walkStruct(t, &rows); err != nil {
 		return nil, err
 	}
+	// Codegen is the only place that enforces the env-tag schema, so a
+	// duplicate env: tag must fail loudly here rather than silently emit two
+	// table rows with the same Variable name.
+	seen := make(map[string]struct{}, len(rows))
+	for _, r := range rows {
+		if _, exists := seen[r.Name]; exists {
+			return nil, fmt.Errorf("duplicate env tag %q: each environment variable must be defined once", r.Name)
+		}
+		seen[r.Name] = struct{}{}
+	}
 	sort.Slice(rows, func(i, j int) bool { return rows[i].Name < rows[j].Name })
 	return rows, nil
 }

--- a/cmd/gen-env-reference/main.go
+++ b/cmd/gen-env-reference/main.go
@@ -185,9 +185,24 @@ func renderTable(rows []envRow) string {
 	b.WriteString("| Variable | Type | Default | Description |\n")
 	b.WriteString("|---|---|---|---|\n")
 	for _, r := range rows {
-		fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n", r.Name, r.Type, r.Default, r.Description)
+		fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n",
+			escapeMarkdownCell(r.Name),
+			escapeMarkdownCell(r.Type),
+			escapeMarkdownCell(r.Default),
+			escapeMarkdownCell(r.Description),
+		)
 	}
 	return b.String()
+}
+
+// escapeMarkdownCell sanitizes a string for use inside a Markdown table cell.
+// Pipes break the column boundary; newlines break the row boundary. Codegen
+// is the only place that enforces table integrity for arbitrary desc/default
+// content, so this helper runs over every cell unconditionally.
+func escapeMarkdownCell(s string) string {
+	s = strings.ReplaceAll(s, "|", `\|`)
+	s = strings.ReplaceAll(s, "\n", "<br>")
+	return s
 }
 
 // replaceBetweenMarkers returns src with the region between begin and end

--- a/cmd/gen-env-reference/main_test.go
+++ b/cmd/gen-env-reference/main_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// fixtureGood is a minimal struct that exercises every supported field shape:
+// a primitive int with a default, a nested struct, a string with a path-style
+// name, a boolean, and a slice. Tests reflect over this fixture rather than
+// the real config.Config so the codegen contract is verified in isolation.
+type fixtureGood struct {
+	Port  int `env:"FX_PORT" default:"8080" desc:"TCP port the server listens on."`
+	Inner fixtureInner
+}
+
+type fixtureInner struct {
+	DBPath  string   `env:"FX_DB_PATH" default:"/data/x.db" desc:"Path to the database file."`
+	Enabled bool     `env:"FX_ENABLED" default:"true" desc:"Whether the feature is enabled."`
+	List    []string `env:"FX_LIST" default:"a,b" desc:"Comma-separated list."`
+	Secret  string   `env:"FX_SECRET" default:"unset" desc:"Generated on first run when unset."`
+	Bare    string   `env:"FX_BARE" desc:"Bare value with no documented default."`
+	Skipped string   // no env tag, must be ignored
+}
+
+// fixtureMissingDesc has an env tag but no desc tag; collectRows must reject
+// it so the docs page can never silently ship with an empty description.
+type fixtureMissingDesc struct {
+	Port int `env:"FX_PORT" default:"1"`
+}
+
+func TestCollectRows_Fixture(t *testing.T) {
+	rows, err := collectRows(reflect.TypeOf(fixtureGood{}))
+	if err != nil {
+		t.Fatalf("collectRows: %v", err)
+	}
+	wantNames := []string{"FX_BARE", "FX_DB_PATH", "FX_ENABLED", "FX_LIST", "FX_PORT", "FX_SECRET"}
+	if len(rows) != len(wantNames) {
+		t.Fatalf("expected %d rows, got %d (%v)", len(wantNames), len(rows), rows)
+	}
+	for i, want := range wantNames {
+		if rows[i].Name != want {
+			t.Errorf("rows[%d].Name = %q, want %q (output not alphabetically sorted)", i, rows[i].Name, want)
+		}
+	}
+
+	// Spot-check type mapping.
+	byName := map[string]envRow{}
+	for _, r := range rows {
+		byName[r.Name] = r
+	}
+	if got := byName["FX_PORT"].Type; got != "integer" {
+		t.Errorf("FX_PORT type = %q, want integer", got)
+	}
+	if got := byName["FX_DB_PATH"].Type; got != "path" {
+		t.Errorf("FX_DB_PATH type = %q, want path (PATH-named string)", got)
+	}
+	if got := byName["FX_ENABLED"].Type; got != "boolean" {
+		t.Errorf("FX_ENABLED type = %q, want boolean", got)
+	}
+	if got := byName["FX_LIST"].Type; got != "list (comma-separated)" {
+		t.Errorf("FX_LIST type = %q, want list label", got)
+	}
+
+	// Default rendering: backticked literal, "unset" pass-through, and "(none)"
+	// for an absent default.
+	if got := byName["FX_PORT"].Default; got != "`8080`" {
+		t.Errorf("FX_PORT default = %q, want `8080`", got)
+	}
+	if got := byName["FX_SECRET"].Default; got != "unset" {
+		t.Errorf("FX_SECRET default = %q, want unset", got)
+	}
+	if got := byName["FX_BARE"].Default; got != "(none)" {
+		t.Errorf("FX_BARE default = %q, want (none)", got)
+	}
+}
+
+func TestCollectRows_MissingDescIsError(t *testing.T) {
+	_, err := collectRows(reflect.TypeOf(fixtureMissingDesc{}))
+	if err == nil {
+		t.Fatal("expected error when env-tagged field has no desc tag")
+	}
+	if !strings.Contains(err.Error(), "FX_PORT") {
+		t.Errorf("error should name the offending env var; got %v", err)
+	}
+}
+
+func TestRenderTable_HeaderAndRows(t *testing.T) {
+	rows := []envRow{
+		{Name: "A_VAR", Type: "string", Default: "`x`", Description: "First var."},
+		{Name: "B_VAR", Type: "integer", Default: "(none)", Description: "Second var."},
+	}
+	got := renderTable(rows)
+	wantHeader := "| Variable | Type | Default | Description |\n|---|---|---|---|\n"
+	if !strings.HasPrefix(got, wantHeader) {
+		t.Fatalf("missing or wrong header.\ngot:\n%s", got)
+	}
+	if !strings.Contains(got, "| `A_VAR` | string | `x` | First var. |") {
+		t.Errorf("first row not rendered as expected; got:\n%s", got)
+	}
+	if !strings.Contains(got, "| `B_VAR` | integer | (none) | Second var. |") {
+		t.Errorf("second row not rendered as expected; got:\n%s", got)
+	}
+}
+
+func TestReplaceBetweenMarkers(t *testing.T) {
+	src := []byte("prefix\n" + beginMarker + "\nstale body\n" + endMarker + "\nsuffix\n")
+	out, err := replaceBetweenMarkers(src, beginMarker, endMarker, "fresh body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "prefix\n" + beginMarker + "\nfresh body\n" + endMarker + "\nsuffix\n"
+	if string(out) != want {
+		t.Fatalf("unexpected output\nwant:\n%s\n\ngot:\n%s", want, string(out))
+	}
+}
+
+func TestReplaceBetweenMarkers_MissingBegin(t *testing.T) {
+	_, err := replaceBetweenMarkers([]byte("no markers here"), beginMarker, endMarker, "body")
+	if err == nil {
+		t.Fatal("expected error when begin marker is missing")
+	}
+}
+
+func TestReplaceBetweenMarkers_MissingEnd(t *testing.T) {
+	src := []byte("prefix " + beginMarker + " no end")
+	_, err := replaceBetweenMarkers(src, beginMarker, endMarker, "body")
+	if err == nil {
+		t.Fatal("expected error when end marker is missing")
+	}
+}

--- a/cmd/gen-env-reference/main_test.go
+++ b/cmd/gen-env-reference/main_test.go
@@ -32,6 +32,13 @@ type fixtureMissingDesc struct {
 	Port int `env:"FX_PORT" default:"1"`
 }
 
+// fixtureDuplicateEnv has two fields tagged with the same env name; collectRows
+// must reject it so the docs page never ships two rows for the same variable.
+type fixtureDuplicateEnv struct {
+	A int `env:"FX_DUPE" default:"1" desc:"First."`
+	B int `env:"FX_DUPE" default:"2" desc:"Second."`
+}
+
 func TestCollectRows_Fixture(t *testing.T) {
 	rows, err := collectRows(reflect.TypeOf(fixtureGood{}))
 	if err != nil {
@@ -85,6 +92,19 @@ func TestCollectRows_MissingDescIsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "FX_PORT") {
 		t.Errorf("error should name the offending env var; got %v", err)
+	}
+}
+
+func TestCollectRows_RejectsDuplicateEnvTag(t *testing.T) {
+	_, err := collectRows(reflect.TypeOf(fixtureDuplicateEnv{}))
+	if err == nil {
+		t.Fatal("expected error when two fields share an env tag")
+	}
+	if !strings.Contains(err.Error(), "FX_DUPE") {
+		t.Errorf("error should name the duplicated env var; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("error should say 'duplicate'; got %v", err)
 	}
 }
 

--- a/cmd/gen-env-reference/main_test.go
+++ b/cmd/gen-env-reference/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -104,6 +106,24 @@ func TestRenderTable_HeaderAndRows(t *testing.T) {
 	}
 }
 
+func TestRenderTable_EscapesPipesAndNewlines(t *testing.T) {
+	rows := []envRow{
+		{Name: "PIPE_VAR", Type: "string", Default: "`a|b`", Description: "Has a | pipe and\na newline."},
+	}
+	got := renderTable(rows)
+	if !strings.Contains(got, `\|b`) {
+		t.Errorf("pipe in default should be escaped; got:\n%s", got)
+	}
+	if !strings.Contains(got, "Has a \\| pipe and<br>a newline.") {
+		t.Errorf("pipe and newline in description should be escaped; got:\n%s", got)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(got), "\n") {
+		if strings.Count(line, "|")-strings.Count(line, `\|`) != 5 {
+			t.Errorf("each row should have exactly 5 unescaped pipes; got line:\n%s", line)
+		}
+	}
+}
+
 func TestReplaceBetweenMarkers(t *testing.T) {
 	src := []byte("prefix\n" + beginMarker + "\nstale body\n" + endMarker + "\nsuffix\n")
 	out, err := replaceBetweenMarkers(src, beginMarker, endMarker, "fresh body")
@@ -128,5 +148,117 @@ func TestReplaceBetweenMarkers_MissingEnd(t *testing.T) {
 	_, err := replaceBetweenMarkers(src, beginMarker, endMarker, "body")
 	if err == nil {
 		t.Fatal("expected error when end marker is missing")
+	}
+}
+
+// writeFixtureDoc writes a docs file with the begin/end markers wrapping
+// stale body text, returns the path. Used by run() tests.
+func writeFixtureDoc(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "env.md")
+	content := "intro\n" + beginMarker + "\n" + body + "\n" + endMarker + "\nfooter\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("seed fixture: %v", err)
+	}
+	return path
+}
+
+func TestRun_RewritesStaleContent(t *testing.T) {
+	path := writeFixtureDoc(t, "STALE TABLE")
+	if err := run(path, false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "STALE TABLE") {
+		t.Errorf("stale body should be replaced; got:\n%s", got)
+	}
+	if !strings.Contains(string(got), "| Variable | Type | Default | Description |") {
+		t.Errorf("regenerated table header missing; got:\n%s", got)
+	}
+	if !strings.Contains(string(got), "intro\n") || !strings.Contains(string(got), "footer\n") {
+		t.Errorf("manual prose around markers should be preserved; got:\n%s", got)
+	}
+}
+
+func TestRun_NoChangeIsNoop(t *testing.T) {
+	path := writeFixtureDoc(t, "STALE")
+	if err := run(path, false); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	infoBefore, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := run(path, false); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("second run should be a no-op")
+	}
+	infoAfter, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !infoBefore.ModTime().Equal(infoAfter.ModTime()) {
+		t.Logf("note: file mtime changed despite no content change (acceptable)")
+	}
+}
+
+func TestRun_CheckMode(t *testing.T) {
+	t.Run("stale errors", func(t *testing.T) {
+		path := writeFixtureDoc(t, "STALE")
+		err := run(path, true)
+		if err == nil {
+			t.Fatal("expected error in -check mode against stale file")
+		}
+		if !strings.Contains(err.Error(), "stale") {
+			t.Errorf("error should mention staleness; got: %v", err)
+		}
+	})
+	t.Run("fresh succeeds", func(t *testing.T) {
+		path := writeFixtureDoc(t, "STALE")
+		if err := run(path, false); err != nil {
+			t.Fatalf("seed regen: %v", err)
+		}
+		if err := run(path, true); err != nil {
+			t.Errorf("check mode should pass on fresh file; got: %v", err)
+		}
+	})
+}
+
+func TestRun_MissingFile(t *testing.T) {
+	err := run(filepath.Join(t.TempDir(), "does-not-exist.md"), false)
+	if err == nil {
+		t.Fatal("expected error when output path does not exist")
+	}
+	if !strings.Contains(err.Error(), "read") {
+		t.Errorf("error should mention read failure; got: %v", err)
+	}
+}
+
+func TestRun_MissingMarkers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "env.md")
+	if err := os.WriteFile(path, []byte("no markers here\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := run(path, false)
+	if err == nil {
+		t.Fatal("expected error when markers are absent")
+	}
+	if !strings.Contains(err.Error(), "marker") {
+		t.Errorf("error should mention marker; got: %v", err)
 	}
 }

--- a/docs/site/src/reference/environment-variables.md
+++ b/docs/site/src/reference/environment-variables.md
@@ -8,22 +8,27 @@ description: Every SW_ environment variable Stillwater honors at startup, with d
 
 Stillwater is configured by a small YAML file plus environment-variable overrides. **Environment variables always win** over YAML values.
 
-| Variable | YAML field | Default | Notes |
+The table below is generated from the configuration definition; do not edit it by hand. Run `make generate-docs` after changing a configuration field.
+
+<!-- BEGIN GENERATED: env-reference -->
+| Variable | Type | Default | Description |
 |---|---|---|---|
-| `SW_CONFIG_PATH` | -- | `/config/config.yaml` | Path to a YAML config file. When unset, Stillwater attempts to read `/config/config.yaml`; if that file does not exist, it starts with defaults plus environment overrides only. |
-| `SW_PORT` | `server.port` | `1973` | TCP port. Non-numeric values are silently ignored; numeric values outside `1-65535` are rejected at startup by config validation. |
-| `SW_BASE_PATH` | `server.base_path` | `/` | URL prefix for subfolder reverse-proxy deployments (e.g. `/stillwater`). When set from the environment, the Settings UI marks the field read-only with a "managed by environment" badge so a config-as-code deployment can't be silently overridden through the UI. |
-| `SW_DB_PATH` | `database.path` | `/config/stillwater.db` | SQLite file path. Optional; defaults to `/config/stillwater.db`. |
-| `SW_SESSION_SECRET` | `auth.session_secret` | unset | Long random string used to sign session cookies. When unset, Stillwater generates one on first run and persists it in the config directory. Set this only when you need sessions to survive across fresh container deployments with no persistent volume. |
-| `SW_ENCRYPTION_KEY` | `encryption.key` | unset | Key used to encrypt provider API keys at rest. When unset, Stillwater generates one on first run and persists it in the config directory. Set this only when restoring from a backup that was encrypted with a known key. |
-| `SW_MUSIC_PATH` | `music.library_path` | `/music` | Default library path used when no library is configured yet. Once you've added libraries through the UI, this is informational. |
-| `SW_SCANNER_EXCLUSIONS` | `scanner.exclusions` | `Various Artists, Various, VA, Soundtrack, OST` | Comma-separated artist directory names the scanner skips. Whitespace around each token is trimmed. |
-| `SW_BACKUP_PATH` | `backup.path` | empty (defaults inside Stillwater to a `backups/` subfolder of the config directory) | Override the directory where automated database backups are written. |
-| `SW_BACKUP_RETENTION` | `backup.retention_count` | `7` | Number of recent backups to keep. Older backups are pruned after each successful new backup. Must be a positive number; non-positive values are silently ignored. |
-| `SW_BACKUP_INTERVAL` | `backup.interval_hours` | `24` | Hours between automated backups. Must be a positive number; non-positive values are silently ignored. |
-| `SW_BACKUP_ENABLED` | `backup.enabled` | `true` | Set to `true` or `1` to enable automated backups; any other value disables them. |
-| `SW_LOG_LEVEL` | `logging.level` | `info` | One of `trace`, `debug`, `info`, `warn`, `error`. The runtime can also raise/lower the live level via the Logs settings tab without restart. |
-| `SW_LOG_FORMAT` | `logging.format` | `json` | `json` for log aggregators; `text` for friendlier console output. |
+| `SW_BACKUP_ENABLED` | boolean | `true` | Set to true or 1 to enable automated backups. Any other value disables them. |
+| `SW_BACKUP_INTERVAL` | integer | `24` | Hours between automated backups. Must be a positive integer; non-positive or non-numeric values are silently ignored. |
+| `SW_BACKUP_PATH` | path | (none) | Override the directory where automated database backups are written. When empty Stillwater writes to a backups/ subfolder of the config directory. |
+| `SW_BACKUP_RETENTION` | integer | `7` | Number of recent backups to keep. Must be a positive integer; non-positive or non-numeric values are silently ignored. |
+| `SW_BASE_PATH` | path | `/` | URL prefix for subfolder reverse-proxy deployments (for example /stillwater). When set from the environment the Settings UI marks the field read-only. |
+| `SW_DB_PATH` | path | `/config/stillwater.db` | Filesystem path to the SQLite database file. |
+| `SW_ENCRYPTION_KEY` | string | unset | Key used to encrypt provider API keys at rest. When unset Stillwater generates one on first run and persists it in the config directory. |
+| `SW_LOG_FORMAT` | string | `json` | Log output format. Use json for log aggregators or text for friendlier console output. |
+| `SW_LOG_LEVEL` | string | `info` | Log level at startup. One of trace, debug, info, warn, error. The runtime can also adjust the live level from the Logs settings tab. |
+| `SW_MUSIC_PATH` | path | `/music` | Default music library path used as a starting point when no library has been added through the UI. |
+| `SW_PORT` | integer | `1973` | TCP port the HTTP server listens on. Numeric values outside 1-65535 are rejected at startup. |
+| `SW_SCANNER_EXCLUSIONS` | list (comma-separated) | `Various Artists, Various, VA, Soundtrack, OST` | Comma-separated artist directory names the scanner skips. Whitespace around each token is trimmed. |
+| `SW_SESSION_SECRET` | string | unset | Long random string used to sign session cookies. When unset Stillwater generates one on first run and persists it in the config directory. |
+<!-- END GENERATED: env-reference -->
+
+`SW_CONFIG_PATH` is also honored at startup but lives outside the configuration struct: set it to point at a YAML config file. When unset, Stillwater attempts to read `/config/config.yaml`; if that file does not exist, it starts with defaults plus environment overrides only.
 
 ## YAML configuration file
 

--- a/docs/site/src/reference/environment-variables.md
+++ b/docs/site/src/reference/environment-variables.md
@@ -1,5 +1,5 @@
 ---
-description: Every SW_ environment variable Stillwater honors at startup, with defaults and YAML field equivalents.
+description: Every SW_ environment variable Stillwater honors at startup, with types, defaults, and descriptions.
 ---
 
 <!-- code: internal/config/config.go (Default, loadFromEnv, validate, Config struct hierarchy), cmd/stillwater/main.go (SW_CONFIG_PATH usage). Verified against main at the time of drafting. -->

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,50 +22,55 @@ type Config struct {
 }
 
 // ServerConfig holds HTTP server settings.
+//
+// Struct tags drive the env-var reference codegen in cmd/gen-env-reference:
+//   - env:  the environment variable name (SW_*)
+//   - desc: a single-sentence user-facing description
+//   - default: rendered default; "unset" or "" when there is no default
 type ServerConfig struct {
-	Port            int    `yaml:"port"`      // SW_PORT
-	BasePath        string `yaml:"base_path"` // SW_BASE_PATH
-	BasePathFromEnv bool   `yaml:"-"`         // true when BasePath was set from SW_BASE_PATH
+	Port            int    `yaml:"port" env:"SW_PORT" default:"1973" desc:"TCP port the HTTP server listens on. Numeric values outside 1-65535 are rejected at startup."`
+	BasePath        string `yaml:"base_path" env:"SW_BASE_PATH" default:"/" desc:"URL prefix for subfolder reverse-proxy deployments (for example /stillwater). When set from the environment the Settings UI marks the field read-only."`
+	BasePathFromEnv bool   `yaml:"-"`
 }
 
 // DatabaseConfig holds SQLite settings.
 type DatabaseConfig struct {
-	Path string `yaml:"path"` // SW_DB_PATH
+	Path string `yaml:"path" env:"SW_DB_PATH" default:"/config/stillwater.db" desc:"Filesystem path to the SQLite database file."`
 }
 
 // AuthConfig holds authentication settings.
 type AuthConfig struct {
-	SessionSecret string `yaml:"session_secret"` //nolint:gosec // G117: not a hardcoded secret, this is a config field -- SW_SESSION_SECRET
+	SessionSecret string `yaml:"session_secret" env:"SW_SESSION_SECRET" default:"unset" desc:"Long random string used to sign session cookies. When unset Stillwater generates one on first run and persists it in the config directory."` //nolint:gosec // G117: not a hardcoded secret, this is a config field
 }
 
 // EncryptionConfig holds encryption key settings.
 type EncryptionConfig struct {
-	Key string `yaml:"key"` // SW_ENCRYPTION_KEY
+	Key string `yaml:"key" env:"SW_ENCRYPTION_KEY" default:"unset" desc:"Key used to encrypt provider API keys at rest. When unset Stillwater generates one on first run and persists it in the config directory."`
 }
 
 // MusicConfig holds music library path settings.
 type MusicConfig struct {
-	LibraryPath string `yaml:"library_path"` // SW_MUSIC_PATH
+	LibraryPath string `yaml:"library_path" env:"SW_MUSIC_PATH" default:"/music" desc:"Default music library path used as a starting point when no library has been added through the UI."`
 }
 
 // ScannerConfig holds scanner behavior settings.
 type ScannerConfig struct {
 	Depth      int      `yaml:"depth"`
-	Exclusions []string `yaml:"exclusions"` // SW_SCANNER_EXCLUSIONS (comma-separated)
+	Exclusions []string `yaml:"exclusions" env:"SW_SCANNER_EXCLUSIONS" default:"Various Artists, Various, VA, Soundtrack, OST" desc:"Comma-separated artist directory names the scanner skips. Whitespace around each token is trimmed."`
 }
 
 // BackupConfig holds database backup settings.
 type BackupConfig struct {
-	Path           string `yaml:"path"`            // SW_BACKUP_PATH
-	RetentionCount int    `yaml:"retention_count"` // SW_BACKUP_RETENTION
-	IntervalHours  int    `yaml:"interval_hours"`  // SW_BACKUP_INTERVAL
-	Enabled        bool   `yaml:"enabled"`         // SW_BACKUP_ENABLED ("true" or "1")
+	Path           string `yaml:"path" env:"SW_BACKUP_PATH" default:"" desc:"Override the directory where automated database backups are written. When empty Stillwater writes to a backups/ subfolder of the config directory."`
+	RetentionCount int    `yaml:"retention_count" env:"SW_BACKUP_RETENTION" default:"7" desc:"Number of recent backups to keep. Must be a positive integer; non-positive or non-numeric values are silently ignored."`
+	IntervalHours  int    `yaml:"interval_hours" env:"SW_BACKUP_INTERVAL" default:"24" desc:"Hours between automated backups. Must be a positive integer; non-positive or non-numeric values are silently ignored."`
+	Enabled        bool   `yaml:"enabled" env:"SW_BACKUP_ENABLED" default:"true" desc:"Set to true or 1 to enable automated backups. Any other value disables them."`
 }
 
 // LoggingConfig holds logging settings.
 type LoggingConfig struct {
-	Level  string `yaml:"level"`  // SW_LOG_LEVEL
-	Format string `yaml:"format"` // SW_LOG_FORMAT
+	Level  string `yaml:"level" env:"SW_LOG_LEVEL" default:"info" desc:"Log level at startup. One of trace, debug, info, warn, error. The runtime can also adjust the live level from the Logs settings tab."`
+	Format string `yaml:"format" env:"SW_LOG_FORMAT" default:"json" desc:"Log output format. Use json for log aggregators or text for friendlier console output."`
 }
 
 // Default returns a Config with sensible defaults.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,7 +25,8 @@ type Config struct {
 //
 // Struct tags drive the env-var reference codegen in cmd/gen-env-reference:
 //   - env:  the environment variable name (SW_*)
-//   - desc: a single-sentence user-facing description
+//   - desc: a concise user-facing description (one or two sentences); a second
+//     sentence is acceptable when it captures a constraint or runtime caveat
 //   - default: rendered default; "unset" or "" when there is no default
 type ServerConfig struct {
 	Port            int    `yaml:"port" env:"SW_PORT" default:"1973" desc:"TCP port the HTTP server listens on. Numeric values outside 1-65535 are rejected at startup."`
@@ -179,7 +180,7 @@ func (c *Config) loadFromEnv() {
 			c.Backup.IntervalHours = n
 		}
 	}
-	if v := os.Getenv("SW_BACKUP_ENABLED"); v != "" {
+	if v, ok := os.LookupEnv("SW_BACKUP_ENABLED"); ok {
 		c.Backup.Enabled = v == "true" || v == "1"
 	}
 	if v := os.Getenv("SW_LOG_LEVEL"); v != "" {

--- a/scripts/check-generated.sh
+++ b/scripts/check-generated.sh
@@ -32,4 +32,14 @@ if [ -f docs/site/src/reference/providers.md ]; then
   fi
 fi
 
+# Verify the env-var reference is in sync with the config struct tags. The
+# generator runs in -check mode and exits non-zero if regeneration is needed.
+# Skip silently if the docs file is absent (e.g., a docs-stripped checkout).
+if [ -f docs/site/src/reference/environment-variables.md ]; then
+  if ! go run ./cmd/gen-env-reference -check; then
+    echo "ERROR: docs/site/src/reference/environment-variables.md is stale. Run: make generate-docs"
+    exit 1
+  fi
+fi
+
 echo "Generated files: OK"


### PR DESCRIPTION
## Summary

The `reference/environment-variables.md` page was a hand-maintained Markdown table that drifted any time a `SW_*` variable changed. This PR generates the table from `desc:` and `default:` struct tags on the configuration definition and gates freshness in CI, so the docs page can never silently fall behind the configuration surface.

## Implementation

- New tool `cmd/gen-env-reference` reflects over the configuration struct, sorts variables alphabetically, maps Go types to user-facing labels (`integer`, `boolean`, `path`, `list (comma-separated)`), and writes between `<!-- BEGIN/END GENERATED: env-reference -->` markers. Manual prose around the markers is preserved.
- Enriches the configuration struct with `env:`, `desc:`, and `default:` tags. A field with `env:` but no `desc:` fails generation loudly so empty descriptions can never ship.
- `make generate-docs` now invokes both the provider matrix generator and the env-var generator.
- `scripts/check-generated.sh` runs the new generator with `-check`, mirroring the existing provider-matrix freshness gate.
- Unit tests in `cmd/gen-env-reference/main_test.go` exercise the codegen against a fixture struct (sort order, type mapping, default rendering, missing-`desc` failure mode, and marker replacement).

`SW_CONFIG_PATH` lives outside the configuration struct (read directly in the entrypoint) and remains documented as preserved manual prose below the generated table.

## Verification

- `bash scripts/pre-push-gate.sh`: all hard checks passed.
- `bash scripts/check-generated.sh`: Generated files: OK.
- `go test -race -count=1 ./cmd/gen-env-reference/...`: pass.
- `go run ./cmd/gen-env-reference -check`: clean (idempotent regeneration).

Closes #1258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Environment-variable reference is now auto-generated (Variable/Type/Default/Description); one variable moved out of the generated table and documented separately. Defaults and descriptions refreshed.
* **New Features**
  * Docs generation now regenerates the environment-variable reference alongside other docs; added a check to verify generated docs are up-to-date.
* **Bug Fix**
  * Backup-enable environment override now applies even when set to an empty value.
* **Tests**
  * Comprehensive tests added to validate env-reference generation, formatting, and update/check behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->