### PR TITLE
ci(1292): shard Test job into 4 matrix shards by per-package profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
+    strategy:
+      # One shard's failure should not cancel the others -- a flake in one
+      # shard hides real failures in the others if fail-fast is on.
+      fail-fast: false
+      matrix:
+        shard: [api, rule, services, core]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -93,14 +99,53 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # Resolve the package list for this shard. The api / rule / services
+      # shards have static lists derived from a per-package profile (api 83s,
+      # rule+settingsio 110s, auth+image+artist 105s). The core shard is
+      # dynamic -- whatever is left after excluding the static buckets --
+      # so newly-added packages auto-fall into core without further matrix
+      # edits. Wall time = max(shards) + runner overhead (~60s).
+      - name: Resolve shard package list
+        id: shard
+        run: |
+          case "${{ matrix.shard }}" in
+            api)
+              echo "packages=./internal/api/..." >> "$GITHUB_OUTPUT"
+              ;;
+            rule)
+              echo "packages=./internal/rule/... ./internal/settingsio/..." >> "$GITHUB_OUTPUT"
+              ;;
+            services)
+              echo "packages=./internal/auth/... ./internal/image/... ./internal/artist/..." >> "$GITHUB_OUTPUT"
+              ;;
+            core)
+              # Everything not covered by the named shards above. Keep the
+              # exclusion list in sync with the case branches.
+              pkgs=$(go list ./... | grep -v -E '^github\.com/sydlexius/stillwater/(internal/api|internal/rule|internal/settingsio|internal/auth|internal/image|internal/artist)(/|$)' | tr '\n' ' ')
+              echo "packages=${pkgs}" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unknown shard: ${{ matrix.shard }}" >&2
+              exit 1
+              ;;
+          esac
+
+      # -coverpkg=./... is intentionally cross-shard: each shard's coverage
+      # profile records hits across the WHOLE module, not just its own
+      # packages. Codecov OR-merges multiple uploads on the same commit, so
+      # a line marked covered by any shard wins -- the final report is
+      # accurate regardless of which shard executed which test.
       - name: Run tests
-        run: go test -v -race -count=1 -timeout 8m -coverpkg=./... -coverprofile=coverage.out ./...
+        run: go test -v -race -count=1 -timeout 8m -coverpkg=./... -coverprofile=coverage.out ${{ steps.shard.outputs.packages }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
+          # Tag uploads with the shard name so codecov can attribute and
+          # merge per-shard coverage cleanly across the matrix.
+          flags: shard-${{ matrix.shard }}
           fail_ci_if_error: true
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,27 +112,45 @@ jobs:
       - name: Resolve shard package list
         id: shard
         run: |
-          case "${{ matrix.shard }}" in
-            api)
-              echo "packages=./internal/api/..." >> "$GITHUB_OUTPUT"
-              ;;
-            rule)
-              echo "packages=./internal/rule/... ./internal/settingsio/..." >> "$GITHUB_OUTPUT"
-              ;;
-            services)
-              echo "packages=./internal/auth/... ./internal/image/... ./internal/artist/..." >> "$GITHUB_OUTPUT"
-              ;;
+          # Single source of truth for named-shard package mappings. Adding
+          # or moving packages between shards is a one-line change here; the
+          # named-shard branches and the core exclusion regex both derive
+          # from this map, so they cannot drift. Adding a NEW shard also
+          # requires updating the matrix.shard list above.
+          declare -A SHARDS=(
+            [api]="internal/api"
+            [rule]="internal/rule internal/settingsio"
+            [services]="internal/auth internal/image internal/artist"
+          )
+
+          shard="${{ matrix.shard }}"
+          case "${shard}" in
             core)
-              # Everything not covered by the named shards above. Keep the
-              # exclusion list in sync with the case branches.
-              pkgs=$(go list ./... | grep -v -E '^github\.com/sydlexius/stillwater/(internal/api|internal/rule|internal/settingsio|internal/auth|internal/image|internal/artist)(/|$)' | tr '\n' ' ')
-              echo "packages=${pkgs}" >> "$GITHUB_OUTPUT"
+              # Dynamic exclusion: derive the regex from SHARDS so this
+              # branch cannot drift from the named-shard branches. Module
+              # path comes from `go list -m` so a go.mod rename does not
+              # silently break sharding.
+              module=$(go list -m)
+              excludes=""
+              for k in "${!SHARDS[@]}"; do
+                for p in ${SHARDS[$k]}; do
+                  excludes="${excludes:+${excludes}|}${p}"
+                done
+              done
+              pkgs=$(go list ./... | grep -v -E "^${module}/(${excludes})(/|$)" | tr '\n' ' ')
               ;;
             *)
-              echo "Unknown shard: ${{ matrix.shard }}" >&2
-              exit 1
+              if [ -z "${SHARDS[${shard}]+x}" ]; then
+                echo "Unknown shard: ${shard}" >&2
+                exit 1
+              fi
+              pkgs=""
+              for p in ${SHARDS[${shard}]}; do
+                pkgs="${pkgs}./${p}/... "
+              done
               ;;
           esac
+          echo "packages=${pkgs}" >> "$GITHUB_OUTPUT"
 
       # -coverpkg=./... is intentionally cross-shard: each shard's coverage
       # profile records hits across the WHOLE module, not just its own

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,11 @@ jobs:
         run: npx --yes @stoplight/spectral-cli@6.15.0 lint internal/api/openapi.yaml --ruleset .spectral.yaml --fail-severity=warn
 
   test:
-    name: Test
+    # Per-shard display names render as "Test Shard (api)", "Test Shard (rule)",
+    # etc. The bare name "Test" is owned by the test-summary job below so the
+    # pre-existing required check remains satisfied without a branch-protection
+    # update at merge time.
+    name: Test Shard
     runs-on: ubuntu-latest
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
@@ -147,6 +151,24 @@ jobs:
           # merge per-shard coverage cleanly across the matrix.
           flags: shard-${{ matrix.shard }}
           fail_ci_if_error: true
+
+  # Aggregate gate that owns the "Test" check name. Branch protection can keep
+  # requiring "Test" without enumerating every shard, and this job will fail
+  # iff any matrix shard did not succeed. always() ensures we still emit a
+  # status when shards fail or are cancelled (default needs behavior would
+  # skip the gate, leaving "Test" unreported and branch protection stuck).
+  test-summary:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: [changes, test]
+    if: always() && needs.changes.outputs.code == 'true'
+    steps:
+      - name: Verify all shards succeeded
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "One or more Test shards did not succeed: ${{ needs.test.result }}"
+            exit 1
+          fi
 
   build:
     name: Build


### PR DESCRIPTION
## Summary

Closes #1292.

The Test job ran `go test ./...` serially across all packages. Go's test runner only parallelizes within a package, so packages still ran one after another. Sharding lets independent packages run on parallel runners; wall time becomes `max(shards) + runner overhead` instead of `sum`.

## Per-package profile (basis for the shard split)

| Package | Time |
|---|---|
| internal/api | 82.8s |
| internal/settingsio | 54.9s |
| internal/rule | 54.8s |
| internal/auth | 44.8s |
| internal/image | 34.5s |
| internal/artist | 26.3s |
| internal/updater | 20.4s |
| (~30 smaller packages) | ~80s combined |

The issue's original `api / artist / core` proposal would have left core holding ~80% of total wall time (artist is #6, not #2; `settingsio`, `rule`, `auth`, `image` are all bigger). LPT bin-packing across 4 shards balances much better.

## Shard split

| Shard | Packages | ~Time |
|---|---|---|
| api | `internal/api/...` | 83s |
| rule | `internal/rule/...`, `internal/settingsio/...` | 110s |
| services | `internal/auth/...`, `internal/image/...`, `internal/artist/...` | 105s |
| core | everything else (dynamic via `go list \| grep -v`) | ~119s |

**Expected wall time: ~3:00** (max shard ~119s + runner/setup ~60s), down from current ~7:22. Roughly **60% reduction**. 3 shards would have saved only ~40% because `settingsio + rule` together is already 110s.

## Implementation notes

- `fail-fast: false` -- a flake in one shard must not mask real failures in others.
- Single-source-of-truth `SHARDS` associative array drives both the named-shard branches and the core exclusion regex; the case branches and the core filter cannot drift. Adding/moving packages between shards is a one-line change.
- Module path resolved dynamically via `go list -m` so a `go.mod` rename does not silently break sharding.
- `-coverpkg=./...` per shard: each shard records cross-module coverage, codecov OR-merges multiple uploads on the same commit, final report stays accurate regardless of which shard ran which test.
- Codecov upload tagged with `flags: shard-<name>` for per-shard attribution in the codecov UI.

## Branch protection: no manual update required at merge time

The matrix produces `Test Shard (api)` / `Test Shard (rule)` / etc. as individual checks, but a separate `test-summary` job named `Test` runs after the matrix and fails iff any shard did not succeed. That keeps the existing `Test` required-check name satisfied without a branch-protection edit. You can later choose to require the four shard names instead and remove the umbrella; not required to merge this PR.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` -- clean
- [x] Bash logic smoke-tested locally; api/rule/services emit expected `./<pkg>/...` lists, core resolves to 54 packages
- [x] `bash scripts/pre-push-gate.sh` -- clean
- [ ] First post-merge CI run completes inside expected wall-time budget (~3:00)
- [ ] Codecov report aggregates cleanly across 4 shards
- [ ] `Test` umbrella check reports pass/fail correctly under matrix success and failure scenarios

## Related

- #1290 (parent CI wall-time work; landed `t.Parallel()` sweep)
- #1294 (related test-sleep audit; merged)
- #1293 (template DB caching -- separate axis, complementary)
- #1295 (clock-precision sleeps -- structural follow-up)