### PR TITLE
fix(api): make stillwater-managed toggle idempotent

### DIFF
--- a/internal/api/handlers_conflict.go
+++ b/internal/api/handlers_conflict.go
@@ -250,6 +250,26 @@ func (r *Router) handleSetStillwaterManaged(w http.ResponseWriter, req *http.Req
 		return
 	}
 
+	// Idempotency guard. If the connection is already in the requested state
+	// the side effects (snapshotLibraryOptions / SetPreStillwaterConfig on the
+	// enable side; restoreLibraryOptions / SetPreStillwaterConfig clear on the
+	// disable side) are not just wasted work, they are destructive: a second
+	// enable=true would re-snapshot the peer's current (already-disabled)
+	// LibraryOptions and overwrite pre_stillwater_config_json with that
+	// post-managed state, so a future disable would replay Stillwater's own
+	// settings instead of the user's original config. The matching disable
+	// side would re-clear an already-cleared snapshot column. Returning the
+	// current state in the same shape as a real toggle keeps the response
+	// contract stable for clients that don't branch on no-op vs. apply.
+	// See issue #1190 for the data-loss reproduction.
+	if body.Enabled == conn.FeatureManageServerFiles {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"connection_id":               conn.ID,
+			"feature_manage_server_files": conn.FeatureManageServerFiles,
+		})
+		return
+	}
+
 	// refreshConflictState rebuilds the cached ledger and emits a
 	// ConflictChanged event so the UI banner and write gate pick up the
 	// new connection state immediately. It MUST run on every error path

--- a/internal/api/handlers_conflict.go
+++ b/internal/api/handlers_conflict.go
@@ -245,12 +245,27 @@ func (r *Router) handleSetStillwaterManaged(w http.ResponseWriter, req *http.Req
 		return
 	}
 
+	// Resolve the connection BEFORE allocating per-id serialization state.
+	// Otherwise every request with an arbitrary unknown {id} would
+	// LoadOrStore a fresh *sync.Mutex into stillwaterManagedMu and leave
+	// it there forever, letting a stream of 404 requests grow the map
+	// without bound. With this gate the map's cardinality is bounded by
+	// real connection IDs the process has ever seen (entries for deleted
+	// connections still linger -- a separate, lower-priority cleanup).
+	// We discard the resolved connection here on purpose -- it is only
+	// the existence gate; the canonical post-lock snapshot is fetched
+	// below, after we hold connMu.
+	if _, err := r.connectionService.GetByID(req.Context(), id); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "connection not found"})
+		return
+	}
+
 	// Serialize read-modify-write for this connection so two concurrent
-	// requests cannot both observe a stale snapshot at the top of the
-	// handler and both fall through the idempotency guard below. The
-	// mutex is released after writeJSON via the deferred unlock when this
-	// handler returns. LoadOrStore guarantees a single *sync.Mutex per
-	// connection ID for the lifetime of the process.
+	// requests cannot both observe a stale snapshot below and both fall
+	// through the idempotency guard. The mutex is released after
+	// writeJSON via the deferred unlock when this handler returns.
+	// LoadOrStore guarantees a single *sync.Mutex per connection ID for
+	// the lifetime of the process.
 	muIface, _ := r.stillwaterManagedMu.LoadOrStore(id, &sync.Mutex{})
 	connMu := muIface.(*sync.Mutex)
 	connMu.Lock()

--- a/internal/api/handlers_conflict.go
+++ b/internal/api/handlers_conflict.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/sydlexius/stillwater/internal/conflict"
 	"github.com/sydlexius/stillwater/internal/connection"
@@ -244,6 +245,17 @@ func (r *Router) handleSetStillwaterManaged(w http.ResponseWriter, req *http.Req
 		return
 	}
 
+	// Serialize read-modify-write for this connection so two concurrent
+	// requests cannot both observe a stale snapshot at the top of the
+	// handler and both fall through the idempotency guard below. The
+	// mutex is released after writeJSON via the deferred unlock when this
+	// handler returns. LoadOrStore guarantees a single *sync.Mutex per
+	// connection ID for the lifetime of the process.
+	muIface, _ := r.stillwaterManagedMu.LoadOrStore(id, &sync.Mutex{})
+	connMu := muIface.(*sync.Mutex)
+	connMu.Lock()
+	defer connMu.Unlock()
+
 	conn, err := r.connectionService.GetByID(req.Context(), id)
 	if err != nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "connection not found"})
@@ -251,18 +263,31 @@ func (r *Router) handleSetStillwaterManaged(w http.ResponseWriter, req *http.Req
 	}
 
 	// Idempotency guard. If the connection is already in the requested state
-	// the side effects (snapshotLibraryOptions / SetPreStillwaterConfig on the
-	// enable side; restoreLibraryOptions / SetPreStillwaterConfig clear on the
-	// disable side) are not just wasted work, they are destructive: a second
-	// enable=true would re-snapshot the peer's current (already-disabled)
+	// AND the snapshot column is in the shape that state implies (non-empty
+	// when managed, empty when unmanaged) the side effects
+	// (snapshotLibraryOptions / SetPreStillwaterConfig on the enable side;
+	// restoreLibraryOptions / SetPreStillwaterConfig clear on the disable
+	// side) are not just wasted work, they are destructive: a second
+	// enable=true would re-snapshot the peer's already-disabled
 	// LibraryOptions and overwrite pre_stillwater_config_json with that
 	// post-managed state, so a future disable would replay Stillwater's own
-	// settings instead of the user's original config. The matching disable
-	// side would re-clear an already-cleared snapshot column. Returning the
-	// current state in the same shape as a real toggle keeps the response
-	// contract stable for clients that don't branch on no-op vs. apply.
-	// See issue #1190 for the data-loss reproduction.
-	if body.Enabled == conn.FeatureManageServerFiles {
+	// settings instead of the user's original config.
+	//
+	// We deliberately DO fall through when the snapshot column is in the
+	// wrong shape for the current flag (non-empty while disabled, or empty
+	// while enabled). That state means a prior toggle failed mid-flight --
+	// e.g. clearStillwaterManaged ran SetManageServerFiles(false) but the
+	// peer restoreLibraryOptions or the SetPreStillwaterConfig clear failed
+	// after that. The user must be able to retry the toggle to recover; a
+	// blanket short-circuit on flag-equality would trap them.
+	//
+	// Returning the current state in the same shape as a real toggle keeps
+	// the response contract stable for clients that don't branch on no-op
+	// vs. apply. See issue #1190 for the data-loss reproduction.
+	snapshotEmpty := conn.PreStillwaterConfigJSON == ""
+	stateConsistent := (conn.FeatureManageServerFiles && !snapshotEmpty) ||
+		(!conn.FeatureManageServerFiles && snapshotEmpty)
+	if body.Enabled == conn.FeatureManageServerFiles && stateConsistent {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"connection_id":               conn.ID,
 			"feature_manage_server_files": conn.FeatureManageServerFiles,

--- a/internal/api/handlers_conflict_integration_test.go
+++ b/internal/api/handlers_conflict_integration_test.go
@@ -809,3 +809,161 @@ func TestSetStillwaterManaged_RollsBackWhenPeerDisableFails(t *testing.T) {
 		t.Errorf("snapshot should be cleared after rollback, got %q", updated.PreStillwaterConfigJSON)
 	}
 }
+
+// TestSetStillwaterManaged_IdempotentEnablePreservesSnapshot pins the
+// idempotency contract from issue #1190. When a client sends enabled:true
+// twice in a row (stale HTMX hx-vals payload, repeated curl, concurrent
+// clicks), the second call must NOT re-snapshot the peer. If it did, the
+// fresh snapshot would capture the post-managed (savers-off) state and
+// overwrite pre_stillwater_config_json, so a future "disable" would replay
+// Stillwater's own settings instead of the user's original config. The
+// regression assertion is byte-equal: the JSON stored after call #1 must
+// match what is stored after call #2.
+func TestSetStillwaterManaged_IdempotentEnablePreservesSnapshot(t *testing.T) {
+	t.Parallel()
+	r, svc := testRouterForConflictToggle(t)
+	fake, _ := startFakeEmby(t)
+	defer fake.Close()
+
+	ctx := context.Background()
+	conn := &connection.Connection{Name: "TestEmby", Type: connection.TypeEmby, URL: fake.URL, APIKey: "key"}
+	if err := svc.Create(ctx, conn); err != nil {
+		t.Fatalf("create conn: %v", err)
+	}
+
+	// First enable: stores the genuine pre-Stillwater snapshot (savers on).
+	body := bytes.NewReader([]byte(`{"enabled":true}`))
+	req := httptest.NewRequest(http.MethodPost, "/", body)
+	req.SetPathValue("id", conn.ID)
+	w := httptest.NewRecorder()
+	r.handleSetStillwaterManaged(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("first enable status = %d body=%s", w.Code, w.Body.String())
+	}
+
+	afterFirst, err := svc.GetByID(ctx, conn.ID)
+	if err != nil {
+		t.Fatalf("reload after first enable: %v", err)
+	}
+	originalSnapshot := afterFirst.PreStillwaterConfigJSON
+	if originalSnapshot == "" {
+		t.Fatal("first enable should have populated pre_stillwater_config_json")
+	}
+
+	// Second enable: must be a no-op. The handler should detect the
+	// already-managed state and skip applyStillwaterManaged entirely.
+	body = bytes.NewReader([]byte(`{"enabled":true}`))
+	req = httptest.NewRequest(http.MethodPost, "/", body)
+	req.SetPathValue("id", conn.ID)
+	w = httptest.NewRecorder()
+	r.handleSetStillwaterManaged(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("second enable status = %d body=%s", w.Code, w.Body.String())
+	}
+	assertSetManagedResponse(t, w, conn.ID, true)
+
+	// Snapshot column must be byte-equal to what call #1 wrote. Pre-fix,
+	// the second call would re-snapshot the peer's now-disabled
+	// LibraryOptions and SetPreStillwaterConfig would clobber this.
+	afterSecond, err := svc.GetByID(ctx, conn.ID)
+	if err != nil {
+		t.Fatalf("reload after second enable: %v", err)
+	}
+	if afterSecond.PreStillwaterConfigJSON != originalSnapshot {
+		t.Errorf("idempotent enable clobbered snapshot:\nfirst:  %s\nsecond: %s", originalSnapshot, afterSecond.PreStillwaterConfigJSON)
+	}
+	if !afterSecond.FeatureManageServerFiles {
+		t.Error("FeatureManageServerFiles should remain true after idempotent enable")
+	}
+}
+
+// TestSetStillwaterManaged_IdempotentDisableSkipsPeerCall pins the disable-side
+// idempotency contract from issue #1190. Two successive enabled:false POSTs
+// against an already-unmanaged connection must NOT re-trigger the peer
+// restoreLibraryOptions call or re-clear pre_stillwater_config_json. Asserting
+// the peer-side POST count stays at zero across both calls is the most
+// direct signal that the second invocation short-circuited.
+func TestSetStillwaterManaged_IdempotentDisableSkipsPeerCall(t *testing.T) {
+	t.Parallel()
+	r, svc := testRouterForConflictToggle(t)
+
+	var (
+		mu        sync.Mutex
+		postCount int
+	)
+	initial := map[string]any{
+		"Name":           "Music",
+		"CollectionType": "music",
+		"ItemId":         "lib1",
+		"LibraryOptions": map[string]any{
+			"SaveLocalMetadata": true,
+			"MetadataSavers":    []string{"Nfo"},
+		},
+	}
+	fake := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/Library/VirtualFolders":
+			_ = json.NewEncoder(w).Encode([]any{initial})
+		case "/Library/VirtualFolders/LibraryOptions":
+			mu.Lock()
+			postCount++
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	defer fake.Close()
+
+	ctx := context.Background()
+	conn := &connection.Connection{Name: "TestEmby", Type: connection.TypeEmby, URL: fake.URL, APIKey: "key"}
+	if err := svc.Create(ctx, conn); err != nil {
+		t.Fatalf("create conn: %v", err)
+	}
+	// Connection starts unmanaged (FeatureManageServerFiles=false), no
+	// snapshot in the column, so the disable path has nothing legitimate
+	// to do.
+
+	post := func(body string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(body)))
+		req.SetPathValue("id", conn.ID)
+		w := httptest.NewRecorder()
+		r.handleSetStillwaterManaged(w, req)
+		return w
+	}
+
+	for i, label := range []string{"first", "second"} {
+		w := post(`{"enabled":false}`)
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s disable (i=%d) status = %d body=%s", label, i, w.Code, w.Body.String())
+		}
+		assertSetManagedResponse(t, w, conn.ID, false)
+	}
+
+	mu.Lock()
+	gotPosts := postCount
+	mu.Unlock()
+	// Pre-fix, the first call would (harmlessly) skip the restore because
+	// the snapshot column was empty, but still issue a SetPreStillwaterConfig
+	// clear; the second call would do the same again. The peer POST count
+	// is the cleanest invariant: zero in both paths means we never reached
+	// restoreLibraryOptions, which is what idempotency demands. Any future
+	// regression that re-routes the second call through clearStillwaterManaged
+	// while a snapshot happens to exist (e.g. via a separate enable in
+	// between) would push this above zero.
+	if gotPosts != 0 {
+		t.Errorf("peer POST count = %d after two no-op disables, want 0", gotPosts)
+	}
+
+	updated, err := svc.GetByID(ctx, conn.ID)
+	if err != nil {
+		t.Fatalf("reload conn: %v", err)
+	}
+	if updated.FeatureManageServerFiles {
+		t.Error("FeatureManageServerFiles should remain false after idempotent disable")
+	}
+	if updated.PreStillwaterConfigJSON != "" {
+		t.Errorf("snapshot should remain empty, got %q", updated.PreStillwaterConfigJSON)
+	}
+}

--- a/internal/api/handlers_conflict_integration_test.go
+++ b/internal/api/handlers_conflict_integration_test.go
@@ -878,11 +878,13 @@ func TestSetStillwaterManaged_IdempotentEnablePreservesSnapshot(t *testing.T) {
 }
 
 // TestSetStillwaterManaged_IdempotentDisableSkipsPeerCall pins the disable-side
-// idempotency contract from issue #1190. Two successive enabled:false POSTs
-// against an already-unmanaged connection must NOT re-trigger the peer
-// restoreLibraryOptions call or re-clear pre_stillwater_config_json. Asserting
-// the peer-side POST count stays at zero across both calls is the most
-// direct signal that the second invocation short-circuited.
+// idempotency contract from issue #1190. The sequence enable -> disable ->
+// disable must hit the peer LibraryOptions endpoint exactly twice (the disable
+// PATCH on the first disable plus the restore PATCH that follows it); the
+// second disable, against the now-cleared snapshot, must short-circuit before
+// reaching the peer. Earlier shape of this test seeded an already-unmanaged
+// connection with no snapshot, so it would have passed even if the no-op
+// guard were removed; this version exercises the actual regression path.
 func TestSetStillwaterManaged_IdempotentDisableSkipsPeerCall(t *testing.T) {
 	t.Parallel()
 	r, svc := testRouterForConflictToggle(t)
@@ -920,9 +922,6 @@ func TestSetStillwaterManaged_IdempotentDisableSkipsPeerCall(t *testing.T) {
 	if err := svc.Create(ctx, conn); err != nil {
 		t.Fatalf("create conn: %v", err)
 	}
-	// Connection starts unmanaged (FeatureManageServerFiles=false), no
-	// snapshot in the column, so the disable path has nothing legitimate
-	// to do.
 
 	post := func(body string) *httptest.ResponseRecorder {
 		t.Helper()
@@ -933,27 +932,32 @@ func TestSetStillwaterManaged_IdempotentDisableSkipsPeerCall(t *testing.T) {
 		return w
 	}
 
-	for i, label := range []string{"first", "second"} {
-		w := post(`{"enabled":false}`)
-		if w.Code != http.StatusOK {
-			t.Fatalf("%s disable (i=%d) status = %d body=%s", label, i, w.Code, w.Body.String())
-		}
-		assertSetManagedResponse(t, w, conn.ID, false)
+	// Step 1: enable. This is one peer POST (the disable PATCH issued by
+	// applyStillwaterManaged) and writes a non-empty snapshot.
+	if w := post(`{"enabled":true}`); w.Code != http.StatusOK {
+		t.Fatalf("enable status = %d body=%s", w.Code, w.Body.String())
 	}
+
+	// Step 2: first disable. This is one more peer POST (the restore PATCH
+	// issued by clearStillwaterManaged) and clears the snapshot.
+	if w := post(`{"enabled":false}`); w.Code != http.StatusOK {
+		t.Fatalf("first disable status = %d body=%s", w.Code, w.Body.String())
+	}
+
+	// Step 3: second disable against the now-cleared snapshot. The
+	// idempotency guard has to short-circuit -- otherwise we hit the peer
+	// again and gotPosts climbs to 3.
+	w := post(`{"enabled":false}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("second disable status = %d body=%s", w.Code, w.Body.String())
+	}
+	assertSetManagedResponse(t, w, conn.ID, false)
 
 	mu.Lock()
 	gotPosts := postCount
 	mu.Unlock()
-	// Pre-fix, the first call would (harmlessly) skip the restore because
-	// the snapshot column was empty, but still issue a SetPreStillwaterConfig
-	// clear; the second call would do the same again. The peer POST count
-	// is the cleanest invariant: zero in both paths means we never reached
-	// restoreLibraryOptions, which is what idempotency demands. Any future
-	// regression that re-routes the second call through clearStillwaterManaged
-	// while a snapshot happens to exist (e.g. via a separate enable in
-	// between) would push this above zero.
-	if gotPosts != 0 {
-		t.Errorf("peer POST count = %d after two no-op disables, want 0", gotPosts)
+	if gotPosts != 2 {
+		t.Errorf("peer POST count = %d, want 2 (1 disable PATCH on enable + 1 restore PATCH on first disable; second/third disables must short-circuit)", gotPosts)
 	}
 
 	updated, err := svc.GetByID(ctx, conn.ID)
@@ -961,9 +965,9 @@ func TestSetStillwaterManaged_IdempotentDisableSkipsPeerCall(t *testing.T) {
 		t.Fatalf("reload conn: %v", err)
 	}
 	if updated.FeatureManageServerFiles {
-		t.Error("FeatureManageServerFiles should remain false after idempotent disable")
+		t.Error("FeatureManageServerFiles should be false after disable")
 	}
 	if updated.PreStillwaterConfigJSON != "" {
-		t.Errorf("snapshot should remain empty, got %q", updated.PreStillwaterConfigJSON)
+		t.Errorf("snapshot should be empty after disable, got %q", updated.PreStillwaterConfigJSON)
 	}
 }

--- a/internal/api/handlers_conflict_integration_test.go
+++ b/internal/api/handlers_conflict_integration_test.go
@@ -971,3 +971,83 @@ func TestSetStillwaterManaged_IdempotentDisableSkipsPeerCall(t *testing.T) {
 		t.Errorf("snapshot should be empty after disable, got %q", updated.PreStillwaterConfigJSON)
 	}
 }
+
+// TestSetStillwaterManaged_ConcurrentEnableSerializes is the regression
+// test Copilot asked for on PR #1307: two enabled:true requests issued
+// concurrently against the same connection must end up in the same
+// post-state as one serial pair. Without per-connection serialization,
+// both requests can race past the idempotency guard simultaneously --
+// each sees an unmanaged snapshot, both call applyStillwaterManaged,
+// and the second snapshot captures the post-managed peer state and
+// clobbers pre_stillwater_config_json.
+//
+// We seed the connection unmanaged, fire two enable goroutines in
+// parallel, then assert that a) both succeed (200), b) the snapshot
+// column reflects the genuine pre-Stillwater config (savers on), and
+// c) FeatureManageServerFiles is true. If the per-id mutex regresses,
+// the second request's re-snapshot would write savers-off into
+// pre_stillwater_config_json and this test would fail.
+func TestSetStillwaterManaged_ConcurrentEnableSerializes(t *testing.T) {
+	t.Parallel()
+	r, svc := testRouterForConflictToggle(t)
+	fake, _ := startFakeEmby(t)
+	defer fake.Close()
+
+	ctx := context.Background()
+	conn := &connection.Connection{Name: "TestEmby", Type: connection.TypeEmby, URL: fake.URL, APIKey: "key"}
+	if err := svc.Create(ctx, conn); err != nil {
+		t.Fatalf("create conn: %v", err)
+	}
+
+	const concurrent = 2
+	var (
+		wg     sync.WaitGroup
+		mu     sync.Mutex
+		codes  []int
+		bodies []string
+	)
+	wg.Add(concurrent)
+	start := make(chan struct{})
+	for i := 0; i < concurrent; i++ {
+		go func() {
+			defer wg.Done()
+			body := bytes.NewReader([]byte(`{"enabled":true}`))
+			req := httptest.NewRequest(http.MethodPost, "/", body)
+			req.SetPathValue("id", conn.ID)
+			w := httptest.NewRecorder()
+			<-start
+			r.handleSetStillwaterManaged(w, req)
+			mu.Lock()
+			codes = append(codes, w.Code)
+			bodies = append(bodies, w.Body.String())
+			mu.Unlock()
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i, code := range codes {
+		if code != http.StatusOK {
+			t.Fatalf("concurrent enable #%d status = %d body=%s", i, code, bodies[i])
+		}
+	}
+
+	final, err := svc.GetByID(ctx, conn.ID)
+	if err != nil {
+		t.Fatalf("reload after concurrent enable: %v", err)
+	}
+	if !final.FeatureManageServerFiles {
+		t.Error("FeatureManageServerFiles should be true after concurrent enables")
+	}
+	if final.PreStillwaterConfigJSON == "" {
+		t.Fatal("snapshot must be populated after concurrent enables")
+	}
+	// The genuine pre-Stillwater snapshot has save_local_metadata:true. If
+	// the second request re-snapshotted post-managed state, the stored
+	// JSON would carry save_local_metadata:false instead -- exactly the
+	// data-loss the per-id mutex prevents. (The serialized field is
+	// snake_case via the snapshot's JSON tags, not Emby's CamelCase.)
+	if !bytes.Contains([]byte(final.PreStillwaterConfigJSON), []byte(`"save_local_metadata":true`)) {
+		t.Errorf("snapshot looks post-managed; concurrent enables clobbered it: %s", final.PreStillwaterConfigJSON)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -145,6 +145,22 @@ type Router struct {
 	i18nBundle            *i18n.Bundle
 	conflictDetector      *conflict.Detector
 	conflictGate          *conflict.Gate
+	// stillwaterManagedMu serializes read-modify-write inside
+	// handleSetStillwaterManaged on a per-connection basis. Without it,
+	// two concurrent enable=true requests for the same connection could
+	// both observe FeatureManageServerFiles=false on the snapshot loaded
+	// at the top of the handler, both fall through the idempotency guard,
+	// and both run applyStillwaterManaged -- the second snapshot of an
+	// already-managed peer would clobber pre_stillwater_config_json with
+	// the already-cleared library options, making restore unable to
+	// recover the real pre-Stillwater settings (issue #1190).
+	//
+	// Map values are *sync.Mutex pulled via LoadOrStore; entries
+	// accumulate for the lifetime of the process. Cardinality is bounded
+	// by the number of connections (small for realistic deployments) so
+	// we accept the leak rather than racing removal against late-arriving
+	// requests.
+	stillwaterManagedMu sync.Map
 	// foreignRepo persists foreign-file ledger rows and the allowlist
 	// (#1185). Always non-nil after NewRouter when DB is provided so the
 	// foreign-files settings page never has to special-case a missing dep.


### PR DESCRIPTION
## Summary

Closes #1190. The handleSetStillwaterManaged endpoint was non-idempotent: two POSTs with the same desired state would re-snapshot the connection's pre-managed config the second time, capturing the post-managed state instead. A future "restore on disable" would then replay Stillwater's own settings.

- Added an early no-op return when body.Enabled == current FeatureManageServerFiles
- Symmetric guard on clearStillwaterManaged
- Two regression tests (idempotent enable, idempotent disable)

## Test plan

- [x] go test -race ./internal/api/...
- [x] bash scripts/pre-push-gate.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Toggling server-file management is now idempotent: repeated requests that match current state return success, skip redundant snapshot/restore, and avoid unnecessary peer calls. Concurrent toggles for the same connection are serialized to prevent conflicting updates.

* **Tests**
  * Added integration tests verifying idempotent enable/disable behavior, snapshot preservation on repeated enables, skipped peer calls on repeated disables, and serialized handling of concurrent enables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->