### PR TITLE
test(event): replace time.Sleep with WaitGroup signaling in bus_test; add make test-shuffle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks check-openapi hadolint scan
+.PHONY: build run test test-shuffle test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks check-openapi hadolint scan
 
 # Binary name
 BINARY=stillwater

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ dev:
 test:
 	go test -v -race -count=1 ./...
 
+## test-shuffle: Run tests with random ordering to surface order-dependent tests (local hygiene; reproduce a failure with -shuffle=<seed>)
+test-shuffle:
+	go test -race -count=1 -shuffle=on ./...
+
 ## test-race: Run tests with race detector via WSL2 (requires WSL2 with Go and GCC installed)
 test-race:
 	@wsl_path=$$(echo "$(CURDIR)" | sed 's|^/\([a-zA-Z]\)/|/mnt/\1/|'); \

--- a/internal/event/bus_test.go
+++ b/internal/event/bus_test.go
@@ -100,11 +100,20 @@ func TestNoSubscribers(t *testing.T) {
 	go bus.Start()
 	defer bus.Stop()
 
-	// Publish must not panic when no subscribers are registered. With no
-	// handlers there is nothing to wait on -- the bus dispatch loop simply
-	// drops the event. The synchronous Publish call returning is the only
-	// signal we need; defer bus.Stop() drains the loop.
-	bus.Publish(Event{Type: ArtistNew})
+	// Publish must not panic and must not stall the dispatch loop when no
+	// subscribers are registered for the event type. Subscribe a sentinel
+	// handler on a *different* event type and publish that immediately
+	// after; events are processed in order, so the sentinel firing proves
+	// the dispatcher consumed the no-subscriber event without panicking
+	// or wedging.
+	var sentinel sync.WaitGroup
+	sentinel.Add(1)
+	bus.Subscribe(BulkCompleted, func(_ Event) { sentinel.Done() })
+
+	bus.Publish(Event{Type: ArtistNew}) // no subscribers
+	bus.Publish(Event{Type: BulkCompleted})
+
+	waitOrFail(t, &sentinel, "dispatcher did not process events past the no-subscriber publish within 1s")
 }
 
 func TestBufferFull(t *testing.T) {
@@ -171,11 +180,12 @@ func TestStopDrainsBuffer(t *testing.T) {
 	bus.Publish(Event{Type: ScanCompleted})
 
 	go bus.Start()
-	// Wait until both buffered events have been dispatched, then Stop. The
-	// wg signal is the contract: "both handlers ran". Bus.Stop() is then
-	// the synchronous drain barrier; no second wait needed.
-	waitOrFail(t, &wg, "buffered events not drained within 1s")
+	// Call Stop without waiting for handlers first -- the test name promises
+	// that Stop itself drains buffered events. Calling waitOrFail BEFORE
+	// Stop would let this test pass even if Stop did nothing, since the
+	// dispatcher would have already drained the buffer on its own.
 	bus.Stop()
+	waitOrFail(t, &wg, "buffered events not drained after Stop within 1s")
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/event/bus_test.go
+++ b/internal/event/bus_test.go
@@ -161,12 +161,31 @@ func TestHandlerPanicRecovery(t *testing.T) {
 }
 
 func TestStopDrainsBuffer(t *testing.T) {
-	bus := NewBus(testLogger(), 16)
+	// Why N=16 and Stop-before-Start:
+	//
+	// Bus.Start's outer select races `case e := <-b.ch` against
+	// `case <-b.done`. With both ready, Go's select picks randomly each
+	// iteration. A 2-event version of this test could drain the buffer
+	// entirely through the outer ch path and never enter the inner drain
+	// loop -- so a regression that breaks the inner drain (e.g. Stop just
+	// returns without draining) would still let the test pass.
+	//
+	// Calling Stop *before* Start ensures done is closed when Start enters
+	// its select. Publishing N=16 events (matching the buffer size) makes
+	// the probability of the outer ch path winning all 16 iterations
+	// (1/2)^16 ~= 1.5e-5 -- effectively guaranteeing the inner drain path
+	// runs at least once. A regression that breaks the inner drain would
+	// produce count < 16 with overwhelming probability.
+	//
+	// True determinism would require restructuring Start to make the
+	// drain path the only post-Stop dispatch route. Out of scope here.
+	const N = 16
+	bus := NewBus(testLogger(), N)
 
 	var mu sync.Mutex
 	count := 0
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(N)
 
 	bus.Subscribe(ScanCompleted, func(_ Event) {
 		defer wg.Done()
@@ -175,21 +194,19 @@ func TestStopDrainsBuffer(t *testing.T) {
 		count++
 	})
 
-	// Publish before starting -- both events sit in the channel buffer.
-	bus.Publish(Event{Type: ScanCompleted})
-	bus.Publish(Event{Type: ScanCompleted})
+	// Fill the buffer before Start runs; Stop closes done while every event
+	// is still queued.
+	for range N {
+		bus.Publish(Event{Type: ScanCompleted})
+	}
+	bus.Stop()
 
 	go bus.Start()
-	// Call Stop without waiting for handlers first -- the test name promises
-	// that Stop itself drains buffered events. Calling waitOrFail BEFORE
-	// Stop would let this test pass even if Stop did nothing, since the
-	// dispatcher would have already drained the buffer on its own.
-	bus.Stop()
 	waitOrFail(t, &wg, "buffered events not drained after Stop within 1s")
 
 	mu.Lock()
 	defer mu.Unlock()
-	if count != 2 {
-		t.Errorf("got %d events, want 2 (all drained)", count)
+	if count != N {
+		t.Errorf("got %d events, want %d (all drained)", count, N)
 	}
 }

--- a/internal/event/bus_test.go
+++ b/internal/event/bus_test.go
@@ -12,6 +12,23 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 }
 
+// waitOrFail blocks until wg signals done or the timeout fires. Tests use
+// this to join handler goroutines deterministically -- a fixed time.Sleep
+// would either under-wait (flake) or over-wait (slow).
+func waitOrFail(t *testing.T, wg *sync.WaitGroup, msg string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal(msg)
+	}
+}
+
 func TestPublishSubscribe(t *testing.T) {
 	bus := NewBus(testLogger(), 16)
 	go bus.Start()
@@ -19,8 +36,11 @@ func TestPublishSubscribe(t *testing.T) {
 
 	var mu sync.Mutex
 	var received []Event
+	var wg sync.WaitGroup
+	wg.Add(1)
 
 	bus.Subscribe(ScanCompleted, func(e Event) {
+		defer wg.Done()
 		mu.Lock()
 		defer mu.Unlock()
 		received = append(received, e)
@@ -31,8 +51,7 @@ func TestPublishSubscribe(t *testing.T) {
 		Data: map[string]any{"artists": 42},
 	})
 
-	// Give the goroutine time to process
-	time.Sleep(50 * time.Millisecond)
+	waitOrFail(t, &wg, "handler not invoked within 1s")
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -54,9 +73,12 @@ func TestMultipleSubscribers(t *testing.T) {
 
 	var mu sync.Mutex
 	count := 0
+	var wg sync.WaitGroup
+	wg.Add(3)
 
 	for range 3 {
 		bus.Subscribe(BulkCompleted, func(_ Event) {
+			defer wg.Done()
 			mu.Lock()
 			defer mu.Unlock()
 			count++
@@ -64,7 +86,7 @@ func TestMultipleSubscribers(t *testing.T) {
 	}
 
 	bus.Publish(Event{Type: BulkCompleted})
-	time.Sleep(50 * time.Millisecond)
+	waitOrFail(t, &wg, "all 3 handlers not invoked within 1s")
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -78,9 +100,11 @@ func TestNoSubscribers(t *testing.T) {
 	go bus.Start()
 	defer bus.Stop()
 
-	// Should not panic
+	// Publish must not panic when no subscribers are registered. With no
+	// handlers there is nothing to wait on -- the bus dispatch loop simply
+	// drops the event. The synchronous Publish call returning is the only
+	// signal we need; defer bus.Stop() drains the loop.
 	bus.Publish(Event{Type: ArtistNew})
-	time.Sleep(50 * time.Millisecond)
 }
 
 func TestBufferFull(t *testing.T) {
@@ -101,18 +125,24 @@ func TestHandlerPanicRecovery(t *testing.T) {
 
 	var mu sync.Mutex
 	secondCalled := false
+	var wg sync.WaitGroup
+	wg.Add(2)
 
 	bus.Subscribe(MetadataFixed, func(_ Event) {
+		// The bus must still call wg.Done() for this handler even though
+		// it panics; the bus's recover() path is what we are testing.
+		defer wg.Done()
 		panic("test panic")
 	})
 	bus.Subscribe(MetadataFixed, func(_ Event) {
+		defer wg.Done()
 		mu.Lock()
 		defer mu.Unlock()
 		secondCalled = true
 	})
 
 	bus.Publish(Event{Type: MetadataFixed})
-	time.Sleep(50 * time.Millisecond)
+	waitOrFail(t, &wg, "both handlers not invoked within 1s")
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -126,21 +156,26 @@ func TestStopDrainsBuffer(t *testing.T) {
 
 	var mu sync.Mutex
 	count := 0
+	var wg sync.WaitGroup
+	wg.Add(2)
 
 	bus.Subscribe(ScanCompleted, func(_ Event) {
+		defer wg.Done()
 		mu.Lock()
 		defer mu.Unlock()
 		count++
 	})
 
-	// Publish before starting
+	// Publish before starting -- both events sit in the channel buffer.
 	bus.Publish(Event{Type: ScanCompleted})
 	bus.Publish(Event{Type: ScanCompleted})
 
 	go bus.Start()
-	time.Sleep(50 * time.Millisecond)
+	// Wait until both buffered events have been dispatched, then Stop. The
+	// wg signal is the contract: "both handlers ran". Bus.Stop() is then
+	// the synchronous drain barrier; no second wait needed.
+	waitOrFail(t, &wg, "buffered events not drained within 1s")
 	bus.Stop()
-	time.Sleep(50 * time.Millisecond)
 
 	mu.Lock()
 	defer mu.Unlock()


### PR DESCRIPTION
## Summary

Follow-up to #1290 (CI Test job wall-time work). Implements the `time.Sleep` audit suggestion from that PR's retrospective. Two small changes:

1. **`internal/event/bus_test.go`**: convert the 6 fixed `time.Sleep(50ms)` waits to a `waitOrFail` helper that joins handler goroutines via `sync.WaitGroup` with a 1s safety timeout. Tests now exit as soon as handlers have actually been invoked, not after a fixed wall-clock window. Removes flake risk on busy CI runners and shaves ~300ms off the package suite.

2. **`Makefile`**: add `test-shuffle` target (`go test -race -count=1 -shuffle=on ./...`) for local hygiene checks. Surfaces order-dependent tests; the shuffle seed is printed on failure so any failure is reproducible. Not wired into CI.

## Issue linkage

- **Closes**: none (no pre-existing issue tracked this audit; it was scoped from #1290's review discussion).
- **Related**: #1290 (parent CI wall-time work).
- **Spawned**: #1295 (clock-precision sleeps -- the highest structural payoff that fell out of the audit but was out of scope here).
- **Adjacent CI/test follow-ups**: #1292 (matrix sharding), #1293 (template DB caching).

## Audit context

Of 68 `time.Sleep` call sites across `_test.go` files, only the 6 in `internal/event/bus_test.go` were straightforwardly convertible to signal-based waits. The rest fall into categories that are either correct as-is or require structural changes:

| Category | Count | Action |
|---|---|---|
| Inside polling loops (`for { if cond break; sleep N }`) | ~20 | Correct pattern, leave |
| Clock-advancement for SQLite second-precision timestamps | ~10 | Structural -- tracked in #1295 |
| Negative-signal waits ("give goroutine a moment to fail") | ~6 | Provably unfixable without test redesign |
| fsnotify OS-event waits in `watcher_test.go` | 19 | Inherently async, structural |
| File mtime precision waits | ~4 | Filesystem-precision constraint |

## Test plan

- [x] `go test -race -count=10 ./internal/event/` -- 10 consecutive clean runs
- [x] `bash scripts/pre-push-gate.sh` -- clean
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability with deterministic synchronization mechanisms.
  * Added shuffled test execution option to identify ordering-dependent issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->