### PR TITLE
test(conflict): make detector test hook race-safe (Copilot follow-up #1306)

### DIFF
--- a/internal/conflict/detector.go
+++ b/internal/conflict/detector.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/connection"
@@ -79,12 +80,14 @@ type Detector struct {
 	// return without re-querying peers. See Current() for the pattern.
 	refreshMu sync.Mutex
 
-	// onBeforeRefreshLock, if non-nil, is invoked from Current() on the
-	// slow path immediately before refreshMu.Lock(). Test-only hook used
-	// by the cache-stampede coalescing tests to deterministically wait
-	// until every concurrent caller has reached the contention point;
-	// production callers leave it nil.
-	onBeforeRefreshLock func()
+	// onBeforeRefreshLock, if loaded non-nil, is invoked from Current() on
+	// the slow path immediately before refreshMu.Lock(). Test-only hook
+	// used by the cache-stampede coalescing tests to deterministically
+	// wait until every concurrent caller has reached the contention
+	// point; production callers leave it nil. Stored as atomic.Pointer so
+	// hot-path readers in Current() incur no mutex contention and tests
+	// can install or clear the hook without racing concurrent callers.
+	onBeforeRefreshLock atomic.Pointer[func()]
 }
 
 // NewDetector returns a detector wired to the live connection service and
@@ -187,8 +190,8 @@ func (d *Detector) Current(ctx context.Context) Ledger {
 	if fresh {
 		return ledger
 	}
-	if d.onBeforeRefreshLock != nil {
-		d.onBeforeRefreshLock()
+	if hook := d.onBeforeRefreshLock.Load(); hook != nil {
+		(*hook)()
 	}
 	d.refreshMu.Lock()
 	defer d.refreshMu.Unlock()

--- a/internal/conflict/detector_coalesce_test.go
+++ b/internal/conflict/detector_coalesce_test.go
@@ -99,7 +99,8 @@ func TestDetectorCurrentCoalescesConcurrentRefresh(t *testing.T) {
 	// barrier: once entered == goroutines, the leader holds refreshMu and
 	// every follower has reached (or is about to park on) Lock().
 	var entered atomic.Int32
-	d.onBeforeRefreshLock = func() { entered.Add(1) }
+	hook := func() { entered.Add(1) }
+	d.onBeforeRefreshLock.Store(&hook)
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
@@ -169,7 +170,8 @@ func TestDetectorCurrentCoalescesAfterTTLExpiry(t *testing.T) {
 	// reached the slow path. The priming Current() above ran before this
 	// hook was installed, so it does not contribute to the count.
 	var entered atomic.Int32
-	d.onBeforeRefreshLock = func() { entered.Add(1) }
+	hook := func() { entered.Add(1) }
+	d.onBeforeRefreshLock.Store(&hook)
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1306. Copilot's review flagged that the `onBeforeRefreshLock` test hook added to `Detector` in #1306 was a plain `func()` field read on the hot path of `Detector.Current()` with no synchronization, undermining the "all state goes through a mutex" guarantee documented on the struct. Any future test that installed or cleared the hook while goroutines were calling `Current()` would trip the race detector.

This PR converts the field to `atomic.Pointer[func()]`:

- Production hot-path readers in `Current()` stay lock-free (single atomic load, nil-guard, dereference).
- Tests install the hook with `hook := func(){...}; d.onBeforeRefreshLock.Store(&hook)`.
- No behavior change. Tests still pile concurrent goroutines on `refreshMu` via the deterministic `entered` counter and assert exactly one `repo.List` call per refresh.

Triage of the four Copilot comments on #1306:

1. Cold-start "started.Done() + sleep" coordination concern -- already not present in the merged code (the merged version uses an `entered atomic.Int32` barrier driven by `onBeforeRefreshLock`).
2. Same concern for the post-TTL test -- same answer.
3. PR #1306 description claimed "test-only, no production code changes" while adding the hook field. Acknowledged; this PR's description is honest about the production touch.
4. **Race on `onBeforeRefreshLock`** -- fixed here.

Production touch is intentionally minimal: one struct-field type change, one Load+nil-check on the slow path of `Current()`. The hook stays nil in every production code path (`NewDetector`, `newDetectorWithClients`, `NewBlockingForTest`, `NewForTest`).

## Test plan

- [x] `go test -race -run TestDetectorCurrentCoalesces ./internal/conflict/ -count=3` (clean)
- [x] `bash scripts/pre-push-gate.sh` (clean)
- [x] `/pr-review-toolkit:code-reviewer` (clean: ship it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal conflict detection mechanisms to enhance thread-safety and performance during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->