### PR TITLE
chore(ui): rename settings_appearance to preferences

### DIFF
--- a/cmd/gen-settings-reference/main.go
+++ b/cmd/gen-settings-reference/main.go
@@ -57,16 +57,14 @@ const templTrunkPath = "web/templates/settings.templ"
 const templSubTemplateGlob = "web/templates/settings_*.templ"
 
 // subTemplateExclude names files (by basename) that look like sub-templates
-// by glob match but are not consumed by the Settings page's @-call tree:
-//   - settings_appearance.templ backs the standalone User Preferences page
-//     (route /preferences). Its keys live under settings.appearance.* and
-//     are out of scope for the Settings tabs reference.
+// by glob match but are not consumed by the Settings page's @-call tree.
+// The standalone User Preferences page (route /preferences) lives in
+// preferences.templ, which does not match the settings_*.templ glob and
+// therefore needs no entry here.
 //
 // Keying on basename rather than full path keeps the exclude list portable
 // across worktrees and test fixtures.
-var subTemplateExclude = map[string]struct{}{
-	"settings_appearance.templ": {},
-}
+var subTemplateExclude = map[string]struct{}{}
 
 // discoverTemplSources auto-discovers the trunk + sub-template files the
 // panel scanner walks, replacing what used to be a hand-maintained allowlist.

--- a/cmd/gen-settings-reference/main_test.go
+++ b/cmd/gen-settings-reference/main_test.go
@@ -664,9 +664,9 @@ templ helperScript() {
 }
 
 // TestDiscoverTemplSources verifies that the auto-discovery picks up new
-// settings_*.templ files without manual generator edits, while honoring the
-// excluded-files map (settings_appearance.templ stays out of the Settings
-// reference because it backs the standalone User Preferences page).
+// settings_*.templ files without manual generator edits. The standalone User
+// Preferences page lives in preferences.templ (does not match the glob), so
+// no exclusion entry is needed for it.
 func TestDiscoverTemplSources(t *testing.T) {
 	dir := t.TempDir()
 	must := func(name string) string {
@@ -679,11 +679,11 @@ func TestDiscoverTemplSources(t *testing.T) {
 	trunk := must("settings.templ")
 	users := must("settings_users.templ")
 	auth := must("settings_auth_providers.templ")
-	must("settings_appearance.templ") // present but excluded
+	// preferences.templ deliberately does NOT match settings_*.templ; create
+	// it to confirm the glob ignores it without needing an exclude entry.
+	must("preferences.templ")
 	future := must("settings_billing.templ")
 
-	// Override the exclude map for this test by passing a custom glob and
-	// asserting the auto-derived owner mapping for each file.
 	sources, owner, err := discoverTemplSources(trunk, filepath.Join(dir, "settings_*.templ"))
 	if err != nil {
 		t.Fatal(err)
@@ -693,8 +693,7 @@ func TestDiscoverTemplSources(t *testing.T) {
 	if len(sources) == 0 || sources[0] != trunk {
 		t.Errorf("expected trunk first; got %v", sources)
 	}
-	// Sub-templates discovered by glob (sorted): auth, appearance (excluded
-	// at runtime), billing, users.
+	// Sub-templates discovered by glob (sorted): auth, billing, users.
 	wantOwners := map[string]string{
 		users:  "users",
 		auth:   "auth_providers",
@@ -710,10 +709,10 @@ func TestDiscoverTemplSources(t *testing.T) {
 			t.Errorf("owner[%s] = %q, want %q", path, got, wantPanel)
 		}
 	}
-	// Excluded file must not appear.
+	// preferences.templ must not be picked up by the settings_*.templ glob.
 	for _, src := range sources {
-		if filepath.Base(src) == "settings_appearance.templ" {
-			t.Errorf("settings_appearance.templ should be excluded; got in sources: %v", sources)
+		if filepath.Base(src) == "preferences.templ" {
+			t.Errorf("preferences.templ should not match settings_*.templ glob; got in sources: %v", sources)
 		}
 	}
 }

--- a/cmd/gen-settings-reference/main_test.go
+++ b/cmd/gen-settings-reference/main_test.go
@@ -693,6 +693,20 @@ func TestDiscoverTemplSources(t *testing.T) {
 	if len(sources) == 0 || sources[0] != trunk {
 		t.Errorf("expected trunk first; got %v", sources)
 	}
+	// Pin the full discovered order, not just membership: the generator's
+	// output is only stable if discoverTemplSources sorts sub-templates
+	// deterministically. A regression that returned sources in
+	// filesystem-iteration order would still satisfy the membership
+	// check below, so assert the exact slice here.
+	wantSources := []string{trunk, auth, future, users}
+	if len(sources) != len(wantSources) {
+		t.Fatalf("expected %d sources, got %d: %v", len(wantSources), len(sources), sources)
+	}
+	for i, want := range wantSources {
+		if sources[i] != want {
+			t.Errorf("sources[%d] = %q, want %q (full slice: %v)", i, sources[i], want, sources)
+		}
+	}
 	// Sub-templates discovered by glob (sorted): auth, billing, users.
 	wantOwners := map[string]string{
 		users:  "users",

--- a/internal/api/handlers_preferences.go
+++ b/internal/api/handlers_preferences.go
@@ -636,7 +636,7 @@ func (r *Router) handleUserPreferencesPage(w http.ResponseWriter, req *http.Requ
 		autoFetchImages = normalized
 	}
 
-	prefs := templates.AppearancePrefsData{
+	prefs := templates.PreferencesData{
 		Theme:             pref(PrefTheme),
 		ThumbnailSize:     pref(PrefThumbnailSize),
 		SidebarState:      pref(PrefSidebarState),

--- a/internal/api/handlers_preferences_test.go
+++ b/internal/api/handlers_preferences_test.go
@@ -1172,3 +1172,44 @@ func TestValidateMetadataLanguages(t *testing.T) {
 // NOTE: the low-level tag validator has moved to the internal/langpref
 // package and is covered by TestValidate there. The api-package surface
 // we care about here is validateMetadataLanguages, tested above.
+
+// TestUserPreferencesPage_RendersWithDefaults exercises the page-render
+// handler so the templates.PreferencesData literal at line 639 is covered.
+// Asserts a 200 plus the rendered body contains a marker the page is known
+// to emit (sufficient to prove the template was reached without coupling
+// the test to layout details).
+func TestUserPreferencesPage_RendersWithDefaults(t *testing.T) {
+	t.Parallel()
+	r, _, userID := testRouterWithAuth(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/preferences", nil)
+	req = withUserCtx(req, userID)
+	w := httptest.NewRecorder()
+
+	r.handleUserPreferencesPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if w.Body.Len() == 0 {
+		t.Fatal("expected non-empty rendered body")
+	}
+}
+
+// TestUserPreferencesPage_UnauthenticatedRendersLogin verifies the
+// short-circuit branch that defers to the login page when no user is
+// in context. Together with the authenticated case above this covers
+// both arms of the entry guard.
+func TestUserPreferencesPage_UnauthenticatedRendersLogin(t *testing.T) {
+	t.Parallel()
+	r, _, _ := testRouterWithAuth(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/preferences", nil)
+	w := httptest.NewRecorder()
+
+	r.handleUserPreferencesPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (login page), got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/handlers_preferences_test.go
+++ b/internal/api/handlers_preferences_test.go
@@ -1175,9 +1175,10 @@ func TestValidateMetadataLanguages(t *testing.T) {
 
 // TestUserPreferencesPage_RendersWithDefaults exercises the page-render
 // handler so the templates.PreferencesData literal at line 639 is covered.
-// Asserts a 200 plus the rendered body contains a marker the page is known
-// to emit (sufficient to prove the template was reached without coupling
-// the test to layout details).
+// Asserts a 200 plus markers unique to the preferences page (the
+// appearance tab panel and one of its preference inputs) so the test
+// fails if the handler accidentally renders the login page or an
+// unrelated template.
 func TestUserPreferencesPage_RendersWithDefaults(t *testing.T) {
 	t.Parallel()
 	r, _, userID := testRouterWithAuth(t)
@@ -1191,8 +1192,17 @@ func TestUserPreferencesPage_RendersWithDefaults(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
-	if w.Body.Len() == 0 {
-		t.Fatal("expected non-empty rendered body")
+	body := w.Body.String()
+	for _, marker := range []string{
+		`data-tab-panel="appearance"`,
+		`id="pref-theme"`,
+	} {
+		if !strings.Contains(body, marker) {
+			t.Errorf("expected preferences-page marker %q in rendered body", marker)
+		}
+	}
+	if strings.Contains(body, `id="login-result"`) {
+		t.Error("expected preferences page, but login-page marker id=\"login-result\" was rendered")
 	}
 }
 
@@ -1211,5 +1221,12 @@ func TestUserPreferencesPage_UnauthenticatedRendersLogin(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 (login page), got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `id="login-result"`) {
+		t.Errorf("expected login-page marker id=\"login-result\" in rendered body; got %d bytes", w.Body.Len())
+	}
+	if strings.Contains(body, `data-tab-panel="appearance"`) {
+		t.Error("expected login page, but preferences-page marker data-tab-panel=\"appearance\" was rendered")
 	}
 }

--- a/web/templates/preferences.templ
+++ b/web/templates/preferences.templ
@@ -8,7 +8,7 @@ import (
 
 // UserPreferencesPage renders a standalone page for user-level appearance
 // preferences. It is accessible to all authenticated users (not admin-only).
-templ UserPreferencesPage(assets AssetPaths, prefs AppearancePrefsData) {
+templ UserPreferencesPage(assets AssetPaths, prefs PreferencesData) {
 	@Layout(t(ctx, "settings.appearance"), assets) {
 		<div class="space-y-6">
 			<div class="sw-card rounded-lg px-6 py-4">
@@ -24,10 +24,10 @@ templ UserPreferencesPage(assets AssetPaths, prefs AppearancePrefsData) {
 	}
 }
 
-// AppearancePrefsData holds the current user preference values shown in the
+// PreferencesData holds the current user preference values shown in the
 // Appearance settings tab. All fields are pre-populated from the user_preferences
 // table (or the compiled defaults) by the settings page handler.
-type AppearancePrefsData struct {
+type PreferencesData struct {
 	Theme             string // "dark" | "light" | "system"
 	ThumbnailSize     string // "small" | "medium" | "large"
 	SidebarState      string // "full" | "icon-only" | "hidden"
@@ -44,7 +44,7 @@ type AppearancePrefsData struct {
 }
 
 // settingsAppearanceTab renders the Appearance settings tab.
-templ settingsAppearanceTab(prefs AppearancePrefsData) {
+templ settingsAppearanceTab(prefs PreferencesData) {
 	@components.ContextHelpScript()
 	<!-- Theme -->
 	<div class="sw-card bg-white dark:bg-gray-800 shadow rounded-lg">

--- a/web/templates/preferences_templ.go
+++ b/web/templates/preferences_templ.go
@@ -5,11 +5,12 @@ package templates
 
 //lint:file-ignore SA4006 This context is only used if a nested component is present.
 
+import "github.com/a-h/templ"
+import templruntime "github.com/a-h/templ/runtime"
+
 import (
 	"strconv"
 
-	"github.com/a-h/templ"
-	templruntime "github.com/a-h/templ/runtime"
 	"github.com/sydlexius/stillwater/web/components"
 )
 

--- a/web/templates/preferences_templ.go
+++ b/web/templates/preferences_templ.go
@@ -5,18 +5,17 @@ package templates
 
 //lint:file-ignore SA4006 This context is only used if a nested component is present.
 
-import "github.com/a-h/templ"
-import templruntime "github.com/a-h/templ/runtime"
-
 import (
 	"strconv"
 
+	"github.com/a-h/templ"
+	templruntime "github.com/a-h/templ/runtime"
 	"github.com/sydlexius/stillwater/web/components"
 )
 
 // UserPreferencesPage renders a standalone page for user-level appearance
 // preferences. It is accessible to all authenticated users (not admin-only).
-func UserPreferencesPage(assets AssetPaths, prefs AppearancePrefsData) templ.Component {
+func UserPreferencesPage(assets AssetPaths, prefs PreferencesData) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -56,7 +55,7 @@ func UserPreferencesPage(assets AssetPaths, prefs AppearancePrefsData) templ.Com
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 15, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 15, Col: 66}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -69,7 +68,7 @@ func UserPreferencesPage(assets AssetPaths, prefs AppearancePrefsData) templ.Com
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.page.description"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 17, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 17, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -97,10 +96,10 @@ func UserPreferencesPage(assets AssetPaths, prefs AppearancePrefsData) templ.Com
 	})
 }
 
-// AppearancePrefsData holds the current user preference values shown in the
+// PreferencesData holds the current user preference values shown in the
 // Appearance settings tab. All fields are pre-populated from the user_preferences
 // table (or the compiled defaults) by the settings page handler.
-type AppearancePrefsData struct {
+type PreferencesData struct {
 	Theme             string // "dark" | "light" | "system"
 	ThumbnailSize     string // "small" | "medium" | "large"
 	SidebarState      string // "full" | "icon-only" | "hidden"
@@ -117,7 +116,7 @@ type AppearancePrefsData struct {
 }
 
 // settingsAppearanceTab renders the Appearance settings tab.
-func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
+func settingsAppearanceTab(prefs PreferencesData) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -149,7 +148,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.theme_and_color.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 52, Col: 123}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 52, Col: 123}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
@@ -162,7 +161,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.theme_and_color.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 54, Col: 63}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 54, Col: 63}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
@@ -175,7 +174,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.theme.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 62, Col: 115}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 62, Col: 115}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
@@ -188,7 +187,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var9 string
 		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.theme.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 63, Col: 109}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 63, Col: 109}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
@@ -224,7 +223,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var10 string
 		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.bg_opacity.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 80, Col: 120}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 80, Col: 120}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
@@ -237,7 +236,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var11 string
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.bg_opacity.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 81, Col: 114}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 81, Col: 114}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
@@ -258,7 +257,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.bg_opacity.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 93, Col: 65}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 93, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
@@ -271,7 +270,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(prefs.BackgroundOpacity)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 94, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 94, Col: 37}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
@@ -284,7 +283,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(prefs.BackgroundOpacity)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 98, Col: 135}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 98, Col: 135}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
@@ -297,7 +296,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.layout.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 106, Col: 114}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 106, Col: 114}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
@@ -310,7 +309,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.layout.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 108, Col: 54}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 108, Col: 54}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
@@ -323,7 +322,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.thumbnail_size.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 115, Col: 123}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 115, Col: 123}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
@@ -336,7 +335,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.thumbnail_size.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 116, Col: 117}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 116, Col: 117}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
@@ -364,7 +363,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.sidebar_default_state.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 130, Col: 130}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 130, Col: 130}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
@@ -377,7 +376,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.sidebar_default_state.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 131, Col: 124}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 131, Col: 124}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
@@ -405,7 +404,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.content_width.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 145, Col: 122}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 145, Col: 122}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
@@ -418,7 +417,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var22 string
 		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.content_width.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 146, Col: 116}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 146, Col: 116}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
@@ -445,7 +444,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.page_size.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 159, Col: 118}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 159, Col: 118}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
@@ -458,7 +457,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var24 string
 		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.page_size.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 160, Col: 112}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 160, Col: 112}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 		if templ_7745c5c3_Err != nil {
@@ -471,7 +470,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var25 string
 		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.page_size.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 168, Col: 63}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 168, Col: 63}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 		if templ_7745c5c3_Err != nil {
@@ -484,7 +483,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(prefs.PageSize))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 170, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 170, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
@@ -497,7 +496,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.typography.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 179, Col: 118}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 179, Col: 118}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
@@ -510,7 +509,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var28 string
 		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.typography.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 181, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 181, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
@@ -523,7 +522,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var29 string
 		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.font_family.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 188, Col: 120}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 188, Col: 120}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 		if templ_7745c5c3_Err != nil {
@@ -536,7 +535,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var30 string
 		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.font_family.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 189, Col: 114}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 189, Col: 114}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 		if templ_7745c5c3_Err != nil {
@@ -564,7 +563,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var31 string
 		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.font_license"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 200, Col: 110}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 200, Col: 110}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 		if templ_7745c5c3_Err != nil {
@@ -577,7 +576,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var32 string
 		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.letter_spacing.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 205, Col: 124}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 205, Col: 124}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 		if templ_7745c5c3_Err != nil {
@@ -590,7 +589,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var33 string
 		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.letter_spacing.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 206, Col: 118}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 206, Col: 118}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 		if templ_7745c5c3_Err != nil {
@@ -626,7 +625,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var34 string
 		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.font_size.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 222, Col: 118}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 222, Col: 118}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 		if templ_7745c5c3_Err != nil {
@@ -639,7 +638,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var35 string
 		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.font_size.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 223, Col: 112}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 223, Col: 112}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 		if templ_7745c5c3_Err != nil {
@@ -667,7 +666,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var36 string
 		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.accessibility_and_performance.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 239, Col: 137}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 239, Col: 137}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 		if templ_7745c5c3_Err != nil {
@@ -680,7 +679,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var37 string
 		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.accessibility_and_performance.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 241, Col: 77}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 241, Col: 77}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 		if templ_7745c5c3_Err != nil {
@@ -693,7 +692,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var38 string
 		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.reduced_motion.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 249, Col: 124}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 249, Col: 124}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 		if templ_7745c5c3_Err != nil {
@@ -706,7 +705,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var39 string
 		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.reduced_motion.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 250, Col: 118}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 250, Col: 118}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 		if templ_7745c5c3_Err != nil {
@@ -742,7 +741,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var40 string
 		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.lite_mode.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 267, Col: 119}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 267, Col: 119}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 		if templ_7745c5c3_Err != nil {
@@ -755,7 +754,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var41 string
 		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.lite_mode.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 268, Col: 113}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 268, Col: 113}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 		if templ_7745c5c3_Err != nil {
@@ -791,7 +790,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var42 string
 		templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.behavior.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 286, Col: 116}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 286, Col: 116}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 		if templ_7745c5c3_Err != nil {
@@ -804,7 +803,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var43 string
 		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.behavior.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 288, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 288, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 		if templ_7745c5c3_Err != nil {
@@ -817,7 +816,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var44 string
 		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.auto_fetch.title"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 295, Col: 108}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 295, Col: 108}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 		if templ_7745c5c3_Err != nil {
@@ -830,7 +829,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var45 string
 		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.auto_fetch.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 296, Col: 102}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 296, Col: 102}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 		if templ_7745c5c3_Err != nil {
@@ -855,7 +854,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var47 string
 		templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var46).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 		if templ_7745c5c3_Err != nil {
@@ -868,7 +867,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var48 string
 		templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(prefs.AutoFetchImages)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 307, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 307, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 		if templ_7745c5c3_Err != nil {
@@ -881,7 +880,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var49 string
 		templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.auto_fetch.title"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 308, Col: 53}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 308, Col: 53}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 		if templ_7745c5c3_Err != nil {
@@ -906,7 +905,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var51 string
 		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var50).String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 1, Col: 0}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 		if templ_7745c5c3_Err != nil {
@@ -919,7 +918,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var52 string
 		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.language_section.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 325, Col: 124}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 325, Col: 124}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 		if templ_7745c5c3_Err != nil {
@@ -932,7 +931,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var53 string
 		templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.language_section.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 327, Col: 64}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 327, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 		if templ_7745c5c3_Err != nil {
@@ -945,7 +944,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var54 string
 		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.language.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 333, Col: 117}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 333, Col: 117}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 		if templ_7745c5c3_Err != nil {
@@ -958,7 +957,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var55 string
 		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.language.description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 334, Col: 111}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 334, Col: 111}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 		if templ_7745c5c3_Err != nil {
@@ -971,7 +970,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var56 string
 		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.appearance.language.label"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 338, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 338, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 		if templ_7745c5c3_Err != nil {
@@ -994,7 +993,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var57 string
 		templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(translationBefore(t(ctx, "settings.appearance.metadata_lang_hint"), "{link}"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 346, Col: 83}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 346, Col: 83}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 		if templ_7745c5c3_Err != nil {
@@ -1007,7 +1006,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var58 templ.SafeURL
 		templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath() + "/settings?tab=providers"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 348, Col: 65}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 348, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 		if templ_7745c5c3_Err != nil {
@@ -1020,7 +1019,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var59 string
 		templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "settings.tab.providers"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 351, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 351, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
 		if templ_7745c5c3_Err != nil {
@@ -1033,7 +1032,7 @@ func settingsAppearanceTab(prefs AppearancePrefsData) templ.Component {
 		var templ_7745c5c3_Var60 string
 		templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(translationAfter(t(ctx, "settings.appearance.metadata_lang_hint"), "{link}"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/settings_appearance.templ`, Line: 353, Col: 82}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/preferences.templ`, Line: 353, Col: 82}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

Closes #1079. Aligns the file and symbol names with the existing /preferences route. No behavior change.

- web/templates/settings_appearance.templ renamed to preferences.templ (git mv)
- AppearancePrefsData renamed to PreferencesData
- internal/api/handlers_preferences.go updated to use the new name
- old _templ.go removed; preferences_templ.go regenerated
- cmd/gen-settings-reference adjusted: removed obsolete exclude entry, test asserts the new file is no longer matched by the settings_*.templ glob
- Two new tests for handleUserPreferencesPage (covers the renamed line + the unauthenticated short-circuit)

## Test plan

- [x] templ generate clean (514 updates)
- [x] go build ./... clean
- [x] go test ./internal/api/ -run TestUserPreferencesPage pass
- [x] bash scripts/pre-push-gate.sh pass; patch coverage 100% on handlers_preferences.go
- [x] grep for AppearancePrefsData and settings_appearance returns zero residual references
- [x] UAT: /preferences renders identically; setting change persists across reload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Settings discovery now includes the appearance/preferences sub-template (glob-based discovery), updating generated "Settings, by tab" content and anchors.

* **Tests**
  * Added preferences-page tests (authenticated renders preferences; unauthenticated renders login) and updated sub-template discovery tests to reflect the new glob discovery and deterministic ordering.

* **Refactor**
  * Renamed and consolidated appearance-related template data to a unified PreferencesData type; UI fields and behavior preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->