### PR TITLE
ci(1289): cut Test job wall time -- webhook sleeps, t.Parallel sweep, redundant templ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@v0.3.1001
@@ -90,15 +91,10 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
-
-      - name: Install templ
-        run: go install github.com/a-h/templ/cmd/templ@v0.3.1001
-
-      - name: Generate templ
-        run: templ generate
+          cache: true
 
       - name: Run tests
-        run: go test -v -race -count=1 -coverpkg=./... -coverprofile=coverage.out ./...
+        run: go test -v -race -count=1 -timeout 8m -coverpkg=./... -coverprofile=coverage.out ./...
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
@@ -118,6 +114,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
+          cache: true
 
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@v0.3.1001

--- a/internal/api/handlers_apitoken_test.go
+++ b/internal/api/handlers_apitoken_test.go
@@ -83,6 +83,7 @@ func withUserCtx(req *http.Request, userID string) *http.Request {
 }
 
 func TestTokenLifecycle_ActiveToRevokedToDeleted(t *testing.T) {
+	t.Parallel()
 	r, authSvc, userID := testRouterWithAuth(t)
 
 	// Step 1: Create a token.
@@ -138,6 +139,7 @@ func TestTokenLifecycle_ActiveToRevokedToDeleted(t *testing.T) {
 }
 
 func TestDeleteActiveToken_Returns409(t *testing.T) {
+	t.Parallel()
 	r, authSvc, userID := testRouterWithAuth(t)
 
 	// Create an active token.
@@ -159,6 +161,7 @@ func TestDeleteActiveToken_Returns409(t *testing.T) {
 }
 
 func TestDeleteRevokedToken_AuditAnonymization(t *testing.T) {
+	t.Parallel()
 	r, authSvc, userID := testRouterWithAuth(t)
 
 	// Create and revoke a token.
@@ -236,6 +239,7 @@ func TestDeleteRevokedToken_AuditAnonymization(t *testing.T) {
 }
 
 func TestRevokedToken_CannotAuthenticate(t *testing.T) {
+	t.Parallel()
 	_, authSvc, userID := testRouterWithAuth(t)
 
 	plaintext, tokenID, err := authSvc.CreateAPIToken(context.Background(), userID, "revoke-auth-test", "read")
@@ -267,6 +271,7 @@ func TestRevokedToken_CannotAuthenticate(t *testing.T) {
 }
 
 func TestCreateAPIToken_ReturnsStatusField(t *testing.T) {
+	t.Parallel()
 	_, authSvc, userID := testRouterWithAuth(t)
 
 	_, tokenID, err := authSvc.CreateAPIToken(context.Background(), userID, "status-test", "read")
@@ -286,6 +291,7 @@ func TestCreateAPIToken_ReturnsStatusField(t *testing.T) {
 // TestDeleteRevokedToken_DirectlyWithoutArchiving verifies that a revoked
 // token can be permanently deleted.
 func TestDeleteRevokedToken_DirectlyWithoutArchiving(t *testing.T) {
+	t.Parallel()
 	router, authSvc, userID := testRouterWithAuth(t)
 
 	_, tokenID, err := authSvc.CreateAPIToken(context.Background(), userID, "direct-delete-test", "read")

--- a/internal/api/handlers_artist_lock_test.go
+++ b/internal/api/handlers_artist_lock_test.go
@@ -14,6 +14,7 @@ import (
 // endpoints. It uses the handler functions directly, setting path values via
 // SetPathValue because the tests bypass the router's pattern matching.
 func TestHandleLockArtistField(t *testing.T) {
+	t.Parallel()
 	r, svc := testRouter(t)
 	ctx := context.Background()
 
@@ -61,6 +62,7 @@ func TestHandleLockArtistField(t *testing.T) {
 // TestHandleLockArtistField_NotFound verifies the handler emits a 404 when
 // the artist does not exist.
 func TestHandleLockArtistField_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/missing/field-locks/biography", nil)
 	req.SetPathValue("id", "missing")
@@ -75,6 +77,7 @@ func TestHandleLockArtistField_NotFound(t *testing.T) {
 // TestHandleLockArtistImage verifies per-image lock toggling and the
 // cross-artist ownership check.
 func TestHandleLockArtistImage(t *testing.T) {
+	t.Parallel()
 	r, svc := testRouter(t)
 	ctx := context.Background()
 
@@ -139,6 +142,7 @@ func TestHandleLockArtistImage(t *testing.T) {
 // TestHandleUnlockArtistField_NotFound verifies 404 from the DELETE endpoint
 // when the artist does not exist.
 func TestHandleUnlockArtistField_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/artists/missing/field-locks/biography", nil)
 	req.SetPathValue("id", "missing")
@@ -154,6 +158,7 @@ func TestHandleUnlockArtistField_NotFound(t *testing.T) {
 // the path does not resolve to any images (GetImagesForArtist returns empty,
 // so the ownership check fails).
 func TestHandleLockArtistImage_MissingArtist(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/missing/image-locks/img-1", nil)
 	req.SetPathValue("id", "missing")
@@ -169,6 +174,7 @@ func TestHandleLockArtistImage_MissingArtist(t *testing.T) {
 // POST sets the lock, GET confirms it, DELETE removes it. PushLocks runs
 // inline; without a configured connection it is a no-op.
 func TestHandleLockArtist(t *testing.T) {
+	t.Parallel()
 	r, svc := testRouter(t)
 	ctx := context.Background()
 	a := &artist.Artist{Name: "Wholesale Lock"}
@@ -226,6 +232,7 @@ func TestHandleLockArtist(t *testing.T) {
 }
 
 func TestHandleLockArtist_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/missing/lock", nil)
 	req.SetPathValue("id", "missing")
@@ -237,6 +244,7 @@ func TestHandleLockArtist_NotFound(t *testing.T) {
 }
 
 func TestHandleUnlockArtist_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/artists/missing/lock", nil)
 	req.SetPathValue("id", "missing")
@@ -250,6 +258,7 @@ func TestHandleUnlockArtist_NotFound(t *testing.T) {
 // TestHandleUnlockArtistImage_WrongImage verifies 404 when the imageId does
 // not belong to the artist on the DELETE path.
 func TestHandleUnlockArtistImage_WrongImage(t *testing.T) {
+	t.Parallel()
 	r, svc := testRouter(t)
 	ctx := context.Background()
 	a := &artist.Artist{Name: "Unlock Wrong", Path: "/music/unlock-wrong"}

--- a/internal/api/handlers_artist_test.go
+++ b/internal/api/handlers_artist_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestHandleArtistsBadge_ZeroCount(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/badge", nil)
 	w := httptest.NewRecorder()
@@ -28,6 +29,7 @@ func TestHandleArtistsBadge_ZeroCount(t *testing.T) {
 }
 
 func TestHandleArtistsBadge_NonZeroCount(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	if err := artistSvc.Create(context.Background(), &artist.Artist{Name: "Badge Artist"}); err != nil {
 		t.Fatalf("creating artist: %v", err)
@@ -44,6 +46,7 @@ func TestHandleArtistsBadge_NonZeroCount(t *testing.T) {
 }
 
 func TestHandleArtistsBadge_ServiceError(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	// Close the DB to force a service error. testRouter's t.Cleanup will
 	// attempt a second close; that error is intentionally ignored there.
@@ -59,6 +62,7 @@ func TestHandleArtistsBadge_ServiceError(t *testing.T) {
 }
 
 func TestArtistsPageSortParams(t *testing.T) {
+	t.Parallel()
 	r, _, artistSvc := testRouterWithLibrary(t)
 
 	a1 := &artist.Artist{Name: "Zydeco Band"}
@@ -116,6 +120,7 @@ func TestArtistsPageSortParams(t *testing.T) {
 // change to the selection controller. This test pins (a)-(c) so a future
 // edit cannot regress the behavior described in #1081.
 func TestArtistsPage_BulkSelectionSurvivesSort(t *testing.T) {
+	t.Parallel()
 	r, _, artistSvc := testRouterWithLibrary(t)
 
 	// Two artists are enough to assert per-row uniqueness while keeping the
@@ -220,6 +225,7 @@ func TestArtistsPage_BulkSelectionSurvivesSort(t *testing.T) {
 // would otherwise expose. Without this round-trip the cross-page selection
 // still appears "lost" because the user has no way to focus on it.
 func TestArtistsPage_IDsFilter(t *testing.T) {
+	t.Parallel()
 	r, _, artistSvc := testRouterWithLibrary(t)
 
 	// Three artists give the test something to filter against. We pick
@@ -281,6 +287,7 @@ func TestArtistsPage_IDsFilter(t *testing.T) {
 // strips the param on its own (older htmx, manual URL edits) does not show
 // an empty list with an alarming "Showing 0 selected" chip.
 func TestArtistsPage_IDsFilter_Empty(t *testing.T) {
+	t.Parallel()
 	r, _, artistSvc := testRouterWithLibrary(t)
 	if err := artistSvc.Create(context.Background(), &artist.Artist{Name: "Solo Artist"}); err != nil {
 		t.Fatalf("creating artist: %v", err)
@@ -333,6 +340,7 @@ func TestArtistsPage_IDsFilter_Empty(t *testing.T) {
 // overview when the setting is disabled, when no connections exist, or when
 // only non-debug-capable (Lidarr) connections exist.
 func TestArtistDetailPage_TabDebugFallback(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Debug Tab Artist")
 

--- a/internal/api/handlers_artist_url_test.go
+++ b/internal/api/handlers_artist_url_test.go
@@ -14,6 +14,7 @@ import (
 // clients cannot navigate to the correct item and frequently show a
 // generic home page or fail to load in multi-server setups.
 func TestBuildPlatformArtistURL_ServerIDPlumbing(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name    string
 		conn    *connection.Connection

--- a/internal/api/handlers_artist_violations_tab_test.go
+++ b/internal/api/handlers_artist_violations_tab_test.go
@@ -14,6 +14,7 @@ import (
 // a blank path value must fail the request fast so the rule service is never
 // queried with an unconstrained filter.
 func TestHandleArtistViolationsTab_EmptyArtistID(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/artists//violations/tab", nil)
@@ -31,6 +32,7 @@ func TestHandleArtistViolationsTab_EmptyArtistID(t *testing.T) {
 // active violations renders the tab partial with the empty-state copy and the
 // OOB badge swap that hides the tab-bar count.
 func TestHandleArtistViolationsTab_EmptyState(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Empty Artist")
 
@@ -61,6 +63,7 @@ func TestHandleArtistViolationsTab_EmptyState(t *testing.T) {
 // the row for the open violation, the Fix button for a fixable rule, and the
 // OOB badge count reflecting the number of active rows.
 func TestHandleArtistViolationsTab_WithViolations(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, ruleSvc := testRouterWithPipelineFull(t)
 	a := addTestArtist(t, artistSvc, "Violation Artist")
 

--- a/internal/api/handlers_backdrop_test.go
+++ b/internal/api/handlers_backdrop_test.go
@@ -117,6 +117,7 @@ func addTestConnectionWithURLForBackdrop(t *testing.T, r *Router, id, name, conn
 }
 
 func TestHandlePlatformBackdrops_NoConnections(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterForBackdrops(t)
 	a := addTestArtist(t, artistSvc, "TestArtist")
 
@@ -142,6 +143,7 @@ func TestHandlePlatformBackdrops_NoConnections(t *testing.T) {
 }
 
 func TestHandlePlatformBackdrops_WithBackdrops(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterForBackdrops(t)
 
 	// Mock Emby server that returns an artist with 3 backdrops.
@@ -210,6 +212,7 @@ func TestHandlePlatformBackdrops_WithBackdrops(t *testing.T) {
 }
 
 func TestHandlePlatformBackdropThumbnail(t *testing.T) {
+	t.Parallel()
 	jpegData := createTestJPEGForBackdrop(t)
 
 	r, artistSvc := testRouterForBackdrops(t)
@@ -250,6 +253,7 @@ func TestHandlePlatformBackdropThumbnail(t *testing.T) {
 }
 
 func TestHandleFanartSlotAssign(t *testing.T) {
+	t.Parallel()
 	jpegData := createTestJPEGForBackdrop(t)
 	artistDir := t.TempDir()
 
@@ -301,6 +305,7 @@ func TestHandleFanartSlotAssign(t *testing.T) {
 }
 
 func TestHandleFanartSlotAssign_GapRejected(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterForBackdrops(t)
 	artistDir := t.TempDir()
 
@@ -334,6 +339,7 @@ func TestHandleFanartSlotAssign_GapRejected(t *testing.T) {
 }
 
 func TestHandleFanartSlotDelete(t *testing.T) {
+	t.Parallel()
 	artistDir := t.TempDir()
 
 	r, artistSvc := testRouterForBackdrops(t)
@@ -378,6 +384,7 @@ func TestHandleFanartSlotDelete(t *testing.T) {
 }
 
 func TestHandleFanartSlotDelete_OnlySlot(t *testing.T) {
+	t.Parallel()
 	artistDir := t.TempDir()
 	r, artistSvc := testRouterForBackdrops(t)
 
@@ -424,6 +431,7 @@ func TestHandleFanartSlotDelete_OnlySlot(t *testing.T) {
 }
 
 func TestHandleFanartReorder(t *testing.T) {
+	t.Parallel()
 	artistDir := t.TempDir()
 	r, artistSvc := testRouterForBackdrops(t)
 
@@ -479,6 +487,7 @@ func TestHandleFanartReorder(t *testing.T) {
 }
 
 func TestHandleFanartReorder_InvalidPermutation(t *testing.T) {
+	t.Parallel()
 	artistDir := t.TempDir()
 	r, artistSvc := testRouterForBackdrops(t)
 
@@ -526,6 +535,7 @@ func TestHandleFanartReorder_InvalidPermutation(t *testing.T) {
 }
 
 func TestHandleFanartSyncState_NoConnections(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterForBackdrops(t)
 	a := addTestArtist(t, artistSvc, "TestArtist")
 
@@ -555,6 +565,7 @@ func TestHandleFanartSyncState_NoConnections(t *testing.T) {
 }
 
 func TestHandleFanartSyncState_AllSynced(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterForBackdrops(t)
 	artistDir := t.TempDir()
 
@@ -637,6 +648,7 @@ func TestHandleFanartSyncState_AllSynced(t *testing.T) {
 }
 
 func TestHandleFanartSyncState_Partial(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterForBackdrops(t)
 	artistDir := t.TempDir()
 
@@ -721,6 +733,7 @@ func TestHandleFanartSyncState_Partial(t *testing.T) {
 }
 
 func TestHandleFanartSyncState_MultipleConnections(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterForBackdrops(t)
 	artistDir := t.TempDir()
 
@@ -851,6 +864,7 @@ func TestHandleFanartSyncState_MultipleConnections(t *testing.T) {
 }
 
 func TestHandlePlatformBackdropThumbnail_InvalidIndex(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterForBackdrops(t)
 	a := addTestArtist(t, artistSvc, "TestArtist")
 	addTestConnectionWithURLForBackdrop(t, r, "conn-emby", "My Emby", "emby", "http://unused:8096")
@@ -884,6 +898,7 @@ func TestHandlePlatformBackdropThumbnail_InvalidIndex(t *testing.T) {
 }
 
 func TestHandleFanartSlotDelete_OutOfRange(t *testing.T) {
+	t.Parallel()
 	artistDir := t.TempDir()
 	r, artistSvc := testRouterForBackdrops(t)
 
@@ -932,6 +947,7 @@ func TestHandleFanartSlotDelete_OutOfRange(t *testing.T) {
 }
 
 func TestIsValidPermutation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		order []int
 		want  bool

--- a/internal/api/handlers_backup_test.go
+++ b/internal/api/handlers_backup_test.go
@@ -61,6 +61,7 @@ func testRouterWithBackup(t *testing.T) (*Router, *backup.Service) {
 }
 
 func TestHandleBackupCreate_JSON(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithBackup(t)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/settings/backup", nil)
@@ -90,6 +91,7 @@ func TestHandleBackupCreate_JSON(t *testing.T) {
 }
 
 func TestHandleBackupCreate_HTMX(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithBackup(t)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/settings/backup", nil)
@@ -114,6 +116,7 @@ func TestHandleBackupCreate_HTMX(t *testing.T) {
 }
 
 func TestHandleBackupHistory_JSONEmpty(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithBackup(t)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/settings/backup/history", nil)
@@ -140,6 +143,7 @@ func TestHandleBackupHistory_JSONEmpty(t *testing.T) {
 }
 
 func TestHandleBackupHistory_JSONWithBackups(t *testing.T) {
+	t.Parallel()
 	r, backupSvc := testRouterWithBackup(t)
 
 	if _, err := backupSvc.Backup(context.Background()); err != nil {
@@ -165,6 +169,7 @@ func TestHandleBackupHistory_JSONWithBackups(t *testing.T) {
 }
 
 func TestHandleBackupHistory_HTMXEmpty(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithBackup(t)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/settings/backup/history", nil)
@@ -184,6 +189,7 @@ func TestHandleBackupHistory_HTMXEmpty(t *testing.T) {
 }
 
 func TestHandleBackupHistory_HTMXWithBackups(t *testing.T) {
+	t.Parallel()
 	r, backupSvc := testRouterWithBackup(t)
 
 	if _, err := backupSvc.Backup(context.Background()); err != nil {
@@ -215,6 +221,7 @@ func TestHandleBackupHistory_HTMXWithBackups(t *testing.T) {
 }
 
 func TestHandleBackupDownload_InvalidFilename(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithBackup(t)
 
 	cases := []struct {
@@ -243,6 +250,7 @@ func TestHandleBackupDownload_InvalidFilename(t *testing.T) {
 }
 
 func TestHandleBackupDownload_ValidFile(t *testing.T) {
+	t.Parallel()
 	r, backupSvc := testRouterWithBackup(t)
 
 	info, err := backupSvc.Backup(context.Background())
@@ -279,6 +287,7 @@ func TestHandleBackupDownload_ValidFile(t *testing.T) {
 }
 
 func TestHandleBackupDownload_FileNotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithBackup(t)
 
 	filename := "stillwater-20260101-120000.db"
@@ -294,6 +303,7 @@ func TestHandleBackupDownload_FileNotFound(t *testing.T) {
 }
 
 func TestHandleBackupDelete_JSON(t *testing.T) {
+	t.Parallel()
 	r, backupSvc := testRouterWithBackup(t)
 
 	info, err := backupSvc.Backup(context.Background())
@@ -321,6 +331,7 @@ func TestHandleBackupDelete_JSON(t *testing.T) {
 }
 
 func TestHandleBackupDelete_HTMX(t *testing.T) {
+	t.Parallel()
 	r, backupSvc := testRouterWithBackup(t)
 
 	info, err := backupSvc.Backup(context.Background())
@@ -351,6 +362,7 @@ func TestHandleBackupDelete_HTMX(t *testing.T) {
 }
 
 func TestHandleBackupDelete_InvalidFilename(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithBackup(t)
 
 	cases := []struct {
@@ -378,6 +390,7 @@ func TestHandleBackupDelete_InvalidFilename(t *testing.T) {
 }
 
 func TestHandleBackupDelete_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithBackup(t)
 
 	filename := "stillwater-20260101-120000.db"
@@ -393,6 +406,7 @@ func TestHandleBackupDelete_NotFound(t *testing.T) {
 }
 
 func TestFormatBytes(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		input int64
 		want  string

--- a/internal/api/handlers_bulk_actions_test.go
+++ b/internal/api/handlers_bulk_actions_test.go
@@ -22,6 +22,7 @@ var errBulkPipelineTest = errors.New("bulk pipeline test failure")
 // TestBulkAction_Cancel_NoRun verifies the cancel endpoint returns 409 when
 // there is no in-flight bulk action to stop.
 func TestBulkAction_Cancel_NoRun(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/bulk-actions/cancel", nil)
 	w := httptest.NewRecorder()
@@ -34,6 +35,7 @@ func TestBulkAction_Cancel_NoRun(t *testing.T) {
 // TestBulkAction_Cancel_Running covers the happy path: a running progress
 // with a non-nil cancelFn returns 200 and invokes the cancel function.
 func TestBulkAction_Cancel_Running(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	canceled := false
 	cancel := func() { canceled = true }
@@ -55,6 +57,7 @@ func TestBulkAction_Cancel_Running(t *testing.T) {
 // TestBulkAction_Cancel_StaleProgress handles the case where a completed
 // snapshot lingers with a nil cancelFn; cancel must 409 rather than panic.
 func TestBulkAction_Cancel_StaleProgress(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	r.bulkActionMu.Lock()
 	r.bulkActionProgress = &BulkActionProgress{Status: "completed", Action: "run_rules", Total: 1}
@@ -69,6 +72,7 @@ func TestBulkAction_Cancel_StaleProgress(t *testing.T) {
 
 // TestBulkAction_InvalidAction rejects unknown action values with 400.
 func TestBulkAction_InvalidAction(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	body := strings.NewReader(`{"action":"delete_everything","ids":["abc"]}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/bulk-actions", body)
@@ -84,6 +88,7 @@ func TestBulkAction_InvalidAction(t *testing.T) {
 
 // TestBulkAction_EmptyIDs rejects empty id lists with 400.
 func TestBulkAction_EmptyIDs(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	body := strings.NewReader(`{"action":"run_rules","ids":[]}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/bulk-actions", body)
@@ -99,6 +104,7 @@ func TestBulkAction_EmptyIDs(t *testing.T) {
 
 // TestBulkAction_InvalidIDFormat rejects IDs that fail the format regex.
 func TestBulkAction_InvalidIDFormat(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	body := strings.NewReader(`{"action":"run_rules","ids":["../../etc/passwd"]}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/bulk-actions", body)
@@ -115,6 +121,7 @@ func TestBulkAction_InvalidIDFormat(t *testing.T) {
 // TestBulkAction_ConcurrentReject ensures a second bulk action while one is
 // already running returns 409 Conflict, matching the fix-all pattern.
 func TestBulkAction_ConcurrentReject(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 
 	// Simulate an in-flight run by claiming the progress slot directly.
@@ -144,6 +151,7 @@ func TestBulkAction_ConcurrentReject(t *testing.T) {
 
 // TestBulkActionStatus_Idle returns idle when no progress is set.
 func TestBulkActionStatus_Idle(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/bulk-actions/status", nil)
 	w := httptest.NewRecorder()
@@ -165,6 +173,7 @@ func TestBulkActionStatus_Idle(t *testing.T) {
 // TestBulkAction_TooManyIDs bounds the request size so a single call cannot
 // monopolize the singleton slot indefinitely.
 func TestBulkAction_TooManyIDs(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 
 	var b strings.Builder
@@ -194,6 +203,7 @@ func TestBulkAction_TooManyIDs(t *testing.T) {
 // misleading 202 + completed snapshot; the fix routes this case through the
 // upfront 503 path so the progress slot is released immediately.
 func TestBulkAction_ScanRequiresPipeline(t *testing.T) {
+	t.Parallel()
 	// testRouterWithIdentify wires an artistService but no pipeline, so scan
 	// must fail availability.
 	r, _, _ := testRouterWithIdentify(t)
@@ -220,6 +230,7 @@ func TestBulkAction_ScanRequiresPipeline(t *testing.T) {
 // TestBulkAction_RunRulesRequiresPipeline locks in the 503 + slot-release
 // path for run_rules when the pipeline is absent.
 func TestBulkAction_RunRulesRequiresPipeline(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 
 	body := strings.NewReader(`{"action":"run_rules","ids":["abc123"]}`)
@@ -272,6 +283,7 @@ func waitBulkActionCompleted(t *testing.T, r *Router) {
 //     exactly once per unique ID (no arbitrary sleeps; mirrors the fix-all
 //     polling pattern)
 func TestBulkAction_SuccessDedupKickoff(t *testing.T) {
+	t.Parallel()
 	var calls atomic.Int32
 	stub := &stubPipeline{
 		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
@@ -357,6 +369,7 @@ func TestBulkAction_SuccessDedupKickoff(t *testing.T) {
 // TestBulkAction_Scan_Success exercises the scan action end-to-end through
 // the pipeline so the success branch of applyBulkAction is covered.
 func TestBulkAction_Scan_Success(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, artistSvc := testRouterWithStubPipeline(t, stub)
 	a := addTestArtist(t, artistSvc, "Scan Artist")
@@ -392,6 +405,7 @@ func TestBulkAction_Scan_Success(t *testing.T) {
 // TestBulkAction_MissingArtistSkipped exercises the not-found branch in the
 // per-artist loop so coverage reflects the skipped outcome.
 func TestBulkAction_MissingArtistSkipped(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, _ := testRouterWithStubPipeline(t, stub)
 
@@ -427,6 +441,7 @@ func TestBulkAction_MissingArtistSkipped(t *testing.T) {
 // applyBulkAction (same pipeline hop as run_rules, but a distinct action
 // label so progress reports the right value).
 func TestBulkAction_FetchImages_Success(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, artistSvc := testRouterWithStubPipeline(t, stub)
 	a := addTestArtist(t, artistSvc, "Fetch Images Artist")
@@ -457,6 +472,7 @@ func TestBulkAction_FetchImages_Success(t *testing.T) {
 // TestBulkAction_PipelineError marks the per-artist work as failed when the
 // pipeline returns an error so operators see the real outcome.
 func TestBulkAction_PipelineError(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
 			return nil, errBulkPipelineTest
@@ -488,6 +504,7 @@ func TestBulkAction_PipelineError(t *testing.T) {
 // TestBulkAction_ReIdentifyNoOrchestrator verifies the skipped path when
 // neither an orchestrator nor a connection index is available.
 func TestBulkAction_ReIdentifyNoOrchestrator(t *testing.T) {
+	t.Parallel()
 	// The stub-pipeline router has no orchestrator and no connections, so the
 	// per-artist re-identify branch will return bulkOutcomeSkipped.
 	stub := &stubPipeline{}
@@ -518,6 +535,7 @@ func TestBulkAction_ReIdentifyNoOrchestrator(t *testing.T) {
 // completed run must still be visible via /status (not idle) so callers can
 // see per-action outcome without an active job.
 func TestBulkAction_StatusAfterCompletion(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, artistSvc := testRouterWithStubPipeline(t, stub)
 	a := addTestArtist(t, artistSvc, "Status Artist")

--- a/internal/api/handlers_conflict_integration_test.go
+++ b/internal/api/handlers_conflict_integration_test.go
@@ -140,6 +140,7 @@ func startFakeEmby(t *testing.T) (*httptest.Server, *sync.Map) {
 }
 
 func TestSetStillwaterManaged_EnableSnapshotsAndDisablesPeer(t *testing.T) {
+	t.Parallel()
 	r, svc := testRouterForConflictToggle(t)
 	fake, received := startFakeEmby(t)
 	defer fake.Close()
@@ -195,6 +196,7 @@ func TestSetStillwaterManaged_EnableSnapshotsAndDisablesPeer(t *testing.T) {
 }
 
 func TestSetStillwaterManaged_DisableRestoresSnapshot(t *testing.T) {
+	t.Parallel()
 	r, svc := testRouterForConflictToggle(t)
 	fake, received := startFakeEmby(t)
 	defer fake.Close()
@@ -386,6 +388,7 @@ func startFakeLidarr(t *testing.T) (*httptest.Server, func() map[string]any) {
 }
 
 func TestSetStillwaterManaged_JellyfinBranch(t *testing.T) {
+	t.Parallel()
 	r, svc := testRouterForConflictToggle(t)
 	fake, snapshot := startFakeJellyfin(t)
 	defer fake.Close()
@@ -419,6 +422,7 @@ func TestSetStillwaterManaged_JellyfinBranch(t *testing.T) {
 }
 
 func TestSetStillwaterManaged_LidarrBranch(t *testing.T) {
+	t.Parallel()
 	r, svc := testRouterForConflictToggle(t)
 	fake, snapshot := startFakeLidarr(t)
 	defer fake.Close()
@@ -503,6 +507,7 @@ func lidarrField(consumer map[string]any, name string) any {
 }
 
 func TestSetStillwaterManaged_404OnUnknownConnection(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterForConflictToggle(t)
 	body := bytes.NewReader([]byte(`{"enabled":true}`))
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/ghost/stillwater-managed", body)
@@ -520,6 +525,7 @@ func TestSetStillwaterManaged_404OnUnknownConnection(t *testing.T) {
 // 500 (local side). This is the inverse of the apply-side rollback test
 // and pins the symmetric behavior across both directions.
 func TestSetStillwaterManaged_DisableReturns502OnPeerRestoreFailure(t *testing.T) {
+	t.Parallel()
 	r, svc := testRouterForConflictToggle(t)
 
 	var (
@@ -615,6 +621,7 @@ func TestSetStillwaterManaged_DisableReturns502OnPeerRestoreFailure(t *testing.T
 // still surface the original 502 to the caller and the snapshot row must
 // still be cleared. The rollback restore error is logged but not returned.
 func TestSetStillwaterManaged_RollbackRestoreFailureLogged(t *testing.T) {
+	t.Parallel()
 	r, svc := testRouterForConflictToggle(t)
 
 	// postCount tracks how many LibraryOptions POSTs the fake peer received.
@@ -698,6 +705,7 @@ func TestSetStillwaterManaged_RollbackRestoreFailureLogged(t *testing.T) {
 // resnaps the savers-off peer and overwrites the real pre-Stillwater config,
 // breaking opt-out forever.
 func TestSetStillwaterManaged_RollsBackWhenPeerDisableFails(t *testing.T) {
+	t.Parallel()
 	r, svc := testRouterForConflictToggle(t)
 
 	var (

--- a/internal/api/handlers_conflict_test.go
+++ b/internal/api/handlers_conflict_test.go
@@ -40,6 +40,7 @@ func newConflictHarness(t *testing.T, conns []connection.Connection) *Router {
 }
 
 func TestHandleGetConflicts_ReturnsLedger(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, []connection.Connection{
 		{ID: "a", Name: "A", Type: connection.TypeEmby, Enabled: true},
 	})
@@ -60,6 +61,7 @@ func TestHandleGetConflicts_ReturnsLedger(t *testing.T) {
 }
 
 func TestHandleGetConflicts_503WhenDetectorMissing(t *testing.T) {
+	t.Parallel()
 	r := &Router{logger: testDiscardLogger()}
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/conflicts", nil)
 	w := httptest.NewRecorder()
@@ -70,6 +72,7 @@ func TestHandleGetConflicts_503WhenDetectorMissing(t *testing.T) {
 }
 
 func TestHandleGetConflicts_RefreshInvalidatesCache(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/conflicts?refresh=1", nil)
 	w := httptest.NewRecorder()
@@ -80,6 +83,7 @@ func TestHandleGetConflicts_RefreshInvalidatesCache(t *testing.T) {
 }
 
 func TestHandleGetConflictBanner_RendersHTML(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, []connection.Connection{
 		{ID: "a", Name: "A", Type: connection.TypeEmby, Enabled: true},
 	})
@@ -97,6 +101,7 @@ func TestHandleGetConflictBanner_RendersHTML(t *testing.T) {
 }
 
 func TestHandleGetConflictBanner_204WhenDetectorMissing(t *testing.T) {
+	t.Parallel()
 	r := &Router{logger: testDiscardLogger()}
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/config/conflict-banner", nil)
 	w := httptest.NewRecorder()
@@ -107,6 +112,7 @@ func TestHandleGetConflictBanner_204WhenDetectorMissing(t *testing.T) {
 }
 
 func TestHandleGetConflictBanner_RefreshInvalidatesCache(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, []connection.Connection{
 		{ID: "a", Name: "A", Type: connection.TypeEmby, Enabled: true},
 	})
@@ -122,6 +128,7 @@ func TestHandleGetConflictBanner_RefreshInvalidatesCache(t *testing.T) {
 }
 
 func TestHandleGetConnectionConflictDetail_RendersForKnownID(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, []connection.Connection{
 		{ID: "abc", Name: "Emby One", Type: connection.TypeEmby, Enabled: true},
 	})
@@ -140,6 +147,7 @@ func TestHandleGetConnectionConflictDetail_RendersForKnownID(t *testing.T) {
 }
 
 func TestHandleGetConnectionConflictDetail_204WhenMissing(t *testing.T) {
+	t.Parallel()
 	r := &Router{logger: testDiscardLogger()}
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/connections/abc/conflict-detail", nil)
 	req.SetPathValue("id", "abc")
@@ -151,6 +159,7 @@ func TestHandleGetConnectionConflictDetail_204WhenMissing(t *testing.T) {
 }
 
 func TestHandleSetStillwaterManaged_RejectsMissingID(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections//stillwater-managed", bytes.NewReader([]byte(`{"enabled":true}`)))
 	req.SetPathValue("id", "")
@@ -162,6 +171,7 @@ func TestHandleSetStillwaterManaged_RejectsMissingID(t *testing.T) {
 }
 
 func TestHandleSetStillwaterManaged_RejectsBadJSON(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/abc/stillwater-managed", bytes.NewReader([]byte(`{not json`)))
 	req.SetPathValue("id", "abc")
@@ -177,6 +187,7 @@ func TestHandleSetStillwaterManaged_RejectsBadJSON(t *testing.T) {
 // silently coerce to enabled=false (which would be a destructive state change
 // triggered by a dropped HTMX body or a curl typo).
 func TestHandleSetStillwaterManaged_RejectsEmptyBody(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/abc/stillwater-managed", bytes.NewReader(nil))
 	req.SetPathValue("id", "abc")
@@ -192,6 +203,7 @@ func TestHandleSetStillwaterManaged_RejectsEmptyBody(t *testing.T) {
 // to false here would silently flip the toggle off on any caller that sent
 // {"foo":"bar"} or {} -- exactly what strict validation is meant to prevent.
 func TestHandleSetStillwaterManaged_RejectsJSONWithoutEnabled(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/abc/stillwater-managed", bytes.NewReader([]byte(`{"foo":"bar"}`)))
 	req.SetPathValue("id", "abc")
@@ -206,6 +218,7 @@ func TestHandleSetStillwaterManaged_RejectsJSONWithoutEnabled(t *testing.T) {
 // where "enabled" is present but not parseable as bool (string "maybe", a
 // number, etc.).
 func TestHandleSetStillwaterManaged_RejectsInvalidEnabledValue(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/abc/stillwater-managed", bytes.NewReader([]byte(`{"enabled":"maybe"}`)))
 	req.SetPathValue("id", "abc")
@@ -220,6 +233,7 @@ func TestHandleSetStillwaterManaged_RejectsInvalidEnabledValue(t *testing.T) {
 // HTMX-style application/x-www-form-urlencoded path. A form body that omits
 // "enabled" or sends a malformed value (e.g. enabled=maybe) must 400.
 func TestHandleSetStillwaterManaged_RejectsFormBodyWithoutEnabled(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/abc/stillwater-managed", bytes.NewReader([]byte(`other=field`)))
 	req.SetPathValue("id", "abc")
@@ -231,6 +245,7 @@ func TestHandleSetStillwaterManaged_RejectsFormBodyWithoutEnabled(t *testing.T) 
 }
 
 func TestWriteConflictError_EmitsExpectedShape(t *testing.T) {
+	t.Parallel()
 	w := httptest.NewRecorder()
 	writeConflictError(w, &conflict.BlockedError{
 		Axis:   conflict.AxisImage,
@@ -258,6 +273,7 @@ func TestWriteConflictError_EmitsExpectedShape(t *testing.T) {
 }
 
 func TestConflictBannerView_PopulatesFromLedger(t *testing.T) {
+	t.Parallel()
 	l := conflict.Ledger{
 		Connections: []conflict.ConnectionState{
 			{ConnectionID: "a", ConnectionName: "A", ConnectionType: connection.TypeEmby,
@@ -279,6 +295,7 @@ func TestConflictBannerView_PopulatesFromLedger(t *testing.T) {
 }
 
 func TestWriteConflictError_AllAxes(t *testing.T) {
+	t.Parallel()
 	for _, axis := range []conflict.Axis{conflict.AxisImage, conflict.AxisNFO, conflict.AxisRoundTrip} {
 		w := httptest.NewRecorder()
 		writeConflictError(w, &conflict.BlockedError{Axis: axis, Reason: "x"})
@@ -302,6 +319,7 @@ func TestWriteConflictError_AllAxes(t *testing.T) {
 }
 
 func TestGateImageWrite_AllowsCleanWrite(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, nil)
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -311,6 +329,7 @@ func TestGateImageWrite_AllowsCleanWrite(t *testing.T) {
 }
 
 func TestGateImageWrite_Blocks409(t *testing.T) {
+	t.Parallel()
 	d := conflict.NewBlockingForTest(testDiscardLogger())
 	r := &Router{
 		logger:           testDiscardLogger(),
@@ -328,6 +347,7 @@ func TestGateImageWrite_Blocks409(t *testing.T) {
 }
 
 func TestGateNFOWrite_Blocks409(t *testing.T) {
+	t.Parallel()
 	d := conflict.NewBlockingForTest(testDiscardLogger())
 	r := &Router{
 		logger:           testDiscardLogger(),
@@ -345,6 +365,7 @@ func TestGateNFOWrite_Blocks409(t *testing.T) {
 }
 
 func TestGateNFOWrite_AllowsCleanWrite(t *testing.T) {
+	t.Parallel()
 	// The blocked-write 409 shape is covered by TestWriteConflictError_EmitsExpectedShape
 	// here and by TestGateBlocksOn{Image,NFO,RoundTrip}Conflict in the
 	// conflict package. This test pins down the clean-allow path for the NFO
@@ -361,6 +382,7 @@ func TestGateNFOWrite_AllowsCleanWrite(t *testing.T) {
 // branch where "enabled" is present but unparsable (e.g. "maybe"). This
 // path returns 400 from inside parseBoolStrict.
 func TestHandleSetStillwaterManaged_FormBodyInvalidValue(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/abc/stillwater-managed", bytes.NewReader([]byte(`enabled=maybe`)))
 	req.SetPathValue("id", "abc")
@@ -375,6 +397,7 @@ func TestHandleSetStillwaterManaged_FormBodyInvalidValue(t *testing.T) {
 // query-string fallback where ?enabled=??? is unparsable. The handler
 // must reject with 400 from the URL branch, not silently fall through.
 func TestHandleSetStillwaterManaged_QueryParamInvalidValue(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, nil)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/connections/abc/stillwater-managed?enabled=banana", nil)
 	req.SetPathValue("id", "abc")
@@ -391,6 +414,7 @@ func TestHandleSetStillwaterManaged_QueryParamInvalidValue(t *testing.T) {
 // disableFileWriteBack; testing one keeps the policy assertion local
 // without standing up three near-identical fakes.
 func TestRestoreLibraryOptions_RejectsUnsupportedType(t *testing.T) {
+	t.Parallel()
 	r := &Router{logger: testDiscardLogger()}
 	err := r.restoreLibraryOptions(context.Background(), &connection.Connection{Type: "unknown"}, "{}")
 	if err == nil {
@@ -407,6 +431,7 @@ func TestRestoreLibraryOptions_RejectsUnsupportedType(t *testing.T) {
 // rejection (false, false) signal that lets the handler distinguish a
 // missing or garbled value from an explicit false.
 func TestParseBoolStrict(t *testing.T) {
+	t.Parallel()
 	truthy := []string{"1", "true", "TRUE", "On", "yes", "y", "t", "  true  "}
 	falsy := []string{"0", "false", "FALSE", "off", "no", "n", "f", " 0\n"}
 	rejected := []string{"", "maybe", "2", "tr", "yes please"}
@@ -438,6 +463,7 @@ func TestParseBoolStrict(t *testing.T) {
 // falls through to the historical 502 so unrelated regressions do not
 // silently change the status code.
 func TestStillwaterManagedErrorResponse(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name     string
 		err      error

--- a/internal/api/handlers_connection_library_test.go
+++ b/internal/api/handlers_connection_library_test.go
@@ -81,6 +81,7 @@ func testRouterForLibraryOps(t *testing.T) *Router {
 }
 
 func TestHandleLibraryOpStatus_Idle(t *testing.T) {
+	t.Parallel()
 	r := testRouterForLibraryOps(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/libraries/nonexistent/operation/status", nil)
@@ -103,6 +104,7 @@ func TestHandleLibraryOpStatus_Idle(t *testing.T) {
 }
 
 func TestHandleLibraryOpStatus_Running(t *testing.T) {
+	t.Parallel()
 	r := testRouterForLibraryOps(t)
 
 	// Simulate a running operation.
@@ -139,6 +141,7 @@ func TestHandleLibraryOpStatus_Running(t *testing.T) {
 }
 
 func TestHandleLibraryOpStatus_Completed(t *testing.T) {
+	t.Parallel()
 	r := testRouterForLibraryOps(t)
 
 	now := time.Now().UTC()
@@ -177,6 +180,7 @@ func TestHandleLibraryOpStatus_Completed(t *testing.T) {
 }
 
 func TestScheduleOpCleanup(t *testing.T) {
+	t.Parallel()
 	r := testRouterForLibraryOps(t)
 
 	op := &LibraryOpResult{
@@ -214,6 +218,7 @@ func TestScheduleOpCleanup(t *testing.T) {
 }
 
 func TestScheduleOpCleanup_SkipsRunningOp(t *testing.T) {
+	t.Parallel()
 	r := testRouterForLibraryOps(t)
 
 	op := &LibraryOpResult{
@@ -245,6 +250,7 @@ func TestScheduleOpCleanup_SkipsRunningOp(t *testing.T) {
 }
 
 func TestScheduleOpCleanup_SkipsNewerOp(t *testing.T) {
+	t.Parallel()
 	r := testRouterForLibraryOps(t)
 
 	oldOp := &LibraryOpResult{
@@ -285,6 +291,7 @@ func TestScheduleOpCleanup_SkipsNewerOp(t *testing.T) {
 }
 
 func TestPopulateFromEmby_ImportsMetadataFields(t *testing.T) {
+	t.Parallel()
 	// Stand up a fake Emby server returning one artist with full metadata.
 	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -365,6 +372,7 @@ func TestPopulateFromEmby_ImportsMetadataFields(t *testing.T) {
 }
 
 func TestPopulateFromJellyfin_ImportsMetadataFields(t *testing.T) {
+	t.Parallel()
 	// Stand up a fake Jellyfin server returning one artist with full metadata.
 	jfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -433,6 +441,7 @@ func TestPopulateFromJellyfin_ImportsMetadataFields(t *testing.T) {
 }
 
 func TestPopulateLibrary_ConflictWhenRunning(t *testing.T) {
+	t.Parallel()
 	r := testRouterForLibraryOps(t)
 	ctx := context.Background()
 
@@ -502,6 +511,7 @@ func createTestJPEGForHandler(t *testing.T) []byte {
 }
 
 func TestPopulateFromEmby_DownloadsImages(t *testing.T) {
+	t.Parallel()
 	jpegData := createTestJPEGForHandler(t)
 	artistDir, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {
@@ -602,6 +612,7 @@ func TestPopulateFromEmby_DownloadsImages(t *testing.T) {
 }
 
 func TestPopulateFromEmby_SkipsExistingImage(t *testing.T) {
+	t.Parallel()
 	artistDir := t.TempDir()
 	libPath := filepath.Dir(artistDir)
 
@@ -674,6 +685,7 @@ func TestPopulateFromEmby_SkipsExistingImage(t *testing.T) {
 }
 
 func TestPopulateFromEmby_UsesImageCacheWhenNoPath(t *testing.T) {
+	t.Parallel()
 	jpegData := createTestJPEGForHandler(t)
 	var imageRequested atomic.Bool
 	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -762,6 +774,7 @@ func TestPopulateFromEmby_UsesImageCacheWhenNoPath(t *testing.T) {
 }
 
 func TestPopulateFromJellyfin_DownloadsImages(t *testing.T) {
+	t.Parallel()
 	jpegData := createTestJPEGForHandler(t)
 	tmpDir := t.TempDir()
 	artistDir, err := filepath.EvalSymlinks(tmpDir)
@@ -862,6 +875,7 @@ func TestPopulateFromJellyfin_DownloadsImages(t *testing.T) {
 }
 
 func TestPopulateFromEmby_DownloadsImagesForExistingArtist(t *testing.T) {
+	t.Parallel()
 	jpegData := createTestJPEGForHandler(t)
 	artistDir := t.TempDir()
 
@@ -973,6 +987,7 @@ func TestPopulateFromEmby_DownloadsImagesForExistingArtist(t *testing.T) {
 }
 
 func TestValidatedArtistPath(t *testing.T) {
+	t.Parallel()
 	// Use real temp dirs so filepath.Abs produces valid absolute paths.
 	libDir := t.TempDir()
 	artistDir := filepath.Join(libDir, "Radiohead")
@@ -1022,6 +1037,7 @@ func TestValidatedArtistPath(t *testing.T) {
 }
 
 func TestPopulateFromEmby_PlatformPathNotStoredWhenPathless(t *testing.T) {
+	t.Parallel()
 	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
@@ -1077,6 +1093,7 @@ func TestPopulateFromEmby_PlatformPathNotStoredWhenPathless(t *testing.T) {
 }
 
 func TestPopulateFromEmby_PlatformPathStoredWhenUnderLibraryRoot(t *testing.T) {
+	t.Parallel()
 	artistDir, err := filepath.EvalSymlinks(t.TempDir())
 	if err != nil {
 		t.Fatalf("resolving temp dir symlinks: %v", err)
@@ -1139,6 +1156,7 @@ func TestPopulateFromEmby_PlatformPathStoredWhenUnderLibraryRoot(t *testing.T) {
 }
 
 func TestPopulateFromEmby_PlatformPathRejectedWhenOutsideLibraryRoot(t *testing.T) {
+	t.Parallel()
 	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
@@ -1194,6 +1212,7 @@ func TestPopulateFromEmby_PlatformPathRejectedWhenOutsideLibraryRoot(t *testing.
 }
 
 func TestPopulateFromEmby_BackfillsMBID(t *testing.T) {
+	t.Parallel()
 	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/Artists/AlbumArtists":
@@ -1268,6 +1287,7 @@ func TestPopulateFromEmby_BackfillsMBID(t *testing.T) {
 }
 
 func TestPopulateFromEmby_SkipsOnMBIDConflict(t *testing.T) {
+	t.Parallel()
 	// Platform provides MBID-A for "Radiohead", but DB already has "Radiohead"
 	// with MBID-B. These are different artists with the same name.
 	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1341,6 +1361,7 @@ func TestPopulateFromEmby_SkipsOnMBIDConflict(t *testing.T) {
 }
 
 func TestPopulateFromJellyfin_SkipsOnMBIDConflict(t *testing.T) {
+	t.Parallel()
 	jfSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
@@ -1409,6 +1430,7 @@ func TestPopulateFromJellyfin_SkipsOnMBIDConflict(t *testing.T) {
 }
 
 func TestValidatedArtistPath_SymlinkEscape(t *testing.T) {
+	t.Parallel()
 	// Create a library root and an external directory, then symlink from
 	// inside the library to the external directory. The validation should
 	// reject the symlinked path.
@@ -1427,6 +1449,7 @@ func TestValidatedArtistPath_SymlinkEscape(t *testing.T) {
 }
 
 func TestPopulateFromEmby_DownloadsMultipleBackdrops(t *testing.T) {
+	t.Parallel()
 	jpegData := createTestJPEGForHandler(t)
 	artistDir := t.TempDir()
 	libPath := filepath.Dir(artistDir)
@@ -1517,6 +1540,7 @@ func TestPopulateFromEmby_DownloadsMultipleBackdrops(t *testing.T) {
 }
 
 func TestPopulateFromEmby_SkipsExistingBackdrop(t *testing.T) {
+	t.Parallel()
 	jpegData := createTestJPEGForHandler(t)
 	artistDir := t.TempDir()
 	libPath := filepath.Dir(artistDir)
@@ -1599,6 +1623,7 @@ func TestPopulateFromEmby_SkipsExistingBackdrop(t *testing.T) {
 }
 
 func TestPopulateFromJellyfin_DownloadsMultipleBackdrops(t *testing.T) {
+	t.Parallel()
 	jpegData := createTestJPEGForHandler(t)
 	artistDir := t.TempDir()
 	libPath := filepath.Dir(artistDir)
@@ -1688,6 +1713,7 @@ func TestPopulateFromJellyfin_DownloadsMultipleBackdrops(t *testing.T) {
 }
 
 func TestPopulateFromEmby_NoBackdropsWhenTagsEmpty(t *testing.T) {
+	t.Parallel()
 	jpegData := createTestJPEGForHandler(t)
 	artistDir := t.TempDir()
 	libPath := filepath.Dir(artistDir)
@@ -1758,6 +1784,7 @@ func TestPopulateFromEmby_NoBackdropsWhenTagsEmpty(t *testing.T) {
 }
 
 func TestPopulateFromEmby_PartialBackdropDownloadFailure(t *testing.T) {
+	t.Parallel()
 	// Backdrop index 0 returns 404; index 1 returns a valid JPEG.
 	// The loop must continue past the failure and count only the successful download.
 	jpegData := createTestJPEGForHandler(t)
@@ -1841,6 +1868,7 @@ func TestPopulateFromEmby_PartialBackdropDownloadFailure(t *testing.T) {
 }
 
 func TestScanFromEmby_FanartExistsFromBackdropImageTags(t *testing.T) {
+	t.Parallel()
 	artistDir := t.TempDir()
 	libPath := filepath.Dir(artistDir)
 
@@ -1916,6 +1944,7 @@ func TestScanFromEmby_FanartExistsFromBackdropImageTags(t *testing.T) {
 }
 
 func TestScanFromJellyfin_FanartExistsFromBackdropImageTags(t *testing.T) {
+	t.Parallel()
 	artistDir := t.TempDir()
 	libPath := filepath.Dir(artistDir)
 
@@ -1991,6 +2020,7 @@ func TestScanFromJellyfin_FanartExistsFromBackdropImageTags(t *testing.T) {
 }
 
 func TestPopulateFromEmby_NonKodiBackdropNaming(t *testing.T) {
+	t.Parallel()
 	jpegData := createTestJPEGForHandler(t)
 	artistDir := t.TempDir()
 	libPath := filepath.Dir(artistDir)
@@ -2087,6 +2117,7 @@ func TestPopulateFromEmby_NonKodiBackdropNaming(t *testing.T) {
 }
 
 func TestImportLibraries_AutoPopulate(t *testing.T) {
+	t.Parallel()
 	// Stand up a fake Emby server that returns one artist.
 	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -2173,6 +2204,7 @@ func TestImportLibraries_AutoPopulate(t *testing.T) {
 }
 
 func TestScanFromEmby_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
+	t.Parallel()
 	artistDir := t.TempDir()
 	libPath := filepath.Dir(artistDir)
 
@@ -2293,6 +2325,7 @@ func TestScanFromEmby_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 }
 
 func TestPopulateFromEmby_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
+	t.Parallel()
 	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
@@ -2398,6 +2431,7 @@ func TestPopulateFromEmby_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 }
 
 func TestScanFromEmby_BackfillsCaseInsensitiveName(t *testing.T) {
+	t.Parallel()
 	artistDir := t.TempDir()
 	libPath := filepath.Dir(artistDir)
 
@@ -2514,6 +2548,7 @@ func TestScanFromEmby_BackfillsCaseInsensitiveName(t *testing.T) {
 }
 
 func TestResolveAndBackfillPlatformID_NilWhenNoConnectionMatch(t *testing.T) {
+	t.Parallel()
 	router := testRouterForLibraryOps(t)
 	ctx := context.Background()
 
@@ -2539,6 +2574,7 @@ func TestResolveAndBackfillPlatformID_NilWhenNoConnectionMatch(t *testing.T) {
 }
 
 func TestBackfillPlatformIDToManualLibs_SkipsWhenNoMatch(t *testing.T) {
+	t.Parallel()
 	router := testRouterForLibraryOps(t)
 	ctx := context.Background()
 
@@ -2564,6 +2600,7 @@ func TestBackfillPlatformIDToManualLibs_SkipsWhenNoMatch(t *testing.T) {
 }
 
 func TestBackfillPlatformIDToManualLibs_MultipleManualLibraries(t *testing.T) {
+	t.Parallel()
 	router := testRouterForLibraryOps(t)
 	ctx := context.Background()
 
@@ -2625,6 +2662,7 @@ func TestBackfillPlatformIDToManualLibs_MultipleManualLibraries(t *testing.T) {
 }
 
 func TestBackfillPlatformIDToManualLibs_SkipsSameArtist(t *testing.T) {
+	t.Parallel()
 	router := testRouterForLibraryOps(t)
 	ctx := context.Background()
 
@@ -2672,6 +2710,7 @@ func TestBackfillPlatformIDToManualLibs_SkipsSameArtist(t *testing.T) {
 }
 
 func TestScanFromJellyfin_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
+	t.Parallel()
 	artistDir := t.TempDir()
 	libPath := filepath.Dir(artistDir)
 
@@ -2778,6 +2817,7 @@ func TestScanFromJellyfin_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 }
 
 func TestScanFromLidarr_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
+	t.Parallel()
 	lidarrSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v1/artist" {
 			w.Header().Set("Content-Type", "application/json")
@@ -2875,6 +2915,7 @@ func TestScanFromLidarr_BackfillsPlatformIDToFilesystemArtist(t *testing.T) {
 // scenario). Emby populates first and creates the artist; Jellyfin
 // populates second and absorbs into the existing row.
 func TestPopulate_EmbyAndJellyfin_CollapsesIntoOneArtist(t *testing.T) {
+	t.Parallel()
 	const mbid = "mbid-12-stones"
 
 	embySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/handlers_contribution_test.go
+++ b/internal/api/handlers_contribution_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestHandleGetMBDiffs_ArtistNotFound(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithHistory(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/no-such-artist/musicbrainz/diffs", nil)
@@ -25,6 +26,7 @@ func TestHandleGetMBDiffs_ArtistNotFound(t *testing.T) {
 }
 
 func TestHandleGetMBDiffs_NoMBID(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, _ := testRouterWithHistory(t)
 
 	a := addTestArtist(t, artistSvc, "No MBID Artist")
@@ -41,6 +43,7 @@ func TestHandleGetMBDiffs_NoMBID(t *testing.T) {
 }
 
 func TestHandleGetMBDiffs_EmptyDiffs(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, _ := testRouterWithHistory(t)
 
 	a := &artist.Artist{
@@ -90,6 +93,7 @@ func TestHandleGetMBDiffs_EmptyDiffs(t *testing.T) {
 }
 
 func TestHandleGetMBDiffs_WithDiffs(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, _ := testRouterWithHistory(t)
 
 	a := &artist.Artist{

--- a/internal/api/handlers_dashboard_test.go
+++ b/internal/api/handlers_dashboard_test.go
@@ -42,6 +42,7 @@ func withTestUser(req *http.Request) *http.Request {
 // --- handleDashboardActionQueue tests (#876) ---
 
 func TestHandleDashboardActionQueue_LimitCapping(t *testing.T) {
+	t.Parallel()
 	r := testDashboardRouter(t, false)
 	ctx := context.Background()
 
@@ -106,6 +107,7 @@ func TestHandleDashboardActionQueue_LimitCapping(t *testing.T) {
 }
 
 func TestHandleDashboardActionQueue_OffsetBranching(t *testing.T) {
+	t.Parallel()
 	r := testDashboardRouter(t, false)
 	ctx := context.Background()
 
@@ -166,6 +168,7 @@ func TestHandleDashboardActionQueue_OffsetBranching(t *testing.T) {
 }
 
 func TestHandleDashboardActionQueue_Unauthorized(t *testing.T) {
+	t.Parallel()
 	r := testDashboardRouter(t, false)
 
 	// No user in context -- should return 401.
@@ -180,6 +183,7 @@ func TestHandleDashboardActionQueue_Unauthorized(t *testing.T) {
 }
 
 func TestHandleDashboardActionQueue_NegativeOffset(t *testing.T) {
+	t.Parallel()
 	r := testDashboardRouter(t, false)
 	ctx := context.Background()
 
@@ -227,6 +231,7 @@ func TestHandleDashboardActionQueue_NegativeOffset(t *testing.T) {
 // --- handleDashboardActivityFeed tests (#876) ---
 
 func TestHandleDashboardActivityFeed_WithHistoryService(t *testing.T) {
+	t.Parallel()
 	r := testDashboardRouter(t, true)
 
 	req := httptest.NewRequest(http.MethodGet, "/dashboard/activity", nil)
@@ -254,6 +259,7 @@ func TestHandleDashboardActivityFeed_WithHistoryService(t *testing.T) {
 }
 
 func TestHandleDashboardActivityFeed_NilHistoryService(t *testing.T) {
+	t.Parallel()
 	r := testDashboardRouter(t, false) // historyService = nil
 
 	req := httptest.NewRequest(http.MethodGet, "/dashboard/activity", nil)
@@ -269,6 +275,7 @@ func TestHandleDashboardActivityFeed_NilHistoryService(t *testing.T) {
 }
 
 func TestHandleDashboardActivityFeed_Unauthorized(t *testing.T) {
+	t.Parallel()
 	r := testDashboardRouter(t, true)
 
 	// No user in context.
@@ -283,6 +290,7 @@ func TestHandleDashboardActivityFeed_Unauthorized(t *testing.T) {
 }
 
 func TestHandleDashboardActivityFeed_EmptyResultSet(t *testing.T) {
+	t.Parallel()
 	// Verifies the handler renders successfully when the history service is
 	// present but returns an empty result set (no metadata changes recorded).
 	r := testDashboardRouter(t, true)
@@ -313,6 +321,7 @@ func TestHandleDashboardActivityFeed_EmptyResultSet(t *testing.T) {
 // the request is issued. The rule service retains its own open connection so
 // the violation-list queries succeed normally.
 func TestHandleDashboardActionQueue_StatsError(t *testing.T) {
+	t.Parallel()
 	r := testDashboardRouter(t, false)
 
 	// Open a separate in-memory database for the artist service so we can
@@ -362,6 +371,7 @@ func TestHandleDashboardActionQueue_StatsError(t *testing.T) {
 }
 
 func TestUrlValuesFromFilters(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input dashboardFilterParams
@@ -426,6 +436,7 @@ func TestUrlValuesFromFilters(t *testing.T) {
 }
 
 func TestDashboardPushURLFromFilters(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		basePath string

--- a/internal/api/handlers_discography_test.go
+++ b/internal/api/handlers_discography_test.go
@@ -43,6 +43,7 @@ const discographyTestNFO = `<?xml version="1.0" encoding="UTF-8"?>
 `
 
 func TestHandleArtistDiscographyTab_HappyPath(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	dir := writeArtistNFO(t, discographyTestNFO)
@@ -78,6 +79,7 @@ func TestHandleArtistDiscographyTab_HappyPath(t *testing.T) {
 }
 
 func TestHandleArtistDiscographyTab_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	ctx := testI18nCtx(t, context.Background())
@@ -103,6 +105,7 @@ func TestHandleArtistDiscographyTab_NotFound(t *testing.T) {
 }
 
 func TestHandleArtistDiscographyTab_InternalError(t *testing.T) {
+	t.Parallel()
 	// Force a repository error by closing the underlying DB before dispatch.
 	// GetByID will then return a non-NotFound error, exercising the 500 path.
 	r, artistSvc := testRouter(t)
@@ -139,6 +142,7 @@ func TestHandleArtistDiscographyTab_InternalError(t *testing.T) {
 }
 
 func TestHandleArtistDiscographyTab_MissingID(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	ctx := testI18nCtx(t, context.Background())
@@ -154,6 +158,7 @@ func TestHandleArtistDiscographyTab_MissingID(t *testing.T) {
 }
 
 func TestHandleArtistDiscographyTab_NFOAbsent(t *testing.T) {
+	t.Parallel()
 	// Artist exists but NFOExists is false -- handler should render empty state.
 	r, artistSvc := testRouter(t)
 
@@ -180,6 +185,7 @@ func TestHandleArtistDiscographyTab_NFOAbsent(t *testing.T) {
 }
 
 func TestHandleArtistDiscographyTab_NFOMalformed(t *testing.T) {
+	t.Parallel()
 	// Malformed NFO: parseNFOFile returns nil; handler should still 200 with
 	// empty state AND emit a structured warn log so operators can diagnose.
 	r, artistSvc := testRouter(t)
@@ -218,6 +224,7 @@ func TestHandleArtistDiscographyTab_NFOMalformed(t *testing.T) {
 }
 
 func TestHandleArtistDiscographyTab_NFOWithoutAlbums(t *testing.T) {
+	t.Parallel()
 	// Valid NFO but no <album> entries -- empty state.
 	r, artistSvc := testRouter(t)
 
@@ -244,18 +251,21 @@ func TestHandleArtistDiscographyTab_NFOWithoutAlbums(t *testing.T) {
 }
 
 func TestDiscographyFromNFO_Nil(t *testing.T) {
+	t.Parallel()
 	if got := discographyFromNFO(nil); got != nil {
 		t.Errorf("discographyFromNFO(nil) = %v, want nil", got)
 	}
 }
 
 func TestDiscographyFromNFO_Empty(t *testing.T) {
+	t.Parallel()
 	if got := discographyFromNFO(&nfo.ArtistNFO{}); got != nil {
 		t.Errorf("discographyFromNFO(empty) = %v, want nil", got)
 	}
 }
 
 func TestDiscographyFromNFO_MapsFields(t *testing.T) {
+	t.Parallel()
 	in := &nfo.ArtistNFO{
 		Albums: []nfo.DiscographyAlbum{
 			{Title: "A", Year: "2001"},

--- a/internal/api/handlers_field_autopush_test.go
+++ b/internal/api/handlers_field_autopush_test.go
@@ -12,6 +12,7 @@ import (
 // TestFieldUpdate_AutoPush_FiresForPlatformArtist verifies that a PATCH field
 // request triggers an async metadata push to the connected Emby server.
 func TestFieldUpdate_AutoPush_FiresForPlatformArtist(t *testing.T) {
+	t.Parallel()
 	received := make(chan struct{}, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/Items/") {
@@ -55,6 +56,7 @@ func TestFieldUpdate_AutoPush_FiresForPlatformArtist(t *testing.T) {
 // TestFieldClear_AutoPush_FiresForPlatformArtist verifies that a DELETE field
 // request also triggers an async metadata push.
 func TestFieldClear_AutoPush_FiresForPlatformArtist(t *testing.T) {
+	t.Parallel()
 	received := make(chan struct{}, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/Items/") {
@@ -100,6 +102,7 @@ func TestFieldClear_AutoPush_FiresForPlatformArtist(t *testing.T) {
 // TestFieldUpdate_AutoPush_SkipsLocalArtist verifies that artists with no
 // platform ID mappings do not trigger any outbound push requests.
 func TestFieldUpdate_AutoPush_SkipsLocalArtist(t *testing.T) {
+	t.Parallel()
 	called := make(chan struct{}, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		select {
@@ -139,6 +142,7 @@ func TestFieldUpdate_AutoPush_SkipsLocalArtist(t *testing.T) {
 // TestFieldUpdate_AutoPush_SkipsDisabledConnection verifies that disabled
 // connections are not pushed to.
 func TestFieldUpdate_AutoPush_SkipsDisabledConnection(t *testing.T) {
+	t.Parallel()
 	called := make(chan struct{}, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		select {
@@ -190,6 +194,7 @@ func TestFieldUpdate_AutoPush_SkipsDisabledConnection(t *testing.T) {
 // TestFieldUpdate_AutoPush_JellyfinFires verifies that the Jellyfin connection
 // type is also pushed to (not silently skipped by the type switch).
 func TestFieldUpdate_AutoPush_JellyfinFires(t *testing.T) {
+	t.Parallel()
 	received := make(chan struct{}, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Jellyfin PushMetadata now GETs the current item before POSTing the
@@ -241,6 +246,7 @@ func TestFieldUpdate_AutoPush_JellyfinFires(t *testing.T) {
 // server returns 500, the PATCH handler still returns HTTP 200 immediately,
 // and that the push was still attempted (error path is exercised, not skipped).
 func TestFieldUpdate_AutoPush_DoesNotBlockSave(t *testing.T) {
+	t.Parallel()
 	attempted := make(chan struct{}, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		select {

--- a/internal/api/handlers_field_new_test.go
+++ b/internal/api/handlers_field_new_test.go
@@ -14,6 +14,7 @@ import (
 // TestHandleFieldUpdate_Name verifies that updating the "name" field
 // persists correctly through the API.
 func TestHandleFieldUpdate_Name(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Old Name")
 
@@ -41,6 +42,7 @@ func TestHandleFieldUpdate_Name(t *testing.T) {
 
 // TestHandleFieldUpdate_NameEmpty verifies that an empty name is rejected with 400.
 func TestHandleFieldUpdate_NameEmpty(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Some Artist")
 
@@ -60,6 +62,7 @@ func TestHandleFieldUpdate_NameEmpty(t *testing.T) {
 
 // TestHandleFieldUpdate_SortName verifies that sort_name is editable.
 func TestHandleFieldUpdate_SortName(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "The Beatles")
 
@@ -87,6 +90,7 @@ func TestHandleFieldUpdate_SortName(t *testing.T) {
 
 // TestHandleFieldUpdate_Disambiguation verifies that disambiguation is editable.
 func TestHandleFieldUpdate_Disambiguation(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Genesis")
 
@@ -115,6 +119,7 @@ func TestHandleFieldUpdate_Disambiguation(t *testing.T) {
 // TestHandleFieldUpdate_MusicBrainzID verifies that musicbrainz_id is
 // editable via the API and persists through the normalized provider_ids table.
 func TestHandleFieldUpdate_MusicBrainzID(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Radiohead")
 
@@ -153,6 +158,7 @@ func TestHandleFieldUpdate_MusicBrainzID(t *testing.T) {
 // TestHandleFieldUpdate_MusicBrainzID_InvalidFormat verifies that an invalid
 // UUID format is rejected with 400.
 func TestHandleFieldUpdate_MusicBrainzID_InvalidFormat(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Test Artist")
 
@@ -172,6 +178,7 @@ func TestHandleFieldUpdate_MusicBrainzID_InvalidFormat(t *testing.T) {
 
 // TestHandleFieldUpdate_AudioDBID verifies that audiodb_id is editable.
 func TestHandleFieldUpdate_AudioDBID(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Tool")
 
@@ -200,6 +207,7 @@ func TestHandleFieldUpdate_AudioDBID(t *testing.T) {
 // TestHandleFieldClear_MusicBrainzID verifies that clearing musicbrainz_id
 // removes it from the provider_ids table.
 func TestHandleFieldClear_MusicBrainzID(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	a := addTestArtist(t, artistSvc, "Led Zeppelin")
@@ -231,6 +239,7 @@ func TestHandleFieldClear_MusicBrainzID(t *testing.T) {
 // TestHandleFieldClear_Name_Rejected verifies that clearing the name field
 // returns 400, enforcing the non-empty invariant.
 func TestHandleFieldClear_Name_Rejected(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "The Beatles")
 
@@ -259,6 +268,7 @@ func TestHandleFieldClear_Name_Rejected(t *testing.T) {
 // provider ID fields are accepted by IsEditableField and the handler routes them
 // correctly without returning 400 "unknown field".
 func TestHandleFieldUpdate_ProviderIDFields_AllEditable(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Pink Floyd")
 
@@ -298,6 +308,7 @@ func TestHandleFieldUpdate_ProviderIDFields_AllEditable(t *testing.T) {
 // TestHandleFieldDisplay_NewFields verifies that the display handler accepts
 // all new field names without returning 400.
 func TestHandleFieldDisplay_NewFields(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Artist For Display")
 

--- a/internal/api/handlers_field_test.go
+++ b/internal/api/handlers_field_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestHandleFieldUpdate_WritesBackNFO(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	dir := t.TempDir()
@@ -62,6 +63,7 @@ func TestHandleFieldUpdate_WritesBackNFO(t *testing.T) {
 }
 
 func TestHandleFieldUpdate_NoPath_SkipsWriteBack(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	a := addTestArtist(t, artistSvc, "No Path Artist")
@@ -86,6 +88,7 @@ func TestHandleFieldUpdate_NoPath_SkipsWriteBack(t *testing.T) {
 }
 
 func TestHandleFieldUpdate_NoNFO_SkipsWriteBack(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	dir := t.TempDir()
@@ -116,6 +119,7 @@ func TestHandleFieldUpdate_NoNFO_SkipsWriteBack(t *testing.T) {
 }
 
 func TestHandleFieldClear_WritesBackNFO(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	dir := t.TempDir()
@@ -158,6 +162,7 @@ func TestHandleFieldClear_WritesBackNFO(t *testing.T) {
 }
 
 func TestWriteBackNFO_CreatesSnapshot(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	dir := t.TempDir()
@@ -197,6 +202,7 @@ func TestWriteBackNFO_CreatesSnapshot(t *testing.T) {
 }
 
 func TestExtractFieldValue(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		field       string
@@ -300,6 +306,7 @@ func TestExtractFieldValue(t *testing.T) {
 // TestExtractFieldValue_QueryParamNotAccepted verifies that form-encoded
 // requests only read from the POST body, not from URL query parameters.
 func TestExtractFieldValue_QueryParamNotAccepted(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodPatch, "/test?value=injected", strings.NewReader(""))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	got, err := extractFieldValue(req, "biography")
@@ -312,6 +319,7 @@ func TestExtractFieldValue_QueryParamNotAccepted(t *testing.T) {
 }
 
 func TestWriteBackNFO_StatNotExist(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	dir := t.TempDir()

--- a/internal/api/handlers_filesystem_browse_test.go
+++ b/internal/api/handlers_filesystem_browse_test.go
@@ -24,6 +24,7 @@ func newBrowseRouter(t *testing.T) *Router {
 }
 
 func TestHandleFilesystemBrowse_Valid(t *testing.T) {
+	t.Parallel()
 	// Create a temp directory with some subdirectories and a file.
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, "albums"), 0o755); err != nil {
@@ -77,6 +78,7 @@ func TestHandleFilesystemBrowse_Valid(t *testing.T) {
 }
 
 func TestHandleFilesystemBrowse_EmptyDirectory(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	r := newBrowseRouter(t)
@@ -100,6 +102,7 @@ func TestHandleFilesystemBrowse_EmptyDirectory(t *testing.T) {
 }
 
 func TestHandleFilesystemBrowse_MissingPath(t *testing.T) {
+	t.Parallel()
 	r := newBrowseRouter(t)
 	ctx := middleware.WithTestRole(context.Background(), "administrator")
 	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/filesystem/browse", nil)
@@ -113,6 +116,7 @@ func TestHandleFilesystemBrowse_MissingPath(t *testing.T) {
 }
 
 func TestHandleFilesystemBrowse_RelativePath(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		path string
@@ -139,6 +143,7 @@ func TestHandleFilesystemBrowse_RelativePath(t *testing.T) {
 }
 
 func TestHandleFilesystemBrowse_SymlinkResolvesToValidPath(t *testing.T) {
+	t.Parallel()
 	// Create a symlink inside innerDir that points to outerDir.
 	// When browsing the symlink path directly, it must resolve to outerDir.
 	outerDir := t.TempDir()
@@ -181,6 +186,7 @@ func TestHandleFilesystemBrowse_SymlinkResolvesToValidPath(t *testing.T) {
 }
 
 func TestHandleFilesystemBrowse_NonExistentPath(t *testing.T) {
+	t.Parallel()
 	r := newBrowseRouter(t)
 	ctx := middleware.WithTestRole(context.Background(), "administrator")
 	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/filesystem/browse?path=/nonexistent/path/that/does/not/exist", nil)
@@ -194,6 +200,7 @@ func TestHandleFilesystemBrowse_NonExistentPath(t *testing.T) {
 }
 
 func TestHandleFilesystemBrowse_RequireAdmin(t *testing.T) {
+	t.Parallel()
 	// The RequireAdmin middleware is applied at route registration, but we
 	// verify the pattern directly by wrapping the handler as the router does.
 	r := newBrowseRouter(t)
@@ -223,6 +230,7 @@ func TestHandleFilesystemBrowse_RequireAdmin(t *testing.T) {
 }
 
 func TestHandleFilesystemBrowse_ParentPath(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	// Resolve the dir through any OS-level symlinks (e.g. /var -> /private/var on macOS).
@@ -254,6 +262,7 @@ func TestHandleFilesystemBrowse_ParentPath(t *testing.T) {
 }
 
 func TestHandleFilesystemBrowse_SortOrder(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	// Create directories in non-alphabetical order to verify case-insensitive sort.
 	for _, name := range []string{"Zebra", "apple", "Mango", "banana"} {
@@ -294,6 +303,7 @@ func TestHandleFilesystemBrowse_SortOrder(t *testing.T) {
 }
 
 func TestHandleFilesystemBrowse_PathIsFile(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "afile.txt")
 	if err := os.WriteFile(filePath, []byte("content"), 0o644); err != nil {
@@ -313,6 +323,7 @@ func TestHandleFilesystemBrowse_PathIsFile(t *testing.T) {
 }
 
 func TestHandleFilesystemBrowse_RootParentIsEmpty(t *testing.T) {
+	t.Parallel()
 	// filepath.Dir of the filesystem root returns the root itself.
 	// The handler must detect this and return parent="" so the UI
 	// can disable the "go up" control at the root level.

--- a/internal/api/handlers_fix.go
+++ b/internal/api/handlers_fix.go
@@ -544,12 +544,16 @@ func (r *Router) runFixAll(reqCtx context.Context, violations []rule.RuleViolati
 			time.Sleep(10 * time.Millisecond)
 		}
 
+		// Invalidate the health cache after bulk fixes complete so the next
+		// dashboard poll reflects the updated health scores. Done before the
+		// "completed" status flip so observers polling for completion never
+		// see a "completed" state while the cache invalidation is still
+		// pending -- this also makes the status flip a true end-of-goroutine
+		// signal for tests that join on it.
+		r.InvalidateHealthCache()
+
 		progress.mu.Lock()
 		progress.Status = "completed"
 		progress.mu.Unlock()
-
-		// Invalidate the health cache after bulk fixes complete so the next
-		// dashboard poll reflects the updated health scores.
-		r.InvalidateHealthCache()
 	}()
 }

--- a/internal/api/handlers_fix_test.go
+++ b/internal/api/handlers_fix_test.go
@@ -24,6 +24,7 @@ func (n *noopRevert) fn(_ context.Context) error {
 }
 
 func TestHandleFixViolation_Success(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		fixViolationFn: func(_ context.Context, _ string) (*rule.FixResult, error) {
 			return &rule.FixResult{RuleID: "nfo_exists", Fixed: true, Message: "NFO created"}, nil
@@ -54,6 +55,7 @@ func TestHandleFixViolation_Success(t *testing.T) {
 }
 
 func TestHandleFixViolation_NotFixable(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		fixViolationFn: func(_ context.Context, _ string) (*rule.FixResult, error) {
 			return &rule.FixResult{RuleID: "nfo_exists", Fixed: false, Message: "not fixable"}, nil
@@ -81,6 +83,7 @@ func TestHandleFixViolation_NotFixable(t *testing.T) {
 }
 
 func TestHandleFixViolation_PipelineError(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		fixViolationFn: func(_ context.Context, _ string) (*rule.FixResult, error) {
 			return nil, fmt.Errorf("db error")
@@ -100,6 +103,7 @@ func TestHandleFixViolation_PipelineError(t *testing.T) {
 }
 
 func TestHandleFixAll_StartsJob(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, artistSvc := testRouterWithStubPipeline(t, stub)
 	ctx := context.Background()
@@ -142,6 +146,7 @@ func TestHandleFixAll_StartsJob(t *testing.T) {
 }
 
 func TestHandleFixAll_NoFixable(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, _ := testRouterWithStubPipeline(t, stub)
 	ctx := context.Background()
@@ -174,6 +179,7 @@ func TestHandleFixAll_NoFixable(t *testing.T) {
 }
 
 func TestHandleFixAllStatus_NoJob(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, _ := testRouterWithStubPipeline(t, stub)
 
@@ -196,6 +202,7 @@ func TestHandleFixAllStatus_NoJob(t *testing.T) {
 }
 
 func TestHandleFixAllStatus_WithProgress(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, _ := testRouterWithStubPipeline(t, stub)
 
@@ -237,6 +244,7 @@ func TestHandleFixAllStatus_WithProgress(t *testing.T) {
 }
 
 func TestHandleFixAll_Completion(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		fixViolationFn: func(_ context.Context, _ string) (*rule.FixResult, error) {
 			return &rule.FixResult{Fixed: true, Message: "fixed"}, nil
@@ -301,6 +309,7 @@ func TestHandleFixAll_Completion(t *testing.T) {
 // --- Undo handler tests ---
 
 func TestHandleUndoFix_Success(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, _ := testRouterWithStubPipeline(t, stub)
 
@@ -331,6 +340,7 @@ func TestHandleUndoFix_Success(t *testing.T) {
 }
 
 func TestHandleUndoFix_Expired(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, _ := testRouterWithStubPipeline(t, stub)
 
@@ -354,6 +364,7 @@ func TestHandleUndoFix_Expired(t *testing.T) {
 }
 
 func TestHandleUndoFix_NotFound(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, _ := testRouterWithStubPipeline(t, stub)
 
@@ -369,6 +380,7 @@ func TestHandleUndoFix_NotFound(t *testing.T) {
 }
 
 func TestHandleUndoFix_AlreadyUsed(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, _ := testRouterWithStubPipeline(t, stub)
 
@@ -395,6 +407,7 @@ func TestHandleUndoFix_AlreadyUsed(t *testing.T) {
 }
 
 func TestHandleUndoFix_ConcurrentSameID(t *testing.T) {
+	t.Parallel()
 	// Two goroutines calling undo with the same ID concurrently: exactly one
 	// should get 200 and the other should get 410. The UndoStore.Pop is
 	// atomic (mutex-protected), so this verifies no double-revert.
@@ -441,6 +454,7 @@ func TestHandleUndoFix_ConcurrentSameID(t *testing.T) {
 }
 
 func TestHandleFixViolation_NoUndo_PathlessArtist(t *testing.T) {
+	t.Parallel()
 	// A fix that succeeds for a pathless artist (no on-disk directory) should
 	// not return undo_id because there are no files to snapshot or revert.
 	stub := &stubPipeline{
@@ -507,6 +521,7 @@ func TestHandleFixViolation_NoUndo_PathlessArtist(t *testing.T) {
 }
 
 func TestHandleFixViolation_ReturnsUndoID(t *testing.T) {
+	t.Parallel()
 	// A fix that succeeds for an artist with a path should return undo_id
 	// and undo_expires_in in the response.
 	stub := &stubPipeline{
@@ -573,6 +588,7 @@ func TestHandleFixViolation_ReturnsUndoID(t *testing.T) {
 // to status-only errors and the dashboard card would fail without
 // explanation.
 func TestHandleFixViolation_HTMX_FailureCarriesMessage(t *testing.T) {
+	t.Parallel()
 	const failureMsg = "no image found from any configured provider"
 	stub := &stubPipeline{
 		fixViolationFn: func(_ context.Context, _ string) (*rule.FixResult, error) {
@@ -613,6 +629,7 @@ func TestHandleFixViolation_HTMX_FailureCarriesMessage(t *testing.T) {
 // via HTMX and an undo entry exists, the response contains UndoToast HTML
 // and does NOT set the HX-Trigger header (to avoid destroying the toast).
 func TestHandleFixViolation_HTMX_WithUndo(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		fixViolationFn: func(_ context.Context, _ string) (*rule.FixResult, error) {
 			return &rule.FixResult{RuleID: "nfo_exists", Fixed: true, Message: "NFO created"}, nil
@@ -670,6 +687,7 @@ func TestHandleFixViolation_HTMX_WithUndo(t *testing.T) {
 // via HTMX and there is no undo entry (pathless artist), the response sets
 // HX-Trigger to refresh the queue and returns an empty body.
 func TestHandleFixViolation_HTMX_NoUndo(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		fixViolationFn: func(_ context.Context, _ string) (*rule.FixResult, error) {
 			return &rule.FixResult{RuleID: "nfo_exists", Fixed: true, Message: "NFO created"}, nil
@@ -731,6 +749,7 @@ func TestHandleFixViolation_HTMX_NoUndo(t *testing.T) {
 // TestHandleUndoFix_HTMX verifies that when the undo endpoint is called via
 // HTMX, it returns an empty body and sets HX-Trigger to refresh the queue.
 func TestHandleUndoFix_HTMX(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, _ := testRouterWithStubPipeline(t, stub)
 

--- a/internal/api/handlers_fix_test.go
+++ b/internal/api/handlers_fix_test.go
@@ -145,22 +145,30 @@ func TestHandleFixAll_StartsJob(t *testing.T) {
 	}
 
 	// Wait for the background goroutine to finish so cleanup does not race
-	// with router-state mutations after the test returns.
+	// with router-state mutations after the test returns. Fail loudly if the
+	// worker never settles -- a silent timeout would reintroduce the very
+	// flake this wait is meant to remove.
 	deadline := time.Now().Add(5 * time.Second)
+	settled := false
 	for time.Now().Before(deadline) {
 		r.fixAllMu.RLock()
 		p := r.fixAllProgress
 		r.fixAllMu.RUnlock()
 		if p == nil {
+			settled = true
 			break
 		}
 		p.mu.RLock()
 		done := p.Status == "completed"
 		p.mu.RUnlock()
 		if done {
+			settled = true
 			break
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+	if !settled {
+		t.Fatal("timed out waiting for fix-all background job to finish")
 	}
 }
 

--- a/internal/api/handlers_fix_test.go
+++ b/internal/api/handlers_fix_test.go
@@ -143,6 +143,25 @@ func TestHandleFixAll_StartsJob(t *testing.T) {
 	if resp["total"] != float64(2) {
 		t.Errorf("total = %v, want 2", resp["total"])
 	}
+
+	// Wait for the background goroutine to finish so cleanup does not race
+	// with router-state mutations after the test returns.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		r.fixAllMu.RLock()
+		p := r.fixAllProgress
+		r.fixAllMu.RUnlock()
+		if p == nil {
+			break
+		}
+		p.mu.RLock()
+		done := p.Status == "completed"
+		p.mu.RUnlock()
+		if done {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func TestHandleFixAll_NoFixable(t *testing.T) {

--- a/internal/api/handlers_foreign_files_test.go
+++ b/internal/api/handlers_foreign_files_test.go
@@ -65,6 +65,7 @@ func newTestRouterWithForeign(t *testing.T) (*Router, *sql.DB) {
 }
 
 func TestHandleForeignFilesList(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','Aretha','/m/Aretha')`)
 	if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{
@@ -93,6 +94,7 @@ func TestHandleForeignFilesList(t *testing.T) {
 }
 
 func TestHandleForeignFileAllowlist(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','Aretha','/m/Aretha')`)
 	if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{
@@ -131,6 +133,7 @@ func TestHandleForeignFileAllowlist(t *testing.T) {
 }
 
 func TestHandleForeignFileDelete(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	dir := t.TempDir()
 	target := filepath.Join(dir, "backdrop.jpg")
@@ -163,6 +166,7 @@ func TestHandleForeignFileDelete(t *testing.T) {
 }
 
 func TestHandleForeignAllowlistRemove(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','Aretha','/m/Aretha')`)
 	if err := r.foreignRepo.AddAllowlist(context.Background(), foreign.AllowlistEntry{
@@ -196,6 +200,7 @@ func TestHandleForeignAllowlistRemove(t *testing.T) {
 }
 
 func TestHandleForeignAllowlistList(t *testing.T) {
+	t.Parallel()
 	r, _ := newTestRouterWithForeign(t)
 	if err := r.foreignRepo.AddAllowlist(context.Background(), foreign.AllowlistEntry{
 		Scope: foreign.ScopeGlobal, FileName: "fanart.jpg",
@@ -220,6 +225,7 @@ func TestHandleForeignAllowlistList(t *testing.T) {
 }
 
 func TestForeignSummaryForBanner(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','x','/x')`)
 	if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{
@@ -239,6 +245,7 @@ func TestForeignSummaryForBanner(t *testing.T) {
 }
 
 func TestHandleForeignFilesDismiss(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','x','/x')`)
 	for _, fn := range []string{"backdrop.jpg", "fanart.jpg"} {
@@ -278,6 +285,7 @@ func TestHandleForeignFilesDismiss(t *testing.T) {
 }
 
 func TestForeignHandlers_NoRepoServiceUnavailable(t *testing.T) {
+	t.Parallel()
 	r := &Router{logger: slog.Default()}
 	cases := []struct {
 		name    string
@@ -310,6 +318,7 @@ func TestForeignHandlers_NoRepoServiceUnavailable(t *testing.T) {
 }
 
 func TestHandleForeignFile_MissingID(t *testing.T) {
+	t.Parallel()
 	r, _ := newTestRouterWithForeign(t)
 	cases := []func(http.ResponseWriter, *http.Request){
 		r.handleForeignFileAllowlist,
@@ -327,6 +336,7 @@ func TestHandleForeignFile_MissingID(t *testing.T) {
 }
 
 func TestHandleForeignFileDelete_MissingFileStillSucceeds(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','x','/x')`)
 	// Ledger row points at a non-existent path; the handler should still
@@ -362,6 +372,7 @@ func mustExec(t *testing.T, db *sql.DB, q string, args ...any) {
 // (HTML) so HTMX can swap the whole container, fixing the stale empty-state
 // + bulk-dismiss button bug from PR #1246 round 2.
 func TestHandleForeignFile_RenderRefreshedTable_AfterRowActions(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','Aretha','/m/Aretha')`)
 	dir := t.TempDir()
@@ -419,6 +430,7 @@ func TestHandleForeignFile_RenderRefreshedTable_AfterRowActions(t *testing.T) {
 // TestHandleForeignAllowlistRemove_RendersRefreshedTable pins the same
 // behavior for the allowlist page's per-row Remove action.
 func TestHandleForeignAllowlistRemove_RendersRefreshedTable(t *testing.T) {
+	t.Parallel()
 	r, _ := newTestRouterWithForeign(t)
 	if err := r.foreignRepo.AddAllowlist(context.Background(), foreign.AllowlistEntry{
 		Scope: foreign.ScopeGlobal, FileName: "fanart.jpg",
@@ -450,6 +462,7 @@ func TestHandleForeignAllowlistRemove_RendersRefreshedTable(t *testing.T) {
 // dismiss must render the actual remaining rows (not an unconditional empty
 // view) so a partial-success run does not hide surviving detections.
 func TestHandleForeignFilesDismiss_RendersSurvivingRows(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','x','/x')`)
 	for _, fn := range []string{"backdrop.jpg", "fanart.jpg"} {
@@ -477,6 +490,7 @@ func TestHandleForeignFilesDismiss_RendersSurvivingRows(t *testing.T) {
 // 1 review (slog.Error before writeJSON 500) and lifts patch coverage on the
 // previously-untested error branches.
 func TestHandleForeignFiles_DBErrorPaths(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name   string
 		method string
@@ -538,6 +552,7 @@ func TestHandleForeignFiles_DBErrorPaths(t *testing.T) {
 // (static assets, auth service) to render the wrapping page; testing the
 // loader directly captures the data-shaping logic without that machinery.
 func TestLoadForeignFilesView(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 
 	// Empty repo -> empty view, no error.
@@ -580,6 +595,7 @@ func TestLoadForeignFilesView(t *testing.T) {
 // TestLoadForeignAllowlistView mirrors the foreign-files loader test for
 // the allowlist page.
 func TestLoadForeignAllowlistView(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 
 	view, err := r.loadForeignAllowlistView(context.Background())
@@ -621,6 +637,7 @@ func TestLoadForeignAllowlistView(t *testing.T) {
 // path without needing the full Router wiring (static assets, auth service)
 // that the templ render at the end of the handler requires.
 func TestHandleForeignFilesPage_DBErrorPath(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	if err := db.Close(); err != nil {
 		t.Fatalf("close: %v", err)
@@ -638,6 +655,7 @@ func TestHandleForeignFilesPage_DBErrorPath(t *testing.T) {
 // TestHandleForeignAllowlistPage_DBErrorPath is the analog for the
 // allowlist page handler.
 func TestHandleForeignAllowlistPage_DBErrorPath(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	if err := db.Close(); err != nil {
 		t.Fatalf("close: %v", err)
@@ -655,6 +673,7 @@ func TestHandleForeignAllowlistPage_DBErrorPath(t *testing.T) {
 // TestForeignSummaryForBanner_CountError pins the Warn-and-return-zero
 // fallback when the repo's Count call fails (closed DB).
 func TestForeignSummaryForBanner_CountError(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	if err := db.Close(); err != nil {
 		t.Fatalf("close: %v", err)
@@ -668,6 +687,7 @@ func TestForeignSummaryForBanner_CountError(t *testing.T) {
 // The anon path (empty userID) calls renderLoginPage which needs full Router
 // wiring; that branch is integration-test territory.
 func TestRequireForeignAdmin_NonAdminGetsForbidden(t *testing.T) {
+	t.Parallel()
 	r, _ := newTestRouterWithForeign(t)
 	ctx := middleware.WithTestUserID(context.Background(), "u1")
 	ctx = middleware.WithTestRole(ctx, "operator")
@@ -686,6 +706,7 @@ func TestRequireForeignAdmin_NonAdminGetsForbidden(t *testing.T) {
 // List call fails. We seed a row, complete the mutation against the open DB,
 // then invoke the handler with the foreign_files table dropped so List errors.
 func TestHandleForeignFile_RenderListErrorAfterMutation(t *testing.T) {
+	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
 	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','x','/x')`)
 	if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{

--- a/internal/api/handlers_guide_test.go
+++ b/internal/api/handlers_guide_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestHandleGuidePage_Authenticated(t *testing.T) {
+	t.Parallel()
 	r := testRouterForOnboarding(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/guide", nil)
@@ -31,6 +32,7 @@ func TestHandleGuidePage_Authenticated(t *testing.T) {
 }
 
 func TestHandleGuidePage_Unauthenticated(t *testing.T) {
+	t.Parallel()
 	r := testRouterForOnboarding(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/guide", nil)
@@ -62,6 +64,7 @@ func testRouterWithBasePath(t *testing.T, bp string) *Router {
 // prefixed with server.base_path when it is set to a non-empty value. This is the
 // primary regression check for sub-path deployments (e.g. /stillwater).
 func TestLayout_NavLinksUseBasePath(t *testing.T) {
+	t.Parallel()
 	const bp = "/stillwater"
 	r := testRouterWithBasePath(t, bp)
 
@@ -126,6 +129,7 @@ func TestLayout_NavLinksUseBasePath(t *testing.T) {
 // TestLayout_NavLinksNoBasePath verifies that when base_path is empty the layout
 // renders standard root-relative links so the default deployment is unaffected.
 func TestLayout_NavLinksNoBasePath(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithBasePath(t, "")
 
 	req := httptest.NewRequest(http.MethodGet, "/guide", nil)

--- a/internal/api/handlers_history_test.go
+++ b/internal/api/handlers_history_test.go
@@ -102,6 +102,7 @@ func addHistoryChange(t *testing.T, svc *artist.HistoryService, artistID, field,
 }
 
 func TestHandleListArtistHistory_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithHistory(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/no-such-artist/history", nil)
@@ -116,6 +117,7 @@ func TestHandleListArtistHistory_NotFound(t *testing.T) {
 }
 
 func TestHandleListArtistHistory_Empty(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, _ := testRouterWithHistory(t)
 
 	a := addTestArtist(t, artistSvc, "Empty History Artist")
@@ -148,6 +150,7 @@ func TestHandleListArtistHistory_Empty(t *testing.T) {
 }
 
 func TestHandleListArtistHistory_WithChanges(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)
 
 	a := addTestArtist(t, artistSvc, "History Artist")
@@ -183,6 +186,7 @@ func TestHandleListArtistHistory_WithChanges(t *testing.T) {
 }
 
 func TestHandleListArtistHistory_Pagination(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)
 
 	a := addTestArtist(t, artistSvc, "Pagination Artist")
@@ -248,6 +252,7 @@ func TestHandleListArtistHistory_Pagination(t *testing.T) {
 }
 
 func TestHandleListArtistHistory_ResponseShape(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)
 
 	a := addTestArtist(t, artistSvc, "Shape Artist")
@@ -305,6 +310,7 @@ func TestHandleListArtistHistory_ResponseShape(t *testing.T) {
 }
 
 func TestHandleArtistHistoryTab_HTML(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)
 
 	a := addTestArtist(t, artistSvc, "History Tab Artist")
@@ -332,6 +338,7 @@ func TestHandleArtistHistoryTab_HTML(t *testing.T) {
 }
 
 func TestHandleArtistHistoryTab_Empty(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, _ := testRouterWithHistory(t)
 
 	a := addTestArtist(t, artistSvc, "No History Artist")
@@ -353,6 +360,7 @@ func TestHandleArtistHistoryTab_Empty(t *testing.T) {
 }
 
 func TestHandleArtistHistoryTab_NilHistoryService(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, _ := testRouterWithHistory(t)
 	r.historyService = nil // simulate unconfigured service
 
@@ -372,6 +380,7 @@ func TestHandleArtistHistoryTab_NilHistoryService(t *testing.T) {
 }
 
 func TestHandleRevertHistory(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)
 	artistSvc.SetHistoryService(historySvc)
 
@@ -464,6 +473,7 @@ func TestHandleRevertHistory(t *testing.T) {
 }
 
 func TestHandleListGlobalHistory(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)
 
 	a := addTestArtist(t, artistSvc, "Global History Artist")
@@ -554,6 +564,7 @@ func TestHandleListGlobalHistory(t *testing.T) {
 }
 
 func TestHandleListGlobalHistory_WildcardSource(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)
 
 	a := addTestArtist(t, artistSvc, "Wildcard Source Artist")
@@ -581,6 +592,7 @@ func TestHandleListGlobalHistory_WildcardSource(t *testing.T) {
 }
 
 func TestHandleListGlobalHistory_DateRange(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)
 
 	a := addTestArtist(t, artistSvc, "Date Range Artist")
@@ -653,6 +665,7 @@ func TestHandleListGlobalHistory_DateRange(t *testing.T) {
 }
 
 func TestHandleActivityPage(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithHistory(t)
 
 	ctx := testI18nCtx(t, middleware.WithTestUserID(context.Background(), "test-user"))
@@ -674,6 +687,7 @@ func TestHandleActivityPage(t *testing.T) {
 // renders activityRow entries including the old/new value blocks.
 // This covers the whitespace-pre-wrap change in the generated activity_templ.go.
 func TestHandleActivityContent_RendersRow(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)
 	a := addTestArtist(t, artistSvc, "Activity Row Artist")
 
@@ -760,6 +774,7 @@ func seedHistoryChanges(t *testing.T, svc *artist.HistoryService, artistID strin
 // seeded and 40 rows rendered (DOM count from a hypothetical second
 // load-more), the OOB counter fragment must reflect 40, not the page-1 size.
 func TestHandleRevertHistory_ActivityShowingCounter_LoadMoreHint(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)
 	artistSvc.SetHistoryService(historySvc)
 
@@ -888,6 +903,7 @@ func TestHandleRevertHistory_ActivityShowingCounter_LoadMoreHint(t *testing.T) {
 // regresses to the first-page count after the user has loaded additional pages.
 // The hint must override that fallback.
 func TestHandleRevertHistory_ArtistTabShowingCounter_LoadMoreHint(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)
 	artistSvc.SetHistoryService(historySvc)
 
@@ -951,6 +967,7 @@ func TestHandleRevertHistory_ArtistTabShowingCounter_LoadMoreHint(t *testing.T) 
 // tab) call to honor the hx-vals "showing" hint while degrading gracefully
 // when the hint is missing, malformed, or out of range.
 func TestResolveShowingCount(t *testing.T) {
+	t.Parallel()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	// includeShowing distinguishes "no showing key in body" from
@@ -1015,6 +1032,7 @@ func TestResolveShowingCount(t *testing.T) {
 // the activity-feed fragment is rendered, otherwise the artist-tab fragment.
 // This is the contract the hint relies on to drive the right rendering branch.
 func TestHandleRevertHistory_ActivityFromArtistPageRoute(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)
 	artistSvc.SetHistoryService(historySvc)
 

--- a/internal/api/handlers_identify_test.go
+++ b/internal/api/handlers_identify_test.go
@@ -23,6 +23,7 @@ func testRouterWithIdentify(t *testing.T) (*Router, *library.Service, *artist.Se
 }
 
 func TestBulkIdentify_ConcurrentReject(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 
 	// Simulate a running identify job by setting progress directly.
@@ -50,6 +51,7 @@ func TestBulkIdentify_ConcurrentReject(t *testing.T) {
 }
 
 func TestBulkIdentifyProgress_Idle(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/bulk-identify", nil)
@@ -71,6 +73,7 @@ func TestBulkIdentifyProgress_Idle(t *testing.T) {
 }
 
 func TestBulkIdentifyProgress_WithRunningJob(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 
 	// Simulate a running job with progress.
@@ -116,6 +119,7 @@ func TestBulkIdentifyProgress_WithRunningJob(t *testing.T) {
 }
 
 func TestBulkIdentifyCancel_NoJob(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/artists/bulk-identify", nil)
@@ -137,6 +141,7 @@ func TestBulkIdentifyCancel_NoJob(t *testing.T) {
 }
 
 func TestBulkIdentifyCancel_RunningJob(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 
 	_, cancel := context.WithCancel(context.Background())
@@ -167,6 +172,7 @@ func TestBulkIdentifyCancel_RunningJob(t *testing.T) {
 }
 
 func TestBulkIdentify_NoUnidentified(t *testing.T) {
+	t.Parallel()
 	r, _, artistSvc := testRouterWithIdentify(t)
 
 	// Create an artist with an MBID (should not appear in missing_mbid filter).
@@ -203,6 +209,7 @@ func TestBulkIdentify_NoUnidentified(t *testing.T) {
 }
 
 func TestBulkIdentify_ExcludedSkipped(t *testing.T) {
+	t.Parallel()
 	r, _, artistSvc := testRouterWithIdentify(t)
 
 	// Create an excluded artist without MBID.
@@ -237,6 +244,7 @@ func TestBulkIdentify_ExcludedSkipped(t *testing.T) {
 }
 
 func TestBulkIdentify_Tier1_ConnectionMatch(t *testing.T) {
+	t.Parallel()
 	r, libSvc, artistSvc := testRouterWithIdentify(t)
 	ctx := context.Background()
 
@@ -344,6 +352,7 @@ func TestBulkIdentify_Tier1_ConnectionMatch(t *testing.T) {
 }
 
 func TestBulkIdentify_LockedArtistSkipped(t *testing.T) {
+	t.Parallel()
 	r, _, artistSvc := testRouterWithIdentify(t)
 	ctx := context.Background()
 
@@ -404,6 +413,7 @@ func TestBulkIdentify_LockedArtistSkipped(t *testing.T) {
 }
 
 func TestBulkIdentifyLink(t *testing.T) {
+	t.Parallel()
 	r, _, artistSvc := testRouterWithIdentify(t)
 	ctx := context.Background()
 
@@ -468,6 +478,7 @@ func TestBulkIdentifyLink(t *testing.T) {
 }
 
 func TestBulkIdentifyLink_MissingFields(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		body string
@@ -495,6 +506,7 @@ func TestBulkIdentifyLink_MissingFields(t *testing.T) {
 }
 
 func TestBulkIdentifyLink_ArtistNotFound(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 
 	body := strings.NewReader(`{"artist_id":"nonexistent","mbid":"test-mbid"}`)
@@ -510,6 +522,7 @@ func TestBulkIdentifyLink_ArtistNotFound(t *testing.T) {
 }
 
 func TestBulkIdentify_CompletedJobAllowsRestart(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 
 	// Simulate a completed identify job.
@@ -538,6 +551,7 @@ func TestBulkIdentify_CompletedJobAllowsRestart(t *testing.T) {
 }
 
 func TestBulkIdentify_WithLibraryFilter(t *testing.T) {
+	t.Parallel()
 	r, libSvc, artistSvc := testRouterWithIdentify(t)
 	ctx := context.Background()
 

--- a/internal/api/handlers_image_registry_hygiene_test.go
+++ b/internal/api/handlers_image_registry_hygiene_test.go
@@ -21,6 +21,7 @@ import (
 // registry row on first failed fetch; this test pins the rendering invariant
 // so the FIRST page load degrades gracefully.
 func TestArtistDetail_StaleImageRow_RendersPlaceholderNot500(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	// Insert an artist with empty path so image lookups cannot find files

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -110,6 +110,7 @@ func writeJPEGWithProvenance(t *testing.T, path string, w, h int, meta *img.Exif
 }
 
 func TestSetArtistImageFlag_LowRes(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()
 	a := &artist.Artist{Name: "Test", SortName: "Test", Path: dir}
@@ -134,6 +135,7 @@ func TestSetArtistImageFlag_LowRes(t *testing.T) {
 }
 
 func TestSetArtistImageFlag_GoodRes(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()
 	a := &artist.Artist{Name: "Test", SortName: "Test", Path: dir}
@@ -158,6 +160,7 @@ func TestSetArtistImageFlag_GoodRes(t *testing.T) {
 }
 
 func TestSetArtistImageFlag_Delete(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()
 	a := &artist.Artist{
@@ -182,6 +185,7 @@ func TestSetArtistImageFlag_Delete(t *testing.T) {
 }
 
 func TestRequireArtistPath_Pathless(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithPlatform(t)
 
 	// Artist with empty path (pathless library)
@@ -210,6 +214,7 @@ func TestRequireArtistPath_Pathless(t *testing.T) {
 }
 
 func TestRequireImageDir_WithCacheDir(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithPlatform(t)
 	cacheDir := t.TempDir()
 	setImageCacheDir(r, cacheDir)
@@ -239,6 +244,7 @@ func TestRequireImageDir_WithCacheDir(t *testing.T) {
 }
 
 func TestRequireImageDir_RejectsNoCacheNoPath(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithPlatform(t)
 	// No cache dir, no artist path.
 	setImageCacheDir(r, "")
@@ -257,6 +263,7 @@ func TestRequireImageDir_RejectsNoCacheNoPath(t *testing.T) {
 }
 
 func TestIsPrivateURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		url  string
@@ -283,6 +290,7 @@ func TestIsPrivateURL(t *testing.T) {
 }
 
 func TestSSRFSafeTransport_PreservesDefaults(t *testing.T) {
+	t.Parallel()
 	transport := ssrfSafeTransport()
 	if transport.DialContext == nil {
 		t.Fatal("DialContext should be set")
@@ -300,6 +308,7 @@ func TestSSRFSafeTransport_PreservesDefaults(t *testing.T) {
 }
 
 func TestSSRFSafeTransport_BlocksPrivateIP(t *testing.T) {
+	t.Parallel()
 	transport := ssrfSafeTransport()
 	client := &http.Client{Transport: transport}
 
@@ -313,6 +322,7 @@ func TestSSRFSafeTransport_BlocksPrivateIP(t *testing.T) {
 }
 
 func TestSSRFSafeTransport_EmptyDNS(t *testing.T) {
+	t.Parallel()
 	// The empty-DNS guard is exercised when a hostname resolves to zero addresses.
 	// We cannot easily force that in a unit test (net.DefaultResolver is global),
 	// but we verify the guard exists by reading the function.
@@ -330,6 +340,7 @@ func TestSSRFSafeTransport_EmptyDNS(t *testing.T) {
 }
 
 func TestSetArtistImageFlag_UnreadableFile(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()
 	a := &artist.Artist{Name: "Test", SortName: "Test", Path: dir}
@@ -357,6 +368,7 @@ func TestSetArtistImageFlag_UnreadableFile(t *testing.T) {
 }
 
 func TestSetArtistImageFlag_TransientPreservesPlaceholder(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()
 
@@ -387,6 +399,7 @@ func TestSetArtistImageFlag_TransientPreservesPlaceholder(t *testing.T) {
 }
 
 func TestHandleImageUpload_SyncsToPlatform(t *testing.T) {
+	t.Parallel()
 	type syncCapture struct {
 		contentLength int64
 		contentType   string
@@ -469,6 +482,7 @@ func TestHandleImageUpload_SyncsToPlatform(t *testing.T) {
 }
 
 func TestHandleDeleteImage_SyncsToPlatform(t *testing.T) {
+	t.Parallel()
 	deletedCh := make(chan struct{}, 3)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == http.MethodDelete && strings.Contains(req.URL.Path, "/Images/Primary") {
@@ -557,6 +571,7 @@ func buildThumbUploadRequest(t *testing.T, artistID string) *http.Request {
 }
 
 func TestHandleImageUpload_SyncWarnings_NoPlatforms(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()
 	a := &artist.Artist{Name: "Local Artist", SortName: "Local Artist", Path: dir}
@@ -590,6 +605,7 @@ func TestHandleImageUpload_SyncWarnings_NoPlatforms(t *testing.T) {
 }
 
 func TestHandleImageUpload_SyncWarnings_PlatformFailure(t *testing.T) {
+	t.Parallel()
 	// Mock server that returns 500 for every request, simulating a broken platform.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -652,6 +668,7 @@ func TestHandleImageUpload_SyncWarnings_PlatformFailure(t *testing.T) {
 }
 
 func TestHandleDeleteImage_SyncWarnings_PlatformFailure(t *testing.T) {
+	t.Parallel()
 	// Mock server that returns 500 for every request, simulating a broken platform.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -714,6 +731,7 @@ func TestHandleDeleteImage_SyncWarnings_PlatformFailure(t *testing.T) {
 }
 
 func TestSyncImageToPlatforms_GetByIDError(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()
 	a := &artist.Artist{Name: "Test Artist", SortName: "Test Artist", Path: dir}
@@ -753,6 +771,7 @@ func TestSyncImageToPlatforms_GetByIDError(t *testing.T) {
 }
 
 func TestHandleImageUpload_SyncWarnings_UnsupportedConnType(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	setImageCacheDir(r, t.TempDir())
 
@@ -796,6 +815,7 @@ func TestHandleImageUpload_SyncWarnings_UnsupportedConnType(t *testing.T) {
 }
 
 func TestDeleteImageFromPlatforms_GetByIDError(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()
 	a := &artist.Artist{Name: "Test Artist", SortName: "Test Artist", Path: dir}
@@ -831,6 +851,7 @@ func TestDeleteImageFromPlatforms_GetByIDError(t *testing.T) {
 }
 
 func TestHandleDeleteImage_SyncWarnings_UnsupportedConnType(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	cacheDir := t.TempDir()
 	setImageCacheDir(r, cacheDir)
@@ -884,6 +905,7 @@ func TestHandleDeleteImage_SyncWarnings_UnsupportedConnType(t *testing.T) {
 }
 
 func TestSetSyncWarningTrigger_Truncation(t *testing.T) {
+	t.Parallel()
 	// assertTruncated decodes the HX-Trigger header, verifies the first warning
 	// was cut to exactly maxWarningRunes runes with the "(truncated)" suffix, and
 	// confirms the header is valid JSON.
@@ -1019,6 +1041,7 @@ func TestSetSyncWarningTrigger_Truncation(t *testing.T) {
 }
 
 func TestHandleImageCrop_SyncWarnings_NoPlatforms(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()
 	a := &artist.Artist{Name: "Crop Artist", SortName: "Crop Artist", Path: dir}
@@ -1070,6 +1093,7 @@ func TestHandleImageCrop_SyncWarnings_NoPlatforms(t *testing.T) {
 }
 
 func TestHandleImageCrop_SyncWarnings_PlatformFailure(t *testing.T) {
+	t.Parallel()
 	// Mock server that returns 500 for every request, simulating a broken platform.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -1138,6 +1162,7 @@ func TestHandleImageCrop_SyncWarnings_PlatformFailure(t *testing.T) {
 }
 
 func TestExtractImageFetchParams_MalformedJSON(t *testing.T) {
+	t.Parallel()
 	body := strings.NewReader(`{bad json`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/x/images/fetch", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -1152,6 +1177,7 @@ func TestExtractImageFetchParams_MalformedJSON(t *testing.T) {
 }
 
 func TestExtractImageFetchParams_ValidJSON(t *testing.T) {
+	t.Parallel()
 	body := strings.NewReader(`{"url":"https://example.com/img.jpg","type":"thumb"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/x/images/fetch", body)
 	req.Header.Set("Content-Type", "application/json")
@@ -1169,6 +1195,7 @@ func TestExtractImageFetchParams_ValidJSON(t *testing.T) {
 }
 
 func TestHandleDeleteImage_FanartRemoveFailure(t *testing.T) {
+	t.Parallel()
 	// Mock server that records whether a DELETE was received.
 	// Use a channel (not a bare bool) to avoid an unprotected cross-goroutine write
 	// if the production guard is ever relaxed.
@@ -1250,6 +1277,7 @@ func TestHandleDeleteImage_FanartRemoveFailure(t *testing.T) {
 }
 
 func TestHandleFanartBatchDelete_SyncCalledAfterDelete(t *testing.T) {
+	t.Parallel()
 	// Track uploads to the mock platform server. Use a channel so the test
 	// goroutine can wait for the uploads to arrive without polling.
 	type uploadCapture struct {
@@ -1350,6 +1378,7 @@ func TestHandleFanartBatchDelete_SyncCalledAfterDelete(t *testing.T) {
 }
 
 func TestHandleFanartBatchDelete_RenumberFailureSkipsSync(t *testing.T) {
+	t.Parallel()
 	// Track whether any upload reaches the mock platform server.
 	uploadCh := make(chan struct{}, 10)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -1436,6 +1465,7 @@ func TestHandleFanartBatchDelete_RenumberFailureSkipsSync(t *testing.T) {
 }
 
 func TestHandleFanartBatchDelete_SyncWarningsPropagated(t *testing.T) {
+	t.Parallel()
 	// Mock platform server that returns 500, simulating sync failure.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -1500,6 +1530,7 @@ func TestHandleFanartBatchDelete_SyncWarningsPropagated(t *testing.T) {
 }
 
 func TestHandleDeleteImage_ThumbRemoveFailure(t *testing.T) {
+	t.Parallel()
 	// Mock server that records whether a DELETE was received.
 	deletedCh := make(chan struct{}, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -1575,6 +1606,7 @@ func TestHandleDeleteImage_ThumbRemoveFailure(t *testing.T) {
 }
 
 func TestSetArtistImageFlag_RecordsProvenance(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()
 	a := &artist.Artist{Name: "Provenance Test", SortName: "Provenance Test", Path: dir}
@@ -1631,6 +1663,7 @@ func TestSetArtistImageFlag_RecordsProvenance(t *testing.T) {
 }
 
 func TestSetArtistImageFlag_NoProvenance_StillWorks(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()
 	a := &artist.Artist{Name: "No Provenance", SortName: "No Provenance", Path: dir}
@@ -1683,6 +1716,7 @@ func TestSetArtistImageFlag_NoProvenance_StillWorks(t *testing.T) {
 }
 
 func TestSetArtistImageFlag_ClearsProvenance_OnDelete(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	dir := t.TempDir()
 	a := &artist.Artist{Name: "Delete Provenance", SortName: "Delete Provenance", Path: dir}
@@ -1733,6 +1767,7 @@ func TestSetArtistImageFlag_ClearsProvenance_OnDelete(t *testing.T) {
 // asynchronously clears the stale exists flag so subsequent UI renders show a
 // placeholder instead of a broken image.
 func TestHandleServeImage_ClearsStaleFlag(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -1825,6 +1860,7 @@ func TestHandleServeImage_ClearsStaleFlag(t *testing.T) {
 // TestHandleRandomBackdrop_ServesValidFile verifies that the endpoint serves
 // an existing fanart file and returns 200.
 func TestHandleRandomBackdrop_ServesValidFile(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -1859,6 +1895,7 @@ func TestHandleRandomBackdrop_ServesValidFile(t *testing.T) {
 // exists but the file is missing, the endpoint returns 404 and synchronously
 // clears the stale exists_flag so the entry is not returned again.
 func TestHandleRandomBackdrop_ClearsStaleFlag(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPlatform(t)
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -1899,6 +1936,7 @@ func TestHandleRandomBackdrop_ClearsStaleFlag(t *testing.T) {
 // TestHandleRandomBackdrop_EmptyPool verifies that the endpoint returns 404
 // when no artists have fanart flagged as existing.
 func TestHandleRandomBackdrop_EmptyPool(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithPlatform(t)
 
 	req := httptest.NewRequest("GET", "/api/v1/images/random-backdrop", nil)
@@ -1911,6 +1949,7 @@ func TestHandleRandomBackdrop_EmptyPool(t *testing.T) {
 }
 
 func TestSortImageResults(t *testing.T) {
+	t.Parallel()
 	images := []provider.ImageResult{
 		{URL: "a.jpg", Likes: 5, Width: 100, Height: 100},   // area=10000
 		{URL: "b.jpg", Likes: 10, Width: 50, Height: 50},    // area=2500

--- a/internal/api/handlers_inbound_webhook_test.go
+++ b/internal/api/handlers_inbound_webhook_test.go
@@ -13,6 +13,7 @@ import (
 
 // TestHandleEmbyWebhook_OK verifies the handler returns 200 immediately.
 func TestHandleEmbyWebhook_OK(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	body := `{"Event":"system.notificationtest"}`
@@ -30,6 +31,7 @@ func TestHandleEmbyWebhook_OK(t *testing.T) {
 
 // TestHandleEmbyWebhook_InvalidJSON verifies 400 on bad JSON.
 func TestHandleEmbyWebhook_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/inbound/emby",
@@ -46,6 +48,7 @@ func TestHandleEmbyWebhook_InvalidJSON(t *testing.T) {
 
 // TestHandleEmbyWebhook_MissingEvent verifies 400 when Event field is absent.
 func TestHandleEmbyWebhook_MissingEvent(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/inbound/emby",
@@ -62,6 +65,7 @@ func TestHandleEmbyWebhook_MissingEvent(t *testing.T) {
 
 // TestHandleEmbyWebhook_UnknownEventType verifies 200 with unknown event type (handled gracefully).
 func TestHandleEmbyWebhook_UnknownEventType(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	body := `{"Event":"some.unknown.event"}`
@@ -79,6 +83,7 @@ func TestHandleEmbyWebhook_UnknownEventType(t *testing.T) {
 
 // TestHandleJellyfinWebhook_OK verifies the handler returns 200 immediately.
 func TestHandleJellyfinWebhook_OK(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	body := `{"NotificationType":"Test"}`
@@ -96,6 +101,7 @@ func TestHandleJellyfinWebhook_OK(t *testing.T) {
 
 // TestHandleJellyfinWebhook_InvalidJSON verifies 400 on bad JSON.
 func TestHandleJellyfinWebhook_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/inbound/jellyfin",
@@ -112,6 +118,7 @@ func TestHandleJellyfinWebhook_InvalidJSON(t *testing.T) {
 
 // TestHandleJellyfinWebhook_MissingNotificationType verifies 400 when field is absent.
 func TestHandleJellyfinWebhook_MissingNotificationType(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/inbound/jellyfin",
@@ -128,6 +135,7 @@ func TestHandleJellyfinWebhook_MissingNotificationType(t *testing.T) {
 
 // TestHandleJellyfinWebhook_UnknownEventType verifies 200 with unknown event type.
 func TestHandleJellyfinWebhook_UnknownEventType(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	body := `{"NotificationType":"SomeUnknownEvent"}`
@@ -146,6 +154,7 @@ func TestHandleJellyfinWebhook_UnknownEventType(t *testing.T) {
 // TestLidarrArtistAdd_NilPipeline verifies that handleLidarrArtistAdd does not
 // panic when pipeline is nil and an existing artist is found.
 func TestLidarrArtistAdd_NilPipeline(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	// testRouter does not set pipeline, so r.pipeline == nil.
 
@@ -173,6 +182,7 @@ func TestLidarrArtistAdd_NilPipeline(t *testing.T) {
 // TestLidarrDownload_NilPipeline verifies that handleLidarrDownload does not
 // panic when pipeline is nil and an existing artist is found.
 func TestLidarrDownload_NilPipeline(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	mbid := "a74b1b7f-71a5-4011-9441-d0b5e4122711"

--- a/internal/api/handlers_layout_test.go
+++ b/internal/api/handlers_layout_test.go
@@ -26,6 +26,7 @@ import (
 // TestLayoutRenders_ValidHTML verifies that the layout template renders without
 // errors and produces valid HTML with all required landmarks.
 func TestLayoutRenders_ValidHTML(t *testing.T) {
+	t.Parallel()
 
 	// Create sample AssetPaths context.
 	assets := templates.AssetPaths{
@@ -95,6 +96,7 @@ func TestLayoutRenders_ValidHTML(t *testing.T) {
 // TestLayoutSidebar_ContainsRequiredLandmarks verifies the sidebar and main
 // content landmarks exist with correct IDs and semantic roles.
 func TestLayoutSidebar_ContainsRequiredLandmarks(t *testing.T) {
+	t.Parallel()
 
 	assets := templates.AssetPaths{
 		BasePath:       "",
@@ -189,6 +191,7 @@ func TestLayoutSidebar_ContainsRequiredLandmarks(t *testing.T) {
 // TestLayoutAdmin_RendersSharedFilesystemBar verifies that admin users see
 // the shared filesystem bar while non-admin users do not.
 func TestLayoutAdmin_RendersSharedFilesystemBar(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		isAdmin bool
@@ -253,6 +256,7 @@ func TestLayoutAdmin_RendersSharedFilesystemBar(t *testing.T) {
 // TestLayoutContentArea_ContainsMainLandmark verifies that the main content
 // area has proper semantic structure for accessibility.
 func TestLayoutContentArea_ContainsMainLandmark(t *testing.T) {
+	t.Parallel()
 
 	assets := templates.AssetPaths{
 		BasePath:       "/app",
@@ -308,6 +312,7 @@ func TestLayoutContentArea_ContainsMainLandmark(t *testing.T) {
 // TestLayout_AssetPathsWithBasePath verifies that asset paths are correctly
 // prefixed with the BasePath when rendering.
 func TestLayout_AssetPathsWithBasePath(t *testing.T) {
+	t.Parallel()
 	basePath := "/my-app"
 	assets := templates.AssetPaths{
 		BasePath:       basePath,
@@ -368,6 +373,7 @@ func TestLayout_AssetPathsWithBasePath(t *testing.T) {
 // TestLayout_RendersWithoutHandlerContext verifies the layout can be rendered
 // independently for testing purposes, without a full HTTP handler context.
 func TestLayout_RendersWithoutHandlerContext(t *testing.T) {
+	t.Parallel()
 	assets := templates.AssetPaths{
 		BasePath:       "",
 		CSS:            "/css/main.css",
@@ -427,6 +433,7 @@ func TestLayout_RendersWithoutHandlerContext(t *testing.T) {
 // status code and renders the layout with the sidebar landmark (id="sw-sidebar").
 // This is an integration test that uses the real app router and handler registration.
 func TestRootRoute_RendersLayout_WithSidebar(t *testing.T) {
+	t.Parallel()
 	// Set up test database and services
 	db, err := database.Open(":memory:")
 	if err != nil {

--- a/internal/api/handlers_library_test.go
+++ b/internal/api/handlers_library_test.go
@@ -59,6 +59,7 @@ func testRouterWithLibrary(t *testing.T) (*Router, *library.Service, *artist.Ser
 }
 
 func TestHandleListLibraries_Empty(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/libraries", nil)
@@ -80,6 +81,7 @@ func TestHandleListLibraries_Empty(t *testing.T) {
 }
 
 func TestHandleCreateLibrary_JSON(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	dir := t.TempDir()
@@ -113,6 +115,7 @@ func TestHandleCreateLibrary_JSON(t *testing.T) {
 }
 
 func TestHandleCreateLibrary_FormEncoded(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	dir := t.TempDir()
@@ -144,6 +147,7 @@ func TestHandleCreateLibrary_FormEncoded(t *testing.T) {
 }
 
 func TestHandleCreateLibrary_MissingName(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	body := `{"path":"/music","type":"regular"}`
@@ -159,6 +163,7 @@ func TestHandleCreateLibrary_MissingName(t *testing.T) {
 }
 
 func TestHandleCreateLibrary_InvalidType(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	body := `{"name":"Bad","path":"/bad","type":"invalid"}`
@@ -174,6 +179,7 @@ func TestHandleCreateLibrary_InvalidType(t *testing.T) {
 }
 
 func TestHandleCreateLibrary_EmptyPath(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	body := `{"name":"API Only","path":"","type":"regular"}`
@@ -197,6 +203,7 @@ func TestHandleCreateLibrary_EmptyPath(t *testing.T) {
 }
 
 func TestHandleCreateLibrary_RelativePath(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	body := `{"name":"Bad","path":"music/lib","type":"regular"}`
@@ -212,6 +219,7 @@ func TestHandleCreateLibrary_RelativePath(t *testing.T) {
 }
 
 func TestHandleCreateLibrary_TraversalPath(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	body := `{"name":"Bad","path":"../etc/passwd","type":"regular"}`
@@ -227,6 +235,7 @@ func TestHandleCreateLibrary_TraversalPath(t *testing.T) {
 }
 
 func TestHandleCreateLibrary_NonexistentPath(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	dir := filepath.Join(t.TempDir(), "no-such-dir")
@@ -243,6 +252,7 @@ func TestHandleCreateLibrary_NonexistentPath(t *testing.T) {
 }
 
 func TestHandleGetLibrary_WithArtistCount(t *testing.T) {
+	t.Parallel()
 	r, libSvc, artistSvc := testRouterWithLibrary(t)
 
 	dir := t.TempDir()
@@ -278,6 +288,7 @@ func TestHandleGetLibrary_WithArtistCount(t *testing.T) {
 }
 
 func TestHandleGetLibrary_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/libraries/nonexistent", nil)
@@ -292,6 +303,7 @@ func TestHandleGetLibrary_NotFound(t *testing.T) {
 }
 
 func TestHandleUpdateLibrary(t *testing.T) {
+	t.Parallel()
 	r, libSvc, _ := testRouterWithLibrary(t)
 
 	base := t.TempDir()
@@ -334,6 +346,7 @@ func TestHandleUpdateLibrary(t *testing.T) {
 }
 
 func TestHandleUpdateLibrary_InvalidPath(t *testing.T) {
+	t.Parallel()
 	r, libSvc, _ := testRouterWithLibrary(t)
 
 	dir := t.TempDir()
@@ -356,6 +369,7 @@ func TestHandleUpdateLibrary_InvalidPath(t *testing.T) {
 }
 
 func TestHandleUpdateLibrary_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	body := `{"name":"Nope"}`
@@ -372,6 +386,7 @@ func TestHandleUpdateLibrary_NotFound(t *testing.T) {
 }
 
 func TestHandleDeleteLibrary_Empty(t *testing.T) {
+	t.Parallel()
 	r, libSvc, _ := testRouterWithLibrary(t)
 
 	dir := t.TempDir()
@@ -400,6 +415,7 @@ func TestHandleDeleteLibrary_Empty(t *testing.T) {
 }
 
 func TestHandleDeleteLibrary_WithArtists(t *testing.T) {
+	t.Parallel()
 	r, libSvc, artistSvc := testRouterWithLibrary(t)
 
 	dir := t.TempDir()
@@ -434,6 +450,7 @@ func TestHandleDeleteLibrary_WithArtists(t *testing.T) {
 }
 
 func TestHandleListLibraries_AfterCreate(t *testing.T) {
+	t.Parallel()
 	r, libSvc, _ := testRouterWithLibrary(t)
 
 	dir := t.TempDir()
@@ -469,6 +486,7 @@ func TestHandleListLibraries_AfterCreate(t *testing.T) {
 // flips it on, and that omitting the field on a subsequent PUT preserves
 // the current value (pointer-typed -> only updated when present in body).
 func TestHandleUpdateLibrary_NFOLockData_Toggle(t *testing.T) {
+	t.Parallel()
 	r, libSvc, _ := testRouterWithLibrary(t)
 
 	dir := t.TempDir()
@@ -548,6 +566,7 @@ func TestHandleUpdateLibrary_NFOLockData_Toggle(t *testing.T) {
 // the form branch silently dropped the field while the JSON branch wired it
 // through.
 func TestHandleUpdateLibrary_FormEncoded_NFOLockData(t *testing.T) {
+	t.Parallel()
 	r, libSvc, _ := testRouterWithLibrary(t)
 	libDir := t.TempDir()
 	lib := &library.Library{Name: "FormPath", Path: libDir, Type: library.TypeRegular}

--- a/internal/api/handlers_login_test.go
+++ b/internal/api/handlers_login_test.go
@@ -19,6 +19,7 @@ import (
 // setup creates admin, login returns a session cookie, and the cookie grants
 // access to authenticated endpoints with the correct role.
 func TestLocalLoginFlow(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithAuth(t)
 
 	// Wipe all users so handleSetup can run (requires zero existing users).
@@ -99,6 +100,7 @@ func TestLocalLoginFlow(t *testing.T) {
 // TestLocalLoginFlow_WrongPassword verifies that handleLogin rejects invalid
 // credentials with 401.
 func TestLocalLoginFlow_WrongPassword(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithAuth(t)
 
 	loginBody := `{"username":"admin","password":"wrongpassword"}`
@@ -118,6 +120,7 @@ func TestLocalLoginFlow_WrongPassword(t *testing.T) {
 // admin creates invite, new user redeems it, new user logs in and has the
 // correct operator role, and role-based access is enforced correctly.
 func TestInviteRegisterFlow(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 	enableMultiUser(t, r)
 
@@ -200,6 +203,7 @@ func TestInviteRegisterFlow(t *testing.T) {
 // TestInviteRegisterFlow_InvalidCode verifies that handleRegister rejects an
 // invalid invite code with 400.
 func TestInviteRegisterFlow_InvalidCode(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithAuth(t)
 	enableMultiUser(t, r)
 
@@ -242,6 +246,7 @@ func (p *stubFederatedProvider) MapRole(identity *auth.Identity) string {
 // TestFederatedLoginFlow_AutoProvision verifies that a federated provider login
 // auto-provisions the user on first login and creates a valid session.
 func TestFederatedLoginFlow_AutoProvision(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithAuth(t)
 
 	stubProvider := &stubFederatedProvider{
@@ -296,6 +301,7 @@ func TestFederatedLoginFlow_AutoProvision(t *testing.T) {
 // TestFederatedLoginFlow_AdminAutoProvision verifies that a federated provider
 // auto-provisions the user as administrator when IsAdmin is true.
 func TestFederatedLoginFlow_AdminAutoProvision(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithAuth(t)
 
 	stubProvider := &stubFederatedProvider{
@@ -334,6 +340,7 @@ func TestFederatedLoginFlow_AdminAutoProvision(t *testing.T) {
 // TestFederatedLoginFlow_SessionValid verifies that a session cookie returned
 // by federated login is accepted by the Auth middleware.
 func TestFederatedLoginFlow_SessionValid(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithAuth(t)
 
 	stubProvider := &stubFederatedProvider{
@@ -388,6 +395,7 @@ func TestFederatedLoginFlow_SessionValid(t *testing.T) {
 // TestRoleEnforcementFlow_OperatorForbiddenOnAdminRoutes verifies that an
 // operator is denied access to all admin-only endpoints.
 func TestRoleEnforcementFlow_OperatorForbiddenOnAdminRoutes(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 	opID := createOperatorUser(t, authSvc, adminID)
 
@@ -436,6 +444,7 @@ func TestRoleEnforcementFlow_OperatorForbiddenOnAdminRoutes(t *testing.T) {
 // TestRoleEnforcementFlow_OperatorAllowedOnOperatorRoutes verifies that an
 // operator can access endpoints that do not require admin.
 func TestRoleEnforcementFlow_OperatorAllowedOnOperatorRoutes(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 	opID := createOperatorUser(t, authSvc, adminID)
 
@@ -470,6 +479,7 @@ func TestRoleEnforcementFlow_OperatorAllowedOnOperatorRoutes(t *testing.T) {
 // TestRoleEnforcementFlow_AdminCanAccessAll verifies that an administrator
 // can access both admin-only and operator-allowed endpoints.
 func TestRoleEnforcementFlow_AdminCanAccessAll(t *testing.T) {
+	t.Parallel()
 	r, _, adminID := testRouterWithAuth(t)
 
 	cases := []struct {
@@ -515,6 +525,7 @@ func TestRoleEnforcementFlow_AdminCanAccessAll(t *testing.T) {
 // TestRoleEnforcementFlow_AdminCanUpdateRule verifies that an administrator
 // can modify rule configuration (enable/disable/automation mode).
 func TestRoleEnforcementFlow_AdminCanUpdateRule(t *testing.T) {
+	t.Parallel()
 	r, _, adminID := testRouterWithAuth(t)
 
 	// Get an existing rule ID from the seeded defaults.
@@ -539,6 +550,7 @@ func TestRoleEnforcementFlow_AdminCanUpdateRule(t *testing.T) {
 // TestRoleEnforcementFlow_OperatorCanRunScanner verifies that an operator can
 // trigger a scanner run (not admin-gated).
 func TestRoleEnforcementFlow_OperatorCanRunScanner(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 	opID := createOperatorUser(t, authSvc, adminID)
 

--- a/internal/api/handlers_logs_test.go
+++ b/internal/api/handlers_logs_test.go
@@ -27,6 +27,7 @@ func newTestRouterWithLogs(t *testing.T) (*Router, *logging.RingBuffer) {
 }
 
 func TestHandleGetLogs_JSON(t *testing.T) {
+	t.Parallel()
 	r, rb := newTestRouterWithLogs(t)
 
 	now := time.Now()
@@ -62,6 +63,7 @@ func TestHandleGetLogs_JSON(t *testing.T) {
 }
 
 func TestHandleGetLogs_HTMX(t *testing.T) {
+	t.Parallel()
 	r, rb := newTestRouterWithLogs(t)
 
 	now := time.Now()
@@ -96,6 +98,7 @@ func TestHandleGetLogs_HTMX(t *testing.T) {
 }
 
 func TestHandleGetLogs_HTMX_AttrsAndSource(t *testing.T) {
+	t.Parallel()
 	r, rb := newTestRouterWithLogs(t)
 
 	now := time.Now()
@@ -147,6 +150,7 @@ func TestHandleGetLogs_HTMX_AttrsAndSource(t *testing.T) {
 }
 
 func TestHandleGetLogs_LevelFilter(t *testing.T) {
+	t.Parallel()
 	r, rb := newTestRouterWithLogs(t)
 
 	now := time.Now()
@@ -179,6 +183,7 @@ func TestHandleGetLogs_LevelFilter(t *testing.T) {
 }
 
 func TestHandleGetLogs_SearchFilter(t *testing.T) {
+	t.Parallel()
 	r, rb := newTestRouterWithLogs(t)
 
 	now := time.Now()
@@ -207,6 +212,7 @@ func TestHandleGetLogs_SearchFilter(t *testing.T) {
 }
 
 func TestHandleGetLogs_ComponentFilter(t *testing.T) {
+	t.Parallel()
 	r, rb := newTestRouterWithLogs(t)
 
 	now := time.Now()
@@ -241,6 +247,7 @@ func TestHandleGetLogs_ComponentFilter(t *testing.T) {
 }
 
 func TestHandleGetLogs_Empty(t *testing.T) {
+	t.Parallel()
 	r, _ := newTestRouterWithLogs(t)
 
 	req := httptest.NewRequest("GET", "/api/v1/logs?limit=10", nil)
@@ -265,6 +272,7 @@ func TestHandleGetLogs_Empty(t *testing.T) {
 }
 
 func TestHandleGetLogs_EmptyHTMX(t *testing.T) {
+	t.Parallel()
 	r, _ := newTestRouterWithLogs(t)
 
 	req := httptest.NewRequest("GET", "/api/v1/logs?limit=10", nil)
@@ -285,6 +293,7 @@ func TestHandleGetLogs_EmptyHTMX(t *testing.T) {
 }
 
 func TestHandleClearLogs_JSON(t *testing.T) {
+	t.Parallel()
 	r, rb := newTestRouterWithLogs(t)
 
 	rb.Write(logging.LogEntry{Time: time.Now(), Level: "info", Message: "test"})
@@ -308,6 +317,7 @@ func TestHandleClearLogs_JSON(t *testing.T) {
 }
 
 func TestHandleClearLogs_HTMX(t *testing.T) {
+	t.Parallel()
 	r, rb := newTestRouterWithLogs(t)
 
 	rb.Write(logging.LogEntry{Time: time.Now(), Level: "info", Message: "test"})
@@ -337,6 +347,7 @@ func TestHandleClearLogs_HTMX(t *testing.T) {
 }
 
 func TestHandleGetLogs_NilManager(t *testing.T) {
+	t.Parallel()
 	r := &Router{
 		logManager: nil,
 		logger:     slog.Default(),
@@ -355,6 +366,7 @@ func TestHandleGetLogs_NilManager(t *testing.T) {
 }
 
 func TestHandleClearLogs_NilManager(t *testing.T) {
+	t.Parallel()
 	r := &Router{
 		logManager: nil,
 		logger:     slog.Default(),
@@ -373,6 +385,7 @@ func TestHandleClearLogs_NilManager(t *testing.T) {
 }
 
 func TestHandleGetLogs_AfterFilter(t *testing.T) {
+	t.Parallel()
 	r, rb := newTestRouterWithLogs(t)
 
 	base := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
@@ -405,6 +418,7 @@ func TestHandleGetLogs_AfterFilter(t *testing.T) {
 }
 
 func TestHandleGetLogs_InvalidLevel(t *testing.T) {
+	t.Parallel()
 	r, _ := newTestRouterWithLogs(t)
 
 	req := httptest.NewRequest("GET", "/api/v1/logs?level=verbose", nil)
@@ -417,6 +431,7 @@ func TestHandleGetLogs_InvalidLevel(t *testing.T) {
 }
 
 func TestHandleGetLogs_InvalidAfter(t *testing.T) {
+	t.Parallel()
 	r, _ := newTestRouterWithLogs(t)
 
 	req := httptest.NewRequest("GET", "/api/v1/logs?after=not-a-date", nil)
@@ -429,6 +444,7 @@ func TestHandleGetLogs_InvalidAfter(t *testing.T) {
 }
 
 func TestHandleGetLogs_InvalidLimit(t *testing.T) {
+	t.Parallel()
 	r, _ := newTestRouterWithLogs(t)
 
 	req := httptest.NewRequest("GET", "/api/v1/logs?limit=abc", nil)
@@ -441,6 +457,7 @@ func TestHandleGetLogs_InvalidLimit(t *testing.T) {
 }
 
 func TestHandleGetLogs_NegativeLimit(t *testing.T) {
+	t.Parallel()
 	r, _ := newTestRouterWithLogs(t)
 
 	req := httptest.NewRequest("GET", "/api/v1/logs?limit=-5", nil)
@@ -453,6 +470,7 @@ func TestHandleGetLogs_NegativeLimit(t *testing.T) {
 }
 
 func TestLevelBadgeClass(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		level string
 		want  string

--- a/internal/api/handlers_m37_test.go
+++ b/internal/api/handlers_m37_test.go
@@ -47,6 +47,7 @@ func enableMultiUser(t *testing.T, r *Router) {
 // 403 Forbidden when accessing admin-only settings endpoints. The test calls the
 // handler through RequireAdmin to mirror how the router wires it.
 func TestAdminRoute_Operator_Gets403_OnSettings(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 	opID := createOperatorUser(t, authSvc, adminID)
 
@@ -63,6 +64,7 @@ func TestAdminRoute_Operator_Gets403_OnSettings(t *testing.T) {
 // TestAdminRoute_Admin_Gets200_OnSettings verifies that an administrator can
 // access settings endpoints.
 func TestAdminRoute_Admin_Gets200_OnSettings(t *testing.T) {
+	t.Parallel()
 	r, _, adminID := testRouterWithAuth(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
@@ -80,6 +82,7 @@ func TestAdminRoute_Admin_Gets200_OnSettings(t *testing.T) {
 // change rule configuration (enable/disable/set automation mode). The test calls
 // the handler through RequireAdmin to mirror how the router wires it.
 func TestAdminRoute_Operator_Gets403_OnUpdateRule(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 	opID := createOperatorUser(t, authSvc, adminID)
 
@@ -99,6 +102,7 @@ func TestAdminRoute_Operator_Gets403_OnUpdateRule(t *testing.T) {
 // TestAdminRoute_Operator_CanRunRule verifies that an operator can execute a rule
 // (rule execution is not admin-gated).
 func TestAdminRoute_Operator_CanRunRule(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 	opID := createOperatorUser(t, authSvc, adminID)
 
@@ -119,6 +123,7 @@ func TestAdminRoute_Operator_CanRunRule(t *testing.T) {
 // TestMultiUserGate_InviteRoutes_Return404_WhenDisabled verifies that invite
 // endpoints return 404 when multi_user.enabled is not set.
 func TestMultiUserGate_InviteRoutes_Return404_WhenDisabled(t *testing.T) {
+	t.Parallel()
 	r, _, adminID := testRouterWithAuth(t)
 	// multi_user.enabled is not set -- defaults to "false"
 
@@ -137,6 +142,7 @@ func TestMultiUserGate_InviteRoutes_Return404_WhenDisabled(t *testing.T) {
 // TestMultiUserGate_InviteRoutes_Return200_WhenEnabled verifies that invite
 // endpoints are accessible when multi_user.enabled is "true".
 func TestMultiUserGate_InviteRoutes_Return200_WhenEnabled(t *testing.T) {
+	t.Parallel()
 	r, _, adminID := testRouterWithAuth(t)
 	enableMultiUser(t, r)
 
@@ -156,6 +162,7 @@ func TestMultiUserGate_InviteRoutes_Return200_WhenEnabled(t *testing.T) {
 // TestMultiUserGate_LoginFlow_UnaffectedByMultiUser verifies that the login
 // endpoint works regardless of multi_user.enabled (it is not gated).
 func TestMultiUserGate_LoginFlow_UnaffectedByMultiUser(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithAuth(t)
 	// multi_user.enabled is not set -- login should still work.
 
@@ -179,6 +186,7 @@ func TestMultiUserGate_LoginFlow_UnaffectedByMultiUser(t *testing.T) {
 // TestTokenScopeCeiling_Admin_CanCreateAdminToken verifies that an administrator
 // can create a token with admin scope.
 func TestTokenScopeCeiling_Admin_CanCreateAdminToken(t *testing.T) {
+	t.Parallel()
 	r, _, adminID := testRouterWithAuth(t)
 
 	body := `{"name":"admin-token","scopes":"admin"}`
@@ -204,6 +212,7 @@ func TestTokenScopeCeiling_Admin_CanCreateAdminToken(t *testing.T) {
 // TestTokenScopeCeiling_Operator_CanCreateReadToken verifies that an operator
 // can create read-scoped tokens.
 func TestTokenScopeCeiling_Operator_CanCreateReadToken(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 	opID := createOperatorUser(t, authSvc, adminID)
 
@@ -222,6 +231,7 @@ func TestTokenScopeCeiling_Operator_CanCreateReadToken(t *testing.T) {
 // TestTokenScopeCeiling_Operator_CanCreateWriteToken verifies that an operator
 // can create write-scoped tokens.
 func TestTokenScopeCeiling_Operator_CanCreateWriteToken(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 	opID := createOperatorUser(t, authSvc, adminID)
 
@@ -240,6 +250,7 @@ func TestTokenScopeCeiling_Operator_CanCreateWriteToken(t *testing.T) {
 // TestTokenScopeCeiling_Operator_CanCreateWebhookToken verifies that an operator
 // can create webhook-scoped tokens.
 func TestTokenScopeCeiling_Operator_CanCreateWebhookToken(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 	opID := createOperatorUser(t, authSvc, adminID)
 
@@ -258,6 +269,7 @@ func TestTokenScopeCeiling_Operator_CanCreateWebhookToken(t *testing.T) {
 // TestTokenScopeCeiling_Operator_Cannot_CreateAdminToken verifies that an operator
 // receives 403 when attempting to create an admin-scoped token.
 func TestTokenScopeCeiling_Operator_Cannot_CreateAdminToken(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 	opID := createOperatorUser(t, authSvc, adminID)
 
@@ -284,6 +296,7 @@ func TestTokenScopeCeiling_Operator_Cannot_CreateAdminToken(t *testing.T) {
 // TestTokenScopeCeiling_Operator_Cannot_CreateReadPlusAdminToken verifies that
 // mixing admin with other scopes is also rejected for operators.
 func TestTokenScopeCeiling_Operator_Cannot_CreateReadPlusAdminToken(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 	opID := createOperatorUser(t, authSvc, adminID)
 
@@ -305,6 +318,7 @@ func TestTokenScopeCeiling_Operator_Cannot_CreateReadPlusAdminToken(t *testing.T
 // handleSetup endpoint creates an administrator account, including when the
 // auth registry is configured (the registry path must be skipped for local).
 func TestSetup_Local_CreatesAdministrator(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithAuth(t)
 
 	// Wire up a registry with a local provider to match production config.
@@ -342,6 +356,7 @@ func TestSetup_Local_CreatesAdministrator(t *testing.T) {
 // setup via the auth registry always creates the user as Administrator, even if
 // the provider's MapRole would return a lesser role.
 func TestSetup_WithRegistry_FederatedAlwaysAdministrator(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithAuth(t)
 
 	// Register a stub provider that maps roles to "operator".

--- a/internal/api/handlers_members_test.go
+++ b/internal/api/handlers_members_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestHandleClearMembers_JSON(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "The Beatles")
 
@@ -61,6 +62,7 @@ func TestHandleClearMembers_JSON(t *testing.T) {
 }
 
 func TestHandleClearMembers_HTMX(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Radiohead")
 
@@ -101,6 +103,7 @@ func TestHandleClearMembers_HTMX(t *testing.T) {
 }
 
 func TestHandleSaveMembers_JSON(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Nirvana")
 
@@ -149,6 +152,7 @@ func TestHandleSaveMembers_JSON(t *testing.T) {
 }
 
 func TestHandleSaveMembers_HTMX(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Led Zeppelin")
 
@@ -191,6 +195,7 @@ func TestHandleSaveMembers_HTMX(t *testing.T) {
 }
 
 func TestHandleSaveMembers_InvalidBody(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Pink Floyd")
 
@@ -215,6 +220,7 @@ func TestHandleSaveMembers_InvalidBody(t *testing.T) {
 // the apply-path failure surfaces silently, which is the regression that
 // issue #1034 reported.
 func TestHandleSaveMembers_InvalidBody_ToastEnvelope_JSON(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Black Sabbath")
 
@@ -259,6 +265,7 @@ func TestHandleSaveMembers_InvalidBody_ToastEnvelope_JSON(t *testing.T) {
 // fragment shape prevents a future writeError refactor from silently
 // regressing this surface to a status-only failure.
 func TestHandleSaveMembers_InvalidBody_ToastEnvelope_HTMX(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Soundgarden")
 
@@ -299,6 +306,7 @@ func TestHandleSaveMembers_InvalidBody_ToastEnvelope_HTMX(t *testing.T) {
 // records, so a future refactor of convertProviderMembers cannot silently
 // drop a column.
 func TestHandleSaveMembers_PersistsApplyPayload(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Apply Test Band")
 
@@ -367,6 +375,7 @@ func TestHandleSaveMembers_PersistsApplyPayload(t *testing.T) {
 }
 
 func TestHandleSaveMembers_ReplacesExisting(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Queen")
 

--- a/internal/api/handlers_nfo_test.go
+++ b/internal/api/handlers_nfo_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestHandleNFODiff_JSON(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	t.Run("pathless artist shows no diff", func(t *testing.T) {
@@ -127,6 +128,7 @@ func TestHandleNFODiff_JSON(t *testing.T) {
 }
 
 func TestHandleNFODiff_HTMX(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	a := addTestArtist(t, artistSvc, "HTMX Diff")
@@ -149,6 +151,7 @@ func TestHandleNFODiff_HTMX(t *testing.T) {
 }
 
 func TestHandleNFODiff_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/nonexistent/nfo/diff", nil)
@@ -163,6 +166,7 @@ func TestHandleNFODiff_NotFound(t *testing.T) {
 }
 
 func TestHandleNFODiff_PathlessArtist(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	a := &artist.Artist{
@@ -193,6 +197,7 @@ func TestHandleNFODiff_PathlessArtist(t *testing.T) {
 }
 
 func TestHandleNFOConflictCheck_PathlessArtist(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	a := &artist.Artist{
@@ -225,6 +230,7 @@ func TestHandleNFOConflictCheck_PathlessArtist(t *testing.T) {
 }
 
 func TestParseNFOFile_NonExistent(t *testing.T) {
+	t.Parallel()
 	result, err := parseNFOFile("/nonexistent/path/artist.nfo")
 	if result != nil {
 		t.Error("expected nil for non-existent file")
@@ -235,6 +241,7 @@ func TestParseNFOFile_NonExistent(t *testing.T) {
 }
 
 func TestParseNFOFile_Valid(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "artist.nfo")
 	content := []byte(`<?xml version="1.0" encoding="UTF-8"?>

--- a/internal/api/handlers_notifications_test.go
+++ b/internal/api/handlers_notifications_test.go
@@ -41,6 +41,7 @@ func seedNotificationViolations(t *testing.T, svc *rule.Service) {
 }
 
 func TestParseNotificationParams(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		url       string
@@ -98,6 +99,7 @@ func TestParseNotificationParams(t *testing.T) {
 }
 
 func TestParseNotificationParams_DefaultStatus(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/notifications/table", nil)
 	p := parseNotificationParams(req)
 	if p.Status != "active" {
@@ -106,6 +108,7 @@ func TestParseNotificationParams_DefaultStatus(t *testing.T) {
 }
 
 func TestHandleNotificationsExport_CSV(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	seedNotificationViolations(t, r.ruleService)
 
@@ -146,6 +149,7 @@ func TestHandleNotificationsExport_CSV(t *testing.T) {
 }
 
 func TestHandleNotificationsExport_JSON(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	seedNotificationViolations(t, r.ruleService)
 
@@ -193,6 +197,7 @@ func TestHandleNotificationsExport_JSON(t *testing.T) {
 }
 
 func TestHandleNotificationsExport_JSONViaAcceptHeader(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	seedNotificationViolations(t, r.ruleService)
 
@@ -213,6 +218,7 @@ func TestHandleNotificationsExport_JSONViaAcceptHeader(t *testing.T) {
 }
 
 func TestHandleNotificationsExport_SeverityFilter(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	seedNotificationViolations(t, r.ruleService)
 
@@ -239,6 +245,7 @@ func TestHandleNotificationsExport_SeverityFilter(t *testing.T) {
 }
 
 func TestViolationAge(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
 
 	tests := []struct {

--- a/internal/api/handlers_oidc_test.go
+++ b/internal/api/handlers_oidc_test.go
@@ -107,6 +107,7 @@ func signIDToken(t *testing.T, key *rsa.PrivateKey, issuer, clientID, sub, nonce
 }
 
 func TestOIDCProviderInitAndAuthenticate(t *testing.T) {
+	t.Parallel()
 	srv, key := mockOIDCServer(t)
 	defer srv.Close()
 
@@ -223,6 +224,7 @@ func TestOIDCProviderInitAndAuthenticate(t *testing.T) {
 }
 
 func TestOIDCAuthenticateEmptyCode(t *testing.T) {
+	t.Parallel()
 	p := auth.NewOIDCProvider(auth.OIDCConfig{
 		IssuerURL: "https://example.com",
 		ClientID:  "test",
@@ -235,6 +237,7 @@ func TestOIDCAuthenticateEmptyCode(t *testing.T) {
 }
 
 func TestOIDCInitBadIssuer(t *testing.T) {
+	t.Parallel()
 	p := auth.NewOIDCProvider(auth.OIDCConfig{
 		IssuerURL: "https://invalid.example.test.invalid",
 		ClientID:  "test",
@@ -248,6 +251,7 @@ func TestOIDCInitBadIssuer(t *testing.T) {
 
 // TestMockOIDCServerDiscovery verifies the mock OIDC server returns valid discovery.
 func TestMockOIDCServerDiscovery(t *testing.T) {
+	t.Parallel()
 	srv, _ := mockOIDCServer(t)
 	defer srv.Close()
 
@@ -276,6 +280,7 @@ func TestMockOIDCServerDiscovery(t *testing.T) {
 
 // Ensure the RSA key and token signing produce valid outputs.
 func TestSignIDToken(t *testing.T) {
+	t.Parallel()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("generating key: %v", err)

--- a/internal/api/handlers_onboarding_conflict_test.go
+++ b/internal/api/handlers_onboarding_conflict_test.go
@@ -22,6 +22,7 @@ func onboardingConflictRequest(target string) *http.Request {
 }
 
 func TestHasQualifyingConflictConnection(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		conns []connection.Connection
@@ -48,6 +49,7 @@ func TestHasQualifyingConflictConnection(t *testing.T) {
 }
 
 func TestHandleGetOnboardingConflictStep_RendersCleanWhenDetectorMissing(t *testing.T) {
+	t.Parallel()
 	// When the detector is unavailable we render the empty clean body
 	// rather than 204. HTMX skips swap+afterSwap on 204 by default, which
 	// would leave the OOBE spinner up forever and the Continue gate stuck
@@ -70,6 +72,7 @@ func TestHandleGetOnboardingConflictStep_RendersCleanWhenDetectorMissing(t *test
 }
 
 func TestHandleGetOnboardingConflictStep_RendersCleanBody(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, nil)
 	req := onboardingConflictRequest("/api/v1/onboarding/conflict-step")
 	w := httptest.NewRecorder()
@@ -89,6 +92,7 @@ func TestHandleGetOnboardingConflictStep_RendersCleanBody(t *testing.T) {
 }
 
 func TestHandleGetOnboardingConflictStep_RefreshInvalidatesCache(t *testing.T) {
+	t.Parallel()
 	r := newConflictHarness(t, []connection.Connection{
 		{ID: "a", Name: "A", Type: connection.TypeEmby, Enabled: true},
 	})
@@ -104,6 +108,7 @@ func TestHandleGetOnboardingConflictStep_RefreshInvalidatesCache(t *testing.T) {
 }
 
 func TestAggregateProbeError_EmptyWhenAllProbesSucceed(t *testing.T) {
+	t.Parallel()
 	l := conflict.Ledger{
 		Connections: []conflict.ConnectionState{
 			{ConnectionID: "a", ConnectionName: "A", Enabled: true, CheckErr: ""},
@@ -116,6 +121,7 @@ func TestAggregateProbeError_EmptyWhenAllProbesSucceed(t *testing.T) {
 }
 
 func TestAggregateProbeError_SingleFailure(t *testing.T) {
+	t.Parallel()
 	l := conflict.Ledger{
 		Connections: []conflict.ConnectionState{
 			{ConnectionID: "a", ConnectionName: "EmbyOne", Enabled: true, CheckErr: "dial tcp"},
@@ -128,6 +134,7 @@ func TestAggregateProbeError_SingleFailure(t *testing.T) {
 }
 
 func TestAggregateProbeError_DisabledIgnored(t *testing.T) {
+	t.Parallel()
 	l := conflict.Ledger{
 		Connections: []conflict.ConnectionState{
 			{ConnectionID: "a", ConnectionName: "A", Enabled: false, CheckErr: "dial tcp"},
@@ -139,6 +146,7 @@ func TestAggregateProbeError_DisabledIgnored(t *testing.T) {
 }
 
 func TestAggregateProbeError_MultipleFailures(t *testing.T) {
+	t.Parallel()
 	l := conflict.Ledger{
 		Connections: []conflict.ConnectionState{
 			{ConnectionID: "a", ConnectionName: "EmbyOne", Enabled: true, CheckErr: "dial tcp"},
@@ -160,6 +168,7 @@ func TestAggregateProbeError_MultipleFailures(t *testing.T) {
 // onboarding.conflict_check_completed_at so callers can detect that the
 // pre-flight has been visited at least once.
 func TestHandleGetOnboardingConflictStep_PersistsCompletionMarker(t *testing.T) {
+	t.Parallel()
 	r := testRouterForOnboarding(t)
 	r.conflictDetector = conflict.NewForTest(&fakeRepo{}, testDiscardLogger())
 

--- a/internal/api/handlers_onboarding_test.go
+++ b/internal/api/handlers_onboarding_test.go
@@ -67,6 +67,7 @@ func onboardingRequest() *http.Request {
 }
 
 func TestHandleOnboardingPage_DefaultStep(t *testing.T) {
+	t.Parallel()
 	r := testRouterForOnboarding(t)
 
 	req := onboardingRequest()
@@ -90,6 +91,7 @@ func TestHandleOnboardingPage_DefaultStep(t *testing.T) {
 }
 
 func TestHandleOnboardingPage_StoredSteps(t *testing.T) {
+	t.Parallel()
 	r := testRouterForOnboarding(t)
 
 	tests := []struct {
@@ -133,6 +135,7 @@ func TestHandleOnboardingPage_StoredSteps(t *testing.T) {
 }
 
 func TestHandleOnboardingPage_InvalidStep(t *testing.T) {
+	t.Parallel()
 	r := testRouterForOnboarding(t)
 
 	// Store an invalid value.
@@ -159,6 +162,7 @@ func TestHandleOnboardingPage_InvalidStep(t *testing.T) {
 }
 
 func TestHandleOnboardingPage_CompletedRedirects(t *testing.T) {
+	t.Parallel()
 	r := testRouterForOnboarding(t)
 
 	// Mark onboarding as completed.
@@ -184,6 +188,7 @@ func TestHandleOnboardingPage_CompletedRedirects(t *testing.T) {
 }
 
 func TestHandleOnboardingPage_NoAuth(t *testing.T) {
+	t.Parallel()
 	r := testRouterForOnboarding(t)
 
 	// Request without user ID in context.
@@ -198,6 +203,7 @@ func TestHandleOnboardingPage_NoAuth(t *testing.T) {
 }
 
 func TestHandleOnboardingPage_UnidentifiedCount(t *testing.T) {
+	t.Parallel()
 	r := testRouterForOnboarding(t)
 	ctx := context.Background()
 
@@ -252,6 +258,7 @@ func TestHandleOnboardingPage_UnidentifiedCount(t *testing.T) {
 }
 
 func TestHandleOnboardingPage_UserAuthProvider(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		authProvider  string

--- a/internal/api/handlers_platform_ids_test.go
+++ b/internal/api/handlers_platform_ids_test.go
@@ -29,6 +29,7 @@ func addTestConnection(t *testing.T, r *Router, id, name, connType string) {
 }
 
 func TestHandleGetPlatformIDs_Empty(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Radiohead")
 
@@ -52,6 +53,7 @@ func TestHandleGetPlatformIDs_Empty(t *testing.T) {
 }
 
 func TestHandleGetPlatformIDs_WithData(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	addTestConnection(t, r, "conn-1", "Emby", "emby")
 	addTestConnection(t, r, "conn-2", "Jellyfin", "jellyfin")
@@ -79,6 +81,7 @@ func TestHandleGetPlatformIDs_WithData(t *testing.T) {
 }
 
 func TestHandleSetPlatformID(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	addTestConnection(t, r, "conn-1", "Emby", "emby")
 	a := addTestArtist(t, artistSvc, "Radiohead")
@@ -104,6 +107,7 @@ func TestHandleSetPlatformID(t *testing.T) {
 }
 
 func TestHandleSetPlatformID_ArtistNotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	addTestConnection(t, r, "conn-1", "Emby", "emby")
 
@@ -122,6 +126,7 @@ func TestHandleSetPlatformID_ArtistNotFound(t *testing.T) {
 }
 
 func TestHandleSetPlatformID_ConnectionNotFound(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Radiohead")
 
@@ -140,6 +145,7 @@ func TestHandleSetPlatformID_ConnectionNotFound(t *testing.T) {
 }
 
 func TestHandleSetPlatformID_MissingBody(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Radiohead")
 
@@ -158,6 +164,7 @@ func TestHandleSetPlatformID_MissingBody(t *testing.T) {
 }
 
 func TestHandleDeletePlatformID(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	addTestConnection(t, r, "conn-1", "Emby", "emby")
 	a := addTestArtist(t, artistSvc, "Radiohead")
@@ -182,6 +189,7 @@ func TestHandleDeletePlatformID(t *testing.T) {
 }
 
 func TestHandleDeletePlatformID_NotFound(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Radiohead")
 

--- a/internal/api/handlers_platform_test.go
+++ b/internal/api/handlers_platform_test.go
@@ -37,6 +37,7 @@ func testRouterWithPlatformForUpdate(t *testing.T) (*Router, *platform.Service, 
 }
 
 func TestUpdatePlatform_PartialUpdate(t *testing.T) {
+	t.Parallel()
 	r, svc, id := testRouterWithPlatformForUpdate(t)
 
 	// Send only nfo_enabled = false; other fields should remain unchanged.
@@ -70,6 +71,7 @@ func TestUpdatePlatform_PartialUpdate(t *testing.T) {
 }
 
 func TestUpdatePlatform_EmptyStringIgnored(t *testing.T) {
+	t.Parallel()
 	r, svc, id := testRouterWithPlatformForUpdate(t)
 
 	// Send name as empty string; should be treated as "not provided".
@@ -93,6 +95,7 @@ func TestUpdatePlatform_EmptyStringIgnored(t *testing.T) {
 }
 
 func TestUpdatePlatform_BuiltinRenameRejected(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithPlatformForUpdate(t)
 
 	// Attempt to rename the built-in Kodi profile.
@@ -115,6 +118,7 @@ func TestUpdatePlatform_BuiltinRenameRejected(t *testing.T) {
 }
 
 func TestUpdatePlatform_FullUpdate(t *testing.T) {
+	t.Parallel()
 	r, svc, id := testRouterWithPlatformForUpdate(t)
 
 	body := `{
@@ -159,6 +163,7 @@ func TestUpdatePlatform_FullUpdate(t *testing.T) {
 }
 
 func TestUpdatePlatform_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithPlatformForUpdate(t)
 
 	body := `{"name": "whatever"}`
@@ -173,6 +178,7 @@ func TestUpdatePlatform_NotFound(t *testing.T) {
 }
 
 func TestUpdatePlatform_UseSymlinks(t *testing.T) {
+	t.Parallel()
 	r, svc, id := testRouterWithPlatformForUpdate(t)
 
 	body := `{"use_symlinks": true}`
@@ -195,6 +201,7 @@ func TestUpdatePlatform_UseSymlinks(t *testing.T) {
 }
 
 func TestUpdatePlatform_UseSymlinks_BuiltinRejected(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithPlatformForUpdate(t)
 
 	// Attempt to set use_symlinks on the built-in Kodi profile (not editable).
@@ -217,6 +224,7 @@ func TestUpdatePlatform_UseSymlinks_BuiltinRejected(t *testing.T) {
 }
 
 func TestWebhookHost(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		baseURL string
@@ -239,6 +247,7 @@ func TestWebhookHost(t *testing.T) {
 }
 
 func TestWebhookScheme(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		baseURL  string

--- a/internal/api/handlers_preferences_test.go
+++ b/internal/api/handlers_preferences_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestGetPreferences_ReturnsDefaults(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/preferences", nil)
@@ -64,6 +65,7 @@ func TestGetPreferences_ReturnsDefaults(t *testing.T) {
 }
 
 func TestUpdatePreference_ThenGet(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	// PUT a preference.
@@ -106,6 +108,7 @@ func TestUpdatePreference_ThenGet(t *testing.T) {
 }
 
 func TestUpdatePreference_RejectsInvalidKey(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	body := `{"value":"anything"}`
@@ -130,6 +133,7 @@ func TestUpdatePreference_RejectsInvalidKey(t *testing.T) {
 }
 
 func TestUpdatePreference_UpsertOverwrites(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	// First PUT: set theme to light.
@@ -172,6 +176,7 @@ func TestUpdatePreference_UpsertOverwrites(t *testing.T) {
 }
 
 func TestGetPreferences_Unauthenticated(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithAuth(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/preferences", nil)
@@ -185,6 +190,7 @@ func TestGetPreferences_Unauthenticated(t *testing.T) {
 }
 
 func TestUpdatePreference_Unauthenticated(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithAuth(t)
 
 	body := `{"value":"light"}`
@@ -200,6 +206,7 @@ func TestUpdatePreference_Unauthenticated(t *testing.T) {
 }
 
 func TestUpdatePreference_RejectsInvalidValue(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	body := `{"value":"neon_pink"}`
@@ -226,6 +233,7 @@ func TestUpdatePreference_RejectsInvalidValue(t *testing.T) {
 // -- handleGetPreference (single key) tests --
 
 func TestGetPreference_ReturnsDefault(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/preferences/theme", nil)
@@ -252,6 +260,7 @@ func TestGetPreference_ReturnsDefault(t *testing.T) {
 }
 
 func TestGetPreference_ReturnsStoredValue(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	// Store a non-default value.
@@ -287,6 +296,7 @@ func TestGetPreference_ReturnsStoredValue(t *testing.T) {
 }
 
 func TestGetPreference_UnknownKey(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/preferences/nonexistent", nil)
@@ -302,6 +312,7 @@ func TestGetPreference_UnknownKey(t *testing.T) {
 }
 
 func TestGetPreference_SuppressConfirmDefaultsFalse(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/preferences/suppress_confirm_delete_artist", nil)
@@ -325,6 +336,7 @@ func TestGetPreference_SuppressConfirmDefaultsFalse(t *testing.T) {
 }
 
 func TestUpdatePreference_SuppressConfirmAcceptsTrueAndFalse(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	// Suppress the action.
@@ -385,6 +397,7 @@ func TestUpdatePreference_SuppressConfirmAcceptsTrueAndFalse(t *testing.T) {
 }
 
 func TestUpdatePreference_SuppressConfirmRejectsInvalidValue(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	body := `{"value":"yes"}`
@@ -400,6 +413,7 @@ func TestUpdatePreference_SuppressConfirmRejectsInvalidValue(t *testing.T) {
 }
 
 func TestGetPreference_Unauthenticated(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithAuth(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/preferences/theme", nil)
@@ -416,6 +430,7 @@ func TestGetPreference_Unauthenticated(t *testing.T) {
 // -- page_size preference tests --
 
 func TestPageSizePref_DefaultReturned(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/preferences/page_size", nil)
@@ -440,6 +455,7 @@ func TestPageSizePref_DefaultReturned(t *testing.T) {
 }
 
 func TestPageSizePref_StoreAndRetrieve(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	// PUT a valid page_size value.
@@ -475,6 +491,7 @@ func TestPageSizePref_StoreAndRetrieve(t *testing.T) {
 }
 
 func TestPageSizePref_RejectsOutOfRange(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	cases := []struct {
@@ -505,6 +522,7 @@ func TestPageSizePref_RejectsOutOfRange(t *testing.T) {
 }
 
 func TestPageSizePref_AcceptsBoundaryValues(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	for _, v := range []string{"10", "500"} {
@@ -526,6 +544,7 @@ func TestPageSizePref_AcceptsBoundaryValues(t *testing.T) {
 // TestPageSizePref_UsedByArtistList verifies that the page_size preference is
 // respected by the artist list API endpoint when no query param is provided.
 func TestPageSizePref_UsedByArtistList(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	// Establish a known user ID that we will use for the preference.
@@ -586,6 +605,7 @@ func TestPageSizePref_UsedByArtistList(t *testing.T) {
 // TestPageSizePref_QueryParamOverridesPref verifies that an explicit page_size
 // query parameter takes precedence over the stored user preference.
 func TestPageSizePref_QueryParamOverridesPref(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	const testUserID = "test-user-qparam"
@@ -626,6 +646,7 @@ func TestPageSizePref_QueryParamOverridesPref(t *testing.T) {
 }
 
 func TestIsSuppressConfirmKey(t *testing.T) {
+	t.Parallel()
 	valid := []string{
 		"suppress_confirm_delete",
 		"suppress_confirm_delete_artist",
@@ -658,6 +679,7 @@ func TestIsSuppressConfirmKey(t *testing.T) {
 // -- bg_opacity preference tests --
 
 func TestBgOpacityPref_DefaultReturned(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/preferences/bg_opacity", nil)
@@ -682,6 +704,7 @@ func TestBgOpacityPref_DefaultReturned(t *testing.T) {
 }
 
 func TestBgOpacityPref_StoreAndRetrieve(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	body := `{"value":"80"}`
@@ -715,6 +738,7 @@ func TestBgOpacityPref_StoreAndRetrieve(t *testing.T) {
 }
 
 func TestBgOpacityPref_RejectsOutOfRange(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	cases := []struct {
@@ -745,6 +769,7 @@ func TestBgOpacityPref_RejectsOutOfRange(t *testing.T) {
 }
 
 func TestBgOpacityPref_AcceptsBoundaryValues(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	for _, v := range []string{fmt.Sprintf("%d", BgOpacityMin), fmt.Sprintf("%d", BgOpacityMax)} {
@@ -766,6 +791,7 @@ func TestBgOpacityPref_AcceptsBoundaryValues(t *testing.T) {
 // -- auto_fetch_images preference tests --
 
 func TestAutoFetchImagesPref_DefaultReturned(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/preferences/auto_fetch_images", nil)
@@ -790,6 +816,7 @@ func TestAutoFetchImagesPref_DefaultReturned(t *testing.T) {
 }
 
 func TestAutoFetchImagesPref_StoreAndRetrieve(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	body := `{"value":"true"}`
@@ -823,6 +850,7 @@ func TestAutoFetchImagesPref_StoreAndRetrieve(t *testing.T) {
 }
 
 func TestAutoFetchImagesPref_RejectsInvalidValue(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	for _, bad := range []string{"yes", "1", "on", ""} {
@@ -844,6 +872,7 @@ func TestAutoFetchImagesPref_RejectsInvalidValue(t *testing.T) {
 // -- metadata_languages preference tests --
 
 func TestMetadataLanguagesPref_DefaultReturned(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/preferences/metadata_languages", nil)
@@ -867,6 +896,7 @@ func TestMetadataLanguagesPref_DefaultReturned(t *testing.T) {
 }
 
 func TestMetadataLanguagesPref_StoreAndRetrieve(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	body := `{"value":"[\"en-GB\",\"en\",\"ja\"]"}`
@@ -901,6 +931,7 @@ func TestMetadataLanguagesPref_StoreAndRetrieve(t *testing.T) {
 }
 
 func TestMetadataLanguagesPref_CanonicalizesCase(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	// PUT with mixed-case tags.
@@ -936,6 +967,7 @@ func TestMetadataLanguagesPref_CanonicalizesCase(t *testing.T) {
 }
 
 func TestMetadataLanguagesPref_RejectsInvalid(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	cases := []struct {
@@ -974,6 +1006,7 @@ func TestMetadataLanguagesPref_RejectsInvalid(t *testing.T) {
 // langpref.Delete call returns a wrapped error and the handler must
 // respond 500 rather than silently 200ing.
 func TestMetadataLanguagesPref_EmptyArray_DeleteFailure(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 	if err := r.db.Close(); err != nil {
 		t.Fatalf("closing db for error injection: %v", err)
@@ -999,6 +1032,7 @@ func TestMetadataLanguagesPref_EmptyArray_DeleteFailure(t *testing.T) {
 }
 
 func TestMetadataLanguagesPref_EmptyArrayResetsToDefault(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	// Seed a non-default preference first so we can observe the delete.
@@ -1050,6 +1084,7 @@ func TestMetadataLanguagesPref_EmptyArrayResetsToDefault(t *testing.T) {
 }
 
 func TestMetadataLanguagesPref_AcceptsValid(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	cases := []struct {
@@ -1078,6 +1113,7 @@ func TestMetadataLanguagesPref_AcceptsValid(t *testing.T) {
 }
 
 func TestMetadataLanguagesPref_IncludedInGetAll(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/preferences", nil)
@@ -1105,6 +1141,7 @@ func TestMetadataLanguagesPref_IncludedInGetAll(t *testing.T) {
 }
 
 func TestValidateMetadataLanguages(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string

--- a/internal/api/handlers_provider_test.go
+++ b/internal/api/handlers_provider_test.go
@@ -51,6 +51,7 @@ func testRouterWithMirror(t *testing.T) *Router {
 }
 
 func TestHandleSetMirror(t *testing.T) {
+	t.Parallel()
 	// Start a local mirror server so the auto-test in the JSON path succeeds.
 	mirrorSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -115,6 +116,7 @@ func TestHandleSetMirror(t *testing.T) {
 }
 
 func TestHandleSetMirrorValidation(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithMirror(t)
 
 	tests := []struct {
@@ -145,6 +147,7 @@ func TestHandleSetMirrorValidation(t *testing.T) {
 }
 
 func TestHandleSetMirrorTrailingSlash(t *testing.T) {
+	t.Parallel()
 	mirrorSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"artists":[]}`))
@@ -186,6 +189,7 @@ func TestHandleSetMirrorTrailingSlash(t *testing.T) {
 }
 
 func TestHandleSetMirrorDefaultRateLimit(t *testing.T) {
+	t.Parallel()
 	mirrorSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"artists":[]}`))
@@ -218,6 +222,7 @@ func TestHandleSetMirrorDefaultRateLimit(t *testing.T) {
 }
 
 func TestHandleSetMirrorRateLimitCap(t *testing.T) {
+	t.Parallel()
 	mirrorSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"artists":[]}`))
@@ -250,6 +255,7 @@ func TestHandleSetMirrorRateLimitCap(t *testing.T) {
 }
 
 func TestHandleDeleteMirror(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithMirror(t)
 	ctx := context.Background()
 
@@ -293,6 +299,7 @@ func TestHandleDeleteMirror(t *testing.T) {
 }
 
 func TestHandleSetMirrorUnsupportedProvider(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithMirror(t)
 
 	body := `{"base_url":"http://mirror:5000/ws/2"}`

--- a/internal/api/handlers_push_test.go
+++ b/internal/api/handlers_push_test.go
@@ -38,6 +38,7 @@ func addTestConnectionWithURL(t *testing.T, r *Router, id, name, connType, url s
 }
 
 func TestHandleDeletePushImage_Success(t *testing.T) {
+	t.Parallel()
 	type capture struct {
 		method string
 		path   string
@@ -95,6 +96,7 @@ func TestHandleDeletePushImage_Success(t *testing.T) {
 }
 
 func TestHandleDeletePushImage_AutoLookupPlatformID(t *testing.T) {
+	t.Parallel()
 	pathCh := make(chan string, 3)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
@@ -144,6 +146,7 @@ func TestHandleDeletePushImage_AutoLookupPlatformID(t *testing.T) {
 }
 
 func TestHandleDeletePushImage_InvalidType(t *testing.T) {
+	t.Parallel()
 	router, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Radiohead")
 
@@ -162,6 +165,7 @@ func TestHandleDeletePushImage_InvalidType(t *testing.T) {
 }
 
 func TestHandleDeletePushImage_MissingConnectionID(t *testing.T) {
+	t.Parallel()
 	router, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Radiohead")
 
@@ -180,6 +184,7 @@ func TestHandleDeletePushImage_MissingConnectionID(t *testing.T) {
 }
 
 func TestHandleDeletePushImage_ConnectionNotFound(t *testing.T) {
+	t.Parallel()
 	router, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Radiohead")
 
@@ -198,6 +203,7 @@ func TestHandleDeletePushImage_ConnectionNotFound(t *testing.T) {
 }
 
 func TestHandleDeletePushImage_ConnectionDisabled(t *testing.T) {
+	t.Parallel()
 	router, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Radiohead")
 
@@ -230,6 +236,7 @@ func TestHandleDeletePushImage_ConnectionDisabled(t *testing.T) {
 }
 
 func TestHandleDeletePushImage_ArtistNotFound(t *testing.T) {
+	t.Parallel()
 	router, _ := testRouter(t)
 	addTestConnection(t, router, "conn-1", "Emby", "emby")
 
@@ -248,6 +255,7 @@ func TestHandleDeletePushImage_ArtistNotFound(t *testing.T) {
 }
 
 func TestHandleDeletePushImage_JellyfinSuccess(t *testing.T) {
+	t.Parallel()
 	type capture struct {
 		method string
 		path   string
@@ -298,6 +306,7 @@ func TestHandleDeletePushImage_JellyfinSuccess(t *testing.T) {
 }
 
 func TestHandleDeletePushImage_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	router, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Radiohead")
 
@@ -315,6 +324,7 @@ func TestHandleDeletePushImage_InvalidJSON(t *testing.T) {
 }
 
 func TestHandleDeletePushImage_PlatformIDNotStoredAndNotProvided(t *testing.T) {
+	t.Parallel()
 	router, artistSvc := testRouter(t)
 	addTestConnection(t, router, "conn-1", "Emby", "emby")
 	a := addTestArtist(t, artistSvc, "Radiohead")
@@ -337,6 +347,7 @@ func TestHandleDeletePushImage_PlatformIDNotStoredAndNotProvided(t *testing.T) {
 // --- handlePushImages tests ---
 
 func TestHandlePushImages_FanartUploadedAtCorrectIndices(t *testing.T) {
+	t.Parallel()
 	var mu sync.Mutex
 	var captured []int
 
@@ -421,6 +432,7 @@ func TestHandlePushImages_FanartUploadedAtCorrectIndices(t *testing.T) {
 }
 
 func TestHandlePushImages_ReadFailureProducesSanitizedError(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -481,6 +493,7 @@ func TestHandlePushImages_ReadFailureProducesSanitizedError(t *testing.T) {
 }
 
 func TestHandlePushImages_UploadFailureProducesSanitizedError(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -537,6 +550,7 @@ func TestHandlePushImages_UploadFailureProducesSanitizedError(t *testing.T) {
 }
 
 func TestBuildArtistPushData_TypeAwareDates(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		artistType    string

--- a/internal/api/handlers_refresh_test.go
+++ b/internal/api/handlers_refresh_test.go
@@ -27,6 +27,7 @@ func (s *stubScraperExecutor) ScrapeAll(_ context.Context, _, _, _ string, _ map
 }
 
 func TestRenderRefreshWithOOB_ContainsSwapTargets(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "OOB Test Artist")
 
@@ -65,6 +66,7 @@ func TestRenderRefreshWithOOB_ContainsSwapTargets(t *testing.T) {
 }
 
 func TestRenderRefreshWithOOB_MemberFailure_SkipsOOB(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Member Fail Artist")
 
@@ -98,6 +100,7 @@ func TestRenderRefreshWithOOB_MemberFailure_SkipsOOB(t *testing.T) {
 }
 
 func TestApplyRefreshResult_ReidentifyUpdatesName(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		artistName   string
@@ -183,6 +186,7 @@ func TestApplyRefreshResult_ReidentifyUpdatesName(t *testing.T) {
 // an artist. This is the underlying mechanism that executeRefresh relies
 // on to clear stale members when a provider returns an empty member list.
 func TestUpsertMembers_EmptySliceClearsExisting(t *testing.T) {
+	t.Parallel()
 	_, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Stale Members Band")
 
@@ -221,6 +225,7 @@ func TestUpsertMembers_EmptySliceClearsExisting(t *testing.T) {
 // clears members, ensuring UpsertMembers treats nil the same as an empty
 // slice when updating an artist's members.
 func TestUpsertMembers_NilSliceClearsExisting(t *testing.T) {
+	t.Parallel()
 	_, artistSvc := testRouter(t)
 	a := addTestArtist(t, artistSvc, "Nil Members Band")
 
@@ -250,6 +255,7 @@ func TestUpsertMembers_NilSliceClearsExisting(t *testing.T) {
 // executeRefresh skips UpsertMembers when Members is empty, so this path
 // is informational -- verifying the converter itself is well-behaved.
 func TestConvertProviderMembers_EmptyInput(t *testing.T) {
+	t.Parallel()
 	result := convertProviderMembers("artist-1", nil)
 	if result == nil {
 		t.Fatal("convertProviderMembers(nil) returned nil, want empty slice")
@@ -261,6 +267,7 @@ func TestConvertProviderMembers_EmptyInput(t *testing.T) {
 
 // TestConvertProviderMembers_WithData verifies normal conversion.
 func TestConvertProviderMembers_WithData(t *testing.T) {
+	t.Parallel()
 	input := []provider.MemberInfo{
 		{Name: "Thom Yorke", MBID: "mb-1", Instruments: []string{"vocals", "guitar"}},
 		{Name: "Jonny Greenwood", MBID: "mb-2", Instruments: []string{"guitar"}},
@@ -286,6 +293,7 @@ func TestConvertProviderMembers_WithData(t *testing.T) {
 // executeRefreshCtx delegates to for member upsert decisions.
 // Calling the real method ensures coverage of the changed guard condition.
 func TestApplyMemberRefresh(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	seedMembers := func(t *testing.T, artistID string) {
@@ -470,6 +478,7 @@ func TestApplyMemberRefresh(t *testing.T) {
 // silently breaks the user-visible "violation clears after refresh" behavior
 // surfaces here as a failing test instead of as another reopened bug.
 func TestExecuteRefreshAndPostHook_ResolvesBioViolation(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, ruleSvc := testRouterWithPipelineFull(t)
 
 	// Disable every rule except bio_exists so the test is independent of
@@ -576,6 +585,7 @@ func TestExecuteRefreshAndPostHook_ResolvesBioViolation(t *testing.T) {
 // TestRunRulesAfterRefresh_InvokesPipeline verifies that runRulesAfterRefresh
 // calls the pipeline's RunForArtist method with the re-fetched artist.
 func TestRunRulesAfterRefresh_InvokesPipeline(t *testing.T) {
+	t.Parallel()
 	var calledWithID string
 	stub := &stubPipeline{
 		runForArtistFn: func(_ context.Context, a *artist.Artist) (*rule.RunResult, error) {
@@ -600,6 +610,7 @@ func TestRunRulesAfterRefresh_InvokesPipeline(t *testing.T) {
 // TestRunRulesAfterRefresh_NilPipeline verifies that runRulesAfterRefresh
 // is a no-op when the pipeline is not configured (nil).
 func TestRunRulesAfterRefresh_NilPipeline(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithStubPipeline(t, nil)
 	// Set pipeline to nil to simulate unconfigured state.
 	r.pipeline = nil
@@ -614,6 +625,7 @@ func TestRunRulesAfterRefresh_NilPipeline(t *testing.T) {
 // a pipeline error is swallowed (best-effort) and does not panic or
 // return an error to the caller.
 func TestRunRulesAfterRefresh_PipelineError_DoesNotPropagate(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
 			return nil, fmt.Errorf("rule engine exploded")
@@ -631,6 +643,7 @@ func TestRunRulesAfterRefresh_PipelineError_DoesNotPropagate(t *testing.T) {
 // delegates to applyMemberRefresh and persists provider-returned members.
 // This covers the r.applyMemberRefresh call site inside the orchestration path.
 func TestExecuteRefreshCtx_AppliesMemberRefresh(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	// Wire a stub orchestrator so FetchMetadata returns a controlled result
@@ -680,6 +693,7 @@ func TestExecuteRefreshCtx_AppliesMemberRefresh(t *testing.T) {
 // PopulatedFields field from the MergeOptions literal at handlers_refresh.go
 // would silently revert the entire feature.
 func TestExecuteRefreshCtx_PreservesTagsWhenProviderReturnsNoData(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	// Seed an artist with pre-existing tag data. addTestArtist gives us genres
@@ -739,6 +753,7 @@ func TestExecuteRefreshCtx_PreservesTagsWhenProviderReturnsNoData(t *testing.T) 
 // When PopulatedFields does contain a field, the merge is authorized to
 // overwrite the artist's value with the provider's value.
 func TestExecuteRefreshCtx_OverwritesTagsWhenProviderReturnsData(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	a := addTestArtist(t, artistSvc, "Tag Overwrite Artist")
@@ -778,6 +793,7 @@ func TestExecuteRefreshCtx_OverwritesTagsWhenProviderReturnsData(t *testing.T) {
 // ApplyMetadata's MergeOptions.LockedFields guard, so it needs its own
 // coverage.
 func TestApplyProviderName_RespectsLocks(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	t.Run("name_locked_preserves_user_value", func(t *testing.T) {

--- a/internal/api/handlers_reidentify_wizard_test.go
+++ b/internal/api/handlers_reidentify_wizard_test.go
@@ -21,6 +21,7 @@ import (
 // step.Decision before recording the new one; same-decision resubmits are
 // a no-op.
 func TestApplyDecision_Idempotent(t *testing.T) {
+	t.Parallel()
 	t.Run("no_prior_decision", func(t *testing.T) {
 		sess := &reIdentifyWizardSession{}
 		step := &reIdentifyWizardStep{}
@@ -122,6 +123,7 @@ func TestApplyDecision_Idempotent(t *testing.T) {
 // backdate Updated manually so the test does not have to sleep for 30
 // minutes.
 func TestWizardStore(t *testing.T) {
+	t.Parallel()
 	t.Run("create_and_get", func(t *testing.T) {
 		s := newReIdentifyWizardStore()
 		sess, err := s.create([]*reIdentifyWizardStep{{ArtistID: "a1"}})
@@ -205,6 +207,7 @@ func TestWizardStore(t *testing.T) {
 // the AlbumComparison percent when present, falling back to Confidence *
 // 100.
 func TestProjectWizardCandidates(t *testing.T) {
+	t.Parallel()
 	t.Run("not_ready_returns_nil", func(t *testing.T) {
 		step := &reIdentifyWizardStep{ready: false, Candidates: []ScoredCandidate{{}}}
 		if got := projectWizardCandidates(step); got != nil {
@@ -266,6 +269,7 @@ func TestProjectWizardCandidates(t *testing.T) {
 // the start endpoint without a real orchestrator. These paths account for
 // the bulk of unhappy-path code in the handler.
 func TestHandleReIdentifyWizardStart_Validation(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name     string
 		body     string
@@ -295,6 +299,7 @@ func TestHandleReIdentifyWizardStart_Validation(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardStart_TooManyIDs(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	// Build a payload with MaxBulkActionIDs+1 valid IDs so the cap fires
 	// before any per-ID work runs.
@@ -319,6 +324,7 @@ func TestHandleReIdentifyWizardStart_TooManyIDs(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardStart_ServiceUnavailable(t *testing.T) {
+	t.Parallel()
 	// Zero-value Router has nil artistService, which is the 503 branch.
 	r := &Router{reIdentifyWizardStore: newReIdentifyWizardStore()}
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/re-identify/wizard", strings.NewReader(`{"ids":["x"]}`))
@@ -331,6 +337,7 @@ func TestHandleReIdentifyWizardStart_ServiceUnavailable(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardStart_Success(t *testing.T) {
+	t.Parallel()
 	r, _, artistSvc := testRouterWithIdentify(t)
 	a := &artist.Artist{ID: "startHappy1", Name: "Start Happy"}
 	if err := artistSvc.Create(context.Background(), a); err != nil {
@@ -364,6 +371,7 @@ func TestHandleReIdentifyWizardStart_Success(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardStep_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	req := httptest.NewRequest(http.MethodGet, "/artists/re-identify/wizard/unknown/step/0", nil)
 	req.SetPathValue("sid", "unknown")
@@ -376,6 +384,7 @@ func TestHandleReIdentifyWizardStep_NotFound(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardStep_InvalidIndex(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	sess, err := r.reIdentifyWizardStore.create([]*reIdentifyWizardStep{{ArtistID: "a1"}})
 	if err != nil {
@@ -392,6 +401,7 @@ func TestHandleReIdentifyWizardStep_InvalidIndex(t *testing.T) {
 }
 
 func TestWizardStepFromRequest_ServiceUnavailable(t *testing.T) {
+	t.Parallel()
 	r := &Router{reIdentifyWizardStore: newReIdentifyWizardStore()}
 	req := httptest.NewRequest(http.MethodPost, "/any", nil)
 	req.SetPathValue("sid", "x")
@@ -406,6 +416,7 @@ func TestWizardStepFromRequest_ServiceUnavailable(t *testing.T) {
 }
 
 func TestWizardStepFromRequest_IndexOutOfRange(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	sess, err := r.reIdentifyWizardStore.create([]*reIdentifyWizardStep{{ArtistID: "a1"}})
 	if err != nil {
@@ -426,6 +437,7 @@ func TestWizardStepFromRequest_IndexOutOfRange(t *testing.T) {
 // TestHandleReIdentifyWizardSkip exercises the full skip handler: advance the
 // decision counter and return status=advanced for the non-HTMX caller.
 func TestHandleReIdentifyWizardSkip(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	sess, err := r.reIdentifyWizardStore.create([]*reIdentifyWizardStep{
 		{ArtistID: "a1"}, {ArtistID: "a2"},
@@ -465,6 +477,7 @@ func TestHandleReIdentifyWizardSkip(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardDecline(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	sess, err := r.reIdentifyWizardStore.create([]*reIdentifyWizardStep{
 		{ArtistID: "a1"}, {ArtistID: "a2"},
@@ -498,6 +511,7 @@ func TestHandleReIdentifyWizardDecline(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardAccept_MissingMBID(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	sess, err := r.reIdentifyWizardStore.create([]*reIdentifyWizardStep{{ArtistID: "a1"}})
 	if err != nil {
@@ -518,6 +532,7 @@ func TestHandleReIdentifyWizardAccept_MissingMBID(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardAccept_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	sess, err := r.reIdentifyWizardStore.create([]*reIdentifyWizardStep{{ArtistID: "a1"}})
 	if err != nil {
@@ -535,6 +550,7 @@ func TestHandleReIdentifyWizardAccept_InvalidJSON(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardAccept_ArtistNotFound(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	// Step references an artist that does not exist in the DB, so the
 	// accept handler's GetByID returns ErrNotFound.
@@ -554,6 +570,7 @@ func TestHandleReIdentifyWizardAccept_ArtistNotFound(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardAccept_FormBody(t *testing.T) {
+	t.Parallel()
 	// Form-encoded hx-vals path. We expect the handler to reject missing
 	// mbid here too; this exercises the non-JSON branch of the content-type
 	// switch.
@@ -574,6 +591,7 @@ func TestHandleReIdentifyWizardAccept_FormBody(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardAccept_AdvancedSuccess(t *testing.T) {
+	t.Parallel()
 	r, _, artistSvc := testRouterWithIdentify(t)
 	a := &artist.Artist{ID: "acceptAdv1", Name: "Accept Advanced"}
 	if err := artistSvc.Create(context.Background(), a); err != nil {
@@ -615,6 +633,7 @@ func TestHandleReIdentifyWizardAccept_AdvancedSuccess(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardAccept_DoneSuccess(t *testing.T) {
+	t.Parallel()
 	r, _, artistSvc := testRouterWithIdentify(t)
 	a := &artist.Artist{ID: "acceptDone1", Name: "Accept Done"}
 	if err := artistSvc.Create(context.Background(), a); err != nil {
@@ -655,6 +674,7 @@ func TestHandleReIdentifyWizardAccept_DoneSuccess(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardSaveExit(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	sess, err := r.reIdentifyWizardStore.create([]*reIdentifyWizardStep{
 		{ArtistID: "a1", ArtistName: "A One", Decision: ""},
@@ -728,6 +748,7 @@ func TestHandleReIdentifyWizardSaveExit(t *testing.T) {
 }
 
 func TestHandleReIdentifyWizardSaveExit_SessionNotFound(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	req := httptest.NewRequest(http.MethodPost, "/any", nil)
 	req.SetPathValue("sid", "nope")
@@ -743,6 +764,7 @@ func TestHandleReIdentifyWizardSaveExit_SessionNotFound(t *testing.T) {
 // with a sanitized errMsg. The full template-surface for errored is tracked
 // as an M46.5 follow-up but the state on the session is already populated.
 func TestEnsureWizardCandidates_NoOrchestrator(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
 	sess, err := r.reIdentifyWizardStore.create([]*reIdentifyWizardStep{{ArtistID: "a1", ArtistName: "A"}})
 	if err != nil {
@@ -767,6 +789,7 @@ func TestEnsureWizardCandidates_NoOrchestrator(t *testing.T) {
 }
 
 func TestEnsureWizardCandidates_OutOfRange(t *testing.T) {
+	t.Parallel()
 	// idx < 0 or >= len(Steps) is a silent no-op; safe to call from
 	// pre-fetch goroutines without bounds checks.
 	r, _, _ := testRouterWithIdentify(t)
@@ -787,6 +810,7 @@ func TestEnsureWizardCandidates_OutOfRange(t *testing.T) {
 // alias re_identify is normalized to re_identify_auto in the 202 response.
 // This locks in the contract covered by the openapi round-3 update.
 func TestHandleBulkAction_ReIdentifyAliasNormalization(t *testing.T) {
+	t.Parallel()
 	r, _, artistSvc := testRouterWithIdentify(t)
 	a := &artist.Artist{ID: "aliasArtist1", Name: "Alias Artist"}
 	if err := artistSvc.Create(context.Background(), a); err != nil {

--- a/internal/api/handlers_rename_directory_test.go
+++ b/internal/api/handlers_rename_directory_test.go
@@ -54,6 +54,7 @@ func renameRequest(t *testing.T, artistID, newDirname string) (*http.Request, *h
 }
 
 func TestHandleArtistRenameDirectory_Happy(t *testing.T) {
+	t.Parallel()
 	r, a, root := renameHandlerFixture(t)
 	req, w := renameRequest(t, a.ID, "Renamed")
 	r.handleArtistRenameDirectory(w, req)
@@ -75,6 +76,7 @@ func TestHandleArtistRenameDirectory_Happy(t *testing.T) {
 }
 
 func TestHandleArtistRenameDirectory_BadInput(t *testing.T) {
+	t.Parallel()
 	r, a, _ := renameHandlerFixture(t)
 	cases := map[string]string{
 		"empty":         "",
@@ -95,6 +97,7 @@ func TestHandleArtistRenameDirectory_BadInput(t *testing.T) {
 }
 
 func TestHandleArtistRenameDirectory_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _, _ := renameHandlerFixture(t)
 	req, w := renameRequest(t, "no-such-artist", "Anything")
 	r.handleArtistRenameDirectory(w, req)
@@ -104,6 +107,7 @@ func TestHandleArtistRenameDirectory_NotFound(t *testing.T) {
 }
 
 func TestHandleArtistRenameDirectory_Locked(t *testing.T) {
+	t.Parallel()
 	r, a, _ := renameHandlerFixture(t)
 	if err := r.artistService.Lock(context.Background(), a.ID, "user"); err != nil {
 		t.Fatalf("Lock: %v", err)
@@ -116,6 +120,7 @@ func TestHandleArtistRenameDirectory_Locked(t *testing.T) {
 }
 
 func TestHandleArtistRenameDirectory_DestExists(t *testing.T) {
+	t.Parallel()
 	r, a, root := renameHandlerFixture(t)
 	if err := os.Mkdir(filepath.Join(root, "Already Here"), 0o755); err != nil {
 		t.Fatalf("creating collision target: %v", err)
@@ -128,6 +133,7 @@ func TestHandleArtistRenameDirectory_DestExists(t *testing.T) {
 }
 
 func TestHandleArtistRenameDirectory_NoChange(t *testing.T) {
+	t.Parallel()
 	r, a, _ := renameHandlerFixture(t)
 	req, w := renameRequest(t, a.ID, filepath.Base(a.Path))
 	r.handleArtistRenameDirectory(w, req)
@@ -143,6 +149,7 @@ func TestHandleArtistRenameDirectory_NoChange(t *testing.T) {
 // uncovered. A regression that breaks ParseForm or the PostForm lookup
 // would silently pass without this case.
 func TestHandleArtistRenameDirectory_FormBody(t *testing.T) {
+	t.Parallel()
 	r, a, root := renameHandlerFixture(t)
 	form := url.Values{}
 	form.Set("new_dirname", "Form Renamed")
@@ -163,6 +170,7 @@ func TestHandleArtistRenameDirectory_FormBody(t *testing.T) {
 }
 
 func TestHandleArtistRenameDirectory_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	r, a, _ := renameHandlerFixture(t)
 	req := httptest.NewRequest(http.MethodPost,
 		"/api/v1/artists/"+a.ID+"/rename-directory", bytes.NewReader([]byte(`{not json`)))
@@ -182,6 +190,7 @@ func TestHandleArtistRenameDirectory_InvalidJSON(t *testing.T) {
 // the err != nil branch returning "invalid form body" is unreachable in
 // tests.
 func TestHandleArtistRenameDirectory_MalformedFormBody(t *testing.T) {
+	t.Parallel()
 	r, a, _ := renameHandlerFixture(t)
 	// "%" is an incomplete percent-escape; ParseForm rejects with
 	// "invalid URL escape".
@@ -203,6 +212,7 @@ func TestHandleArtistRenameDirectory_MalformedFormBody(t *testing.T) {
 // rename, and confirm the subscriber observed the event with the right
 // artist_id payload. Covers both the nil-check and the Publish call site.
 func TestHandleArtistRenameDirectory_PublishesEvent(t *testing.T) {
+	t.Parallel()
 	r, a, _ := renameHandlerFixture(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	bus := event.NewBus(logger, 4)
@@ -246,6 +256,7 @@ func TestHandleArtistRenameDirectory_PublishesEvent(t *testing.T) {
 // counters off the slog handler call to assert the log fired so a future
 // refactor that drops the slog.Error in the default branch is caught.
 func TestHandleArtistRenameDirectory_FilesystemError500(t *testing.T) {
+	t.Parallel()
 	// Root bypasses POSIX permission bits, so the chmod 0500 below would
 	// not produce EACCES and the default 500 branch we want to exercise
 	// would never fire. Same skip pattern used elsewhere in the repo.

--- a/internal/api/handlers_report_test.go
+++ b/internal/api/handlers_report_test.go
@@ -111,6 +111,7 @@ func addTestArtist(t *testing.T, svc *artist.Service, name string) *artist.Artis
 }
 
 func TestHandleReportHealth_JSON(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	addTestArtist(t, artistSvc, "Artist A")
@@ -139,6 +140,7 @@ func TestHandleReportHealth_JSON(t *testing.T) {
 }
 
 func TestHandleReportHealth_HTMX(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	addTestArtist(t, artistSvc, "HTMX Artist")
@@ -165,6 +167,7 @@ func TestHandleReportHealth_HTMX(t *testing.T) {
 }
 
 func TestHandleReportHealth_Empty(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/reports/health", nil)
@@ -190,6 +193,7 @@ func TestHandleReportHealth_Empty(t *testing.T) {
 }
 
 func TestHandleReportHealthHistory(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	addTestArtist(t, artistSvc, "History Artist")
@@ -220,6 +224,7 @@ func TestHandleReportHealthHistory(t *testing.T) {
 }
 
 func TestHandleReportHealthHistory_Empty(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/reports/health/history", nil)
@@ -242,6 +247,7 @@ func TestHandleReportHealthHistory_Empty(t *testing.T) {
 }
 
 func TestHandleReportCompliance(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	addTestArtist(t, artistSvc, "Compliant Artist")
@@ -282,6 +288,7 @@ func TestHandleReportCompliance(t *testing.T) {
 // always present in the response (stable for clients that rely on its
 // existence).
 func TestHandleReportCompliance_IncludesRulesPassedCount(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	ctx := context.Background()
 
@@ -358,6 +365,7 @@ func testRuleResultsDBFromRouter(r *Router) interface {
 }
 
 func TestSanitizeCSV(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -387,6 +395,7 @@ func TestSanitizeCSV(t *testing.T) {
 }
 
 func TestHandleViolationTrend_DefaultRange(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/violations/trend", nil)
@@ -413,6 +422,7 @@ func TestHandleViolationTrend_DefaultRange(t *testing.T) {
 }
 
 func TestHandleViolationTrend_CustomRange(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/violations/trend?days=7", nil)
@@ -439,6 +449,7 @@ func TestHandleViolationTrend_CustomRange(t *testing.T) {
 }
 
 func TestHandleViolationTrend_PointShape(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/violations/trend?days=1", nil)
@@ -493,6 +504,7 @@ func TestHandleViolationTrend_PointShape(t *testing.T) {
 }
 
 func TestHandleViolationTrend_InvalidDaysClamped(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	// days=0 should be clamped to default (30)
@@ -520,6 +532,7 @@ func TestHandleViolationTrend_InvalidDaysClamped(t *testing.T) {
 }
 
 func TestHandleReportMetadataCompleteness_Empty(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/reports/metadata-completeness", nil)
@@ -559,6 +572,7 @@ func TestHandleReportMetadataCompleteness_Empty(t *testing.T) {
 }
 
 func TestHandleReportMetadataCompleteness_WithArtists(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	// Add two artists: one with biography and NFO, one without.
@@ -629,6 +643,7 @@ func TestHandleReportMetadataCompleteness_WithArtists(t *testing.T) {
 }
 
 func TestHandleReportMetadataCompleteness_ExcludedArtistsOmitted(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	// Regular artist.
@@ -667,6 +682,7 @@ func TestHandleReportMetadataCompleteness_ExcludedArtistsOmitted(t *testing.T) {
 }
 
 func TestHandleReportMetadataCompleteness_HTMX(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 	addTestArtist(t, artistSvc, "HTMX Artist")
 
@@ -687,6 +703,7 @@ func TestHandleReportMetadataCompleteness_HTMX(t *testing.T) {
 }
 
 func TestHandleViolationTrend_UpperBoundClamped(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	// days=366 exceeds the 365 maximum and should be clamped to 30 (default).
@@ -717,6 +734,7 @@ func TestHandleViolationTrend_UpperBoundClamped(t *testing.T) {
 // artists changes the health endpoint response because it reads stored scores
 // from the database, not from a cache.
 func TestHandleReportHealth_StoredScoresReflectNewArtists(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	addTestArtist(t, artistSvc, "Artist A")
@@ -760,6 +778,7 @@ func TestHandleReportHealth_StoredScoresReflectNewArtists(t *testing.T) {
 }
 
 func TestHandleReportHealthByLibrary(t *testing.T) {
+	t.Parallel()
 	db, err := database.Open(":memory:")
 	if err != nil {
 		t.Fatalf("opening test db: %v", err)

--- a/internal/api/handlers_rule_test.go
+++ b/internal/api/handlers_rule_test.go
@@ -24,6 +24,7 @@ func firstRuleID(t *testing.T, svc *rule.Service) string {
 }
 
 func TestHandleUpdateRule_DisabledModeReturns400(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	ruleID := firstRuleID(t, r.ruleService)
@@ -55,6 +56,7 @@ func TestHandleUpdateRule_DisabledModeReturns400(t *testing.T) {
 }
 
 func TestHandleUpdateRule_ValidModesAccepted(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	ruleID := firstRuleID(t, r.ruleService)
@@ -105,6 +107,7 @@ func requireErrorBody(t *testing.T, w *httptest.ResponseRecorder, want string) {
 }
 
 func TestHandleUpdateRule_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	body := strings.NewReader(`{"enabled":true}`)
@@ -122,6 +125,7 @@ func TestHandleUpdateRule_NotFound(t *testing.T) {
 }
 
 func TestHandleRunRule_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/rules/nonexistent/run", nil)
@@ -137,6 +141,7 @@ func TestHandleRunRule_NotFound(t *testing.T) {
 }
 
 func TestHandleRunRule_NilPipeline(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	// testRouter has nil pipeline; use a valid (seeded) rule ID.
 	ruleID := firstRuleID(t, r.ruleService)
@@ -154,6 +159,7 @@ func TestHandleRunRule_NilPipeline(t *testing.T) {
 }
 
 func TestHandleRunRule_Returns202(t *testing.T) {
+	t.Parallel()
 	r, _, ruleSvc := testRouterWithPipelineFull(t)
 	ruleID := firstRuleID(t, ruleSvc)
 
@@ -180,6 +186,7 @@ func TestHandleRunRule_Returns202(t *testing.T) {
 }
 
 func TestHandleRunRule_409WhenAlreadyRunning(t *testing.T) {
+	t.Parallel()
 	// Use a blocking stub so the first run stays in-progress until we release it.
 	blockCh := make(chan struct{})
 	stub := &stubPipeline{
@@ -225,6 +232,7 @@ func TestHandleRunRule_409WhenAlreadyRunning(t *testing.T) {
 // generic 400 without echoing the bad input back to the client. Covers the
 // scope-validation branch added for #698.
 func TestHandleRunRule_InvalidScope400(t *testing.T) {
+	t.Parallel()
 	r, _, ruleSvc := testRouterWithPipelineFull(t)
 	ruleID := firstRuleID(t, ruleSvc)
 
@@ -244,6 +252,7 @@ func TestHandleRunRule_InvalidScope400(t *testing.T) {
 // the pipeline is not wired. Distinct from the single-rule run because
 // handleRunAllRules has its own pipeline-nil check.
 func TestHandleRunAllRules_NilPipeline503(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/rules/run-all", nil)
@@ -261,6 +270,7 @@ func TestHandleRunAllRules_NilPipeline503(t *testing.T) {
 // POST /rules/run-all so the spec's new 400 response is backed by the
 // implementation.
 func TestHandleRunAllRules_InvalidScope400(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithPipelineFull(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/rules/run-all?scope=xyz", nil)
@@ -278,6 +288,7 @@ func TestHandleRunAllRules_InvalidScope400(t *testing.T) {
 // POST /rules/run-all. Uses the stub pipeline so the background goroutine
 // returns immediately and the test does not race on real evaluation work.
 func TestHandleRunAllRules_Returns202(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{}
 	r, _ := testRouterWithStubPipeline(t, stub)
 
@@ -319,6 +330,7 @@ func TestHandleRunAllRules_Returns202(t *testing.T) {
 // POST /rules/run-all. A blocking stub keeps the first run in-progress so the
 // second call must observe r.ruleRun.Running == true and return 409.
 func TestHandleRunAllRules_409WhenAlreadyRunning(t *testing.T) {
+	t.Parallel()
 	blockCh := make(chan struct{})
 	// Register cleanup immediately so a later t.Fatalf cannot strand the
 	// blocked goroutine. Closing an already-closed channel panics, so this
@@ -365,6 +377,7 @@ func (b *blockingStubPipeline) RunAllScoped(_ context.Context, _ rule.RunScope) 
 }
 
 func TestHandleEvaluateArtist_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/nonexistent/health", nil)
@@ -380,6 +393,7 @@ func TestHandleEvaluateArtist_NotFound(t *testing.T) {
 }
 
 func TestHandleEvaluateArtist_ReturnsHealthScore(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouter(t)
 
 	a := addTestArtist(t, artistSvc, "Test Artist")
@@ -412,6 +426,7 @@ func TestHandleEvaluateArtist_ReturnsHealthScore(t *testing.T) {
 }
 
 func TestHandleBulkJobStatus_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.bulkService = rule.NewBulkService(r.db)
 
@@ -428,6 +443,7 @@ func TestHandleBulkJobStatus_NotFound(t *testing.T) {
 }
 
 func TestHandleBulkJobList_ReturnsJobs(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.bulkService = rule.NewBulkService(r.db)
 
@@ -462,6 +478,7 @@ func testRouterWithBulkJob(t *testing.T) (*Router, *artist.Service, string) {
 }
 
 func TestHandleBulkJobStatus_WithJob(t *testing.T) {
+	t.Parallel()
 	r, _, jobID := testRouterWithBulkJob(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/bulk/jobs/"+jobID, nil)

--- a/internal/api/handlers_rule_test.go
+++ b/internal/api/handlers_rule_test.go
@@ -188,15 +188,24 @@ func TestHandleRunRule_Returns202(t *testing.T) {
 func TestHandleRunRule_409WhenAlreadyRunning(t *testing.T) {
 	t.Parallel()
 	// Use a blocking stub so the first run stays in-progress until we release it.
+	// doneCh is closed by the stub once RunRule has been invoked, so cleanup
+	// can join the handler goroutine after closing blockCh -- closing alone
+	// only unblocks the stub, it does not wait for the handler's post-run
+	// processing to finish before the router/DB tear down.
 	blockCh := make(chan struct{})
-	t.Cleanup(func() { close(blockCh) })
+	doneCh := make(chan struct{})
 	stub := &stubPipeline{
 		runRuleFn: func(_ context.Context, _ string) (*rule.RunResult, error) {
+			defer close(doneCh)
 			<-blockCh
 			return &rule.RunResult{}, nil
 		},
 	}
 	r, _ := testRouterWithStubPipeline(t, stub)
+	t.Cleanup(func() {
+		close(blockCh)
+		<-doneCh
+	})
 
 	rules, err := r.ruleService.List(context.Background())
 	if err != nil || len(rules) == 0 {
@@ -331,6 +340,7 @@ func TestHandleRunAllRules_Returns202(t *testing.T) {
 func TestHandleRunAllRules_409WhenAlreadyRunning(t *testing.T) {
 	t.Parallel()
 	blockCh := make(chan struct{})
+	doneCh := make(chan struct{})
 	stub := &stubPipeline{
 		runRuleFn: func(_ context.Context, _ string) (*rule.RunResult, error) {
 			<-blockCh
@@ -338,14 +348,20 @@ func TestHandleRunAllRules_409WhenAlreadyRunning(t *testing.T) {
 		},
 	}
 	// Wrap RunAllScoped too so the goroutine blocks instead of returning fast.
-	stub2 := &blockingStubPipeline{stubPipeline: *stub, block: blockCh}
+	// done is closed inside RunAllScoped (via defer) so cleanup can join the
+	// background goroutine after unblocking it.
+	stub2 := &blockingStubPipeline{stubPipeline: *stub, block: blockCh, done: doneCh}
 	r, _ := testRouterWithStubPipeline(t, &stub2.stubPipeline)
 	// Swap the pipeline to the blocking variant so handleRunAllRules waits.
 	r.pipeline = stub2
 	// Register the unblock AFTER router setup so LIFO cleanup releases the
-	// blocked goroutine before the router/DB are torn down. Closing an
-	// already-closed channel would panic, so this is the sole close site.
-	t.Cleanup(func() { close(blockCh) })
+	// blocked goroutine before the router/DB are torn down. Closing alone is
+	// not enough -- we must also wait for the handler goroutine to finish so
+	// it cannot mutate router state after teardown.
+	t.Cleanup(func() {
+		close(blockCh)
+		<-doneCh
+	})
 
 	req1 := httptest.NewRequest(http.MethodPost, "/api/v1/rules/run-all", nil)
 	w1 := httptest.NewRecorder()
@@ -363,13 +379,17 @@ func TestHandleRunAllRules_409WhenAlreadyRunning(t *testing.T) {
 }
 
 // blockingStubPipeline wraps stubPipeline with a RunAllScoped that blocks on a
-// channel until the test releases it. Used by the 409 test above.
+// channel until the test releases it. Used by the 409 test above. The done
+// channel is closed when RunAllScoped returns so the test can join the
+// background goroutine before tearing down router/DB state.
 type blockingStubPipeline struct {
 	stubPipeline
 	block chan struct{}
+	done  chan struct{}
 }
 
 func (b *blockingStubPipeline) RunAllScoped(_ context.Context, _ rule.RunScope) (*rule.RunResult, error) {
+	defer close(b.done)
 	<-b.block
 	return &rule.RunResult{}, nil
 }

--- a/internal/api/handlers_rule_test.go
+++ b/internal/api/handlers_rule_test.go
@@ -331,11 +331,6 @@ func TestHandleRunAllRules_Returns202(t *testing.T) {
 func TestHandleRunAllRules_409WhenAlreadyRunning(t *testing.T) {
 	t.Parallel()
 	blockCh := make(chan struct{})
-	// Register cleanup immediately so a later t.Fatalf cannot strand the
-	// blocked goroutine. Closing an already-closed channel panics, so this
-	// must only run once -- t.Cleanup is guaranteed to fire exactly once per
-	// registration and close(blockCh) at the bottom of the test is removed.
-	t.Cleanup(func() { close(blockCh) })
 	stub := &stubPipeline{
 		runRuleFn: func(_ context.Context, _ string) (*rule.RunResult, error) {
 			<-blockCh
@@ -347,6 +342,10 @@ func TestHandleRunAllRules_409WhenAlreadyRunning(t *testing.T) {
 	r, _ := testRouterWithStubPipeline(t, &stub2.stubPipeline)
 	// Swap the pipeline to the blocking variant so handleRunAllRules waits.
 	r.pipeline = stub2
+	// Register the unblock AFTER router setup so LIFO cleanup releases the
+	// blocked goroutine before the router/DB are torn down. Closing an
+	// already-closed channel would panic, so this is the sole close site.
+	t.Cleanup(func() { close(blockCh) })
 
 	req1 := httptest.NewRequest(http.MethodPost, "/api/v1/rules/run-all", nil)
 	w1 := httptest.NewRecorder()

--- a/internal/api/handlers_rule_test.go
+++ b/internal/api/handlers_rule_test.go
@@ -189,6 +189,7 @@ func TestHandleRunRule_409WhenAlreadyRunning(t *testing.T) {
 	t.Parallel()
 	// Use a blocking stub so the first run stays in-progress until we release it.
 	blockCh := make(chan struct{})
+	t.Cleanup(func() { close(blockCh) })
 	stub := &stubPipeline{
 		runRuleFn: func(_ context.Context, _ string) (*rule.RunResult, error) {
 			<-blockCh
@@ -223,8 +224,6 @@ func TestHandleRunRule_409WhenAlreadyRunning(t *testing.T) {
 		t.Fatalf("second run: status = %d, want %d; body: %s", w2.Code, http.StatusConflict, w2.Body.String())
 	}
 
-	// Release the blocked goroutine so it can clean up.
-	close(blockCh)
 }
 
 // TestHandleRunRule_InvalidScope400 exercises the parseRunScope error path on

--- a/internal/api/handlers_run_artist_rules_stub_test.go
+++ b/internal/api/handlers_run_artist_rules_stub_test.go
@@ -116,6 +116,7 @@ func testRouterWithStubPipeline(t *testing.T, stub *stubPipeline) (*Router, *art
 }
 
 func TestStub_RunArtistRules_ViolationsFound_JSON(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
 			return &rule.RunResult{
@@ -151,6 +152,7 @@ func TestStub_RunArtistRules_ViolationsFound_JSON(t *testing.T) {
 }
 
 func TestStub_RunArtistRules_ViolationsFound_HTMX(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
 			return &rule.RunResult{
@@ -194,6 +196,7 @@ func TestStub_RunArtistRules_ViolationsFound_HTMX(t *testing.T) {
 }
 
 func TestStub_RunArtistRules_PipelineError_JSON(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
 			return nil, fmt.Errorf("engine exploded")
@@ -214,6 +217,7 @@ func TestStub_RunArtistRules_PipelineError_JSON(t *testing.T) {
 }
 
 func TestStub_RunArtistRules_PipelineError_HTMX(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
 			return nil, fmt.Errorf("engine exploded")
@@ -242,6 +246,7 @@ func TestStub_RunArtistRules_PipelineError_HTMX(t *testing.T) {
 }
 
 func TestStub_RunArtistRules_NoViolations_HTMX(t *testing.T) {
+	t.Parallel()
 	stub := &stubPipeline{
 		runForArtistFn: func(_ context.Context, _ *artist.Artist) (*rule.RunResult, error) {
 			return &rule.RunResult{ArtistsProcessed: 1}, nil

--- a/internal/api/handlers_run_artist_rules_test.go
+++ b/internal/api/handlers_run_artist_rules_test.go
@@ -79,6 +79,7 @@ func testRouterWithPipeline(t *testing.T) (*Router, *artist.Service) {
 }
 
 func TestHandleRunArtistRules_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithPipeline(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/nonexistent/run-rules", nil)
@@ -93,6 +94,7 @@ func TestHandleRunArtistRules_NotFound(t *testing.T) {
 }
 
 func TestHandleRunArtistRules_HTMX_NotFound(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouterWithPipeline(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/nonexistent/run-rules", nil)
@@ -115,6 +117,7 @@ func TestHandleRunArtistRules_HTMX_NotFound(t *testing.T) {
 }
 
 func TestHandleRunArtistRules_ReturnsJSON(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPipeline(t)
 
 	a := addTestArtist(t, artistSvc, "Test Artist")
@@ -146,6 +149,7 @@ func TestHandleRunArtistRules_ReturnsJSON(t *testing.T) {
 }
 
 func TestHandleRunArtistRules_HTMX_NoViolations(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, ruleSvc := testRouterWithPipelineFull(t)
 
 	// Disable all rules so a fresh artist produces zero violations.
@@ -182,6 +186,7 @@ func TestHandleRunArtistRules_HTMX_NoViolations(t *testing.T) {
 }
 
 func TestHandleRunArtistRules_HTMX_ViolationsFound(t *testing.T) {
+	t.Parallel()
 	// Enable only RuleBioExists so the test does not depend on filesystem state or
 	// pathless-library handling.
 	// A fresh artist with no biography always violates this DB-only rule.
@@ -236,6 +241,7 @@ func TestHandleRunArtistRules_HTMX_ViolationsFound(t *testing.T) {
 }
 
 func TestHandleRunArtistRules_BasePath(t *testing.T) {
+	t.Parallel()
 	r, artistSvc, _ := testRouterWithPipelineFull(t)
 	r.basePath = "/app"
 
@@ -264,6 +270,7 @@ func TestHandleRunArtistRules_BasePath(t *testing.T) {
 }
 
 func TestHandleRunArtistRules_HTMX_DBError(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPipeline(t)
 
 	a := addTestArtist(t, artistSvc, "DB Error Artist")
@@ -296,6 +303,7 @@ func TestHandleRunArtistRules_HTMX_DBError(t *testing.T) {
 // Branch-level body assertions are covered by TestHandleRunArtistRules_HTMX_NoViolations
 // and TestHandleRunArtistRules_HTMX_ViolationsFound.
 func TestHandleRunArtistRules_ReturnsHTMLForHTMX(t *testing.T) {
+	t.Parallel()
 	r, artistSvc := testRouterWithPipeline(t)
 
 	a := addTestArtist(t, artistSvc, "HTMX Artist")

--- a/internal/api/handlers_session_test.go
+++ b/internal/api/handlers_session_test.go
@@ -3,6 +3,7 @@ package api
 import "testing"
 
 func TestValidateReturnURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string

--- a/internal/api/handlers_settings_cache_test.go
+++ b/internal/api/handlers_settings_cache_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestHandleCacheStats_Empty(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.imageCacheDir = t.TempDir()
 
@@ -38,6 +39,7 @@ func TestHandleCacheStats_Empty(t *testing.T) {
 }
 
 func TestHandleCacheStats_WithFiles(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.imageCacheDir = t.TempDir()
 
@@ -72,6 +74,7 @@ func TestHandleCacheStats_WithFiles(t *testing.T) {
 }
 
 func TestHandleCacheClear_WithFiles(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.imageCacheDir = t.TempDir()
 
@@ -108,6 +111,7 @@ func TestHandleCacheClear_WithFiles(t *testing.T) {
 }
 
 func TestHandleCacheClear_Empty(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.imageCacheDir = t.TempDir()
 
@@ -132,6 +136,7 @@ func TestHandleCacheClear_Empty(t *testing.T) {
 }
 
 func TestHandleCacheClear_ResetsExistsFlag(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.imageCacheDir = t.TempDir()
 

--- a/internal/api/handlers_settings_io_test.go
+++ b/internal/api/handlers_settings_io_test.go
@@ -145,6 +145,7 @@ func setupTestDBForIO(t *testing.T) *sql.DB {
 // --- Export handler tests ---
 
 func TestHandleSettingsExport_NilService(t *testing.T) {
+	t.Parallel()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	db := setupTestDBForIO(t)
 	authSvc := auth.NewService(db)
@@ -168,6 +169,7 @@ func TestHandleSettingsExport_NilService(t *testing.T) {
 }
 
 func TestHandleSettingsExport_MissingPassphrase(t *testing.T) {
+	t.Parallel()
 	router, _, _ := settingsIOTestDeps(t)
 
 	body := `{"passphrase":""}`
@@ -183,6 +185,7 @@ func TestHandleSettingsExport_MissingPassphrase(t *testing.T) {
 }
 
 func TestHandleSettingsExport_JSON(t *testing.T) {
+	t.Parallel()
 	router, _, db := settingsIOTestDeps(t)
 
 	// Seed two preference rows for one user so summary.user_preferences is
@@ -243,6 +246,7 @@ func TestHandleSettingsExport_JSON(t *testing.T) {
 }
 
 func TestHandleSettingsExport_FormEncoded(t *testing.T) {
+	t.Parallel()
 	router, _, _ := settingsIOTestDeps(t)
 
 	body := "passphrase=hunter2"
@@ -260,6 +264,7 @@ func TestHandleSettingsExport_FormEncoded(t *testing.T) {
 // --- Import handler tests ---
 
 func TestHandleSettingsImport_NilService(t *testing.T) {
+	t.Parallel()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	db := setupTestDBForIO(t)
 	authSvc := auth.NewService(db)
@@ -283,6 +288,7 @@ func TestHandleSettingsImport_NilService(t *testing.T) {
 }
 
 func TestHandleSettingsImport_MissingPassphrase_JSON(t *testing.T) {
+	t.Parallel()
 	router, svc, _ := settingsIOTestDeps(t)
 	envBytes := buildExportedEnvelope(t, svc, "secret")
 
@@ -303,6 +309,7 @@ func TestHandleSettingsImport_MissingPassphrase_JSON(t *testing.T) {
 }
 
 func TestHandleSettingsImport_WrongPassphrase_JSON(t *testing.T) {
+	t.Parallel()
 	router, svc, _ := settingsIOTestDeps(t)
 	envBytes := buildExportedEnvelope(t, svc, "correct-passphrase")
 
@@ -329,6 +336,7 @@ func TestHandleSettingsImport_WrongPassphrase_JSON(t *testing.T) {
 }
 
 func TestHandleSettingsImport_WrongPassphrase_HTMX(t *testing.T) {
+	t.Parallel()
 	router, svc, _ := settingsIOTestDeps(t)
 	envBytes := buildExportedEnvelope(t, svc, "correct-passphrase")
 
@@ -357,6 +365,7 @@ func TestHandleSettingsImport_WrongPassphrase_HTMX(t *testing.T) {
 }
 
 func TestHandleSettingsImport_RoundTrip_JSON(t *testing.T) {
+	t.Parallel()
 	router, svc, db := settingsIOTestDeps(t)
 	// Seed two preference pairs and one user before exporting so the import
 	// counters can be checked against known values.
@@ -399,6 +408,7 @@ func TestHandleSettingsImport_RoundTrip_JSON(t *testing.T) {
 }
 
 func TestHandleSettingsImport_RoundTrip_HTMX(t *testing.T) {
+	t.Parallel()
 	router, svc, _ := settingsIOTestDeps(t)
 	const passphrase = "my-secret"
 	envBytes := buildExportedEnvelope(t, svc, passphrase)
@@ -427,6 +437,7 @@ func TestHandleSettingsImport_RoundTrip_HTMX(t *testing.T) {
 }
 
 func TestHandleSettingsImport_Multipart(t *testing.T) {
+	t.Parallel()
 	router, svc, _ := settingsIOTestDeps(t)
 	const passphrase = "multipart-pass"
 	envBytes := buildExportedEnvelope(t, svc, passphrase)
@@ -463,6 +474,7 @@ func TestHandleSettingsImport_Multipart(t *testing.T) {
 }
 
 func TestHandleSettingsImport_Multipart_MissingFile(t *testing.T) {
+	t.Parallel()
 	router, _, _ := settingsIOTestDeps(t)
 
 	var buf bytes.Buffer
@@ -486,6 +498,7 @@ func TestHandleSettingsImport_Multipart_MissingFile(t *testing.T) {
 }
 
 func TestHandleSettingsImport_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	router, _, _ := settingsIOTestDeps(t)
 
 	body := `{not valid json`

--- a/internal/api/handlers_settings_nfo_test.go
+++ b/internal/api/handlers_settings_nfo_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestHandleGetNFOOutput_Defaults(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	// Attach NFO settings service since testRouter does not set it up
 	r.nfoSettingsService = nfo.NewNFOSettingsService(r.db, r.logger)
@@ -36,6 +37,7 @@ func TestHandleGetNFOOutput_Defaults(t *testing.T) {
 }
 
 func TestHandleUpdateNFOOutput_MoodsAsStyles(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.nfoSettingsService = nfo.NewNFOSettingsService(r.db, r.logger)
 
@@ -66,6 +68,7 @@ func TestHandleUpdateNFOOutput_MoodsAsStyles(t *testing.T) {
 }
 
 func TestHandleUpdateNFOOutput_AdvancedRemap(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.nfoSettingsService = nfo.NewNFOSettingsService(r.db, r.logger)
 
@@ -105,6 +108,7 @@ func TestHandleUpdateNFOOutput_AdvancedRemap(t *testing.T) {
 }
 
 func TestHandleUpdateNFOOutput_InvalidGenreSource(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.nfoSettingsService = nfo.NewNFOSettingsService(r.db, r.logger)
 
@@ -119,6 +123,7 @@ func TestHandleUpdateNFOOutput_InvalidGenreSource(t *testing.T) {
 }
 
 func TestHandleUpdateNFOOutput_InvalidRemapKey(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.nfoSettingsService = nfo.NewNFOSettingsService(r.db, r.logger)
 
@@ -133,6 +138,7 @@ func TestHandleUpdateNFOOutput_InvalidRemapKey(t *testing.T) {
 }
 
 func TestHandleUpdateNFOOutput_InvalidRemapSource(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.nfoSettingsService = nfo.NewNFOSettingsService(r.db, r.logger)
 
@@ -147,6 +153,7 @@ func TestHandleUpdateNFOOutput_InvalidRemapSource(t *testing.T) {
 }
 
 func TestHandleUpdateNFOOutput_InvalidJSON(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	r.nfoSettingsService = nfo.NewNFOSettingsService(r.db, r.logger)
 
@@ -160,6 +167,7 @@ func TestHandleUpdateNFOOutput_InvalidJSON(t *testing.T) {
 }
 
 func TestHandleGetNFOOutput_NilService(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	// Explicitly leave nfoSettingsService nil
 	r.nfoSettingsService = nil
@@ -174,6 +182,7 @@ func TestHandleGetNFOOutput_NilService(t *testing.T) {
 }
 
 func TestHandleUpdateNFOOutput_NilService(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	// Explicitly leave nfoSettingsService nil
 	r.nfoSettingsService = nil

--- a/internal/api/handlers_settings_test.go
+++ b/internal/api/handlers_settings_test.go
@@ -11,6 +11,7 @@ import (
 // TestNormalizeSettingsSection verifies that valid section names pass through
 // unchanged and that unknown names fall back to "general".
 func TestNormalizeSettingsSection(t *testing.T) {
+	t.Parallel()
 	valid := []string{
 		"general", "providers", "connections", "libraries",
 		"automation", "rules", "users", "auth_providers", "maintenance", "logs",
@@ -28,6 +29,7 @@ func TestNormalizeSettingsSection(t *testing.T) {
 }
 
 func TestHandleUpdateSettings_CacheMaxSize_Invalid(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	body := `{"cache.image.max_size_mb": "-5"}`
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", strings.NewReader(body))
@@ -39,6 +41,7 @@ func TestHandleUpdateSettings_CacheMaxSize_Invalid(t *testing.T) {
 }
 
 func TestHandleUpdateSettings_CacheMaxSize_Valid(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	body := `{"cache.image.max_size_mb": "512"}`
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", strings.NewReader(body))
@@ -50,6 +53,7 @@ func TestHandleUpdateSettings_CacheMaxSize_Valid(t *testing.T) {
 }
 
 func TestHandleUpdateSettings_CacheMaxSize_Zero(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	body := `{"cache.image.max_size_mb": "0"}`
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", strings.NewReader(body))
@@ -61,6 +65,7 @@ func TestHandleUpdateSettings_CacheMaxSize_Zero(t *testing.T) {
 }
 
 func TestHandleUpdateSettings_Threshold_Invalid(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		value string
@@ -87,6 +92,7 @@ func TestHandleUpdateSettings_Threshold_Invalid(t *testing.T) {
 // to set auth.providers.local.enabled to a falsy value is rejected with 400,
 // including case and whitespace variants.
 func TestHandleUpdateSettings_LocalAuthCannotBeDisabled(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		value string
@@ -113,6 +119,7 @@ func TestHandleUpdateSettings_LocalAuthCannotBeDisabled(t *testing.T) {
 // TestHandleUpdateSettings_LocalAuthEnabled verifies that setting
 // auth.providers.local.enabled to true is accepted.
 func TestHandleUpdateSettings_LocalAuthEnabled(t *testing.T) {
+	t.Parallel()
 	r, _ := testRouter(t)
 	body := `{"auth.providers.local.enabled": "true"}`
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/settings", strings.NewReader(body))
@@ -198,6 +205,7 @@ func TestHandleUpdateSettings_BasePath_Valid(t *testing.T) {
 }
 
 func TestHandleUpdateSettings_Threshold_Valid(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		value string

--- a/internal/api/handlers_shared_filesystem_test.go
+++ b/internal/api/handlers_shared_filesystem_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestHandleSharedFilesystemStatus(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/shared-filesystem/status", nil)
@@ -50,6 +51,7 @@ func TestHandleSharedFilesystemStatus(t *testing.T) {
 }
 
 func TestHandleSharedFilesystemDismiss(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/shared-filesystem/dismiss", nil)
@@ -75,6 +77,7 @@ func TestHandleSharedFilesystemDismiss(t *testing.T) {
 }
 
 func TestHandleSharedFilesystemStatusOverlapWith(t *testing.T) {
+	t.Parallel()
 	// Verify that OverlapWith is populated when peer library IDs are set.
 	r, libSvc, _ := testRouterWithLibrary(t)
 	ctx := context.Background()
@@ -145,6 +148,7 @@ func TestHandleSharedFilesystemStatusOverlapWith(t *testing.T) {
 }
 
 func TestHandleSharedFilesystemRecheck(t *testing.T) {
+	t.Parallel()
 	r, _, _ := testRouterWithLibrary(t)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/shared-filesystem/recheck", nil)

--- a/internal/api/handlers_sse_test.go
+++ b/internal/api/handlers_sse_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestSSEHub_RegisterUnregister(t *testing.T) {
+	t.Parallel()
 	hub := NewSSEHub(slog.Default())
 
 	c1 := hub.Register("user-1")
@@ -37,6 +38,7 @@ func TestSSEHub_RegisterUnregister(t *testing.T) {
 }
 
 func TestSSEHub_Broadcast(t *testing.T) {
+	t.Parallel()
 	hub := NewSSEHub(slog.Default())
 
 	c1 := hub.Register("user-1")
@@ -74,6 +76,7 @@ func TestSSEHub_Broadcast(t *testing.T) {
 }
 
 func TestSSEHub_BroadcastDropsWhenBufferFull(t *testing.T) {
+	t.Parallel()
 	hub := NewSSEHub(slog.Default())
 	c := hub.Register("user-1")
 	defer hub.Unregister(c)
@@ -103,6 +106,7 @@ done:
 }
 
 func TestSSEHub_SubscribeToEventBus(t *testing.T) {
+	t.Parallel()
 	logger := slog.Default()
 	hub := NewSSEHub(logger)
 	bus := event.NewBus(logger, 64)
@@ -146,6 +150,7 @@ func TestSSEHub_SubscribeToEventBus(t *testing.T) {
 }
 
 func TestHandleSSEStream(t *testing.T) {
+	t.Parallel()
 	logger := slog.Default()
 	hub := NewSSEHub(logger)
 
@@ -250,6 +255,7 @@ func TestHandleSSEStream(t *testing.T) {
 }
 
 func TestHandleSSEStream_NoHub(t *testing.T) {
+	t.Parallel()
 	r := &Router{
 		sseHub: nil,
 		logger: slog.Default(),

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestHandleLogout(t *testing.T) {
+	t.Parallel()
 	t.Run("returns 200 with JSON body and HX-Redirect header", func(t *testing.T) {
 		r := &Router{
 			logger:   slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
@@ -112,6 +113,7 @@ func TestHandleLogout(t *testing.T) {
 }
 
 func TestBuildDashboardInitialQuery(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input url.Values

--- a/internal/api/handlers_updater_test.go
+++ b/internal/api/handlers_updater_test.go
@@ -63,6 +63,7 @@ func testRouterWithUpdater(t *testing.T) *Router {
 }
 
 func TestHandleGetUpdateConfig_Defaults(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/updates/config", nil)
@@ -87,6 +88,7 @@ func TestHandleGetUpdateConfig_Defaults(t *testing.T) {
 }
 
 func TestHandlePutUpdateConfig_Valid(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 
 	body := `{"channel":"prerelease","auto_check":true}`
@@ -138,6 +140,7 @@ func TestHandlePutUpdateConfig_Valid(t *testing.T) {
 // validation; without this test a future handler-side allowlist change
 // could silently reject nightly while SetConfig still accepts it.
 func TestHandlePutUpdateConfig_Nightly(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 
 	body := `{"channel":"nightly","auto_check":false}`
@@ -270,6 +273,7 @@ func TestHandlePutUpdateConfig_NegativeInterval(t *testing.T) {
 }
 
 func TestHandlePutUpdateConfig_Invalid(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 
 	body := `{"channel":"bogus","auto_check":false}`
@@ -286,6 +290,7 @@ func TestHandlePutUpdateConfig_Invalid(t *testing.T) {
 }
 
 func TestHandleGetUpdateStatus_Idle(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/updates/status", nil)
@@ -349,6 +354,7 @@ func TestHandleGetUpdateStatus_Idle(t *testing.T) {
 }
 
 func TestHandlePostUpdateApply_Docker(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 	// Replace the updater service with a Docker-mode one.
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -378,6 +384,7 @@ func TestHandlePostUpdateApply_Docker(t *testing.T) {
 // first apply goroutine in flight (so applyRunning stays set) while the second
 // call races through the CAS and returns the sentinel.
 func TestHandlePostUpdateApply_AlreadyRunning(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 
 	block := make(chan struct{})
@@ -437,6 +444,7 @@ func TestHandlePostUpdateApply_AlreadyRunning(t *testing.T) {
 // has staged a binary, a subsequent request returns 409 with the
 // restart-required error message rather than re-running the download path.
 func TestHandlePostUpdateApply_RestartRequired(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 	r.updaterService.MarkRestartRequiredForTest("v9.9.9")
 
@@ -461,6 +469,7 @@ func TestHandlePostUpdateApply_RestartRequired(t *testing.T) {
 }
 
 func TestHandlePostUpdateCheck_NoNetwork(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 
 	// Override the HTTP client with one that always fails.
@@ -486,6 +495,7 @@ func TestHandlePostUpdateCheck_NoNetwork(t *testing.T) {
 
 // TestHandlePutUpdateConfig_BadJSON verifies that malformed JSON returns 400.
 func TestHandlePutUpdateConfig_BadJSON(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/v1/updates/config",
@@ -502,6 +512,7 @@ func TestHandlePutUpdateConfig_BadJSON(t *testing.T) {
 
 // TestHandleGetUpdateStatus_ContentType verifies the response is JSON.
 func TestHandleGetUpdateStatus_ContentType(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/updates/status", nil)
@@ -517,6 +528,7 @@ func TestHandleGetUpdateStatus_ContentType(t *testing.T) {
 
 // TestHandleNilUpdaterService verifies that nil updaterService returns 503 on all endpoints.
 func TestHandleNilUpdaterService(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 	r.updaterService = nil
 
@@ -545,6 +557,7 @@ func TestHandleNilUpdaterService(t *testing.T) {
 // TestHandlePostUpdateApply_NonDocker verifies that a non-Docker, non-in-progress
 // apply starts successfully and the async goroutine settles before the test exits.
 func TestHandlePostUpdateApply_NonDocker(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 	// Make the updater's HTTP client immediately fail so the goroutine exits fast.
 	r.updaterService.SetHTTPClient(&http.Client{Transport: &alwaysFailTransport{}})
@@ -581,6 +594,7 @@ func TestHandlePostUpdateApply_NonDocker(t *testing.T) {
 
 // TestHandleCheckWithMockServer verifies the full check path with a mock GitHub server.
 func TestHandleCheckWithMockServer(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 
 	releases := []map[string]interface{}{
@@ -689,6 +703,7 @@ func TestHandleCheckWithMockServer(t *testing.T) {
 // when the channel has no builds, and /status must agree with /check for this
 // case so the UI cannot render a stale version after a channel switch.
 func TestHandleCheckWithMockServer_NoMatch(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 
 	// A prerelease-only fixture while the configured channel stays at stable
@@ -771,6 +786,7 @@ func TestHandleCheckWithMockServer_NoMatch(t *testing.T) {
 // TestBuildUpdatesTabData_NilService verifies that buildUpdatesTabData returns
 // sensible defaults when no updater service is wired in.
 func TestBuildUpdatesTabData_NilService(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 	r.updaterService = nil
 
@@ -790,6 +806,7 @@ func TestBuildUpdatesTabData_NilService(t *testing.T) {
 // TestBuildUpdatesTabData_WithService verifies that buildUpdatesTabData reads
 // config values from the updater service.
 func TestBuildUpdatesTabData_WithService(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 	ctx := context.Background()
 
@@ -817,6 +834,7 @@ func TestBuildUpdatesTabData_WithService(t *testing.T) {
 // directly; a future refactor that reintroduces a render-side allowlist must
 // keep nightly in it or this test fails.
 func TestBuildUpdatesTabData_NightlyChannel(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 	ctx := context.Background()
 
@@ -837,6 +855,7 @@ func TestBuildUpdatesTabData_NightlyChannel(t *testing.T) {
 // TestNormalizeSettingsSectionUpdates verifies that "updates" is a valid
 // settings section that routes to the updates tab.
 func TestNormalizeSettingsSectionUpdates(t *testing.T) {
+	t.Parallel()
 	got := normalizeSettingsSection("updates")
 	if got != "updates" {
 		t.Errorf("normalizeSettingsSection(\"updates\") = %q, want \"updates\"", got)
@@ -851,6 +870,7 @@ func TestNormalizeSettingsSectionUpdates(t *testing.T) {
 // dropped them from the JSON payload would silently make Apply look like
 // it did nothing again. Issue #1169.
 func TestHandleGetUpdateStatus_RestartRequiredSurfaced(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 
 	// Drive the in-memory flag to the post-Apply state without exercising
@@ -906,6 +926,7 @@ func TestHandleGetUpdateStatus_RestartRequiredSurfaced(t *testing.T) {
 // /status fetch to land), and is asserted as a unit because the templ
 // branch reads `data.RestartRequired` directly.
 func TestBuildUpdatesTabData_RestartRequired(t *testing.T) {
+	t.Parallel()
 	r := testRouterWithUpdater(t)
 	r.updaterService.MarkRestartRequiredForTest("v9.9.9")
 

--- a/internal/api/handlers_user_test.go
+++ b/internal/api/handlers_user_test.go
@@ -21,6 +21,7 @@ func withAdminCtx(req *http.Request, userID string) *http.Request {
 }
 
 func TestHandleRegister_Success(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 
 	// Create an invite as the admin.
@@ -68,6 +69,7 @@ func TestHandleRegister_Success(t *testing.T) {
 }
 
 func TestHandleRegister_RedeemedInvite(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 
 	// Create and use an invite.
@@ -108,6 +110,7 @@ func TestHandleRegister_RedeemedInvite(t *testing.T) {
 }
 
 func TestHandleDeactivateUser_BootstrapAdmin(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 
 	// Create a second admin so the last-admin guard is not the reason for refusal.
@@ -137,6 +140,7 @@ func TestHandleDeactivateUser_BootstrapAdmin(t *testing.T) {
 }
 
 func TestHandleUpdateUser_InvalidRole(t *testing.T) {
+	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
 
 	body := `{"role":"superadmin"}`
@@ -161,6 +165,7 @@ func TestHandleUpdateUser_InvalidRole(t *testing.T) {
 }
 
 func TestHandleUpdateUser_ValidRole(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 
 	// Create a second admin to downgrade (the first is protected).
@@ -192,6 +197,7 @@ func TestHandleUpdateUser_ValidRole(t *testing.T) {
 }
 
 func TestHandleUpdateUser_BootstrapAdmin(t *testing.T) {
+	t.Parallel()
 	r, authSvc, adminID := testRouterWithAuth(t)
 
 	// Create a second admin so the last-admin guard is not the reason for refusal.

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -39,6 +39,7 @@ func (m *mockAuthProvider) GetUserRole(ctx context.Context, userID string) (stri
 // --- Auth middleware tests ---
 
 func TestAuth_ValidSession(t *testing.T) {
+	t.Parallel()
 	mock := &mockAuthProvider{
 		validateSessionFn: func(_ context.Context, token string) (string, error) {
 			if token == "valid-session" {
@@ -82,6 +83,7 @@ func TestAuth_ValidSession(t *testing.T) {
 }
 
 func TestAuth_ValidAPIToken(t *testing.T) {
+	t.Parallel()
 	mock := &mockAuthProvider{
 		validateAPITokenFn: func(_ context.Context, token string) (string, string, error) {
 			if token == "sw_valid123" {
@@ -129,6 +131,7 @@ func TestAuth_ValidAPIToken(t *testing.T) {
 }
 
 func TestAuth_InactiveUser_Session_Returns401(t *testing.T) {
+	t.Parallel()
 	mock := &mockAuthProvider{
 		validateSessionFn: func(_ context.Context, _ string) (string, error) {
 			return "user-inactive", nil
@@ -153,6 +156,7 @@ func TestAuth_InactiveUser_Session_Returns401(t *testing.T) {
 }
 
 func TestAuth_InactiveUser_APIToken_Returns401(t *testing.T) {
+	t.Parallel()
 	mock := &mockAuthProvider{
 		validateAPITokenFn: func(_ context.Context, _ string) (string, string, error) {
 			return "user-deactivated", "read", nil
@@ -177,6 +181,7 @@ func TestAuth_InactiveUser_APIToken_Returns401(t *testing.T) {
 }
 
 func TestAuth_GetUserRoleError_Session_Returns500(t *testing.T) {
+	t.Parallel()
 	mock := &mockAuthProvider{
 		validateSessionFn: func(_ context.Context, _ string) (string, error) {
 			return "user-1", nil
@@ -201,6 +206,7 @@ func TestAuth_GetUserRoleError_Session_Returns500(t *testing.T) {
 }
 
 func TestAuth_GetUserRoleError_APIToken_Returns500(t *testing.T) {
+	t.Parallel()
 	mock := &mockAuthProvider{
 		validateAPITokenFn: func(_ context.Context, _ string) (string, string, error) {
 			return "user-1", "read", nil
@@ -227,6 +233,7 @@ func TestAuth_GetUserRoleError_APIToken_Returns500(t *testing.T) {
 // --- OptionalAuth middleware tests ---
 
 func TestOptionalAuth_ValidSession(t *testing.T) {
+	t.Parallel()
 	mock := &mockAuthProvider{
 		validateSessionFn: func(_ context.Context, _ string) (string, error) {
 			return "user-1", nil
@@ -264,6 +271,7 @@ func TestOptionalAuth_ValidSession(t *testing.T) {
 }
 
 func TestOptionalAuth_InactiveUser_ContinuesUnauthenticated(t *testing.T) {
+	t.Parallel()
 	mock := &mockAuthProvider{
 		validateSessionFn: func(_ context.Context, _ string) (string, error) {
 			return "user-inactive", nil
@@ -299,6 +307,7 @@ func TestOptionalAuth_InactiveUser_ContinuesUnauthenticated(t *testing.T) {
 }
 
 func TestOptionalAuth_GetUserRoleError_ContinuesUnauthenticated(t *testing.T) {
+	t.Parallel()
 	mock := &mockAuthProvider{
 		validateAPITokenFn: func(_ context.Context, _ string) (string, string, error) {
 			return "user-1", "read", nil
@@ -334,6 +343,7 @@ func TestOptionalAuth_GetUserRoleError_ContinuesUnauthenticated(t *testing.T) {
 }
 
 func TestOptionalAuth_NoToken_ContinuesUnauthenticated(t *testing.T) {
+	t.Parallel()
 	mock := &mockAuthProvider{}
 
 	called := false
@@ -356,6 +366,7 @@ func TestOptionalAuth_NoToken_ContinuesUnauthenticated(t *testing.T) {
 
 // TestExtractToken verifies token extraction from cookie, header, and query.
 func TestExtractToken_Cookie(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest("GET", "/", nil)
 	req.AddCookie(&http.Cookie{Name: "session", Value: "session-abc"})
 
@@ -366,6 +377,7 @@ func TestExtractToken_Cookie(t *testing.T) {
 }
 
 func TestExtractToken_BearerHeader(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Authorization", "Bearer sw_testtoken123")
 
@@ -376,6 +388,7 @@ func TestExtractToken_BearerHeader(t *testing.T) {
 }
 
 func TestExtractToken_QueryParam(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest("GET", "/?apikey=qp-token", nil)
 
 	got := extractToken(req)
@@ -385,6 +398,7 @@ func TestExtractToken_QueryParam(t *testing.T) {
 }
 
 func TestExtractToken_CookieTakesPrecedence(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest("GET", "/?apikey=qp-token", nil)
 	req.AddCookie(&http.Cookie{Name: "session", Value: "cookie-token"})
 	req.Header.Set("Authorization", "Bearer header-token")
@@ -396,6 +410,7 @@ func TestExtractToken_CookieTakesPrecedence(t *testing.T) {
 }
 
 func TestExtractToken_HeaderOverQuery(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest("GET", "/?apikey=qp-token", nil)
 	req.Header.Set("Authorization", "Bearer header-token")
 
@@ -406,6 +421,7 @@ func TestExtractToken_HeaderOverQuery(t *testing.T) {
 }
 
 func TestExtractToken_Empty(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest("GET", "/", nil)
 	got := extractToken(req)
 	if got != "" {
@@ -415,6 +431,7 @@ func TestExtractToken_Empty(t *testing.T) {
 
 // TestHasScope verifies scope checking logic.
 func TestHasScope_SessionHasAll(t *testing.T) {
+	t.Parallel()
 	ctx := context.WithValue(context.Background(), authMethodKey, "session")
 	if !HasScope(ctx, "write") {
 		t.Error("session auth should have all scopes")
@@ -422,6 +439,7 @@ func TestHasScope_SessionHasAll(t *testing.T) {
 }
 
 func TestHasScope_APITokenWithMatchingScope(t *testing.T) {
+	t.Parallel()
 	ctx := context.WithValue(context.Background(), authMethodKey, "api_token")
 	ctx = context.WithValue(ctx, tokenScopesKey, "read,write")
 	if !HasScope(ctx, "write") {
@@ -430,6 +448,7 @@ func TestHasScope_APITokenWithMatchingScope(t *testing.T) {
 }
 
 func TestHasScope_APITokenMissingScope(t *testing.T) {
+	t.Parallel()
 	ctx := context.WithValue(context.Background(), authMethodKey, "api_token")
 	ctx = context.WithValue(ctx, tokenScopesKey, "read")
 	if HasScope(ctx, "write") {
@@ -438,6 +457,7 @@ func TestHasScope_APITokenMissingScope(t *testing.T) {
 }
 
 func TestHasScope_AdminGrantsAll(t *testing.T) {
+	t.Parallel()
 	ctx := context.WithValue(context.Background(), authMethodKey, "api_token")
 	ctx = context.WithValue(ctx, tokenScopesKey, "admin")
 	if !HasScope(ctx, "write") {
@@ -446,6 +466,7 @@ func TestHasScope_AdminGrantsAll(t *testing.T) {
 }
 
 func TestHasScope_NoAuth(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	if HasScope(ctx, "read") {
 		t.Error("no auth context should not have any scope")
@@ -454,6 +475,7 @@ func TestHasScope_NoAuth(t *testing.T) {
 
 // TestRequireScope verifies the scope middleware returns 403 on missing scope.
 func TestRequireScope_Forbidden(t *testing.T) {
+	t.Parallel()
 	called := false
 	handler := RequireScope("write")(func(w http.ResponseWriter, r *http.Request) {
 		called = true
@@ -480,6 +502,7 @@ func TestRequireScope_Forbidden(t *testing.T) {
 }
 
 func TestRequireScope_Allowed(t *testing.T) {
+	t.Parallel()
 	handler := RequireScope("read")(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -498,6 +521,7 @@ func TestRequireScope_Allowed(t *testing.T) {
 
 // TestUserIDFromContext verifies user ID extraction.
 func TestUserIDFromContext(t *testing.T) {
+	t.Parallel()
 	ctx := context.WithValue(context.Background(), userIDKey, "user-123")
 	if got := UserIDFromContext(ctx); got != "user-123" {
 		t.Errorf("UserIDFromContext = %q, want user-123", got)
@@ -505,6 +529,7 @@ func TestUserIDFromContext(t *testing.T) {
 }
 
 func TestUserIDFromContext_Empty(t *testing.T) {
+	t.Parallel()
 	if got := UserIDFromContext(context.Background()); got != "" {
 		t.Errorf("UserIDFromContext(empty) = %q, want empty", got)
 	}

--- a/internal/api/middleware/csrf_test.go
+++ b/internal/api/middleware/csrf_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestCSRF_SafeMethodSetsToken(t *testing.T) {
+	t.Parallel()
 	csrf := NewCSRF()
 	handler := csrf.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -39,6 +40,7 @@ func TestCSRF_SafeMethodSetsToken(t *testing.T) {
 }
 
 func TestCSRF_UnsafeMethodWithoutToken(t *testing.T) {
+	t.Parallel()
 	csrf := NewCSRF()
 	handler := csrf.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -54,6 +56,7 @@ func TestCSRF_UnsafeMethodWithoutToken(t *testing.T) {
 }
 
 func TestCSRF_UnsafeMethodWithValidHeaderToken(t *testing.T) {
+	t.Parallel()
 	csrf := NewCSRF()
 	token := csrf.generate()
 
@@ -72,6 +75,7 @@ func TestCSRF_UnsafeMethodWithValidHeaderToken(t *testing.T) {
 }
 
 func TestCSRF_UnsafeMethodWithInvalidToken(t *testing.T) {
+	t.Parallel()
 	csrf := NewCSRF()
 	handler := csrf.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -88,6 +92,7 @@ func TestCSRF_UnsafeMethodWithInvalidToken(t *testing.T) {
 }
 
 func TestCSRF_ExistingValidCookieNotReplaced(t *testing.T) {
+	t.Parallel()
 	csrf := NewCSRF()
 	token := csrf.generate()
 
@@ -113,6 +118,7 @@ func TestCSRF_ExistingValidCookieNotReplaced(t *testing.T) {
 }
 
 func TestCSRF_HeadAndOptionsAreSafe(t *testing.T) {
+	t.Parallel()
 	csrf := NewCSRF()
 	handler := csrf.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestScrubQuery_RedactsSensitiveParams(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input string
 		want  string
@@ -31,6 +32,7 @@ func TestScrubQuery_RedactsSensitiveParams(t *testing.T) {
 }
 
 func TestScrubQuery_PreservesSafeParams(t *testing.T) {
+	t.Parallel()
 	input := "page=1&page_size=50&sort=name"
 	got := scrubQuery(input)
 	if got != input {
@@ -39,6 +41,7 @@ func TestScrubQuery_PreservesSafeParams(t *testing.T) {
 }
 
 func TestScrubQuery_Empty(t *testing.T) {
+	t.Parallel()
 	got := scrubQuery("")
 	if got != "" {
 		t.Errorf("scrubQuery(\"\") = %q, want empty", got)
@@ -46,6 +49,7 @@ func TestScrubQuery_Empty(t *testing.T) {
 }
 
 func TestScrubQuery_BareKeyNoEquals(t *testing.T) {
+	t.Parallel()
 	// A bare key with no = sign should pass through unchanged (len(kv) == 1).
 	// This verifies the function does not panic or misredact.
 	got := scrubQuery("apikey&page=1")
@@ -56,6 +60,7 @@ func TestScrubQuery_BareKeyNoEquals(t *testing.T) {
 }
 
 func TestScrubQuery_CaseInsensitive(t *testing.T) {
+	t.Parallel()
 	got := scrubQuery("API_KEY=secret&APIKEY=val")
 	want := "API_KEY=REDACTED&APIKEY=REDACTED"
 	if got != want {
@@ -64,6 +69,7 @@ func TestScrubQuery_CaseInsensitive(t *testing.T) {
 }
 
 func TestStatusWriter_ImplementsFlusher(t *testing.T) {
+	t.Parallel()
 	// statusWriter must implement http.Flusher so that the SSE handler can
 	// type-assert the wrapped writer. Without this the SSE endpoint returns 500.
 	rec := httptest.NewRecorder()
@@ -79,6 +85,7 @@ func TestStatusWriter_ImplementsFlusher(t *testing.T) {
 }
 
 func TestStatusWriter_Unwrap(t *testing.T) {
+	t.Parallel()
 	// Unwrap lets http.NewResponseController reach the underlying concrete
 	// writer for operations like SetWriteDeadline used by the SSE handler.
 	rec := httptest.NewRecorder()
@@ -89,6 +96,7 @@ func TestStatusWriter_Unwrap(t *testing.T) {
 }
 
 func TestLogging_LogLevels(t *testing.T) {
+	t.Parallel()
 	// Successful requests must be logged at DEBUG, 4xx at WARN, 5xx at ERROR.
 	tests := []struct {
 		status    int
@@ -128,6 +136,7 @@ func TestLogging_LogLevels(t *testing.T) {
 }
 
 func TestLogging_QuietPaths(t *testing.T) {
+	t.Parallel()
 	// Requests to quiet paths (/api/v1/logs, /static/) should not produce
 	// log output. This prevents self-referential noise from the log viewer
 	// polling endpoint and reduces static-asset log spam.

--- a/internal/api/middleware/ratelimit_test.go
+++ b/internal/api/middleware/ratelimit_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRateLimiter_AllowsBurst(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	rl := NewLoginRateLimiter(ctx)
@@ -30,6 +31,7 @@ func TestRateLimiter_AllowsBurst(t *testing.T) {
 }
 
 func TestRateLimiter_BlocksAfterBurst(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	rl := NewLoginRateLimiter(ctx)
@@ -58,6 +60,7 @@ func TestRateLimiter_BlocksAfterBurst(t *testing.T) {
 }
 
 func TestRateLimiter_DifferentIPsIndependent(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	rl := NewLoginRateLimiter(ctx)
@@ -86,12 +89,14 @@ func TestRateLimiter_DifferentIPsIndependent(t *testing.T) {
 }
 
 func TestRateLimiter_NilContext(t *testing.T) {
+	t.Parallel()
 	// Should not panic with nil context
 	rl := NewLoginRateLimiter(nil) //nolint:staticcheck // SA1012: testing nil context defense
 	_ = rl
 }
 
 func TestClientIP_DirectConnection(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.RemoteAddr = "203.0.113.5:1234"
 
@@ -102,6 +107,7 @@ func TestClientIP_DirectConnection(t *testing.T) {
 }
 
 func TestClientIP_XFFFromPrivateProxy(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.RemoteAddr = "127.0.0.1:1234"
 	req.Header.Set("X-Forwarded-For", "203.0.113.10, 10.0.0.1")
@@ -114,6 +120,7 @@ func TestClientIP_XFFFromPrivateProxy(t *testing.T) {
 }
 
 func TestClientIP_XFFIgnoredFromPublicIP(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.RemoteAddr = "203.0.113.5:1234"
 	req.Header.Set("X-Forwarded-For", "198.51.100.1")
@@ -126,6 +133,7 @@ func TestClientIP_XFFIgnoredFromPublicIP(t *testing.T) {
 }
 
 func TestClientIP_XRealIPFromPrivateProxy(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.RemoteAddr = "192.168.1.1:1234"
 	req.Header.Set("X-Real-Ip", "203.0.113.20")
@@ -137,6 +145,7 @@ func TestClientIP_XRealIPFromPrivateProxy(t *testing.T) {
 }
 
 func TestIsPrivateIP(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		ip   string
 		want bool

--- a/internal/api/middleware/role_test.go
+++ b/internal/api/middleware/role_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRequireAdminAllows(t *testing.T) {
+	t.Parallel()
 	handler := RequireAdmin(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -25,6 +26,7 @@ func TestRequireAdminAllows(t *testing.T) {
 }
 
 func TestRequireAdminBlocksOperator(t *testing.T) {
+	t.Parallel()
 	handler := RequireAdmin(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -42,6 +44,7 @@ func TestRequireAdminBlocksOperator(t *testing.T) {
 }
 
 func TestRequireAdminBlocksNoRole(t *testing.T) {
+	t.Parallel()
 	handler := RequireAdmin(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -56,6 +59,7 @@ func TestRequireAdminBlocksNoRole(t *testing.T) {
 }
 
 func TestRoleFromContext(t *testing.T) {
+	t.Parallel()
 	ctx := context.WithValue(context.Background(), userRoleKey, "operator")
 	if got := RoleFromContext(ctx); got != "operator" {
 		t.Errorf("RoleFromContext() = %q, want %q", got, "operator")
@@ -63,6 +67,7 @@ func TestRoleFromContext(t *testing.T) {
 }
 
 func TestRoleFromContextEmpty(t *testing.T) {
+	t.Parallel()
 	if got := RoleFromContext(context.Background()); got != "" {
 		t.Errorf("RoleFromContext() = %q, want empty", got)
 	}

--- a/internal/api/middleware/security_test.go
+++ b/internal/api/middleware/security_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestSecurityHeaders_Present(t *testing.T) {
+	t.Parallel()
 	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -32,6 +33,7 @@ func TestSecurityHeaders_Present(t *testing.T) {
 }
 
 func TestSecurityHeaders_NoHSTSOverHTTP(t *testing.T) {
+	t.Parallel()
 	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -46,6 +48,7 @@ func TestSecurityHeaders_NoHSTSOverHTTP(t *testing.T) {
 }
 
 func TestSecurityHeaders_HSTSOverForwardedHTTPS(t *testing.T) {
+	t.Parallel()
 	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -65,6 +68,7 @@ func TestSecurityHeaders_HSTSOverForwardedHTTPS(t *testing.T) {
 }
 
 func TestSecurityHeaders_CSPPresent(t *testing.T) {
+	t.Parallel()
 	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -94,6 +98,7 @@ func TestSecurityHeaders_CSPPresent(t *testing.T) {
 }
 
 func TestSecurityHeaders_PassesThrough(t *testing.T) {
+	t.Parallel()
 	called := false
 	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true

--- a/internal/api/openapi_test.go
+++ b/internal/api/openapi_test.go
@@ -28,6 +28,7 @@ import (
 //     positives from route-mapping complexity but may miss cases where a
 //     field exists in the wrong schema.
 func TestOpenAPIConsistency(t *testing.T) {
+	t.Parallel()
 	specFields, err := collectSpecFields("openapi.yaml")
 	if err != nil {
 		t.Fatalf("parsing openapi.yaml: %v", err)

--- a/internal/api/params_test.go
+++ b/internal/api/params_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestRequirePathParam_Present(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/artists/abc123", nil)
 	req.SetPathValue("id", "abc123")
 	w := httptest.NewRecorder()
@@ -26,6 +27,7 @@ func TestRequirePathParam_Present(t *testing.T) {
 }
 
 func TestRequirePathParam_Missing(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/artists/", nil)
 	w := httptest.NewRecorder()
 
@@ -46,6 +48,7 @@ func TestRequirePathParam_Missing(t *testing.T) {
 }
 
 func TestDecodeJSON_Valid(t *testing.T) {
+	t.Parallel()
 	type payload struct {
 		Name string `json:"name"`
 	}
@@ -62,6 +65,7 @@ func TestDecodeJSON_Valid(t *testing.T) {
 }
 
 func TestDecodeJSON_Invalid(t *testing.T) {
+	t.Parallel()
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`not-json`))
 	w := httptest.NewRecorder()
 

--- a/internal/api/pprof_test.go
+++ b/internal/api/pprof_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestRegisterPprof_ShutdownOnContextCancel(t *testing.T) {
-	t.Parallel()
 	// Reset the sync.Once so this test can call registerPprof independently.
 	// This test must NOT use t.Parallel -- the pprofOnce reset and the
 	// hard-coded port 6060 require serial execution.

--- a/internal/api/pprof_test.go
+++ b/internal/api/pprof_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestRegisterPprof_ShutdownOnContextCancel(t *testing.T) {
+	t.Parallel()
 	// Reset the sync.Once so this test can call registerPprof independently.
 	// This test must NOT use t.Parallel -- the pprofOnce reset and the
 	// hard-coded port 6060 require serial execution.

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -12,6 +12,7 @@ import (
 // patterns overlap ambiguously (e.g. "/{id}/dismiss" vs "/undo/{undoId}").
 // This test catches such conflicts at CI time instead of at startup.
 func TestRouterRegistration(t *testing.T) {
+	t.Parallel()
 	r := testRouterForOnboarding(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -30,6 +31,7 @@ func TestRouterRegistration(t *testing.T) {
 // page, not on a separate route). It also verifies the redirect respects
 // base_path and that API routes under /api/v1/notifications are unaffected.
 func TestNotificationsPageRedirect(t *testing.T) {
+	t.Parallel()
 	// Helper: create a user session so requests pass auth middleware.
 	setupSession := func(t *testing.T, r *Router) *http.Cookie {
 		t.Helper()

--- a/internal/api/static_test.go
+++ b/internal/api/static_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestStaticAssets_Path(t *testing.T) {
+	t.Parallel()
 	fsys := fstest.MapFS{
 		"css/styles.css": &fstest.MapFile{Data: []byte("body{}")},
 		"js/htmx.min.js": &fstest.MapFile{Data: []byte("htmx")},
@@ -38,6 +39,7 @@ func TestStaticAssets_Path(t *testing.T) {
 }
 
 func TestStaticAssets_Handler(t *testing.T) {
+	t.Parallel()
 	fsys := fstest.MapFS{
 		"css/styles.css": &fstest.MapFile{Data: []byte("body{}")},
 	}
@@ -92,6 +94,7 @@ func TestStaticAssets_Handler(t *testing.T) {
 }
 
 func TestStaticAssets_DirFS(t *testing.T) {
+	t.Parallel()
 	// Verify StaticAssets works with an on-disk fs.FS rooted at web/static.
 	// This test uses os.DirFS, not the production embedded filesystem.
 	fsys := os.DirFS("../../web/static")
@@ -131,6 +134,7 @@ func TestStaticAssets_DirFS(t *testing.T) {
 }
 
 func TestStaticAssets_NilFS(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Fatal("expected panic for nil fsys")
@@ -141,6 +145,7 @@ func TestStaticAssets_NilFS(t *testing.T) {
 }
 
 func TestStaticAssets_WithBasePath(t *testing.T) {
+	t.Parallel()
 	fsys := fstest.MapFS{
 		"css/styles.css": &fstest.MapFile{Data: []byte("body{}")},
 	}
@@ -164,6 +169,7 @@ func TestStaticAssets_WithBasePath(t *testing.T) {
 // TestStaticAssetsHandlerStripPrefix verifies that the Handler correctly strips
 // the base path prefix when serving files across multiple base path configurations.
 func TestStaticAssetsHandlerStripPrefix(t *testing.T) {
+	t.Parallel()
 	basePaths := []string{"", "/stillwater", "/foo/bar"}
 	for _, bp := range basePaths {
 		t.Run("basePath="+bp, func(t *testing.T) {

--- a/internal/artist/albums_test.go
+++ b/internal/artist/albums_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestListLocalAlbums(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	// Create some album directories.
@@ -34,6 +35,7 @@ func TestListLocalAlbums(t *testing.T) {
 }
 
 func TestListLocalAlbums_NonexistentPath(t *testing.T) {
+	t.Parallel()
 	albums := ListLocalAlbums("/nonexistent/path/12345")
 	if albums != nil {
 		t.Errorf("expected nil for nonexistent path, got %v", albums)
@@ -41,6 +43,7 @@ func TestListLocalAlbums_NonexistentPath(t *testing.T) {
 }
 
 func TestNormalizeAlbumName(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		input string
 		want  string
@@ -65,6 +68,7 @@ func TestNormalizeAlbumName(t *testing.T) {
 }
 
 func TestCompareAlbums(t *testing.T) {
+	t.Parallel()
 	local := []string{"OK Computer", "The Bends", "Kid A", "Live at Glastonbury"}
 	remote := []string{"ok computer", "The Bends", "Kid A (Deluxe Edition)", "Pablo Honey", "Amnesiac"}
 
@@ -91,6 +95,7 @@ func TestCompareAlbums(t *testing.T) {
 }
 
 func TestCompareAlbums_Empty(t *testing.T) {
+	t.Parallel()
 	comp := CompareAlbums(nil, nil)
 	if comp.MatchCount != 0 || comp.MatchPercent != 0 {
 		t.Errorf("expected zero values for empty inputs, got match=%d pct=%d",
@@ -99,6 +104,7 @@ func TestCompareAlbums_Empty(t *testing.T) {
 }
 
 func TestCompareAlbums_AllMatch(t *testing.T) {
+	t.Parallel()
 	local := []string{"Album One", "Album Two"}
 	remote := []string{"album one", "Album Two"}
 
@@ -112,6 +118,7 @@ func TestCompareAlbums_AllMatch(t *testing.T) {
 }
 
 func TestCompareAlbums_NoMatch(t *testing.T) {
+	t.Parallel()
 	local := []string{"Album X", "Album Y"}
 	remote := []string{"Album A", "Album B"}
 

--- a/internal/artist/alias_test.go
+++ b/internal/artist/alias_test.go
@@ -36,6 +36,7 @@ func createTestArtist(t *testing.T, svc *Service, name string) *Artist {
 }
 
 func TestAddAlias(t *testing.T) {
+	t.Parallel()
 	svc := setupAliasTest(t)
 	ctx := context.Background()
 	artist := createTestArtist(t, svc, "Radiohead")
@@ -53,6 +54,7 @@ func TestAddAlias(t *testing.T) {
 }
 
 func TestAddAlias_EmptyAlias(t *testing.T) {
+	t.Parallel()
 	svc := setupAliasTest(t)
 	ctx := context.Background()
 	artist := createTestArtist(t, svc, "Radiohead")
@@ -64,6 +66,7 @@ func TestAddAlias_EmptyAlias(t *testing.T) {
 }
 
 func TestAddAlias_ArtistNotFound(t *testing.T) {
+	t.Parallel()
 	svc := setupAliasTest(t)
 	_, err := svc.AddAlias(context.Background(), "nonexistent", "alias", "manual")
 	if err == nil {
@@ -72,6 +75,7 @@ func TestAddAlias_ArtistNotFound(t *testing.T) {
 }
 
 func TestListAliases(t *testing.T) {
+	t.Parallel()
 	svc := setupAliasTest(t)
 	ctx := context.Background()
 	artist := createTestArtist(t, svc, "Radiohead")
@@ -89,6 +93,7 @@ func TestListAliases(t *testing.T) {
 }
 
 func TestRemoveAlias(t *testing.T) {
+	t.Parallel()
 	svc := setupAliasTest(t)
 	ctx := context.Background()
 	artist := createTestArtist(t, svc, "Radiohead")
@@ -105,6 +110,7 @@ func TestRemoveAlias(t *testing.T) {
 }
 
 func TestRemoveAlias_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := setupAliasTest(t)
 	if err := svc.RemoveAlias(context.Background(), "nonexistent"); err == nil {
 		t.Error("expected error for nonexistent alias")
@@ -112,6 +118,7 @@ func TestRemoveAlias_NotFound(t *testing.T) {
 }
 
 func TestSearchWithAliases(t *testing.T) {
+	t.Parallel()
 	svc := setupAliasTest(t)
 	ctx := context.Background()
 
@@ -144,6 +151,7 @@ func TestSearchWithAliases(t *testing.T) {
 }
 
 func TestFindDuplicates_SharedMBID(t *testing.T) {
+	t.Parallel()
 	svc := setupAliasTest(t)
 	ctx := context.Background()
 
@@ -172,6 +180,7 @@ func TestFindDuplicates_SharedMBID(t *testing.T) {
 }
 
 func TestFindDuplicates_SharedAlias(t *testing.T) {
+	t.Parallel()
 	svc := setupAliasTest(t)
 	ctx := context.Background()
 

--- a/internal/artist/completeness_test.go
+++ b/internal/artist/completeness_test.go
@@ -6,6 +6,7 @@ import (
 
 // TestBuildCompletenessReport_Empty verifies the report structure when there are no artists.
 func TestBuildCompletenessReport_Empty(t *testing.T) {
+	t.Parallel()
 	report := buildCompletenessReport(nil, nil)
 
 	if report.TotalArtists != 0 {
@@ -28,6 +29,7 @@ func TestBuildCompletenessReport_Empty(t *testing.T) {
 // TestBuildCompletenessReport_FullyCovered verifies that 100% coverage is computed
 // when all artists have all fields populated.
 func TestBuildCompletenessReport_FullyCovered(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		{
 			ID:        "1",
@@ -69,6 +71,7 @@ func TestBuildCompletenessReport_FullyCovered(t *testing.T) {
 
 // TestBuildCompletenessReport_NoCoverage verifies 0% coverage when all fields are empty.
 func TestBuildCompletenessReport_NoCoverage(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		{
 			ID:   "1",
@@ -93,6 +96,7 @@ func TestBuildCompletenessReport_NoCoverage(t *testing.T) {
 // TestBuildCompletenessReport_TypeAware verifies that type-specific fields are
 // only counted for applicable artist types.
 func TestBuildCompletenessReport_TypeAware(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		// Group artist: "Formed date" applies, "Born date" does not.
 		{ID: "1", Name: "The Band", Type: "group", Formed: "1985"},
@@ -143,6 +147,7 @@ func TestBuildCompletenessReport_TypeAware(t *testing.T) {
 // TestBuildCompletenessReport_OrchestraType verifies that orchestra artists are
 // treated like groups: "Formed date" applies but "Born date" does not.
 func TestBuildCompletenessReport_OrchestraType(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		// Orchestra: "Formed date" applies, "Born date" does not.
 		{ID: "1", Name: "Berlin Phil", Type: "orchestra", Formed: "1882"},
@@ -181,6 +186,7 @@ func TestBuildCompletenessReport_OrchestraType(t *testing.T) {
 // string are treated as groups for formed/born applicability: "Formed date"
 // applies but "Born date" does not.
 func TestBuildCompletenessReport_EmptyType(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		// Unknown type: empty string. The allFieldDefs rule treats "" like "group"
 		// for "Formed date" and excludes it from "Born date".
@@ -219,6 +225,7 @@ func TestBuildCompletenessReport_EmptyType(t *testing.T) {
 // like groups: "Formed date" and "Disbanded date" apply, "Born date" and
 // "Died date" do not.
 func TestBuildCompletenessReport_ChoirType(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		{ID: "1", Name: "City Choir", Type: "choir", Formed: "1920"},
 	}
@@ -270,6 +277,7 @@ func TestBuildCompletenessReport_ChoirType(t *testing.T) {
 // TestBuildCompletenessReport_SoloType verifies that solo artists get "Born date"
 // and "Died date" counted, not "Formed date" or "Disbanded date".
 func TestBuildCompletenessReport_SoloType(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		{ID: "1", Name: "Solo Singer", Type: "solo", Born: "1975", Died: "2020"},
 	}
@@ -321,6 +329,7 @@ func TestBuildCompletenessReport_SoloType(t *testing.T) {
 // TestBuildCompletenessReport_CharacterType verifies that character artists get
 // "Born date" and "Died date" counted, not "Formed date" or "Disbanded date".
 func TestBuildCompletenessReport_CharacterType(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		{ID: "1", Name: "Fictional Character", Type: "character", Born: "1800"},
 	}
@@ -364,6 +373,7 @@ func TestBuildCompletenessReport_CharacterType(t *testing.T) {
 // TestBuildCompletenessReport_DisbandedDateGroup verifies that Disbanded date
 // is tracked for group artists.
 func TestBuildCompletenessReport_DisbandedDateGroup(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		{ID: "1", Name: "Disbanded Band", Type: "group", Formed: "1980", Disbanded: "1995"},
 		{ID: "2", Name: "Active Band", Type: "group", Formed: "2000"},
@@ -396,6 +406,7 @@ func TestBuildCompletenessReport_DisbandedDateGroup(t *testing.T) {
 // TestBuildCompletenessReport_DiedDatePerson verifies that Died date
 // is tracked for person artists.
 func TestBuildCompletenessReport_DiedDatePerson(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		{ID: "1", Name: "Deceased Artist", Type: "person", Born: "1900", Died: "1980"},
 		{ID: "2", Name: "Living Artist", Type: "person", Born: "1970"},
@@ -428,6 +439,7 @@ func TestBuildCompletenessReport_DiedDatePerson(t *testing.T) {
 // TestBuildCompletenessReport_LibraryCoverage verifies that per-library
 // breakdown is populated when more than one library is present.
 func TestBuildCompletenessReport_LibraryCoverage(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		{ID: "1", Name: "Artist A", Type: "group", LibraryID: "lib-a", Biography: "Bio"},
 		{ID: "2", Name: "Artist B", Type: "group", LibraryID: "lib-a"},
@@ -474,6 +486,7 @@ func TestBuildCompletenessReport_LibraryCoverage(t *testing.T) {
 // TestBuildCompletenessReport_LibraryCoverage_SingleLibrary verifies that
 // LibraryCoverage is nil when all artists belong to the same library.
 func TestBuildCompletenessReport_LibraryCoverage_SingleLibrary(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		{ID: "1", Name: "Artist A", Type: "group", LibraryID: "lib-a"},
 		{ID: "2", Name: "Artist B", Type: "group", LibraryID: "lib-a"},
@@ -488,6 +501,7 @@ func TestBuildCompletenessReport_LibraryCoverage_SingleLibrary(t *testing.T) {
 // TestBuildCompletenessReport_LibraryCoverage_UnknownLibraryID verifies that a
 // library ID with no name entry in the map falls back to the ID itself.
 func TestBuildCompletenessReport_LibraryCoverage_UnknownLibraryID(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		{ID: "1", Name: "Artist A", Type: "group", LibraryID: "lib-x"},
 		{ID: "2", Name: "Artist B", Type: "group", LibraryID: "lib-y"},
@@ -505,6 +519,7 @@ func TestBuildCompletenessReport_LibraryCoverage_UnknownLibraryID(t *testing.T) 
 // TestBuildCompletenessReport_PartialCoverage verifies correct percentage calculation
 // with a mix of populated and missing fields.
 func TestBuildCompletenessReport_PartialCoverage(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		{ID: "1", Name: "Artist A", Type: "group", Biography: "Bio A", NFOExists: true},
 		{ID: "2", Name: "Artist B", Type: "group"}, // no bio, no NFO
@@ -551,6 +566,7 @@ func TestBuildCompletenessReport_PartialCoverage(t *testing.T) {
 // TestBuildCompletenessReport_SortedAscending verifies that FieldCoverage is
 // sorted by percentage ascending (lowest coverage first).
 func TestBuildCompletenessReport_SortedAscending(t *testing.T) {
+	t.Parallel()
 	// Two artists: one with biography, one without. No other fields populated.
 	// Biography should have 50% coverage; all others 0%.
 	rows := []CompletenessRow{
@@ -571,6 +587,7 @@ func TestBuildCompletenessReport_SortedAscending(t *testing.T) {
 // TestBuildCompletenessReport_OverallScore verifies the overall score is the mean
 // field-coverage across all applicable pairs.
 func TestBuildCompletenessReport_OverallScore(t *testing.T) {
+	t.Parallel()
 	// Single artist, group type. Universal fields + Formed and Disbanded date
 	// are applicable. Born date, Died date are not applicable for groups.
 	// The exact count is not asserted here; the test verifies the formula.
@@ -607,6 +624,7 @@ func TestBuildCompletenessReport_OverallScore(t *testing.T) {
 // TestBuildCompletenessReport_LowestCompleteness verifies that the lowest
 // completeness list is passed through unchanged.
 func TestBuildCompletenessReport_LowestCompleteness(t *testing.T) {
+	t.Parallel()
 	lowest := []LowestCompletenessArtist{
 		{ID: "3", Name: "Worst Artist", HealthScore: 10},
 		{ID: "4", Name: "Bad Artist", HealthScore: 25},
@@ -628,6 +646,7 @@ func TestBuildCompletenessReport_LowestCompleteness(t *testing.T) {
 
 // TestRoundOneDecimal verifies rounding behavior.
 func TestRoundOneDecimal(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input float64
 		want  float64
@@ -649,6 +668,7 @@ func TestRoundOneDecimal(t *testing.T) {
 
 // TestSortFieldCoverageAsc verifies the sort is stable and ascending.
 func TestSortFieldCoverageAsc(t *testing.T) {
+	t.Parallel()
 	coverage := []FieldCoverage{
 		{Field: "C", Percentage: 75.0},
 		{Field: "A", Percentage: 25.0},
@@ -675,6 +695,7 @@ func TestSortFieldCoverageAsc(t *testing.T) {
 // TestBuildCompletenessReport_GenresEmpty verifies that the empty JSON array "[]"
 // and the empty string are both treated as missing genres.
 func TestBuildCompletenessReport_GenresEmpty(t *testing.T) {
+	t.Parallel()
 	rows := []CompletenessRow{
 		{ID: "1", Name: "A", Type: "group", Genres: "[]"},
 		{ID: "2", Name: "B", Type: "group", Genres: ""},

--- a/internal/artist/count_test.go
+++ b/internal/artist/count_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestCount_NoArtists(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -20,6 +21,7 @@ func TestCount_NoArtists(t *testing.T) {
 }
 
 func TestCount_AllArtists(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -41,6 +43,7 @@ func TestCount_AllArtists(t *testing.T) {
 }
 
 func TestCount_WithLibraryFilter(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -68,6 +71,7 @@ func TestCount_WithLibraryFilter(t *testing.T) {
 }
 
 func TestCount_WithSearchQuery(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -89,6 +93,7 @@ func TestCount_WithSearchQuery(t *testing.T) {
 }
 
 func TestCount_WithExcludedFilter(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -124,6 +129,7 @@ func TestCount_WithExcludedFilter(t *testing.T) {
 }
 
 func TestCount_ConsistentWithList(t *testing.T) {
+	t.Parallel()
 	// Verify that Count returns the same total as List for several filter
 	// shapes. This catches drift between buildWhereClause and toListParams.
 	db := setupTestDB(t)

--- a/internal/artist/disambiguation_test.go
+++ b/internal/artist/disambiguation_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestSplitNameDisambiguation(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name       string
 		artist     *Artist

--- a/internal/artist/field_test.go
+++ b/internal/artist/field_test.go
@@ -8,6 +8,7 @@ import (
 // --- FieldValueFromArtist ---
 
 func TestFieldValueFromArtist_NewFields(t *testing.T) {
+	t.Parallel()
 	a := &Artist{
 		Name:           "Radiohead",
 		SortName:       "Radiohead",
@@ -46,6 +47,7 @@ func TestFieldValueFromArtist_NewFields(t *testing.T) {
 }
 
 func TestFieldValueFromArtist_UnknownField(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Name: "Test"}
 	got := FieldValueFromArtist(a, "nonexistent")
 	if got != "" {
@@ -56,6 +58,7 @@ func TestFieldValueFromArtist_UnknownField(t *testing.T) {
 // --- IsEditableField ---
 
 func TestIsEditableField_NewFields(t *testing.T) {
+	t.Parallel()
 	editable := []string{
 		"name", "sort_name", "disambiguation",
 		"musicbrainz_id", "audiodb_id", "discogs_id", "wikidata_id", "deezer_id",
@@ -80,6 +83,7 @@ func TestIsEditableField_NewFields(t *testing.T) {
 // --- IsProviderIDField ---
 
 func TestIsProviderIDField(t *testing.T) {
+	t.Parallel()
 	providerFields := []string{
 		"musicbrainz_id", "audiodb_id", "discogs_id", "wikidata_id", "deezer_id",
 	}
@@ -103,6 +107,7 @@ func TestIsProviderIDField(t *testing.T) {
 // --- ValidateFieldUpdate ---
 
 func TestValidateFieldUpdate(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		field   string
@@ -142,6 +147,7 @@ func TestValidateFieldUpdate(t *testing.T) {
 // --- isValidMBID ---
 
 func TestIsValidMBID(t *testing.T) {
+	t.Parallel()
 	valid := []string{
 		"a74b1b7f-71a5-4011-9441-d0b5e4122711",
 		"5b11f4ce-a62d-471e-81fc-a69a8278c7da",
@@ -171,6 +177,7 @@ func TestIsValidMBID(t *testing.T) {
 // --- UpdateProviderField / ClearProviderField ---
 
 func TestUpdateProviderField(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -211,6 +218,7 @@ func TestUpdateProviderField(t *testing.T) {
 }
 
 func TestClearProviderField(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -240,6 +248,7 @@ func TestClearProviderField(t *testing.T) {
 }
 
 func TestUpdateField_NameAndSortName(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()

--- a/internal/artist/history_test.go
+++ b/internal/artist/history_test.go
@@ -23,6 +23,7 @@ func setupHistoryTestDB(t *testing.T) *HistoryService {
 }
 
 func TestHistoryService_Record(t *testing.T) {
+	t.Parallel()
 	svc := setupHistoryTestDB(t)
 	ctx := context.Background()
 
@@ -110,6 +111,7 @@ func TestHistoryService_Record(t *testing.T) {
 }
 
 func TestHistoryService_List(t *testing.T) {
+	t.Parallel()
 	svc := setupHistoryTestDB(t)
 	ctx := context.Background()
 	artistID := "artist-pag"
@@ -242,6 +244,7 @@ func TestHistoryService_List(t *testing.T) {
 }
 
 func TestHistoryService_RecordPreservesTimestamp(t *testing.T) {
+	t.Parallel()
 	svc := setupHistoryTestDB(t)
 	ctx := context.Background()
 
@@ -265,6 +268,7 @@ func TestHistoryService_RecordPreservesTimestamp(t *testing.T) {
 }
 
 func TestHistoryService_GetByID(t *testing.T) {
+	t.Parallel()
 	svc := setupHistoryTestDB(t)
 	ctx := context.Background()
 
@@ -313,6 +317,7 @@ func TestHistoryService_GetByID(t *testing.T) {
 // via context, then fetches the resulting row by ID instead of doing a "most
 // recent revert for field X" lookup that races against concurrent writers.
 func TestHistoryService_RecordUsesContextHistoryID(t *testing.T) {
+	t.Parallel()
 	svc := setupHistoryTestDB(t)
 	preID := "00000000-0000-4000-8000-000000000abc"
 
@@ -353,6 +358,7 @@ func TestHistoryService_RecordUsesContextHistoryID(t *testing.T) {
 // real-world ordering. The query wraps both the WHERE bounds and the
 // ORDER BY in datetime() to normalise both representations.
 func TestHistoryService_ListGlobalOrderMixedTimestampFormats(t *testing.T) {
+	t.Parallel()
 	svc := setupHistoryTestDB(t)
 	ctx := context.Background()
 	db := svc.repo.(*sqliteHistoryRepo).db
@@ -404,6 +410,7 @@ func TestHistoryService_ListGlobalOrderMixedTimestampFormats(t *testing.T) {
 }
 
 func TestHistoryService_ListGlobal(t *testing.T) {
+	t.Parallel()
 	svc := setupHistoryTestDB(t)
 	ctx := context.Background()
 
@@ -628,6 +635,7 @@ func TestHistoryService_ListGlobal(t *testing.T) {
 }
 
 func TestIsTrackableField(t *testing.T) {
+	t.Parallel()
 	trackable := []string{"biography", "genres", "styles", "moods", "formed", "born", "disbanded", "died", "years_active", "type", "gender"}
 	for _, f := range trackable {
 		if !IsTrackableField(f) {

--- a/internal/artist/lock_test.go
+++ b/internal/artist/lock_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestLockAndUnlock(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -72,6 +73,7 @@ func TestLockAndUnlock(t *testing.T) {
 }
 
 func TestLockNotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -86,6 +88,7 @@ func TestLockNotFound(t *testing.T) {
 }
 
 func TestLockAlreadyLocked(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -106,6 +109,7 @@ func TestLockAlreadyLocked(t *testing.T) {
 }
 
 func TestUnlockNotLocked(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -123,6 +127,7 @@ func TestUnlockNotLocked(t *testing.T) {
 }
 
 func TestLockInvalidSource(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -142,6 +147,7 @@ func TestLockInvalidSource(t *testing.T) {
 }
 
 func TestLockImportedSource(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -165,6 +171,7 @@ func TestLockImportedSource(t *testing.T) {
 }
 
 func TestListFilterLocked(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -212,6 +219,7 @@ func TestListFilterLocked(t *testing.T) {
 }
 
 func TestLockPreservedOnUpdate(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -250,6 +258,7 @@ func TestLockPreservedOnUpdate(t *testing.T) {
 }
 
 func TestFieldLocks(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -315,6 +324,7 @@ func TestFieldLocks(t *testing.T) {
 }
 
 func TestImageLocks(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()

--- a/internal/artist/matcher_test.go
+++ b/internal/artist/matcher_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestMatchByMBID_Found(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -36,6 +37,7 @@ func TestMatchByMBID_Found(t *testing.T) {
 }
 
 func TestMatchByMBID_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -50,6 +52,7 @@ func TestMatchByMBID_NotFound(t *testing.T) {
 }
 
 func TestMatchByMBID_EmptyID(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -64,6 +67,7 @@ func TestMatchByMBID_EmptyID(t *testing.T) {
 }
 
 func TestMatchByID_MultipleProviders(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -106,6 +110,7 @@ func TestMatchByID_MultipleProviders(t *testing.T) {
 }
 
 func TestMatchByID_PriorityOrder(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -145,6 +150,7 @@ func TestMatchByID_PriorityOrder(t *testing.T) {
 }
 
 func TestMatchByID_NoIDs(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -159,6 +165,7 @@ func TestMatchByID_NoIDs(t *testing.T) {
 }
 
 func TestMatch_ConfidenceThreshold(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -195,6 +202,7 @@ func TestMatch_ConfidenceThreshold(t *testing.T) {
 }
 
 func TestMatch_AlwaysPromptStrategy(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()

--- a/internal/artist/mb_snapshot_test.go
+++ b/internal/artist/mb_snapshot_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestMBSnapshotRepo_UpsertAll_and_GetForArtist(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	repo := newSQLiteMBSnapshotRepo(db)
@@ -85,6 +86,7 @@ func TestMBSnapshotRepo_UpsertAll_and_GetForArtist(t *testing.T) {
 }
 
 func TestMBSnapshotRepo_DeleteByArtistID(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	repo := newSQLiteMBSnapshotRepo(db)
@@ -117,6 +119,7 @@ func TestMBSnapshotRepo_DeleteByArtistID(t *testing.T) {
 }
 
 func TestMBSnapshotRepo_GetForArtist_empty(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	repo := newSQLiteMBSnapshotRepo(db)
 	ctx := context.Background()

--- a/internal/artist/merge_test.go
+++ b/internal/artist/merge_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestIsIndividualType(t *testing.T) {
+	t.Parallel()
 	individual := []string{"solo", "person", "character"}
 	for _, typ := range individual {
 		if !IsIndividualType(typ) {
@@ -22,6 +23,7 @@ func TestIsIndividualType(t *testing.T) {
 }
 
 func TestApplyMetadata_NilUpdate(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Name: "Test"}
 	if ApplyMetadata(a, nil, FillEmpty, MergeOptions{}) {
 		t.Error("expected no change for nil update")
@@ -31,6 +33,7 @@ func TestApplyMetadata_NilUpdate(t *testing.T) {
 // --- OverwriteAttempted tests ---
 
 func TestOverwriteAttempted_OverwritesAttemptedFields(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Biography: "old bio", Born: "1970"}
 	u := &MetadataUpdate{Biography: "new bio", Born: "1980", Genres: []string{"rock"}}
 	changed := ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{
@@ -57,6 +60,7 @@ func TestOverwriteAttempted_OverwritesAttemptedFields(t *testing.T) {
 // the artist. PopulatedFields is the gate that distinguishes "we asked and got
 // nothing" (preserve) from "we asked and got data" (overwrite).
 func TestOverwriteAttempted_PreservesAttemptedButUnpopulatedFields(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Biography: "old bio", Genres: []string{"jazz"}}
 	u := &MetadataUpdate{} // attempted but no provider returned data
 	changed := ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{
@@ -75,6 +79,7 @@ func TestOverwriteAttempted_PreservesAttemptedButUnpopulatedFields(t *testing.T)
 }
 
 func TestOverwriteAttempted_PreservesUnattemptedFields(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Biography: "keep me", Born: "1970"}
 	u := &MetadataUpdate{Biography: "discard", Born: "discard"}
 	ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{
@@ -89,6 +94,7 @@ func TestOverwriteAttempted_PreservesUnattemptedFields(t *testing.T) {
 }
 
 func TestOverwriteAttempted_TypeGenderNeverCleared(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Type: "person", Gender: "male"}
 	u := &MetadataUpdate{Type: "", Gender: ""}
 	ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{
@@ -103,6 +109,7 @@ func TestOverwriteAttempted_TypeGenderNeverCleared(t *testing.T) {
 }
 
 func TestOverwriteAttempted_OriginNeverCleared(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Origin: "United Kingdom"}
 	u := &MetadataUpdate{Origin: ""}
 	ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{
@@ -120,6 +127,7 @@ func TestOverwriteAttempted_OriginNeverCleared(t *testing.T) {
 }
 
 func TestOverwriteAttempted_TypeGenderOverwriteWhenNonEmpty(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Type: "person", Gender: "male"}
 	u := &MetadataUpdate{Type: "group", Gender: "female"}
 	changed := ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{})
@@ -135,6 +143,7 @@ func TestOverwriteAttempted_TypeGenderOverwriteWhenNonEmpty(t *testing.T) {
 }
 
 func TestOverwriteAttempted_YearsActiveNonEmptyOnly(t *testing.T) {
+	t.Parallel()
 	a := &Artist{YearsActive: "1990-2000"}
 	u := &MetadataUpdate{YearsActive: ""}
 	ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{})
@@ -150,6 +159,7 @@ func TestOverwriteAttempted_YearsActiveNonEmptyOnly(t *testing.T) {
 }
 
 func TestOverwriteAttempted_ProviderIDsFillEmptyOnly(t *testing.T) {
+	t.Parallel()
 	a := &Artist{MusicBrainzID: "existing-mbid"}
 	u := &MetadataUpdate{
 		MusicBrainzID: "new-mbid",
@@ -172,6 +182,7 @@ func TestOverwriteAttempted_ProviderIDsFillEmptyOnly(t *testing.T) {
 }
 
 func TestOverwriteAttempted_SkipsNameSortName(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Name: "Original", SortName: "Original, The", Disambiguation: "UK"}
 	u := &MetadataUpdate{Name: "Changed", SortName: "Changed, The", Disambiguation: "US"}
 	ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{
@@ -194,6 +205,7 @@ func TestOverwriteAttempted_SkipsNameSortName(t *testing.T) {
 // TestOverwriteAttempted_DisambiguationNonEmptyOnly verifies that an empty
 // provider Disambiguation does NOT clear a populated local value.
 func TestOverwriteAttempted_DisambiguationNonEmptyOnly(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Disambiguation: "UK rock band"}
 	u := &MetadataUpdate{Disambiguation: ""}
 	ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{})
@@ -203,6 +215,7 @@ func TestOverwriteAttempted_DisambiguationNonEmptyOnly(t *testing.T) {
 }
 
 func TestOverwriteAttempted_FilterDatesByType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		artistType    string
@@ -245,6 +258,7 @@ func TestOverwriteAttempted_FilterDatesByType(t *testing.T) {
 }
 
 func TestOverwriteAttempted_Sources(t *testing.T) {
+	t.Parallel()
 	a := &Artist{}
 	u := &MetadataUpdate{Biography: "bio"}
 	ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{
@@ -273,6 +287,7 @@ func TestOverwriteAttempted_Sources(t *testing.T) {
 // preserved; an attempted-but-empty merge that wipes them violates #952's
 // graceful-fallback acceptance criterion.
 func TestOverwriteAttempted_GracefulFallbackPreservesExistingTags(t *testing.T) {
+	t.Parallel()
 	a := &Artist{
 		Biography: "existing biography",
 		Genres:    []string{"rock", "indie"},
@@ -306,6 +321,7 @@ func TestOverwriteAttempted_GracefulFallbackPreservesExistingTags(t *testing.T) 
 // mixed case: some fields had a provider returning data (overwrite), others
 // were queried with no data (preserve).
 func TestOverwriteAttempted_PartialPopulationOverwritesOnlyPopulated(t *testing.T) {
+	t.Parallel()
 	a := &Artist{
 		Biography: "existing biography",
 		Genres:    []string{"jazz"},
@@ -330,6 +346,7 @@ func TestOverwriteAttempted_PartialPopulationOverwritesOnlyPopulated(t *testing.
 }
 
 func TestOverwriteAttempted_AllAttemptedSliceFields(t *testing.T) {
+	t.Parallel()
 	a := &Artist{}
 	u := &MetadataUpdate{
 		Styles: []string{"blues"},
@@ -353,6 +370,7 @@ func TestOverwriteAttempted_AllAttemptedSliceFields(t *testing.T) {
 // --- FillEmpty tests ---
 
 func TestFillEmpty_OnlyFillsEmptyFields(t *testing.T) {
+	t.Parallel()
 	a := &Artist{
 		Type:          "person",
 		MusicBrainzID: "existing",
@@ -441,6 +459,7 @@ func TestFillEmpty_OnlyFillsEmptyFields(t *testing.T) {
 }
 
 func TestFillEmpty_SkipsNameSortNameDisambiguation(t *testing.T) {
+	t.Parallel()
 	a := &Artist{}
 	u := &MetadataUpdate{Name: "New", SortName: "New, The", Disambiguation: "UK"}
 	ApplyMetadata(a, u, FillEmpty, MergeOptions{})
@@ -456,6 +475,7 @@ func TestFillEmpty_SkipsNameSortNameDisambiguation(t *testing.T) {
 }
 
 func TestFillEmpty_ReturnsFalseWhenNothingChanged(t *testing.T) {
+	t.Parallel()
 	a := &Artist{
 		Type: "group", Gender: "mixed", MusicBrainzID: "mbid",
 		Biography: "bio", Genres: []string{"rock"}, Born: "1980",
@@ -472,6 +492,7 @@ func TestFillEmpty_ReturnsFalseWhenNothingChanged(t *testing.T) {
 // --- NFOImport tests ---
 
 func TestNFOImport_IdentityFieldsNonEmptyOverwrite(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Name: "Old Name", SortName: "Old", Biography: "old bio", MusicBrainzID: "old-mbid"}
 	u := &MetadataUpdate{Name: "New Name", SortName: "New", Biography: "new bio", MusicBrainzID: "new-mbid"}
 	changed := ApplyMetadata(a, u, NFOImport, MergeOptions{})
@@ -498,6 +519,7 @@ func TestNFOImport_IdentityFieldsNonEmptyOverwrite(t *testing.T) {
 }
 
 func TestNFOImport_ProviderIDsNonEmptyOverwrite(t *testing.T) {
+	t.Parallel()
 	a := &Artist{DiscogsID: "old-discogs"}
 	u := &MetadataUpdate{
 		DiscogsID:  "new-discogs",
@@ -524,6 +546,7 @@ func TestNFOImport_ProviderIDsNonEmptyOverwrite(t *testing.T) {
 }
 
 func TestNFOImport_ProviderIDsPreservedWhenEmpty(t *testing.T) {
+	t.Parallel()
 	a := &Artist{MusicBrainzID: "existing-mbid", DiscogsID: "existing-discogs"}
 	u := &MetadataUpdate{} // all empty
 	ApplyMetadata(a, u, NFOImport, MergeOptions{})
@@ -536,6 +559,7 @@ func TestNFOImport_ProviderIDsPreservedWhenEmpty(t *testing.T) {
 }
 
 func TestNFOImport_ClassificationUnconditional(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Type: "person", Gender: "male", Disambiguation: "UK"}
 	u := &MetadataUpdate{Type: "", Gender: "", Disambiguation: ""}
 	changed := ApplyMetadata(a, u, NFOImport, MergeOptions{})
@@ -554,6 +578,7 @@ func TestNFOImport_ClassificationUnconditional(t *testing.T) {
 }
 
 func TestNFOImport_ListsAndDatesUnconditional(t *testing.T) {
+	t.Parallel()
 	a := &Artist{
 		Genres: []string{"rock"}, Styles: []string{"grunge"}, Moods: []string{"angry"},
 		Born: "1970", Formed: "1980", Died: "2020", Disbanded: "2000", YearsActive: "1980-2000",
@@ -577,6 +602,7 @@ func TestNFOImport_ListsAndDatesUnconditional(t *testing.T) {
 // --- SnapshotRestore tests ---
 
 func TestSnapshotRestore_AllFieldsUnconditional(t *testing.T) {
+	t.Parallel()
 	a := &Artist{
 		Name: "Old", SortName: "Old", Type: "person", Gender: "male",
 		Disambiguation: "UK", MusicBrainzID: "old-mbid", Biography: "old bio",
@@ -609,6 +635,7 @@ func TestSnapshotRestore_AllFieldsUnconditional(t *testing.T) {
 }
 
 func TestSnapshotRestore_PreservesNonMetadataFields(t *testing.T) {
+	t.Parallel()
 	a := &Artist{
 		ID: "test-id", Path: "/music/Test", LibraryID: "lib-1",
 		NFOExists: true, ThumbExists: true, HealthScore: 85.5,
@@ -635,6 +662,7 @@ func TestSnapshotRestore_PreservesNonMetadataFields(t *testing.T) {
 // --- Changed return value ---
 
 func TestApplyMetadata_ReturnsFalseWhenNoChange(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Name: "Same", Type: "group", Biography: "bio"}
 	u := &MetadataUpdate{Name: "Same", Type: "group", Biography: "bio"}
 	if ApplyMetadata(a, u, SnapshotRestore, MergeOptions{}) {
@@ -645,6 +673,7 @@ func TestApplyMetadata_ReturnsFalseWhenNoChange(t *testing.T) {
 // --- FilterDatesByArtistType ---
 
 func TestFilterDatesByArtistType(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name              string
 		artistType        string
@@ -683,6 +712,7 @@ func TestFilterDatesByArtistType(t *testing.T) {
 // --- FetchResultToUpdate ---
 
 func TestFetchResultToUpdate(t *testing.T) {
+	t.Parallel()
 	result := &provider.FetchResult{
 		Metadata: &provider.ArtistMetadata{
 			Name: "Test", SortName: "Test, The", Type: "group", Gender: "mixed",
@@ -717,6 +747,7 @@ func TestFetchResultToUpdate(t *testing.T) {
 }
 
 func TestFetchResultToUpdate_IndividualKeepsGender(t *testing.T) {
+	t.Parallel()
 	result := &provider.FetchResult{
 		Metadata: &provider.ArtistMetadata{
 			Name: "Solo Artist", Type: "solo", Gender: "female",
@@ -729,6 +760,7 @@ func TestFetchResultToUpdate_IndividualKeepsGender(t *testing.T) {
 }
 
 func TestFetchResultToUpdate_UnknownTypeKeepsGender(t *testing.T) {
+	t.Parallel()
 	result := &provider.FetchResult{
 		Metadata: &provider.ArtistMetadata{
 			Name: "Unknown", Type: "", Gender: "male",
@@ -741,6 +773,7 @@ func TestFetchResultToUpdate_UnknownTypeKeepsGender(t *testing.T) {
 }
 
 func TestFetchResultToUpdate_NilMetadata(t *testing.T) {
+	t.Parallel()
 	if FetchResultToUpdate(nil) != nil {
 		t.Error("expected nil for nil result")
 	}
@@ -752,6 +785,7 @@ func TestFetchResultToUpdate_NilMetadata(t *testing.T) {
 // --- LockedFields honored across strategies ---
 
 func TestApplyMetadata_OverwriteAttempted_SkipsLockedFields(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Biography: "keep me", Born: "1970", Genres: []string{"jazz"}}
 	u := &MetadataUpdate{Biography: "overwrite", Born: "1980", Genres: []string{"rock"}}
 	ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{
@@ -771,6 +805,7 @@ func TestApplyMetadata_OverwriteAttempted_SkipsLockedFields(t *testing.T) {
 }
 
 func TestApplyMetadata_OverwriteAttempted_LockedDisambiguationKept(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Disambiguation: "Seattle grunge"}
 	u := &MetadataUpdate{Disambiguation: "replaced"}
 	ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{
@@ -782,6 +817,7 @@ func TestApplyMetadata_OverwriteAttempted_LockedDisambiguationKept(t *testing.T)
 }
 
 func TestApplyMetadata_SnapshotRestore_SkipsLocked(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Name: "Pinned", Biography: "old"}
 	u := &MetadataUpdate{Name: "Snapshot", Biography: "restored"}
 	ApplyMetadata(a, u, SnapshotRestore, MergeOptions{
@@ -796,6 +832,7 @@ func TestApplyMetadata_SnapshotRestore_SkipsLocked(t *testing.T) {
 }
 
 func TestApplyMetadata_FillEmpty_SkipsLockedFields(t *testing.T) {
+	t.Parallel()
 	// Biography and Genres are intentionally empty so FillEmpty would
 	// populate them; the lock must prevent the write even on empty dst.
 	a := &Artist{Biography: "", Genres: nil, Type: ""}
@@ -815,6 +852,7 @@ func TestApplyMetadata_FillEmpty_SkipsLockedFields(t *testing.T) {
 }
 
 func TestApplyMetadata_NFOImport_SkipsLockedFields(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Name: "Pinned", Biography: "old", Genres: []string{"pinned-genre"}}
 	u := &MetadataUpdate{Name: "FromNFO", Biography: "nfo-bio", Genres: []string{"nfo-genre"}}
 	ApplyMetadata(a, u, NFOImport, MergeOptions{
@@ -835,6 +873,7 @@ func TestApplyMetadata_NFOImport_SkipsLockedFields(t *testing.T) {
 // entries in LockedFields never produce a map key that would match a lookup
 // for an empty field name.
 func TestBuildLockedSet_DropsBlankTokens(t *testing.T) {
+	t.Parallel()
 	if got := buildLockedSet(nil); got != nil {
 		t.Errorf("buildLockedSet(nil) = %v, want nil", got)
 	}
@@ -863,6 +902,7 @@ func TestBuildLockedSet_DropsBlankTokens(t *testing.T) {
 // pinned born="1970" on a group should see that date survive the merge AND
 // the post-merge type filter.
 func TestApplyMetadata_LockedDateSurvivesFilterByType(t *testing.T) {
+	t.Parallel()
 	a := &Artist{Type: "group", Born: "1970", Died: "2010"}
 	u := &MetadataUpdate{Type: "group", Born: "2020", Died: "2030"}
 	ApplyMetadata(a, u, OverwriteAttempted, MergeOptions{

--- a/internal/artist/model_test.go
+++ b/internal/artist/model_test.go
@@ -3,6 +3,7 @@ package artist
 import "testing"
 
 func TestMarshalStringSlice(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input []string
@@ -27,6 +28,7 @@ func TestMarshalStringSlice(t *testing.T) {
 }
 
 func TestUnmarshalStringSlice(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		input   string
@@ -54,6 +56,7 @@ func TestUnmarshalStringSlice(t *testing.T) {
 }
 
 func TestMarshalUnmarshalRoundTrip(t *testing.T) {
+	t.Parallel()
 	original := []string{"Rock", "Alternative", "Indie"}
 	marshaled := MarshalStringSlice(original)
 	result := UnmarshalStringSlice(marshaled)

--- a/internal/artist/params_test.go
+++ b/internal/artist/params_test.go
@@ -13,6 +13,7 @@ import (
 // truncation explicitly because a future "tighten cap" change should be a
 // deliberate decision, not silent slack.
 func TestListParams_Validate_CapsIDs(t *testing.T) {
+	t.Parallel()
 	ids := make([]string, MaxListIDs+5)
 	for i := range ids {
 		ids[i] = "id-" + strconv.Itoa(i)
@@ -31,6 +32,7 @@ func TestListParams_Validate_CapsIDs(t *testing.T) {
 // row whose primary key is the empty string. We assert the empty entries
 // are filtered out.
 func TestListParams_Validate_DropsEmptyIDs(t *testing.T) {
+	t.Parallel()
 	p := ListParams{IDs: []string{"a", "", "b", "", "c"}}
 	p.Validate()
 	want := []string{"a", "b", "c"}
@@ -51,6 +53,7 @@ func TestListParams_Validate_DropsEmptyIDs(t *testing.T) {
 // order is preserved so the chip text and the SQL bind order stay stable
 // across reloads.
 func TestListParams_Validate_DedupesIDs(t *testing.T) {
+	t.Parallel()
 	p := ListParams{IDs: []string{"a", "b", "a", "c", "b"}}
 	p.Validate()
 	want := []string{"a", "b", "c"}
@@ -69,6 +72,7 @@ func TestListParams_Validate_DedupesIDs(t *testing.T) {
 // existing caller takes today; a regression here would silently shift the
 // list query into "filter to nothing" via an empty IN-clause.
 func TestListParams_Validate_PreservesNilIDs(t *testing.T) {
+	t.Parallel()
 	p := ListParams{}
 	p.Validate()
 	// Identity check, not length: an empty non-nil slice would also pass

--- a/internal/artist/platform_ids_test.go
+++ b/internal/artist/platform_ids_test.go
@@ -40,6 +40,7 @@ func setupPlatformIDTest(t *testing.T) *Service {
 }
 
 func TestSetPlatformID(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformIDTest(t)
 	ctx := context.Background()
 	artist := createTestArtist(t, svc, "Radiohead")
@@ -59,6 +60,7 @@ func TestSetPlatformID(t *testing.T) {
 }
 
 func TestSetPlatformID_Upsert(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformIDTest(t)
 	ctx := context.Background()
 	artist := createTestArtist(t, svc, "Radiohead")
@@ -79,6 +81,7 @@ func TestSetPlatformID_Upsert(t *testing.T) {
 }
 
 func TestSetPlatformID_Validation(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformIDTest(t)
 	ctx := context.Background()
 
@@ -104,6 +107,7 @@ func TestSetPlatformID_Validation(t *testing.T) {
 }
 
 func TestGetPlatformID_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformIDTest(t)
 	ctx := context.Background()
 	artist := createTestArtist(t, svc, "Radiohead")
@@ -118,6 +122,7 @@ func TestGetPlatformID_NotFound(t *testing.T) {
 }
 
 func TestGetPlatformIDs(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformIDTest(t)
 	ctx := context.Background()
 	artist := createTestArtist(t, svc, "Radiohead")
@@ -146,6 +151,7 @@ func TestGetPlatformIDs(t *testing.T) {
 }
 
 func TestGetPlatformIDs_Empty(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformIDTest(t)
 	ctx := context.Background()
 	artist := createTestArtist(t, svc, "Radiohead")
@@ -160,6 +166,7 @@ func TestGetPlatformIDs_Empty(t *testing.T) {
 }
 
 func TestDeletePlatformID(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformIDTest(t)
 	ctx := context.Background()
 	artist := createTestArtist(t, svc, "Radiohead")
@@ -181,6 +188,7 @@ func TestDeletePlatformID(t *testing.T) {
 }
 
 func TestDeletePlatformID_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformIDTest(t)
 	ctx := context.Background()
 
@@ -194,6 +202,7 @@ func TestDeletePlatformID_NotFound(t *testing.T) {
 }
 
 func TestDeletePlatformIDsByArtist(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformIDTest(t)
 	ctx := context.Background()
 	artist := createTestArtist(t, svc, "Radiohead")
@@ -216,6 +225,7 @@ func TestDeletePlatformIDsByArtist(t *testing.T) {
 }
 
 func TestSetPlatformID_MultipleArtists(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformIDTest(t)
 	ctx := context.Background()
 	a1 := createTestArtist(t, svc, "Radiohead")
@@ -340,6 +350,7 @@ func setupPlatformPresenceTestWithDB(t *testing.T) (*Service, *sql.DB) {
 }
 
 func TestGetPlatformPresenceForArtists(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformPresenceTest(t)
 	ctx := context.Background()
 
@@ -424,6 +435,7 @@ func TestGetPlatformPresenceForArtists(t *testing.T) {
 }
 
 func TestGetPlatformPresenceForArtists_Nil(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformPresenceTest(t)
 	ctx := context.Background()
 
@@ -437,6 +449,7 @@ func TestGetPlatformPresenceForArtists_Nil(t *testing.T) {
 }
 
 func TestGetPlatformPresenceForArtists_EmptySlice(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformPresenceTest(t)
 	ctx := context.Background()
 
@@ -450,6 +463,7 @@ func TestGetPlatformPresenceForArtists_EmptySlice(t *testing.T) {
 }
 
 func TestGetPlatformPresenceForArtists_AllPlatforms(t *testing.T) {
+	t.Parallel()
 	svc := setupPlatformPresenceTest(t)
 	ctx := context.Background()
 
@@ -488,6 +502,7 @@ func TestGetPlatformPresenceForArtists_AllPlatforms(t *testing.T) {
 // artist_libraries membership) must still surface its presence; the
 // fallback branch goes away once the column drop in #1214 lands.
 func TestGetPlatformPresenceForArtists_LegacyLibraryIDFallback(t *testing.T) {
+	t.Parallel()
 	svc, db := setupPlatformPresenceTestWithDB(t)
 	ctx := context.Background()
 
@@ -539,6 +554,7 @@ func TestGetPlatformPresenceForArtists_LegacyLibraryIDFallback(t *testing.T) {
 // artists.library_id pointing at the same library is reported once per
 // presence kind (the UNION + GROUP-equivalent semantics dedupe).
 func TestGetPlatformPresenceForArtists_MembershipAndLegacyDeDuplicate(t *testing.T) {
+	t.Parallel()
 	svc, db := setupPlatformPresenceTestWithDB(t)
 	ctx := context.Background()
 

--- a/internal/artist/service_mn_test.go
+++ b/internal/artist/service_mn_test.go
@@ -21,6 +21,7 @@ func seedLibForMNTests(t *testing.T, ctx context.Context, db *sql.DB, id string,
 }
 
 func TestFindByMBIDOrNameUnscoped_ByMBID(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -51,6 +52,7 @@ func TestFindByMBIDOrNameUnscoped_ByMBID(t *testing.T) {
 }
 
 func TestFindByMBIDOrNameUnscoped_ByNameCaseInsensitive(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -76,6 +78,7 @@ func TestFindByMBIDOrNameUnscoped_ByNameCaseInsensitive(t *testing.T) {
 }
 
 func TestFindByMBIDOrNameUnscoped_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -90,6 +93,7 @@ func TestFindByMBIDOrNameUnscoped_NotFound(t *testing.T) {
 }
 
 func TestFindByMBIDOrNameUnscoped_CrossesLibraries(t *testing.T) {
+	t.Parallel()
 	// The unscoped variant exists specifically to find an artist regardless
 	// of library context. Seed an artist on one library and look it up
 	// without a library scope.
@@ -122,6 +126,7 @@ func TestFindByMBIDOrNameUnscoped_CrossesLibraries(t *testing.T) {
 // Without this guarantee a regression that fell back to case-insensitive
 // name lookup before MBID would still pass the happy-path tests.
 func TestFindByMBIDOrNameUnscoped_MBIDPrecedence(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -157,6 +162,7 @@ func TestFindByMBIDOrNameUnscoped_MBIDPrecedence(t *testing.T) {
 }
 
 func TestGetByName_CaseInsensitive(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -179,6 +185,7 @@ func TestGetByName_CaseInsensitive(t *testing.T) {
 }
 
 func TestGetByName_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -199,6 +206,7 @@ func TestGetByName_NotFound(t *testing.T) {
 // via the Service guards against a future refactor that would silently break
 // the wrapper layer.
 func TestMembershipServicePassthroughs(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -273,6 +281,7 @@ func TestMembershipServicePassthroughs(t *testing.T) {
 // Service: when membership repo wiring is absent, the methods return zero
 // values without erroring, so callers never need to gate on availability.
 func TestMembershipMethods_NoMembershipRepo(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	svc.memberships = nil

--- a/internal/artist/service_rename_test.go
+++ b/internal/artist/service_rename_test.go
@@ -50,6 +50,7 @@ func renameTestArtist(t *testing.T, libID string) (*Service, *Artist, string) {
 }
 
 func TestRenameDirectory_Happy(t *testing.T) {
+	t.Parallel()
 	svc, a, root := renameTestArtist(t, "lib-rename-happy")
 	ctx := context.Background()
 
@@ -86,6 +87,7 @@ func TestRenameDirectory_Happy(t *testing.T) {
 // production-code rationale comment names them together; covering only
 // one would let a regression in the other ship green.
 func TestRenameDirectory_PreservesProviderIDs(t *testing.T) {
+	t.Parallel()
 	svc, a, _ := renameTestArtist(t, "lib-rename-provider")
 	ctx := context.Background()
 
@@ -142,6 +144,7 @@ func TestRenameDirectory_PreservesProviderIDs(t *testing.T) {
 // (newPath/oldPath) or drops the rollback entirely would silently pass
 // every other test in the suite, but would fail this one.
 func TestRenameDirectory_RollbackOnDBFailure(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	root := t.TempDir()
 	ctx := context.Background()
@@ -260,6 +263,7 @@ func (r *concurrentEditRepo) UpdatePath(ctx context.Context, id, path string) er
 // s.artists.Update(ctx, a) call this would fail (the snapshot wins);
 // with UpdatePath it must hold.
 func TestRenameDirectory_PreservesConcurrentMetadataEdit(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	root := t.TempDir()
 	ctx := context.Background()
@@ -320,6 +324,7 @@ func TestRenameDirectory_PreservesConcurrentMetadataEdit(t *testing.T) {
 // "renaming %q to %q: %w". This exercises both the wrapped-error branch in
 // the service and the handler's default 500 mapping for unsentineled errors.
 func TestRenameDirectory_RenameError(t *testing.T) {
+	t.Parallel()
 	// Root bypasses POSIX permission bits, so the chmod 0500 below would
 	// not produce EACCES and the wrapped-error branch we want to exercise
 	// would never fire. Same skip pattern used by maintenance_test.go.
@@ -370,6 +375,7 @@ func TestRenameDirectory_RenameError(t *testing.T) {
 // original db error to the caller; we assert that contract here so any
 // future refactor that swaps which error wins is caught.
 func TestRenameDirectory_RollbackAlsoFails(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	root := t.TempDir()
 	ctx := context.Background()
@@ -419,6 +425,7 @@ func TestRenameDirectory_RollbackAlsoFails(t *testing.T) {
 }
 
 func TestRenameDirectory_InvalidName(t *testing.T) {
+	t.Parallel()
 	svc, a, _ := renameTestArtist(t, "lib-rename-invalid")
 	ctx := context.Background()
 
@@ -434,6 +441,7 @@ func TestRenameDirectory_InvalidName(t *testing.T) {
 }
 
 func TestRenameDirectory_NotFound(t *testing.T) {
+	t.Parallel()
 	svc, _, _ := renameTestArtist(t, "lib-rename-notfound")
 	ctx := context.Background()
 
@@ -444,6 +452,7 @@ func TestRenameDirectory_NotFound(t *testing.T) {
 }
 
 func TestRenameDirectory_Locked(t *testing.T) {
+	t.Parallel()
 	svc, a, _ := renameTestArtist(t, "lib-rename-locked")
 	ctx := context.Background()
 
@@ -457,6 +466,7 @@ func TestRenameDirectory_Locked(t *testing.T) {
 }
 
 func TestRenameDirectory_NoPath(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -480,6 +490,7 @@ func TestRenameDirectory_NoPath(t *testing.T) {
 }
 
 func TestRenameDirectory_NoChange(t *testing.T) {
+	t.Parallel()
 	svc, a, _ := renameTestArtist(t, "lib-rename-nochange")
 	ctx := context.Background()
 
@@ -491,6 +502,7 @@ func TestRenameDirectory_NoChange(t *testing.T) {
 }
 
 func TestRenameDirectory_DestExists(t *testing.T) {
+	t.Parallel()
 	svc, a, root := renameTestArtist(t, "lib-rename-collide")
 	ctx := context.Background()
 
@@ -516,6 +528,7 @@ func TestRenameDirectory_DestExists(t *testing.T) {
 // the link, so the dirent is detected and ErrRenameDestExists fires as
 // intended.
 func TestRenameDirectory_DestExistsDanglingSymlink(t *testing.T) {
+	t.Parallel()
 	svc, a, root := renameTestArtist(t, "lib-rename-dangling")
 	ctx := context.Background()
 

--- a/internal/artist/service_test.go
+++ b/internal/artist/service_test.go
@@ -65,6 +65,7 @@ func testArtist(name, path string) *Artist {
 }
 
 func TestCreateAndGetByID(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -119,6 +120,7 @@ func TestCreateAndGetByID(t *testing.T) {
 // invisible to per-library views, so the artist is rolled back rather
 // than persisted in a partial state.
 func TestCreate_MembershipWriteFailureRollsBack(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -164,6 +166,7 @@ func TestCreate_MembershipWriteFailureRollsBack(t *testing.T) {
 }
 
 func TestGetByID_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -174,6 +177,7 @@ func TestGetByID_NotFound(t *testing.T) {
 }
 
 func TestGetByMBID(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -197,6 +201,7 @@ func TestGetByMBID(t *testing.T) {
 }
 
 func TestGetByMBID_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -210,6 +215,7 @@ func TestGetByMBID_NotFound(t *testing.T) {
 }
 
 func TestGetByProviderID(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -247,6 +253,7 @@ func TestGetByProviderID(t *testing.T) {
 }
 
 func TestGetByPath(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -275,6 +282,7 @@ func TestGetByPath(t *testing.T) {
 }
 
 func TestList_Pagination(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -321,6 +329,7 @@ func TestList_Pagination(t *testing.T) {
 }
 
 func TestList_SearchAndFilter(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -411,6 +420,7 @@ func TestList_SearchAndFilter(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -447,6 +457,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -467,6 +478,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDelete_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -477,6 +489,7 @@ func TestDelete_NotFound(t *testing.T) {
 }
 
 func TestSearch(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -500,6 +513,7 @@ func TestSearch(t *testing.T) {
 }
 
 func TestBandMembers_CRUD(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -551,6 +565,7 @@ func TestBandMembers_CRUD(t *testing.T) {
 }
 
 func TestUpsertMembers(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -591,6 +606,7 @@ func TestUpsertMembers(t *testing.T) {
 }
 
 func TestDeleteMembersByArtistID(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -619,6 +635,7 @@ func TestDeleteMembersByArtistID(t *testing.T) {
 }
 
 func TestArtist_LastScannedAt(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -643,6 +660,7 @@ func TestArtist_LastScannedAt(t *testing.T) {
 }
 
 func TestList_ExcludedFilter(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -679,6 +697,7 @@ func TestList_ExcludedFilter(t *testing.T) {
 }
 
 func TestList_SortOrder(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -704,6 +723,7 @@ func TestList_SortOrder(t *testing.T) {
 }
 
 func TestLibraryID_RoundTrip(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -744,6 +764,7 @@ func TestLibraryID_RoundTrip(t *testing.T) {
 }
 
 func TestLibraryID_NullOnEmpty(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -764,6 +785,7 @@ func TestLibraryID_NullOnEmpty(t *testing.T) {
 }
 
 func TestGetByNameAndLibrary(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -813,6 +835,7 @@ func TestGetByNameAndLibrary(t *testing.T) {
 }
 
 func TestGetByMBIDAndLibrary(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -864,6 +887,7 @@ func TestGetByMBIDAndLibrary(t *testing.T) {
 }
 
 func TestUpdateProviderFetchedAt(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -902,6 +926,7 @@ func TestUpdateProviderFetchedAt(t *testing.T) {
 }
 
 func TestFetchedAt_EmptyProviderID_RoundTrip(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -951,6 +976,7 @@ func TestFetchedAt_EmptyProviderID_RoundTrip(t *testing.T) {
 }
 
 func TestExtractImageMetadata_FanartCountPersistsSlots(t *testing.T) {
+	t.Parallel()
 	// FanartCount > 1 must produce ArtistImage entries for slots 1..FanartCount-1
 	// so that FanartCount round-trips through the database.
 	a := &Artist{
@@ -977,6 +1003,7 @@ func TestExtractImageMetadata_FanartCountPersistsSlots(t *testing.T) {
 }
 
 func TestExtractImageMetadata_FanartCountOneProducesOneSlot(t *testing.T) {
+	t.Parallel()
 	a := &Artist{
 		ID:           "test-id",
 		FanartExists: true,
@@ -996,6 +1023,7 @@ func TestExtractImageMetadata_FanartCountOneProducesOneSlot(t *testing.T) {
 }
 
 func TestExtractImageMetadata_FanartCountZeroProducesNoSlots(t *testing.T) {
+	t.Parallel()
 	a := &Artist{
 		ID:           "test-id",
 		FanartExists: false,
@@ -1011,6 +1039,7 @@ func TestExtractImageMetadata_FanartCountZeroProducesNoSlots(t *testing.T) {
 }
 
 func TestExtractImageMetadata_NoPhantomSlotsWhenFanartNotExists(t *testing.T) {
+	t.Parallel()
 	a := &Artist{
 		ID:           "test-id",
 		FanartExists: false,
@@ -1041,6 +1070,7 @@ func TestExtractImageMetadata_NoPhantomSlotsWhenFanartNotExists(t *testing.T) {
 }
 
 func TestList_LibraryIDFilter(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -1096,6 +1126,7 @@ func TestList_LibraryIDFilter(t *testing.T) {
 }
 
 func TestFindByMBIDOrName_ByMBID(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -1130,6 +1161,7 @@ func TestFindByMBIDOrName_ByMBID(t *testing.T) {
 }
 
 func TestFindByMBIDOrName_ByNameCaseInsensitive(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -1160,6 +1192,7 @@ func TestFindByMBIDOrName_ByNameCaseInsensitive(t *testing.T) {
 }
 
 func TestFindByMBIDOrName_MBIDPreferredOverName(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -1201,6 +1234,7 @@ func TestFindByMBIDOrName_MBIDPreferredOverName(t *testing.T) {
 }
 
 func TestFindByMBIDOrName_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -1221,6 +1255,7 @@ func TestFindByMBIDOrName_NotFound(t *testing.T) {
 }
 
 func TestFindByMBIDOrName_RespectsLibraryScope(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -1253,6 +1288,7 @@ func TestFindByMBIDOrName_RespectsLibraryScope(t *testing.T) {
 }
 
 func TestMigration018_OrphanCleanupAndBackfill(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -1381,6 +1417,7 @@ func setupServiceWithHistory(t *testing.T) (*Service, *HistoryService) {
 }
 
 func TestUpdateRecordsHistory(t *testing.T) {
+	t.Parallel()
 	svc, hsvc := setupServiceWithHistory(t)
 	ctx := context.Background()
 
@@ -1429,6 +1466,7 @@ func TestUpdateRecordsHistory(t *testing.T) {
 }
 
 func TestUpdateFieldRecordsHistory(t *testing.T) {
+	t.Parallel()
 	svc, hsvc := setupServiceWithHistory(t)
 	ctx := context.Background()
 
@@ -1462,6 +1500,7 @@ func TestUpdateFieldRecordsHistory(t *testing.T) {
 }
 
 func TestClearFieldRecordsHistory(t *testing.T) {
+	t.Parallel()
 	svc, hsvc := setupServiceWithHistory(t)
 	ctx := context.Background()
 

--- a/internal/artist/sqlite_completeness_test.go
+++ b/internal/artist/sqlite_completeness_test.go
@@ -18,6 +18,7 @@ func insertCompletenessArtist(t *testing.T, svc *Service, a *Artist) {
 // TestGetCompletenessRows_BasicFlags verifies that NFO, MBID, image, and text
 // field flags are populated correctly from a real SQLite row.
 func TestGetCompletenessRows_BasicFlags(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -84,6 +85,7 @@ func TestGetCompletenessRows_BasicFlags(t *testing.T) {
 // TestGetCompletenessRows_ExcludedArtists verifies that artists marked
 // is_excluded = 1 are omitted from completeness results.
 func TestGetCompletenessRows_ExcludedArtists(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -123,6 +125,7 @@ func TestGetCompletenessRows_ExcludedArtists(t *testing.T) {
 // TestGetCompletenessRows_LibraryFilter verifies that the library_id filter
 // restricts results to the specified library.
 func TestGetCompletenessRows_LibraryFilter(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -171,6 +174,7 @@ func TestGetCompletenessRows_LibraryFilter(t *testing.T) {
 // TestGetLowestCompleteness_Ordering verifies that artists are returned ordered
 // by health_score ascending (lowest score first).
 func TestGetLowestCompleteness_Ordering(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -226,6 +230,7 @@ func TestGetLowestCompleteness_Ordering(t *testing.T) {
 
 // TestGetLowestCompleteness_DefaultLimit verifies that limit <= 0 defaults to 10.
 func TestGetLowestCompleteness_DefaultLimit(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -269,6 +274,7 @@ func TestGetLowestCompleteness_DefaultLimit(t *testing.T) {
 // TestGetLowestCompleteness_ExcludedOmitted verifies that excluded artists are
 // not included in the lowest completeness results.
 func TestGetLowestCompleteness_ExcludedOmitted(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -310,6 +316,7 @@ func TestGetLowestCompleteness_ExcludedOmitted(t *testing.T) {
 // TestGetLowestCompleteness_LibraryFilter verifies that library_id filters
 // the lowest completeness results.
 func TestGetLowestCompleteness_LibraryFilter(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()

--- a/internal/artist/sqlite_dirty_test.go
+++ b/internal/artist/sqlite_dirty_test.go
@@ -10,6 +10,7 @@ import (
 // rules_evaluated_at are always considered dirty -- this is the
 // initial-bootstrap path for fresh installs and newly imported artists.
 func TestListDirtyIDs_NeverEvaluated(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -32,6 +33,7 @@ func TestListDirtyIDs_NeverEvaluated(t *testing.T) {
 // rules_evaluated_at is set and is not flagged dirty drops out of the
 // dirty set -- the property that makes incremental Run Rules cheap.
 func TestListDirtyIDs_CleanArtistOmitted(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -56,6 +58,7 @@ func TestListDirtyIDs_CleanArtistOmitted(t *testing.T) {
 // TestListDirtyIDs_DirtyAfterEvaluated verifies the round trip: evaluate
 // (clean), mark dirty (mutated again), expect the artist back in the set.
 func TestListDirtyIDs_DirtyAfterEvaluated(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -91,6 +94,7 @@ func TestListDirtyIDs_DirtyAfterEvaluated(t *testing.T) {
 // is_excluded=1 or locked=1 never appear in the dirty list, matching the
 // pipeline's own skip semantics so progress counters are not inflated.
 func TestListDirtyIDs_ExcludesLockedAndExcluded(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -127,6 +131,7 @@ func TestListDirtyIDs_ExcludesLockedAndExcluded(t *testing.T) {
 // touches every non-excluded, non-locked artist in a single statement.
 // This is the path triggered when a brand-new rule is added.
 func TestMarkAllDirty_StampsEligibleArtists(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -183,6 +188,7 @@ func TestMarkAllDirty_StampsEligibleArtists(t *testing.T) {
 // TestCountEligibleArtists verifies the denominator count used by progress
 // reporting matches what ListDirtyIDs/RunAll would walk in scope=all.
 func TestCountEligibleArtists(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -220,6 +226,7 @@ func TestCountEligibleArtists(t *testing.T) {
 // Update must not overwrite dirty_since/rules_evaluated_at, otherwise
 // a write-then-event race would silently drop the dirty mark.
 func TestUpdate_DoesNotClobberDirtyTracking(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -280,6 +287,7 @@ func TestUpdate_DoesNotClobberDirtyTracking(t *testing.T) {
 // and the artist would re-appear in ListDirtyIDs immediately, flaking the
 // scheduled sweep.
 func TestUpdateAfterRuleEvaluation_DoesNotStampDirty(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -331,6 +339,7 @@ func TestUpdateAfterRuleEvaluation_DoesNotStampDirty(t *testing.T) {
 // scanners, bulk executor) still schedule a re-evaluation. Together these
 // two tests pin the boundary between external and self-writeback paths.
 func TestUpdate_DoesStampDirty(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()

--- a/internal/artist/sqlite_health_stats_test.go
+++ b/internal/artist/sqlite_health_stats_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestHealthStats_EmptyDB(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -28,6 +29,7 @@ func TestHealthStats_EmptyDB(t *testing.T) {
 }
 
 func TestHealthStats_MixedArtists(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -88,6 +90,7 @@ func TestHealthStats_MixedArtists(t *testing.T) {
 }
 
 func TestHealthStats_ExcludedArtistsOmitted(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -128,6 +131,7 @@ func TestHealthStats_ExcludedArtistsOmitted(t *testing.T) {
 }
 
 func TestHealthStats_LibraryFilter(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -179,6 +183,7 @@ func TestHealthStats_LibraryFilter(t *testing.T) {
 }
 
 func TestListUnevaluatedIDs(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()

--- a/internal/artist/sqlite_image_test.go
+++ b/internal/artist/sqlite_image_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestUpsert_ProvenanceFields(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -61,6 +62,7 @@ func TestUpsert_ProvenanceFields(t *testing.T) {
 }
 
 func TestUpdateProvenance(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -128,6 +130,7 @@ func TestUpdateProvenance(t *testing.T) {
 }
 
 func TestUpdateProvenance_NoRow(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -161,6 +164,7 @@ func TestUpdateProvenance_NoRow(t *testing.T) {
 }
 
 func TestNewestWriteTimesByArtist(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -239,6 +243,7 @@ func TestNewestWriteTimesByArtist(t *testing.T) {
 }
 
 func TestNewestWriteTimesByArtist_NoWrites(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -263,6 +268,7 @@ func TestNewestWriteTimesByArtist_NoWrites(t *testing.T) {
 }
 
 func TestNewestWriteTimesByArtist_EmptyLibrary(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	repo := newSQLiteImageRepo(db)
 	ctx := context.Background()
@@ -278,6 +284,7 @@ func TestNewestWriteTimesByArtist_EmptyLibrary(t *testing.T) {
 }
 
 func TestUpsertAll_PreservesProvenance(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	ctx := context.Background()
 	repo := newSQLiteImageRepo(db)
@@ -345,6 +352,7 @@ func TestUpsertAll_PreservesProvenance(t *testing.T) {
 // artist_images registry to filesystem-truth without touching other artist
 // columns, and rejects a nil/empty-ID Artist.
 func TestReconcileImages(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -403,6 +411,7 @@ func TestReconcileImages(t *testing.T) {
 // TestClearExistsFlag verifies that ClearExistsFlag sets the exists_flag to 0
 // for the targeted image slot without affecting other slots.
 func TestClearExistsFlag(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()

--- a/internal/artist/sqlite_membership_test.go
+++ b/internal/artist/sqlite_membership_test.go
@@ -77,6 +77,7 @@ func seedMembershipFixtures(t *testing.T, db *sql.DB) {
 // TestMembershipAddIsIdempotent verifies Add inserts a row on first call
 // and is a no-op on repeat.
 func TestMembershipAddIsIdempotent(t *testing.T) {
+	t.Parallel()
 	db := openTestDB(t)
 	seedMembershipFixtures(t, db)
 	repo := newSQLiteMembershipRepo(db)
@@ -102,6 +103,7 @@ func TestMembershipAddIsIdempotent(t *testing.T) {
 // many libraries with different sources and that ListForArtist returns
 // them all.
 func TestMembershipMultipleLibraries(t *testing.T) {
+	t.Parallel()
 	db := openTestDB(t)
 	seedMembershipFixtures(t, db)
 	repo := newSQLiteMembershipRepo(db)
@@ -137,6 +139,7 @@ func TestMembershipMultipleLibraries(t *testing.T) {
 // TestMembershipRemove verifies Remove deletes only the targeted pair and
 // is a no-op for nonexistent pairs.
 func TestMembershipRemove(t *testing.T) {
+	t.Parallel()
 	db := openTestDB(t)
 	seedMembershipFixtures(t, db)
 	repo := newSQLiteMembershipRepo(db)
@@ -169,6 +172,7 @@ func TestMembershipRemove(t *testing.T) {
 // TestMembershipCascadeOnArtistDelete verifies that deleting the parent
 // artist cascades to artist_libraries via the FK ON DELETE CASCADE.
 func TestMembershipCascadeOnArtistDelete(t *testing.T) {
+	t.Parallel()
 	db := openTestDB(t)
 	seedMembershipFixtures(t, db)
 	repo := newSQLiteMembershipRepo(db)
@@ -195,6 +199,7 @@ func TestMembershipCascadeOnArtistDelete(t *testing.T) {
 // All three connection-backed types plus the no-connection (filesystem)
 // case are covered, and idempotency is asserted on a repeat call.
 func TestMembershipAddDerivingSource(t *testing.T) {
+	t.Parallel()
 	db := openTestDB(t)
 	seedMembershipFixtures(t, db) // gives us lib-fs (filesystem) + lib-emby (emby)
 	repo := newSQLiteMembershipRepo(db)
@@ -271,6 +276,7 @@ func TestMembershipAddDerivingSource(t *testing.T) {
 // TestArtistGetByName verifies the unscoped name lookup is case-insensitive
 // and returns nil when no match exists.
 func TestArtistGetByName(t *testing.T) {
+	t.Parallel()
 	db := openTestDB(t)
 	ctx := context.Background()
 	_, err := db.ExecContext(ctx, `
@@ -307,6 +313,7 @@ func TestArtistGetByName(t *testing.T) {
 // match wins when present; falls through to case-insensitive name
 // otherwise.
 func TestArtistFindByMBIDOrNameUnscoped(t *testing.T) {
+	t.Parallel()
 	db := openTestDB(t)
 	ctx := context.Background()
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -52,6 +52,7 @@ func createTestUser(t *testing.T, password string) *Service {
 // --- PrehashPassword tests ---
 
 func TestPrehashPassword(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		password string
@@ -82,6 +83,7 @@ func TestPrehashPassword(t *testing.T) {
 }
 
 func TestPrehashPassword_Deterministic(t *testing.T) {
+	t.Parallel()
 	a := PrehashPassword("test-password")
 	b := PrehashPassword("test-password")
 
@@ -91,6 +93,7 @@ func TestPrehashPassword_Deterministic(t *testing.T) {
 }
 
 func TestPrehashPassword_DifferentInputsDifferentOutputs(t *testing.T) {
+	t.Parallel()
 	a := PrehashPassword("password1")
 	b := PrehashPassword("password2")
 
@@ -102,6 +105,7 @@ func TestPrehashPassword_DifferentInputsDifferentOutputs(t *testing.T) {
 // --- NewService tests ---
 
 func TestNewService(t *testing.T) {
+	t.Parallel()
 	db, err := database.Open(":memory:")
 	if err != nil {
 		t.Fatalf("opening test db: %v", err)
@@ -117,6 +121,7 @@ func TestNewService(t *testing.T) {
 // --- Setup tests ---
 
 func TestSetup_CreatesUser(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -139,6 +144,7 @@ func TestSetup_CreatesUser(t *testing.T) {
 }
 
 func TestSetup_NoopWhenUsersExist(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "password123")
 	ctx := context.Background()
 
@@ -155,6 +161,7 @@ func TestSetup_NoopWhenUsersExist(t *testing.T) {
 // --- HasUsers tests ---
 
 func TestHasUsers_EmptyDB(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -168,6 +175,7 @@ func TestHasUsers_EmptyDB(t *testing.T) {
 }
 
 func TestHasUsers_WithUser(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "password")
 	ctx := context.Background()
 
@@ -183,6 +191,7 @@ func TestHasUsers_WithUser(t *testing.T) {
 // --- Login tests ---
 
 func TestLogin_Success(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -200,6 +209,7 @@ func TestLogin_Success(t *testing.T) {
 }
 
 func TestLogin_WrongPassword(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -213,6 +223,7 @@ func TestLogin_WrongPassword(t *testing.T) {
 }
 
 func TestLogin_UnknownUser(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -226,6 +237,7 @@ func TestLogin_UnknownUser(t *testing.T) {
 }
 
 func TestLogin_UniqueTokens(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -247,6 +259,7 @@ func TestLogin_UniqueTokens(t *testing.T) {
 // --- ValidateSession tests ---
 
 func TestValidateSession_Valid(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -265,6 +278,7 @@ func TestValidateSession_Valid(t *testing.T) {
 }
 
 func TestValidateSession_InvalidToken(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -278,6 +292,7 @@ func TestValidateSession_InvalidToken(t *testing.T) {
 }
 
 func TestValidateSession_ExpiredSession(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -314,6 +329,7 @@ func TestValidateSession_ExpiredSession(t *testing.T) {
 // --- Logout tests ---
 
 func TestLogout_DeletesSession(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -334,6 +350,7 @@ func TestLogout_DeletesSession(t *testing.T) {
 }
 
 func TestLogout_NonexistentToken(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -346,6 +363,7 @@ func TestLogout_NonexistentToken(t *testing.T) {
 // --- CleanExpiredSessions tests ---
 
 func TestCleanExpiredSessions(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -387,6 +405,7 @@ func TestCleanExpiredSessions(t *testing.T) {
 }
 
 func TestCleanExpiredSessions_NoSessions(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -399,6 +418,7 @@ func TestCleanExpiredSessions_NoSessions(t *testing.T) {
 // --- CreateAPIToken tests ---
 
 func TestCreateAPIToken(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -429,6 +449,7 @@ func TestCreateAPIToken(t *testing.T) {
 }
 
 func TestCreateAPIToken_UniqueTokens(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -462,6 +483,7 @@ func TestCreateAPIToken_UniqueTokens(t *testing.T) {
 // --- ValidateAPIToken tests ---
 
 func TestValidateAPIToken_Valid(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -492,6 +514,7 @@ func TestValidateAPIToken_Valid(t *testing.T) {
 }
 
 func TestValidateAPIToken_InvalidToken(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -505,6 +528,7 @@ func TestValidateAPIToken_InvalidToken(t *testing.T) {
 }
 
 func TestValidateAPIToken_RevokedToken(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -536,6 +560,7 @@ func TestValidateAPIToken_RevokedToken(t *testing.T) {
 }
 
 func TestValidateAPIToken_UpdatesLastUsedAt(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -579,6 +604,7 @@ func TestValidateAPIToken_UpdatesLastUsedAt(t *testing.T) {
 // --- ListAPITokens tests ---
 
 func TestListAPITokens(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -622,6 +648,7 @@ func TestListAPITokens(t *testing.T) {
 }
 
 func TestListAPITokens_Empty(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -646,6 +673,7 @@ func TestListAPITokens_Empty(t *testing.T) {
 // --- RevokeAPIToken tests ---
 
 func TestRevokeAPIToken(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -681,6 +709,7 @@ func TestRevokeAPIToken(t *testing.T) {
 }
 
 func TestRevokeAPIToken_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -700,6 +729,7 @@ func TestRevokeAPIToken_NotFound(t *testing.T) {
 }
 
 func TestRevokeAPIToken_AlreadyRevoked(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -731,6 +761,7 @@ func TestRevokeAPIToken_AlreadyRevoked(t *testing.T) {
 }
 
 func TestRevokeAPIToken_WrongUser(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -758,6 +789,7 @@ func TestRevokeAPIToken_WrongUser(t *testing.T) {
 // --- DeleteAPIToken tests ---
 
 func TestDeleteAPIToken_Success(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -792,6 +824,7 @@ func TestDeleteAPIToken_Success(t *testing.T) {
 }
 
 func TestDeleteAPIToken_ActiveToken(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -817,6 +850,7 @@ func TestDeleteAPIToken_ActiveToken(t *testing.T) {
 }
 
 func TestDeleteAPIToken_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -836,6 +870,7 @@ func TestDeleteAPIToken_NotFound(t *testing.T) {
 }
 
 func TestDeleteAPIToken_AnonymizesAuditLog(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -899,6 +934,7 @@ func TestDeleteAPIToken_AnonymizesAuditLog(t *testing.T) {
 // --- GetAPIToken tests ---
 
 func TestGetAPIToken_Success(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -939,6 +975,7 @@ func TestGetAPIToken_Success(t *testing.T) {
 }
 
 func TestGetAPIToken_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -958,6 +995,7 @@ func TestGetAPIToken_NotFound(t *testing.T) {
 }
 
 func TestGetAPIToken_WrongUser(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -985,6 +1023,7 @@ func TestGetAPIToken_WrongUser(t *testing.T) {
 // --- WriteAuditLog tests ---
 
 func TestWriteAuditLog(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secret")
 	ctx := context.Background()
 
@@ -1030,6 +1069,7 @@ func TestWriteAuditLog(t *testing.T) {
 // --- Full lifecycle test ---
 
 func TestFullTokenLifecycle(t *testing.T) {
+	t.Parallel()
 	svc := createTestUser(t, "secure-password")
 	ctx := context.Background()
 
@@ -1109,6 +1149,7 @@ func TestFullTokenLifecycle(t *testing.T) {
 // --- Sentinel error tests ---
 
 func TestSentinelErrors(t *testing.T) {
+	t.Parallel()
 	// Verify sentinel errors have distinct, non-empty messages.
 	sentinels := []struct {
 		name string
@@ -1140,6 +1181,7 @@ func TestSentinelErrors(t *testing.T) {
 // --- ValidScopes tests ---
 
 func TestValidScopes(t *testing.T) {
+	t.Parallel()
 	expected := []TokenScope{ScopeRead, ScopeWrite, ScopeWebhook, ScopeAdmin}
 	for _, scope := range expected {
 		if !ValidScopes[scope] {
@@ -1156,12 +1198,14 @@ func TestValidScopes(t *testing.T) {
 // --- Constants tests ---
 
 func TestAPITokenPrefix(t *testing.T) {
+	t.Parallel()
 	if APITokenPrefix != "sw_" {
 		t.Errorf("APITokenPrefix = %q, want %q", APITokenPrefix, "sw_")
 	}
 }
 
 func TestTokenStatusValues(t *testing.T) {
+	t.Parallel()
 	if TokenStatusActive != "active" {
 		t.Errorf("TokenStatusActive = %q, want %q", TokenStatusActive, "active")
 	}
@@ -1173,6 +1217,7 @@ func TestTokenStatusValues(t *testing.T) {
 // --- SetupFederated tests ---
 
 func TestSetupFederated_CreatesUser(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -1224,6 +1269,7 @@ func TestSetupFederated_CreatesUser(t *testing.T) {
 }
 
 func TestSetupFederated_RejectsWhenUsersExist(t *testing.T) {
+	t.Parallel()
 	// Create a local user first using the existing Setup method.
 	svc := createTestUser(t, "password123")
 	ctx := context.Background()
@@ -1247,6 +1293,7 @@ func TestSetupFederated_RejectsWhenUsersExist(t *testing.T) {
 // --- LoginFederated tests ---
 
 func TestLoginFederated_Success(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -1289,6 +1336,7 @@ func TestLoginFederated_Success(t *testing.T) {
 }
 
 func TestLoginFederated_UnknownUser(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -1310,6 +1358,7 @@ func TestLoginFederated_UnknownUser(t *testing.T) {
 }
 
 func TestLoginFederated_SyncsUsername(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -1359,6 +1408,7 @@ func TestLoginFederated_SyncsUsername(t *testing.T) {
 // --- Regression: local auth unchanged ---
 
 func TestSetup_LocalUnchanged(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 

--- a/internal/auth/invite_test.go
+++ b/internal/auth/invite_test.go
@@ -35,6 +35,7 @@ func setupInviteTest(t *testing.T) (*Service, string) {
 }
 
 func TestCreateInvite(t *testing.T) {
+	t.Parallel()
 	svc, adminID := setupInviteTest(t)
 	ctx := context.Background()
 
@@ -65,6 +66,7 @@ func TestCreateInvite(t *testing.T) {
 }
 
 func TestGetInviteByCode(t *testing.T) {
+	t.Parallel()
 	svc, adminID := setupInviteTest(t)
 	ctx := context.Background()
 
@@ -87,6 +89,7 @@ func TestGetInviteByCode(t *testing.T) {
 }
 
 func TestGetInviteByCode_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -97,6 +100,7 @@ func TestGetInviteByCode_NotFound(t *testing.T) {
 }
 
 func TestGetInviteByCode_Expired(t *testing.T) {
+	t.Parallel()
 	svc, adminID := setupInviteTest(t)
 	ctx := context.Background()
 
@@ -113,6 +117,7 @@ func TestGetInviteByCode_Expired(t *testing.T) {
 }
 
 func TestGetInviteByCode_Redeemed(t *testing.T) {
+	t.Parallel()
 	svc, adminID := setupInviteTest(t)
 	ctx := context.Background()
 
@@ -139,6 +144,7 @@ func TestGetInviteByCode_Redeemed(t *testing.T) {
 }
 
 func TestListPendingInvites(t *testing.T) {
+	t.Parallel()
 	svc, adminID := setupInviteTest(t)
 	ctx := context.Background()
 
@@ -181,6 +187,7 @@ func TestListPendingInvites(t *testing.T) {
 }
 
 func TestRedeemInvite(t *testing.T) {
+	t.Parallel()
 	svc, adminID := setupInviteTest(t)
 	ctx := context.Background()
 
@@ -208,6 +215,7 @@ func TestRedeemInvite(t *testing.T) {
 }
 
 func TestRedeemInvite_AlreadyRedeemed(t *testing.T) {
+	t.Parallel()
 	svc, adminID := setupInviteTest(t)
 	ctx := context.Background()
 
@@ -233,6 +241,7 @@ func TestRedeemInvite_AlreadyRedeemed(t *testing.T) {
 }
 
 func TestRevokeInvite(t *testing.T) {
+	t.Parallel()
 	svc, adminID := setupInviteTest(t)
 	ctx := context.Background()
 
@@ -253,6 +262,7 @@ func TestRevokeInvite(t *testing.T) {
 }
 
 func TestRevokeInvite_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 

--- a/internal/auth/provider_emby_test.go
+++ b/internal/auth/provider_emby_test.go
@@ -19,6 +19,7 @@ func newTestEmbyProvider(t *testing.T, serverURL string, autoProvision bool, gua
 }
 
 func TestEmbyProviderAuthenticate(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/Users/AuthenticateByName" {
 			http.NotFound(w, r)
@@ -65,6 +66,7 @@ func TestEmbyProviderAuthenticate(t *testing.T) {
 }
 
 func TestEmbyProviderAuthenticate_Unauthorized(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
@@ -81,6 +83,7 @@ func TestEmbyProviderAuthenticate_Unauthorized(t *testing.T) {
 }
 
 func TestEmbyProviderAuthenticate_ServerError(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -94,6 +97,7 @@ func TestEmbyProviderAuthenticate_ServerError(t *testing.T) {
 }
 
 func TestEmbyProviderType(t *testing.T) {
+	t.Parallel()
 	provider := newTestEmbyProvider(t, "http://localhost", false, "admin")
 	if provider.Type() != "emby" {
 		t.Errorf("Type() = %q, want %q", provider.Type(), "emby")
@@ -101,6 +105,7 @@ func TestEmbyProviderType(t *testing.T) {
 }
 
 func TestEmbyProviderCanAutoProvision(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		guardRail string
@@ -125,6 +130,7 @@ func TestEmbyProviderCanAutoProvision(t *testing.T) {
 }
 
 func TestEmbyProviderCanAutoProvision_NilIdentity(t *testing.T) {
+	t.Parallel()
 	provider := newTestEmbyProvider(t, "http://localhost", true, "any_user")
 	if provider.CanAutoProvision(nil) {
 		t.Error("expected false for nil identity")
@@ -132,6 +138,7 @@ func TestEmbyProviderCanAutoProvision_NilIdentity(t *testing.T) {
 }
 
 func TestEmbyProviderAutoProvisionDisabled(t *testing.T) {
+	t.Parallel()
 	provider := newTestEmbyProvider(t, "http://localhost", false, "admin")
 	identity := &Identity{IsAdmin: true}
 	if provider.CanAutoProvision(identity) {
@@ -140,6 +147,7 @@ func TestEmbyProviderAutoProvisionDisabled(t *testing.T) {
 }
 
 func TestEmbyProviderMapRole(t *testing.T) {
+	t.Parallel()
 	provider := newTestEmbyProvider(t, "http://localhost", true, "admin")
 
 	if got := provider.MapRole(&Identity{IsAdmin: true}); got != "administrator" {
@@ -151,6 +159,7 @@ func TestEmbyProviderMapRole(t *testing.T) {
 }
 
 func TestEmbyProviderMapRole_NilIdentity(t *testing.T) {
+	t.Parallel()
 	provider := newTestEmbyProvider(t, "http://localhost", true, "admin")
 	if got := provider.MapRole(nil); got != "operator" {
 		t.Errorf("MapRole(nil) = %q, want %q", got, "operator")
@@ -158,6 +167,7 @@ func TestEmbyProviderMapRole_NilIdentity(t *testing.T) {
 }
 
 func TestNewEmbyProvider_InvalidURL(t *testing.T) {
+	t.Parallel()
 	_, err := NewEmbyProvider("ftp://bad", false, "admin", "operator")
 	if err == nil {
 		t.Fatal("expected error for invalid URL scheme")

--- a/internal/auth/provider_jellyfin_test.go
+++ b/internal/auth/provider_jellyfin_test.go
@@ -19,6 +19,7 @@ func newTestJellyfinProvider(t *testing.T, serverURL string, autoProvision bool,
 }
 
 func TestJellyfinProviderAuthenticate(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/Users/AuthenticateByName" {
 			http.NotFound(w, r)
@@ -68,6 +69,7 @@ func TestJellyfinProviderAuthenticate(t *testing.T) {
 }
 
 func TestJellyfinProviderAuthenticate_Unauthorized(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
@@ -84,6 +86,7 @@ func TestJellyfinProviderAuthenticate_Unauthorized(t *testing.T) {
 }
 
 func TestJellyfinProviderAuthenticate_ServerError(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
@@ -97,6 +100,7 @@ func TestJellyfinProviderAuthenticate_ServerError(t *testing.T) {
 }
 
 func TestJellyfinProviderCanAutoProvision(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		guardRail string
@@ -121,6 +125,7 @@ func TestJellyfinProviderCanAutoProvision(t *testing.T) {
 }
 
 func TestJellyfinProviderCanAutoProvision_NilIdentity(t *testing.T) {
+	t.Parallel()
 	provider := newTestJellyfinProvider(t, "http://localhost", true, "any_user")
 	if provider.CanAutoProvision(nil) {
 		t.Error("expected false for nil identity")
@@ -128,6 +133,7 @@ func TestJellyfinProviderCanAutoProvision_NilIdentity(t *testing.T) {
 }
 
 func TestJellyfinProviderAutoProvisionDisabled(t *testing.T) {
+	t.Parallel()
 	provider := newTestJellyfinProvider(t, "http://localhost", false, "admin")
 	identity := &Identity{IsAdmin: true}
 	if provider.CanAutoProvision(identity) {
@@ -136,6 +142,7 @@ func TestJellyfinProviderAutoProvisionDisabled(t *testing.T) {
 }
 
 func TestJellyfinProviderMapRole(t *testing.T) {
+	t.Parallel()
 	provider := newTestJellyfinProvider(t, "http://localhost", true, "admin")
 
 	if got := provider.MapRole(&Identity{IsAdmin: true}); got != "administrator" {
@@ -147,6 +154,7 @@ func TestJellyfinProviderMapRole(t *testing.T) {
 }
 
 func TestJellyfinProviderMapRole_NilIdentity(t *testing.T) {
+	t.Parallel()
 	provider := newTestJellyfinProvider(t, "http://localhost", true, "admin")
 	if got := provider.MapRole(nil); got != "operator" {
 		t.Errorf("MapRole(nil) = %q, want %q", got, "operator")
@@ -154,6 +162,7 @@ func TestJellyfinProviderMapRole_NilIdentity(t *testing.T) {
 }
 
 func TestJellyfinProviderType(t *testing.T) {
+	t.Parallel()
 	provider := newTestJellyfinProvider(t, "http://localhost", false, "admin")
 	if provider.Type() != "jellyfin" {
 		t.Errorf("Type() = %q, want %q", provider.Type(), "jellyfin")
@@ -161,6 +170,7 @@ func TestJellyfinProviderType(t *testing.T) {
 }
 
 func TestNewJellyfinProvider_InvalidURL(t *testing.T) {
+	t.Parallel()
 	_, err := NewJellyfinProvider("ftp://bad", false, "admin", "operator")
 	if err == nil {
 		t.Fatal("expected error for invalid URL scheme")

--- a/internal/auth/provider_local_test.go
+++ b/internal/auth/provider_local_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestLocalProviderAuthenticate(t *testing.T) {
+	t.Parallel()
 	db, err := database.Open(":memory:")
 	if err != nil {
 		t.Fatalf("opening test db: %v", err)
@@ -60,6 +61,7 @@ func TestLocalProviderAuthenticate(t *testing.T) {
 }
 
 func TestLocalProviderType(t *testing.T) {
+	t.Parallel()
 	db, err := database.Open(":memory:")
 	if err != nil {
 		t.Fatalf("opening test db: %v", err)
@@ -73,6 +75,7 @@ func TestLocalProviderType(t *testing.T) {
 }
 
 func TestLocalProviderAutoProvision(t *testing.T) {
+	t.Parallel()
 	db, err := database.Open(":memory:")
 	if err != nil {
 		t.Fatalf("opening test db: %v", err)
@@ -86,6 +89,7 @@ func TestLocalProviderAutoProvision(t *testing.T) {
 }
 
 func TestNewLocalProvider_NilDB(t *testing.T) {
+	t.Parallel()
 	defer func() {
 		if r := recover(); r == nil {
 			t.Error("expected panic for nil db")

--- a/internal/auth/provider_oidc_test.go
+++ b/internal/auth/provider_oidc_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestOIDCProviderType(t *testing.T) {
+	t.Parallel()
 	p := NewOIDCProvider(OIDCConfig{})
 	if got := p.Type(); got != "oidc" {
 		t.Errorf("Type() = %q, want %q", got, "oidc")
@@ -12,6 +13,7 @@ func TestOIDCProviderType(t *testing.T) {
 }
 
 func TestOIDCProviderDefaultRole(t *testing.T) {
+	t.Parallel()
 	p := NewOIDCProvider(OIDCConfig{})
 	if p.defaultRole != "operator" {
 		t.Errorf("default role = %q, want %q", p.defaultRole, "operator")
@@ -24,6 +26,7 @@ func TestOIDCProviderDefaultRole(t *testing.T) {
 }
 
 func TestOIDCMapRole(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		adminGroups []string
@@ -83,6 +86,7 @@ func TestOIDCMapRole(t *testing.T) {
 }
 
 func TestOIDCCanAutoProvision(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		autoProv   bool
@@ -154,6 +158,7 @@ func TestOIDCCanAutoProvision(t *testing.T) {
 }
 
 func TestOIDCIsInAdminGroup(t *testing.T) {
+	t.Parallel()
 	p := NewOIDCProvider(OIDCConfig{
 		AdminGroups: []string{"admins", "super-admins"},
 	})
@@ -173,6 +178,7 @@ func TestOIDCIsInAdminGroup(t *testing.T) {
 }
 
 func TestGenerateCodeVerifier(t *testing.T) {
+	t.Parallel()
 	v1 := generateCodeVerifier()
 	v2 := generateCodeVerifier()
 
@@ -188,6 +194,7 @@ func TestGenerateCodeVerifier(t *testing.T) {
 }
 
 func TestComputeS256Challenge(t *testing.T) {
+	t.Parallel()
 	// The challenge must be deterministic for the same verifier.
 	verifier := "test-verifier-12345"
 	c1 := computeS256Challenge(verifier)
@@ -208,6 +215,7 @@ func TestComputeS256Challenge(t *testing.T) {
 }
 
 func TestGenerateState(t *testing.T) {
+	t.Parallel()
 	s1, err := GenerateState()
 	if err != nil {
 		t.Fatalf("GenerateState() error: %v", err)
@@ -226,6 +234,7 @@ func TestGenerateState(t *testing.T) {
 }
 
 func TestGenerateNonce(t *testing.T) {
+	t.Parallel()
 	n1, err := GenerateNonce()
 	if err != nil {
 		t.Fatalf("GenerateNonce() error: %v", err)
@@ -244,6 +253,7 @@ func TestGenerateNonce(t *testing.T) {
 }
 
 func TestOIDCAuthURLIncludesPKCE(t *testing.T) {
+	t.Parallel()
 	p := NewOIDCProvider(OIDCConfig{
 		IssuerURL:   "https://idp.example.com",
 		ClientID:    "test-client",

--- a/internal/auth/provider_test.go
+++ b/internal/auth/provider_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestRegistryRegisterAndGet(t *testing.T) {
+	t.Parallel()
 	reg := NewRegistry()
 	provider := &stubProvider{providerType: "test"}
 	reg.Register(provider)
@@ -20,6 +21,7 @@ func TestRegistryRegisterAndGet(t *testing.T) {
 }
 
 func TestRegistryGetMissing(t *testing.T) {
+	t.Parallel()
 	reg := NewRegistry()
 	_, ok := reg.Get("nonexistent")
 	if ok {
@@ -28,6 +30,7 @@ func TestRegistryGetMissing(t *testing.T) {
 }
 
 func TestRegistryEnabled(t *testing.T) {
+	t.Parallel()
 	reg := NewRegistry()
 	reg.Register(&stubProvider{providerType: "a"})
 	reg.Register(&stubProvider{providerType: "b"})

--- a/internal/auth/user_test.go
+++ b/internal/auth/user_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestGetUserByID(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -45,6 +46,7 @@ func TestGetUserByID(t *testing.T) {
 }
 
 func TestGetUserByID_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -58,6 +60,7 @@ func TestGetUserByID_NotFound(t *testing.T) {
 }
 
 func TestGetUserRole(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -81,6 +84,7 @@ func TestGetUserRole(t *testing.T) {
 }
 
 func TestGetUserRole_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -94,6 +98,7 @@ func TestGetUserRole_NotFound(t *testing.T) {
 }
 
 func TestListUsers(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -126,6 +131,7 @@ func TestListUsers(t *testing.T) {
 }
 
 func TestUpdateUserRole(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -168,6 +174,7 @@ func TestUpdateUserRole(t *testing.T) {
 }
 
 func TestUpdateUserRole_InvalidRole(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -188,6 +195,7 @@ func TestUpdateUserRole_InvalidRole(t *testing.T) {
 }
 
 func TestUpdateUserRole_LastAdmin(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -209,6 +217,7 @@ func TestUpdateUserRole_LastAdmin(t *testing.T) {
 }
 
 func TestDeactivateUser(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -249,6 +258,7 @@ func TestDeactivateUser(t *testing.T) {
 }
 
 func TestDeactivateUser_BootstrapAdmin(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -294,6 +304,7 @@ func TestDeactivateUser_BootstrapAdmin(t *testing.T) {
 }
 
 func TestDeactivateUser_LastAdmin(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -310,6 +321,7 @@ func TestDeactivateUser_LastAdmin(t *testing.T) {
 }
 
 func TestDeactivateUser_NonBootstrapAdmin(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -337,6 +349,7 @@ func TestDeactivateUser_NonBootstrapAdmin(t *testing.T) {
 }
 
 func TestListUsers_BootstrapAdminIsProtected(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -391,6 +404,7 @@ func TestListUsers_BootstrapAdminIsProtected(t *testing.T) {
 }
 
 func TestCreateLocalUser(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -429,6 +443,7 @@ func TestCreateLocalUser(t *testing.T) {
 }
 
 func TestCreateLocalUser_WithInvitedBy(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -454,6 +469,7 @@ func TestCreateLocalUser_WithInvitedBy(t *testing.T) {
 }
 
 func TestCreateFederatedUser(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -490,6 +506,7 @@ func TestCreateFederatedUser(t *testing.T) {
 }
 
 func TestUpdateUserRole_BootstrapAdmin(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -532,6 +549,7 @@ func TestUpdateUserRole_BootstrapAdmin(t *testing.T) {
 }
 
 func TestGetUserByProvider_IsProtected(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -555,6 +573,7 @@ func TestGetUserByProvider_IsProtected(t *testing.T) {
 }
 
 func TestDBTrigger_PreventDeactivateProtectedUser(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -574,6 +593,7 @@ func TestDBTrigger_PreventDeactivateProtectedUser(t *testing.T) {
 }
 
 func TestDBTrigger_PreventRoleChangeProtectedUser(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 

--- a/internal/connection/service_test.go
+++ b/internal/connection/service_test.go
@@ -679,7 +679,10 @@ func TestSetManageServerFiles_RoundTrip(t *testing.T) {
 	if err := svc.SetPreStillwaterConfig(ctx, conn.ID, ""); err != nil {
 		t.Fatalf("clear snapshot: %v", err)
 	}
-	got, _ = svc.GetByID(ctx, conn.ID)
+	got, err = svc.GetByID(ctx, conn.ID)
+	if err != nil {
+		t.Fatalf("reload after clear: %v", err)
+	}
 	if got.FeatureManageServerFiles || got.PreStillwaterConfigJSON != "" {
 		t.Errorf("post-clear state = %+v", got)
 	}

--- a/internal/connection/service_test.go
+++ b/internal/connection/service_test.go
@@ -29,6 +29,7 @@ func setupTestService(t *testing.T) *Service {
 }
 
 func TestCreateAndGetByID(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -70,6 +71,7 @@ func TestCreateAndGetByID(t *testing.T) {
 }
 
 func TestCreate_Validation(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -94,6 +96,7 @@ func TestCreate_Validation(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -121,6 +124,7 @@ func TestList(t *testing.T) {
 }
 
 func TestListByType(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -144,6 +148,7 @@ func TestListByType(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -177,6 +182,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -196,6 +202,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDelete_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	if err := svc.Delete(context.Background(), "nonexistent"); err == nil {
 		t.Error("expected error deleting nonexistent connection")
@@ -203,6 +210,7 @@ func TestDelete_NotFound(t *testing.T) {
 }
 
 func TestList_SkipsUndecryptableRows(t *testing.T) {
+	t.Parallel()
 	db, err := database.Open(":memory:")
 	if err != nil {
 		t.Fatalf("opening test db: %v", err)
@@ -246,6 +254,7 @@ func TestList_SkipsUndecryptableRows(t *testing.T) {
 }
 
 func TestList_EmptyEncryptedKey(t *testing.T) {
+	t.Parallel()
 	db, err := database.Open(":memory:")
 	if err != nil {
 		t.Fatalf("opening test db: %v", err)
@@ -287,6 +296,7 @@ func TestList_EmptyEncryptedKey(t *testing.T) {
 }
 
 func TestGetByTypeAndURL(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -327,6 +337,7 @@ func TestGetByTypeAndURL(t *testing.T) {
 }
 
 func TestDeduplicateByTypeURL(t *testing.T) {
+	t.Parallel()
 	db, err := database.Open(":memory:")
 	if err != nil {
 		t.Fatalf("opening test db: %v", err)
@@ -373,6 +384,7 @@ func TestDeduplicateByTypeURL(t *testing.T) {
 }
 
 func TestCreatePreservesFeatureFlags(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -421,6 +433,7 @@ func TestCreatePreservesFeatureFlags(t *testing.T) {
 }
 
 func TestUpdateFeatures(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -450,6 +463,7 @@ func TestUpdateFeatures(t *testing.T) {
 }
 
 func TestUpdateFeatures_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	if err := svc.UpdateFeatures(context.Background(), "nonexistent", true, true, true, false, false); err == nil {
 		t.Error("expected error updating features for nonexistent connection")
@@ -457,6 +471,7 @@ func TestUpdateFeatures_NotFound(t *testing.T) {
 }
 
 func TestUpdatePlatformUserID(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -484,6 +499,7 @@ func TestUpdatePlatformUserID(t *testing.T) {
 }
 
 func TestUpdate_PreservesPlatformUserID(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -518,6 +534,7 @@ func TestUpdate_PreservesPlatformUserID(t *testing.T) {
 }
 
 func TestUpdateStatus(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -543,6 +560,7 @@ func TestUpdateStatus(t *testing.T) {
 }
 
 func TestNewFeatureFlags_DefaultFalse(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -564,6 +582,7 @@ func TestNewFeatureFlags_DefaultFalse(t *testing.T) {
 }
 
 func TestUpdateFeatures_NewFlags(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -590,6 +609,7 @@ func TestUpdateFeatures_NewFlags(t *testing.T) {
 }
 
 func TestUpdate_PreservesNewFeatureFlags(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 
@@ -626,6 +646,7 @@ func TestUpdate_PreservesNewFeatureFlags(t *testing.T) {
 // "Let Stillwater manage" setter plus the DB column read/write. Also pins
 // down SetPreStillwaterConfig alongside since they are always paired.
 func TestSetManageServerFiles_RoundTrip(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	ctx := context.Background()
 	conn := &Connection{Name: "e", Type: TypeEmby, URL: "http://localhost:8096", APIKey: "k"}
@@ -665,6 +686,7 @@ func TestSetManageServerFiles_RoundTrip(t *testing.T) {
 }
 
 func TestSetManageServerFiles_ErrorOnUnknownID(t *testing.T) {
+	t.Parallel()
 	svc := setupTestService(t)
 	if err := svc.SetManageServerFiles(context.Background(), "ghost", true); err == nil {
 		t.Error("want error on unknown id")

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 
 	"github.com/pressly/goose/v3"
 )
@@ -27,13 +28,24 @@ func (g *gooseLogger) Printf(format string, v ...interface{}) {
 	g.logger.Info(fmt.Sprintf(format, v...))
 }
 
+// gooseOnce guards the one-time initialization of goose's package-level state
+// (filesystem, logger, dialect). These values are always identical across all
+// callers, so initializing once is correct. Without this guard, concurrent
+// calls to Migrate (e.g. from parallel tests) race on goose's global vars.
+var (
+	gooseOnce    sync.Once
+	gooseInitErr error
+)
+
 // Migrate runs all pending database migrations.
 func Migrate(db *sql.DB) error {
-	goose.SetBaseFS(migrations)
-	goose.SetLogger(&gooseLogger{logger: slog.Default().With("component", "database")})
-
-	if err := goose.SetDialect("sqlite3"); err != nil {
-		return fmt.Errorf("setting goose dialect: %w", err)
+	gooseOnce.Do(func() {
+		goose.SetBaseFS(migrations)
+		goose.SetLogger(&gooseLogger{logger: slog.Default().With("component", "database")})
+		gooseInitErr = goose.SetDialect("sqlite3")
+	})
+	if gooseInitErr != nil {
+		return fmt.Errorf("setting goose dialect: %w", gooseInitErr)
 	}
 
 	if err := goose.Up(db, "migrations"); err != nil {

--- a/internal/imagebridge/bridge_test.go
+++ b/internal/imagebridge/bridge_test.go
@@ -49,6 +49,7 @@ func setupTestConnService(t *testing.T) *connection.Service {
 }
 
 func TestFetchArtistImage_Success(t *testing.T) {
+	t.Parallel()
 	// Stand up a fake Emby server that returns image bytes.
 	fakeBody := []byte("fake-png-data")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -102,6 +103,7 @@ func TestFetchArtistImage_Success(t *testing.T) {
 }
 
 func TestFetchArtistImage_NoPlatformIDs(t *testing.T) {
+	t.Parallel()
 	connSvc := setupTestConnService(t)
 	provider := &stubPlatformIDProvider{ids: nil}
 	bridge := New(connSvc, provider, slog.Default())
@@ -116,6 +118,7 @@ func TestFetchArtistImage_NoPlatformIDs(t *testing.T) {
 }
 
 func TestFetchArtistImage_PlatformIDLookupError(t *testing.T) {
+	t.Parallel()
 	connSvc := setupTestConnService(t)
 	provider := &stubPlatformIDProvider{err: fmt.Errorf("db error")}
 	bridge := New(connSvc, provider, slog.Default())
@@ -130,6 +133,7 @@ func TestFetchArtistImage_PlatformIDLookupError(t *testing.T) {
 }
 
 func TestFetchArtistImage_DisabledConnection(t *testing.T) {
+	t.Parallel()
 	connSvc := setupTestConnService(t)
 	ctx := context.Background()
 
@@ -165,6 +169,7 @@ func TestFetchArtistImage_DisabledConnection(t *testing.T) {
 }
 
 func TestUploadArtistImage_Success(t *testing.T) {
+	t.Parallel()
 	expectedData := []byte("trimmed-png")
 	received := make(chan []byte, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -233,6 +238,7 @@ func TestUploadArtistImage_Success(t *testing.T) {
 }
 
 func TestUploadArtistImage_NoImageWriteFeature(t *testing.T) {
+	t.Parallel()
 	connSvc := setupTestConnService(t)
 	ctx := context.Background()
 
@@ -279,6 +285,7 @@ func TestUploadArtistImage_NoImageWriteFeature(t *testing.T) {
 }
 
 func TestFetchArtistImage_JellyfinConnection(t *testing.T) {
+	t.Parallel()
 	fakeBody := []byte("jellyfin-logo-data")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/Images/") {
@@ -331,6 +338,7 @@ func TestFetchArtistImage_JellyfinConnection(t *testing.T) {
 }
 
 func TestFetchArtistImage_UnsupportedConnectionType(t *testing.T) {
+	t.Parallel()
 	connSvc := setupTestConnService(t)
 	ctx := context.Background()
 
@@ -366,6 +374,7 @@ func TestFetchArtistImage_UnsupportedConnectionType(t *testing.T) {
 }
 
 func TestListArtistImageSlots_Success(t *testing.T) {
+	t.Parallel()
 	// Stand up a fake Emby server that returns artist detail with images.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// GetArtistDetail hits /Users/{userID}/Items/{artistID}
@@ -437,6 +446,7 @@ func TestListArtistImageSlots_Success(t *testing.T) {
 }
 
 func TestListArtistImageSlots_NoPlatformIDs(t *testing.T) {
+	t.Parallel()
 	connSvc := setupTestConnService(t)
 	provider := &stubPlatformIDProvider{ids: nil}
 	bridge := New(connSvc, provider, slog.Default())
@@ -451,6 +461,7 @@ func TestListArtistImageSlots_NoPlatformIDs(t *testing.T) {
 }
 
 func TestListArtistImageSlots_UnsupportedType(t *testing.T) {
+	t.Parallel()
 	connSvc := setupTestConnService(t)
 	ctx := context.Background()
 

--- a/internal/library/service_test.go
+++ b/internal/library/service_test.go
@@ -25,6 +25,7 @@ func setupTestDB(t *testing.T) *sql.DB {
 }
 
 func TestCreateAndGetByID(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -61,6 +62,7 @@ func TestCreateAndGetByID(t *testing.T) {
 }
 
 func TestGetByID_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -71,6 +73,7 @@ func TestGetByID_NotFound(t *testing.T) {
 }
 
 func TestGetByPath(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -100,6 +103,7 @@ func TestGetByPath(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -134,6 +138,7 @@ func TestList(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -173,6 +178,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestUpdate_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -184,6 +190,7 @@ func TestUpdate_NotFound(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -205,6 +212,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDelete_WithArtists(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -247,6 +255,7 @@ func TestDelete_WithArtists(t *testing.T) {
 }
 
 func TestDelete_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -257,6 +266,7 @@ func TestDelete_NotFound(t *testing.T) {
 }
 
 func TestCountArtists(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -294,6 +304,7 @@ func TestCountArtists(t *testing.T) {
 }
 
 func TestCreate_Validation(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -312,6 +323,7 @@ func TestCreate_Validation(t *testing.T) {
 }
 
 func TestIsPathless(t *testing.T) {
+	t.Parallel()
 	lib := Library{Name: "API Only", Path: "", Type: TypeRegular}
 	if !lib.IsPathless() {
 		t.Error("expected IsPathless() = true for empty path")
@@ -324,6 +336,7 @@ func TestIsPathless(t *testing.T) {
 }
 
 func TestCreate_DuplicateName(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -351,6 +364,7 @@ func TestCreate_DuplicateName(t *testing.T) {
 }
 
 func TestCreate_InvalidSource(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -365,6 +379,7 @@ func TestCreate_InvalidSource(t *testing.T) {
 }
 
 func TestCreate_DefaultSource(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -388,6 +403,7 @@ func TestCreate_DefaultSource(t *testing.T) {
 }
 
 func TestGetByConnectionAndExternalID(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -441,6 +457,7 @@ func TestGetByConnectionAndExternalID(t *testing.T) {
 }
 
 func TestClearConnectionID(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -505,6 +522,7 @@ func TestClearConnectionID(t *testing.T) {
 }
 
 func TestCreate_PathValidation(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -558,6 +576,7 @@ func TestCreate_PathValidation(t *testing.T) {
 }
 
 func TestUpdate_PathValidation(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -620,6 +639,7 @@ func TestUpdate_PathValidation(t *testing.T) {
 }
 
 func TestUpdate_InvalidSource(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -638,6 +658,7 @@ func TestUpdate_InvalidSource(t *testing.T) {
 }
 
 func TestUpdate_DefaultsEmptySource(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -658,6 +679,7 @@ func TestUpdate_DefaultsEmptySource(t *testing.T) {
 }
 
 func TestIsSharedFS(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		status string
 		want   bool
@@ -677,6 +699,7 @@ func TestIsSharedFS(t *testing.T) {
 }
 
 func TestSetSharedFSStatus_RoundTrip(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -726,6 +749,7 @@ func TestSetSharedFSStatus_RoundTrip(t *testing.T) {
 }
 
 func TestSetSharedFSStatus_InvalidStatus(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -743,6 +767,7 @@ func TestSetSharedFSStatus_InvalidStatus(t *testing.T) {
 }
 
 func TestSetSharedFSStatus_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -753,6 +778,7 @@ func TestSetSharedFSStatus_NotFound(t *testing.T) {
 }
 
 func TestListSharedFS(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -805,6 +831,7 @@ func TestListSharedFS(t *testing.T) {
 }
 
 func TestHasLocalLibrary(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -906,6 +933,7 @@ func seedPlatformID(t *testing.T, db *sql.DB, artistID, connID, platformID strin
 // artist row must remove its artist_platform_ids row via ON DELETE CASCADE.
 // Regression guard for the orphan rows that were observed in production.
 func TestDeleteWithArtists_CascadesPlatformIDs(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	if err := database.EnableForeignKeys(db); err != nil {
 		t.Fatalf("enabling foreign keys: %v", err)
@@ -960,6 +988,7 @@ func TestDeleteWithArtists_CascadesPlatformIDs(t *testing.T) {
 // came from the same connection but have a NULL library_id (because some
 // earlier code path lost the assignment) should also be pruned.
 func TestDeleteWithArtists_PrunesOrphanedConnectionArtists(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	if err := database.EnableForeignKeys(db); err != nil {
 		t.Fatalf("enabling foreign keys: %v", err)
@@ -1045,6 +1074,7 @@ func TestDeleteWithArtists_PrunesOrphanedConnectionArtists(t *testing.T) {
 // connection. The prune fallback is only safe when this is the LAST
 // library on the connection.
 func TestDeleteWithArtists_PrunePreservesSiblingLibraryArtists(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	if err := database.EnableForeignKeys(db); err != nil {
 		t.Fatalf("enabling foreign keys: %v", err)
@@ -1124,6 +1154,7 @@ func TestDeleteWithArtists_PrunePreservesSiblingLibraryArtists(t *testing.T) {
 // "WHERE library_id = ?" delete (or even a naive M:N pruner) would erase
 // the artist from under the still-attached library.
 func TestDeleteWithArtists_PreservesArtistInOtherLibraries(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	if err := database.EnableForeignKeys(db); err != nil {
 		t.Fatalf("enabling foreign keys: %v", err)
@@ -1198,6 +1229,7 @@ func TestDeleteWithArtists_PreservesArtistInOtherLibraries(t *testing.T) {
 // stays alive, and the artist row is preserved by the candidate-prune
 // loop because memberships > 0.
 func TestDeleteWithArtists_PrunesStalePlatformIDsForMultiHomeArtist(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	if err := database.EnableForeignKeys(db); err != nil {
 		t.Fatalf("enabling foreign keys: %v", err)
@@ -1285,6 +1317,7 @@ func TestDeleteWithArtists_PrunesStalePlatformIDsForMultiHomeArtist(t *testing.T
 // unlinked connection must still be cleaned up because the artist no
 // longer has any library backing it on that connection.
 func TestDeleteWithArtists_PrunesStalePlatformIDsForMultiConnArtist(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	if err := database.EnableForeignKeys(db); err != nil {
 		t.Fatalf("enabling foreign keys: %v", err)
@@ -1353,6 +1386,7 @@ func TestDeleteWithArtists_PrunesStalePlatformIDsForMultiConnArtist(t *testing.T
 // (issue #1264) round-trips through Create, Update, scan, and re-fetch.
 // Default is false; explicit true persists; flipping back to false persists.
 func TestNFOLockData_RoundTrip(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -1403,6 +1437,7 @@ func TestNFOLockData_RoundTrip(t *testing.T) {
 // (parent /music/jazz must not claim /music/jazzfusion/album), (3) pathless
 // libraries are skipped, and (4) absent ownership returns nil + nil.
 func TestFindForArtistPath(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()

--- a/internal/platform/service_test.go
+++ b/internal/platform/service_test.go
@@ -22,6 +22,7 @@ func setupTestDB(t *testing.T) *sql.DB {
 }
 
 func TestList_BuiltinProfiles(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -54,6 +55,7 @@ func TestList_BuiltinProfiles(t *testing.T) {
 }
 
 func TestGetByID(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -74,6 +76,7 @@ func TestGetByID(t *testing.T) {
 }
 
 func TestGetByID_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -84,6 +87,7 @@ func TestGetByID_NotFound(t *testing.T) {
 }
 
 func TestGetActive(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -101,6 +105,7 @@ func TestGetActive(t *testing.T) {
 }
 
 func TestSetActive(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -128,6 +133,7 @@ func TestSetActive(t *testing.T) {
 }
 
 func TestSetActive_NotFound(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -138,6 +144,7 @@ func TestSetActive_NotFound(t *testing.T) {
 }
 
 func TestCreate_CustomProfile(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -176,6 +183,7 @@ func TestCreate_CustomProfile(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -209,6 +217,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestDelete_CustomProfile(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -229,6 +238,7 @@ func TestDelete_CustomProfile(t *testing.T) {
 }
 
 func TestDelete_BuiltinProfile_Fails(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 
@@ -239,6 +249,7 @@ func TestDelete_BuiltinProfile_Fails(t *testing.T) {
 }
 
 func TestImageNamingMarshal(t *testing.T) {
+	t.Parallel()
 	n := ImageNaming{
 		Thumb:  []string{"folder.jpg", "artist.jpg"},
 		Fanart: []string{"fanart.jpg"},
@@ -258,6 +269,7 @@ func TestImageNamingMarshal(t *testing.T) {
 }
 
 func TestImageNamingUnmarshal_LegacyFormat(t *testing.T) {
+	t.Parallel()
 	// Legacy format: single strings per type
 	legacy := `{"thumb":"folder.jpg","fanart":"fanart.jpg","logo":"logo.png","banner":"banner.jpg"}`
 	got := UnmarshalImageNaming(legacy)
@@ -271,6 +283,7 @@ func TestImageNamingUnmarshal_LegacyFormat(t *testing.T) {
 }
 
 func TestImageNaming_PrimaryName(t *testing.T) {
+	t.Parallel()
 	n := ImageNaming{
 		Thumb:  []string{"folder.jpg", "artist.jpg"},
 		Fanart: []string{"fanart.jpg"},
@@ -288,6 +301,7 @@ func TestImageNaming_PrimaryName(t *testing.T) {
 }
 
 func TestImageNaming_ToMap(t *testing.T) {
+	t.Parallel()
 	n := ImageNaming{
 		Thumb:  []string{"folder.jpg"},
 		Fanart: []string{"fanart.jpg"},
@@ -305,6 +319,7 @@ func TestImageNaming_ToMap(t *testing.T) {
 }
 
 func TestNamesForType(t *testing.T) {
+	t.Parallel()
 	n := ImageNaming{
 		Thumb:  []string{"folder.jpg", "artist.jpg"},
 		Fanart: []string{"fanart.jpg"},
@@ -335,6 +350,7 @@ func TestNamesForType(t *testing.T) {
 }
 
 func TestValidateImageNaming(t *testing.T) {
+	t.Parallel()
 	// Valid naming
 	valid := ImageNaming{
 		Thumb:  []string{"folder.jpg", "artist.jpg"},

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -94,6 +94,7 @@ func (s *stubLibraryLister) List(_ context.Context) ([]library.Library, error) {
 }
 
 func TestScan_PathlessLibrarySkipped(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Visible Artist")
 	svc, artistSvc := setupScanner(t, libDir)
@@ -129,6 +130,7 @@ func TestScan_PathlessLibrarySkipped(t *testing.T) {
 }
 
 func TestScan_EmptyDirectory(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	svc, _ := setupScanner(t, libDir)
 	ctx := context.Background()
@@ -151,6 +153,7 @@ func TestScan_EmptyDirectory(t *testing.T) {
 }
 
 func TestScan_SingleArtist(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Nirvana", "folder.jpg", "fanart.jpg")
 	svc, artistSvc := setupScanner(t, libDir)
@@ -190,6 +193,7 @@ func TestScan_SingleArtist(t *testing.T) {
 }
 
 func TestScan_MultipleArtists(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Artist A", "folder.jpg")
 	createArtistDir(t, libDir, "Artist B", "fanart.jpg", "logo.png")
@@ -210,6 +214,7 @@ func TestScan_MultipleArtists(t *testing.T) {
 }
 
 func TestScan_DetectFiles(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Full",
 		"artist.nfo", "folder.jpg", "fanart.jpg", "logo.png", "banner.jpg")
@@ -243,6 +248,7 @@ func TestScan_DetectFiles(t *testing.T) {
 }
 
 func TestScan_NFOParsing(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	nfoContent := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <artist>
@@ -281,6 +287,7 @@ func TestScan_NFOParsing(t *testing.T) {
 }
 
 func TestScan_UpdateExisting(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Tool")
 	svc, artistSvc := setupScanner(t, libDir)
@@ -326,6 +333,7 @@ func TestScan_UpdateExisting(t *testing.T) {
 }
 
 func TestScan_RemovedArtist(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Temp Band")
 	svc, artistSvc := setupScanner(t, libDir)
@@ -364,6 +372,7 @@ func TestScan_RemovedArtist(t *testing.T) {
 }
 
 func TestScan_ConcurrentPrevention(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	// Create many dirs to keep scan running longer
 	for i := 0; i < 20; i++ {
@@ -390,6 +399,7 @@ func TestScan_ConcurrentPrevention(t *testing.T) {
 }
 
 func TestScan_SkipsHiddenDirs(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, ".hidden")
 	createArtistDir(t, libDir, "Visible")
@@ -409,6 +419,7 @@ func TestScan_SkipsHiddenDirs(t *testing.T) {
 }
 
 func TestScan_Exclusions(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Various Artists", "folder.jpg")
 	createArtistDir(t, libDir, "Nirvana", "folder.jpg")
@@ -461,6 +472,7 @@ func TestScan_Exclusions(t *testing.T) {
 }
 
 func TestScan_HealthScoreIntegration(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	// Create an artist with NFO, thumb, fanart -- should pass several rules
 	nfoContent := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -554,6 +566,7 @@ func TestScan_HealthScoreIntegration(t *testing.T) {
 }
 
 func TestScan_NilRuleEngine(t *testing.T) {
+	t.Parallel()
 	// Verify scanner works fine when rule engine is nil (backward compat)
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Nirvana", "folder.jpg")
@@ -576,6 +589,7 @@ func TestScan_NilRuleEngine(t *testing.T) {
 }
 
 func TestDetectFiles(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	for _, name := range []string{"artist.nfo", "folder.jpg", "backdrop.jpg", "logo.png", "banner.jpg"} {
 		os.WriteFile(filepath.Join(dir, name), []byte("test"), 0o644) //nolint:errcheck
@@ -604,6 +618,7 @@ func TestDetectFiles(t *testing.T) {
 }
 
 func TestDetectFiles_LowRes(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	// Write real PNG images with known dimensions so probeLowRes can decode them.
@@ -656,6 +671,7 @@ func TestDetectFiles_LowRes(t *testing.T) {
 }
 
 func TestDetectFiles_ReadDirError(t *testing.T) {
+	t.Parallel()
 	// Pass a path that does not exist so os.ReadDir fails.
 	_, err := detectFiles(filepath.Join(t.TempDir(), "nonexistent"), nil)
 	if err == nil {
@@ -664,6 +680,7 @@ func TestDetectFiles_ReadDirError(t *testing.T) {
 }
 
 func TestScan_NoLibraries_NoFallback(t *testing.T) {
+	t.Parallel()
 	legacyDir := t.TempDir()
 	createArtistDir(t, legacyDir, "Ghost Artist")
 
@@ -694,6 +711,7 @@ func TestScan_NoLibraries_NoFallback(t *testing.T) {
 }
 
 func TestScan_DeletedLibrary_NoRepopulate(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Real Artist", "folder.jpg")
 
@@ -744,6 +762,7 @@ func TestScan_DeletedLibrary_NoRepopulate(t *testing.T) {
 }
 
 func TestScan_PlaceholderGenerated(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	artistDir := filepath.Join(libDir, "Placeholders")
 	if err := os.MkdirAll(artistDir, 0o755); err != nil {
@@ -788,6 +807,7 @@ func TestScan_PlaceholderGenerated(t *testing.T) {
 }
 
 func TestDetectFiles_Placeholders(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	// Write real images so placeholder generation can decode them.
@@ -839,6 +859,7 @@ func makeScannerPNG(t *testing.T, w, h int) []byte {
 }
 
 func TestDetectFiles_SkipsExistingPlaceholder(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	// Write a real PNG so probeImageFile can decode dimensions.
@@ -869,6 +890,7 @@ func TestDetectFiles_SkipsExistingPlaceholder(t *testing.T) {
 }
 
 func TestProcessDirectory_TransientFailurePreservesPlaceholder(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	artistDir := filepath.Join(libDir, "Transient")
 	if err := os.MkdirAll(artistDir, 0o755); err != nil {
@@ -926,6 +948,7 @@ func TestProcessDirectory_TransientFailurePreservesPlaceholder(t *testing.T) {
 }
 
 func TestShutdownCancelsInProgressScan(t *testing.T) {
+	t.Parallel()
 	tmp := t.TempDir()
 
 	// Create enough artist directories to keep the scan busy.
@@ -987,6 +1010,7 @@ func setupScannerWithDB(t *testing.T, libraryPath string) (*Service, *artist.Ser
 // persistNormalized -> images.UpsertAll, repopulating the row. This test
 // pins that end-to-end recovery as a regression for #1225.
 func TestScan_ReconcilesArtistImagesRegistry(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Reconcile Test", "fanart.jpg")
 	svc, artistSvc, db := setupScannerWithDB(t, libDir)
@@ -1062,6 +1086,7 @@ func TestScan_ReconcilesArtistImagesRegistry(t *testing.T) {
 // the no-change branch did nothing, leaving stale registries permanently
 // stuck unless some other field happened to flip.
 func TestScan_ReconcileImagesOnUnchangedRescan(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Stable Artist", "fanart.jpg")
 	svc, artistSvc, _ := setupScannerWithDB(t, libDir)
@@ -1116,6 +1141,7 @@ func TestScan_ReconcileImagesOnUnchangedRescan(t *testing.T) {
 // future callers can use for explicit registry repair when they have an
 // authoritative image-flag snapshot to write through.
 func TestArtistService_ReconcileImages_IdempotentConvergence(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	artistSvc := artist.NewService(db)
 	ctx := context.Background()
@@ -1205,6 +1231,7 @@ func TestArtistService_ReconcileImages_IdempotentConvergence(t *testing.T) {
 // that the metadata is locked. Regression coverage for the rescan path that
 // previously discarded populateFromNFO's lockdata return value.
 func TestScan_LockDataImportedOnRescan(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Portishead")
 	svc, artistSvc := setupScanner(t, libDir)
@@ -1261,6 +1288,7 @@ func TestScan_LockDataImportedOnRescan(t *testing.T) {
 // the locked state on rescan. Two NFO variants are exercised in sequence so
 // both the missing-tag and the explicit-false parsing branches are covered.
 func TestScan_NoLockDataLeavesUnlocked(t *testing.T) {
+	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Massive Attack")
 	svc, artistSvc := setupScanner(t, libDir)

--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -25,6 +25,7 @@ type Dispatcher struct {
 	httpClient *http.Client
 	logger     *slog.Logger
 	sem        chan struct{} // semaphore to cap concurrent delivery goroutines
+	sleep      func(time.Duration)
 }
 
 // NewDispatcher creates a webhook dispatcher.
@@ -34,6 +35,7 @@ func NewDispatcher(service *Service, logger *slog.Logger) *Dispatcher {
 		httpClient: &http.Client{Timeout: requestTimeout},
 		logger:     logger.With(slog.String("component", "webhook-dispatcher")),
 		sem:        make(chan struct{}, maxConcurrentDeliveries),
+		sleep:      time.Sleep,
 	}
 }
 
@@ -44,6 +46,7 @@ func NewDispatcherWithHTTPClient(service *Service, httpClient *http.Client, logg
 		httpClient: httpClient,
 		logger:     logger.With(slog.String("component", "webhook-dispatcher")),
 		sem:        make(chan struct{}, maxConcurrentDeliveries),
+		sleep:      time.Sleep,
 	}
 }
 
@@ -85,7 +88,7 @@ func (d *Dispatcher) deliver(w Webhook, e event.Event) {
 	for attempt := range maxRetries {
 		if attempt > 0 {
 			backoff := time.Duration(1<<uint(attempt-1)) * time.Second //nolint:gosec // G115: attempt is bounded by maxRetries (3)
-			time.Sleep(backoff)
+			d.sleep(backoff)
 		}
 
 		lastErr = d.send(w.URL, body, contentType)

--- a/internal/webhook/dispatcher_test.go
+++ b/internal/webhook/dispatcher_test.go
@@ -36,12 +36,14 @@ func TestDispatcher_GenericWebhook(t *testing.T) {
 
 	var mu sync.Mutex
 	var received map[string]any
+	done := make(chan struct{})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
-		defer mu.Unlock()
 		json.NewDecoder(r.Body).Decode(&received) //nolint:errcheck
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
+		close(done)
 	}))
 	defer srv.Close()
 
@@ -63,7 +65,11 @@ func TestDispatcher_GenericWebhook(t *testing.T) {
 		Data:      map[string]any{"artists": float64(42)},
 	})
 
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for webhook delivery")
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -81,12 +87,14 @@ func TestDispatcher_DiscordFormat(t *testing.T) {
 
 	var mu sync.Mutex
 	var received map[string]any
+	done := make(chan struct{})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
-		defer mu.Unlock()
 		json.NewDecoder(r.Body).Decode(&received) //nolint:errcheck
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
+		close(done)
 	}))
 	defer srv.Close()
 
@@ -108,7 +116,11 @@ func TestDispatcher_DiscordFormat(t *testing.T) {
 		Data:      map[string]any{"message": "Scan finished"},
 	})
 
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for webhook delivery")
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -234,10 +246,11 @@ func TestDispatcher_NoMatchingWebhooks(t *testing.T) {
 	}
 
 	dispatcher := NewDispatcher(svc, logger)
-	// Should not panic or hang
+	// Should not panic or hang. No webhook matches ScanCompleted (the
+	// registered webhook listens for bulk.completed), so HandleEvent spawns
+	// no delivery goroutines and there is nothing to wait on.
 	dispatcher.HandleEvent(event.Event{
 		Type:      event.ScanCompleted,
 		Timestamp: time.Now().UTC(),
 	})
-	time.Sleep(50 * time.Millisecond)
 }

--- a/internal/webhook/dispatcher_test.go
+++ b/internal/webhook/dispatcher_test.go
@@ -130,6 +130,7 @@ func TestDispatcher_RetryOn500(t *testing.T) {
 	svc, logger := setupDispatcherTest(t)
 
 	var attempts atomic.Int32
+	done := make(chan struct{})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		n := attempts.Add(1)
@@ -137,6 +138,7 @@ func TestDispatcher_RetryOn500(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
+		close(done)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
@@ -159,7 +161,11 @@ func TestDispatcher_RetryOn500(t *testing.T) {
 		Timestamp: time.Now().UTC(),
 	})
 
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for retry attempts")
+	}
 
 	got := int(attempts.Load())
 	if got != 3 {
@@ -172,9 +178,12 @@ func TestDispatcher_MaxRetries(t *testing.T) {
 	svc, logger := setupDispatcherTest(t)
 
 	var attempts atomic.Int32
+	done := make(chan struct{})
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		attempts.Add(1)
+		if attempts.Add(1) == int32(maxRetries) {
+			close(done)
+		}
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer srv.Close()
@@ -197,7 +206,11 @@ func TestDispatcher_MaxRetries(t *testing.T) {
 		Timestamp: time.Now().UTC(),
 	})
 
-	time.Sleep(100 * time.Millisecond)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for retry attempts")
+	}
 
 	got := int(attempts.Load())
 	if got != 3 {

--- a/internal/webhook/dispatcher_test.go
+++ b/internal/webhook/dispatcher_test.go
@@ -31,6 +31,7 @@ func setupDispatcherTest(t *testing.T) (*Service, *slog.Logger) {
 }
 
 func TestDispatcher_GenericWebhook(t *testing.T) {
+	t.Parallel()
 	svc, logger := setupDispatcherTest(t)
 
 	var mu sync.Mutex
@@ -75,6 +76,7 @@ func TestDispatcher_GenericWebhook(t *testing.T) {
 }
 
 func TestDispatcher_DiscordFormat(t *testing.T) {
+	t.Parallel()
 	svc, logger := setupDispatcherTest(t)
 
 	var mu sync.Mutex
@@ -124,6 +126,7 @@ func TestDispatcher_DiscordFormat(t *testing.T) {
 }
 
 func TestDispatcher_RetryOn500(t *testing.T) {
+	t.Parallel()
 	svc, logger := setupDispatcherTest(t)
 
 	var attempts atomic.Int32
@@ -150,13 +153,13 @@ func TestDispatcher_RetryOn500(t *testing.T) {
 	}
 
 	dispatcher := NewDispatcherWithHTTPClient(svc, srv.Client(), logger)
+	dispatcher.sleep = func(time.Duration) {}
 	dispatcher.HandleEvent(event.Event{
 		Type:      event.ScanCompleted,
 		Timestamp: time.Now().UTC(),
 	})
 
-	// Wait for retries (1s + 2s backoff)
-	time.Sleep(5 * time.Second)
+	time.Sleep(100 * time.Millisecond)
 
 	got := int(attempts.Load())
 	if got != 3 {
@@ -165,6 +168,7 @@ func TestDispatcher_RetryOn500(t *testing.T) {
 }
 
 func TestDispatcher_MaxRetries(t *testing.T) {
+	t.Parallel()
 	svc, logger := setupDispatcherTest(t)
 
 	var attempts atomic.Int32
@@ -187,13 +191,13 @@ func TestDispatcher_MaxRetries(t *testing.T) {
 	}
 
 	dispatcher := NewDispatcherWithHTTPClient(svc, srv.Client(), logger)
+	dispatcher.sleep = func(time.Duration) {}
 	dispatcher.HandleEvent(event.Event{
 		Type:      event.BulkCompleted,
 		Timestamp: time.Now().UTC(),
 	})
 
-	// Wait for all retries (1s + 2s + attempt 3)
-	time.Sleep(6 * time.Second)
+	time.Sleep(100 * time.Millisecond)
 
 	got := int(attempts.Load())
 	if got != 3 {
@@ -202,6 +206,7 @@ func TestDispatcher_MaxRetries(t *testing.T) {
 }
 
 func TestDispatcher_NoMatchingWebhooks(t *testing.T) {
+	t.Parallel()
 	svc, logger := setupDispatcherTest(t)
 
 	w := &Webhook{

--- a/internal/webhook/emby_test.go
+++ b/internal/webhook/emby_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestEmbyPayload_Decode_TestEvent(t *testing.T) {
+	t.Parallel()
 	raw := `{"Event":"system.notificationtest"}`
 	var p EmbyPayload
 	if err := json.Unmarshal([]byte(raw), &p); err != nil {
@@ -20,6 +21,7 @@ func TestEmbyPayload_Decode_TestEvent(t *testing.T) {
 }
 
 func TestEmbyPayload_Decode_ItemAdded_WithMBIDs(t *testing.T) {
+	t.Parallel()
 	raw := `{
 		"Event": "library.new",
 		"Item": {
@@ -59,6 +61,7 @@ func TestEmbyPayload_Decode_ItemAdded_WithMBIDs(t *testing.T) {
 }
 
 func TestEmbyPayload_ArtistMBIDs_EmptyWhenNoProviderIds(t *testing.T) {
+	t.Parallel()
 	item := EmbyItem{Name: "Some Album", Type: "MusicAlbum"}
 	if got := item.ArtistMBIDs(); got != nil {
 		t.Errorf("ArtistMBIDs() = %v, want nil", got)
@@ -66,6 +69,7 @@ func TestEmbyPayload_ArtistMBIDs_EmptyWhenNoProviderIds(t *testing.T) {
 }
 
 func TestEmbyPayload_ArtistMBIDs_EmptyWhenKeyAbsent(t *testing.T) {
+	t.Parallel()
 	item := EmbyItem{
 		Name:        "Some Album",
 		Type:        "MusicAlbum",
@@ -77,6 +81,7 @@ func TestEmbyPayload_ArtistMBIDs_EmptyWhenKeyAbsent(t *testing.T) {
 }
 
 func TestEmbyPayload_ArtistMBIDs_SingleArtist(t *testing.T) {
+	t.Parallel()
 	item := EmbyItem{
 		Name:        "Some Album",
 		Type:        "MusicAlbum",
@@ -89,6 +94,7 @@ func TestEmbyPayload_ArtistMBIDs_SingleArtist(t *testing.T) {
 }
 
 func TestEmbyPayload_LibraryChanged(t *testing.T) {
+	t.Parallel()
 	raw := `{"Event":"library.changed"}`
 	var p EmbyPayload
 	if err := json.Unmarshal([]byte(raw), &p); err != nil {

--- a/internal/webhook/jellyfin_test.go
+++ b/internal/webhook/jellyfin_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestJellyfinPayload_Decode_TestEvent(t *testing.T) {
+	t.Parallel()
 	raw := `{"NotificationType":"Test"}`
 	var p JellyfinPayload
 	if err := json.Unmarshal([]byte(raw), &p); err != nil {
@@ -17,6 +18,7 @@ func TestJellyfinPayload_Decode_TestEvent(t *testing.T) {
 }
 
 func TestJellyfinPayload_Decode_ItemAdded_WithMBID(t *testing.T) {
+	t.Parallel()
 	// Jellyfin sends MusicAlbum items (not MusicArtist); MBID is the album artist ID.
 	// Confirmed via UAT against Jellyfin webhook plugin v18.
 	raw := `{
@@ -49,6 +51,7 @@ func TestJellyfinPayload_Decode_ItemAdded_WithMBID(t *testing.T) {
 }
 
 func TestJellyfinPayload_MBID_EmptyWhenAbsent(t *testing.T) {
+	t.Parallel()
 	p := JellyfinPayload{
 		NotificationType: JellyfinEventItemAdded,
 		ItemType:         "MusicAlbum",
@@ -60,6 +63,7 @@ func TestJellyfinPayload_MBID_EmptyWhenAbsent(t *testing.T) {
 }
 
 func TestJellyfinPayload_NonMusicAlbumType(t *testing.T) {
+	t.Parallel()
 	raw := `{
 		"NotificationType": "ItemAdded",
 		"ItemId": "xyz",
@@ -76,6 +80,7 @@ func TestJellyfinPayload_NonMusicAlbumType(t *testing.T) {
 }
 
 func TestJellyfinPayload_LibraryChanged(t *testing.T) {
+	t.Parallel()
 	raw := `{"NotificationType":"LibraryChanged"}`
 	var p JellyfinPayload
 	if err := json.Unmarshal([]byte(raw), &p); err != nil {
@@ -87,6 +92,7 @@ func TestJellyfinPayload_LibraryChanged(t *testing.T) {
 }
 
 func TestJellyfinPayload_ItemUpdated(t *testing.T) {
+	t.Parallel()
 	raw := `{
 		"NotificationType": "ItemUpdated",
 		"ItemType": "MusicAlbum",

--- a/internal/webhook/service_test.go
+++ b/internal/webhook/service_test.go
@@ -21,6 +21,7 @@ func setupTestDB(t *testing.T) *Service {
 }
 
 func TestCreate(t *testing.T) {
+	t.Parallel()
 	svc := setupTestDB(t)
 	ctx := context.Background()
 
@@ -40,6 +41,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestCreate_ValidationErrors(t *testing.T) {
+	t.Parallel()
 	svc := setupTestDB(t)
 	ctx := context.Background()
 
@@ -52,6 +54,7 @@ func TestCreate_ValidationErrors(t *testing.T) {
 }
 
 func TestGetByID(t *testing.T) {
+	t.Parallel()
 	svc := setupTestDB(t)
 	ctx := context.Background()
 
@@ -82,6 +85,7 @@ func TestGetByID(t *testing.T) {
 }
 
 func TestGetByID_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := setupTestDB(t)
 	ctx := context.Background()
 
@@ -92,6 +96,7 @@ func TestGetByID_NotFound(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
+	t.Parallel()
 	svc := setupTestDB(t)
 	ctx := context.Background()
 
@@ -116,6 +121,7 @@ func TestList(t *testing.T) {
 }
 
 func TestListByEvent(t *testing.T) {
+	t.Parallel()
 	svc := setupTestDB(t)
 	ctx := context.Background()
 
@@ -141,6 +147,7 @@ func TestListByEvent(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
+	t.Parallel()
 	svc := setupTestDB(t)
 	ctx := context.Background()
 
@@ -168,6 +175,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
+	t.Parallel()
 	svc := setupTestDB(t)
 	ctx := context.Background()
 
@@ -187,6 +195,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDelete_NotFound(t *testing.T) {
+	t.Parallel()
 	svc := setupTestDB(t)
 	if err := svc.Delete(context.Background(), "nope"); err == nil {
 		t.Error("expected error for nonexistent webhook")


### PR DESCRIPTION
## Summary

- **Webhook clock injection:** add `sleep func(time.Duration)` field to `Dispatcher`; retry tests inject a no-op, dropping `TestDispatcher_RetryOn500` from ~5 s to <1 s and `TestDispatcher_MaxRetries` from ~6 s to <1 s
- **t.Parallel sweep:** add `t.Parallel()` as the first statement to all serial-safe top-level test functions across `internal/api`, `internal/artist`, `internal/auth`, `internal/webhook`, `internal/connection`, `internal/imagebridge`, `internal/library`, `internal/platform`, and `internal/scanner` (~200+ functions); `internal/rule` excluded (see below)
- **goose race fix:** `database.Migrate()` was calling `goose.SetBaseFS/SetLogger/SetDialect` (package-level globals) on every invocation; parallel tests raced on these; wrap the one-time initialization in `sync.Once`
- **CI yaml:** remove redundant `templ install + generate` from the Test job (Lint already gates this); add `cache: true` to all three `setup-go` steps; add `-timeout 8m` to `go test`

## Excluded: `internal/rule`

`testmain_test.go` populates a shared `templateDBPath` package-level variable from `TestMain`. Parallelizing rule tests without refactoring that pattern is unsafe. Tracked for a follow-up issue.

## Test plan

- [ ] CI Test job passes (all four changes land together)
- [ ] `go test -race -timeout 8m -v ./internal/webhook/...` completes in under 5 s (was ~12 s)
- [ ] `go test -race -count=2 ./internal/api/... ./internal/artist/... ./internal/auth/... ./internal/webhook/...` passes twice (no flakes introduced)
- [ ] `internal/rule/...` tests still pass (parallel not added there)
- [ ] Verify `TestRegisterPprof_ShutdownOnContextCancel` remains serial (has explicit comment + `pprofOnce` reset + port 6060)

Closes #1289

Part of M46.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled broad concurrent test execution to speed CI and surface issues sooner.
  * Added/expanded tests for library NFO lock handling, platform presence detection, compliance reporting counts, webhook delivery/retry behavior, and other areas to increase confidence.

* **Chores**
  * CI: enabled Go module caching and standardized test timeouts for more reliable builds.
  * Improved test and migration initialization to reduce flakiness during parallel runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->