### PR TITLE
fix(database): record pre-002 marker for DBs whose nfo_lock_data column predates goose

### DIFF
--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -48,6 +48,17 @@ func Migrate(db *sql.DB) error {
 		return fmt.Errorf("setting goose dialect: %w", gooseInitErr)
 	}
 
+	// On databases created before migration 002 was added to the codebase,
+	// libraries.nfo_lock_data was created by the now-retired ensureXColumns
+	// runtime helper rather than by goose. The goose_db_version tracker has
+	// no row for version_id=2, so goose tries to re-apply 002 on next start
+	// and aborts with "duplicate column name". Insert the missing tracker row
+	// before goose runs so 002 is treated as already applied. Fresh DBs and
+	// already-upgraded DBs skip the insert.
+	if err := markPre002Applied(db); err != nil {
+		return fmt.Errorf("reconciling pre-002 goose tracker: %w", err)
+	}
+
 	if err := goose.Up(db, "migrations"); err != nil {
 		return fmt.Errorf("running migrations: %w", err)
 	}
@@ -148,6 +159,54 @@ func backfillRuleResultsFromViolations(db *sql.DB) error {
 	`)
 	if err != nil {
 		return fmt.Errorf("inserting rule_results backfill rows: %w", err)
+	}
+	return nil
+}
+
+// markPre002Applied inserts the goose tracker row for migration 002 on
+// pre-002 databases where libraries.nfo_lock_data was added by the retired
+// ensureXColumns runtime helper. Without this shim, goose.Up retries 002
+// against an existing column and aborts with "duplicate column name".
+// Idempotent: skipped on fresh DBs (no tracker yet) and no-op when the
+// marker row already exists.
+func markPre002Applied(db *sql.DB) error {
+	ctx := context.Background()
+	logger := slog.Default().With("component", "database")
+
+	hasTracker, err := tableExists(db, "goose_db_version")
+	if err != nil {
+		return fmt.Errorf("checking goose_db_version presence: %w", err)
+	}
+	if !hasTracker {
+		return nil
+	}
+
+	hasColumn, err := columnExists(db, "libraries", "nfo_lock_data")
+	if err != nil {
+		return fmt.Errorf("checking libraries.nfo_lock_data presence: %w", err)
+	}
+	if !hasColumn {
+		return nil
+	}
+
+	// Idempotency rides entirely on WHERE NOT EXISTS: goose's tracker has
+	// only an autoincrement PK on id, no unique constraint on version_id, so
+	// a bare INSERT would happily produce duplicate version_id=2 rows on a
+	// re-run.
+	res, err := db.ExecContext(ctx, `
+		INSERT INTO goose_db_version (version_id, is_applied, tstamp)
+		SELECT 2, 1, datetime('now')
+		WHERE NOT EXISTS (
+			SELECT 1 FROM goose_db_version WHERE version_id = 2
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("recording pre-applied 002 marker: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n > 0 {
+		logger.Info(
+			"recorded pre-applied marker for migration 002 (libraries.nfo_lock_data column predates goose tracker)",
+		)
 	}
 	return nil
 }
@@ -866,6 +925,22 @@ func rebuildArtistLibrariesIfStaleCheck(ctx context.Context, db *sql.DB) error {
 	slog.Default().With("component", "database").Info(
 		"rebuilt artist_libraries table to refresh CHECK constraint")
 	return nil
+}
+
+// tableExists returns true if the named table is present in the database.
+// Uses sqlite_master rather than PRAGMA so the call is cheap on databases
+// that have not yet been touched by goose (no tracker table yet).
+func tableExists(db *sql.DB, name string) (bool, error) {
+	var found string
+	err := db.QueryRowContext(context.Background(),
+		`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, name).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("querying sqlite_master for %s: %w", name, err)
+	}
+	return true, nil
 }
 
 // columnExists returns true if the named column is present on the table.

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -842,3 +842,91 @@ func TestMigration002_LibraryNFOLockData_Idempotent(t *testing.T) {
 		t.Errorf("nfo_lock_data column count = %d, want 1 (idempotent re-run must not duplicate)", count)
 	}
 }
+
+// TestMigrate_Pre002Shim_RecoversFromMissingTrackerRow simulates a database
+// where libraries.nfo_lock_data was added by the now-retired ensureXColumns
+// runtime helper before migration 002 existed: the column is present, but
+// goose_db_version has no row for version_id=2. Without the shim, goose.Up
+// would re-run 002 and abort startup with "duplicate column name". With the
+// shim, Migrate inserts the marker row and returns cleanly.
+func TestMigrate_Pre002Shim_RecoversFromMissingTrackerRow(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	// Simulate the pre-002 state by deleting the goose tracker row for
+	// version 2. The column itself remains in place, mirroring a DB that
+	// got nfo_lock_data via the retired runtime helper instead of goose.
+	if _, err := db.ExecContext(ctx,
+		`DELETE FROM goose_db_version WHERE version_id = 2`); err != nil {
+		t.Fatalf("simulating pre-002 state: %v", err)
+	}
+
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate after pre-002 simulation: %v", err)
+	}
+
+	var version int
+	if err := db.QueryRowContext(ctx,
+		`SELECT version_id FROM goose_db_version WHERE version_id = 2`).Scan(&version); err != nil {
+		t.Fatalf("expected version_id=2 row after recovery: %v", err)
+	}
+	if version != 2 {
+		t.Errorf("recovered version_id = %d, want 2", version)
+	}
+
+	// Capture the marker tstamp so we can prove the next Migrate call did
+	// not re-insert (which would refresh the tstamp). Idempotency is carried
+	// by the WHERE NOT EXISTS guard, not by a unique constraint, so this is
+	// the only assertion that distinguishes "skipped" from "inserted again".
+	var firstTstamp string
+	if err := db.QueryRowContext(ctx,
+		`SELECT tstamp FROM goose_db_version WHERE version_id = 2`).Scan(&firstTstamp); err != nil {
+		t.Fatalf("reading initial tstamp: %v", err)
+	}
+
+	if err := Migrate(db); err != nil {
+		t.Fatalf("second Migrate call after recovery: %v", err)
+	}
+	var rowCount int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM goose_db_version WHERE version_id = 2`).Scan(&rowCount); err != nil {
+		t.Fatalf("counting version_id=2 rows: %v", err)
+	}
+	if rowCount != 1 {
+		t.Errorf("version_id=2 row count = %d, want 1 (shim must be idempotent)", rowCount)
+	}
+	var secondTstamp string
+	if err := db.QueryRowContext(ctx,
+		`SELECT tstamp FROM goose_db_version WHERE version_id = 2`).Scan(&secondTstamp); err != nil {
+		t.Fatalf("reading second tstamp: %v", err)
+	}
+	if secondTstamp != firstTstamp {
+		t.Errorf("tstamp changed across re-runs: first=%q second=%q (shim must skip, not re-insert)",
+			firstTstamp, secondTstamp)
+	}
+}
+
+// TestMarkPre002Applied_FreshDBSkips verifies that markPre002Applied is a
+// no-op on a database that has no goose_db_version table yet. Fresh-install
+// startup must not synthesize a tracker row before goose has had a chance to
+// create the table itself.
+func TestMarkPre002Applied_FreshDBSkips(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("opening db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := markPre002Applied(db); err != nil {
+		t.Fatalf("markPre002Applied on fresh db: %v", err)
+	}
+
+	var n int
+	if err := db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='goose_db_version'`).Scan(&n); err != nil {
+		t.Fatalf("checking sqlite_master: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("goose_db_version table count after fresh-DB shim = %d, want 0 (shim must not create the tracker)", n)
+	}
+}

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 )
 
@@ -903,6 +904,73 @@ func TestMigrate_Pre002Shim_RecoversFromMissingTrackerRow(t *testing.T) {
 	if secondTstamp != firstTstamp {
 		t.Errorf("tstamp changed across re-runs: first=%q second=%q (shim must skip, not re-insert)",
 			firstTstamp, secondTstamp)
+	}
+}
+
+// TestMarkPre002Applied_TrackerExistsColumnAbsent covers the branch where
+// goose_db_version is present but libraries.nfo_lock_data has not been
+// created yet. The shim must not synthesize a marker row for a migration
+// whose target column does not exist; it would mask a genuinely missing 002.
+func TestMarkPre002Applied_TrackerExistsColumnAbsent(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("opening db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+
+	// Create only what the shim's pre-checks need: a tracker table (so
+	// hasTracker is true) and a libraries table without nfo_lock_data (so
+	// hasColumn is false). The schema does not need to match goose's exact
+	// shape -- the shim only reads via sqlite_master / PRAGMA.
+	if _, err := db.ExecContext(ctx, `
+		CREATE TABLE goose_db_version (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			version_id INTEGER NOT NULL,
+			is_applied INTEGER NOT NULL,
+			tstamp TIMESTAMP DEFAULT (datetime('now'))
+		)
+	`); err != nil {
+		t.Fatalf("creating tracker: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `CREATE TABLE libraries (id TEXT PRIMARY KEY)`); err != nil {
+		t.Fatalf("creating libraries: %v", err)
+	}
+
+	if err := markPre002Applied(db); err != nil {
+		t.Fatalf("markPre002Applied with column absent: %v", err)
+	}
+
+	var n int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM goose_db_version WHERE version_id = 2`).Scan(&n); err != nil {
+		t.Fatalf("counting tracker rows: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("tracker rows for version_id=2 = %d, want 0 (shim must not synthesize a marker without the column)", n)
+	}
+}
+
+// TestMarkPre002Applied_PropagatesErrorOnClosedDB verifies that errors from
+// the underlying sqlite_master query propagate as wrapped errors rather than
+// silently turning into a "no tracker" skip. A closed handle is the cheapest
+// way to force the query to fail without mocks.
+func TestMarkPre002Applied_PropagatesErrorOnClosedDB(t *testing.T) {
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("opening db: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing db: %v", err)
+	}
+
+	err = markPre002Applied(db)
+	if err == nil {
+		t.Fatal("markPre002Applied on closed db returned nil; want wrapped error")
+	}
+	if !strings.Contains(err.Error(), "checking goose_db_version presence") {
+		t.Errorf("error = %q, want wrap containing %q", err.Error(), "checking goose_db_version presence")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stillwater binaries built from current `main` fail to start against any database whose `libraries.nfo_lock_data` column was added by the now-retired `ensureXColumns` runtime helper rather than by migration `002_library_nfo_lock_data.sql`. Goose retries 002, hits the existing column, and aborts startup with `duplicate column name: nfo_lock_data`.
- Add a defensive shim `markPre002Applied` in `Migrate()` that runs before `goose.Up`. When `libraries.nfo_lock_data` already exists and `goose_db_version` has no row for `version_id=2`, it inserts the marker row so goose treats 002 as already applied. Idempotent across fresh installs (no tracker yet -> skip), pre-002 upgrades (insert marker), and already-upgraded DBs (no-op via `WHERE NOT EXISTS`).
- Adds `tableExists` helper next to the existing `columnExists` helper.
- Two new regression tests:
  - `TestMigrate_Pre002Shim_RecoversFromMissingTrackerRow` -- simulates a pre-002 DB by deleting the `version_id=2` row from `goose_db_version`, runs `Migrate`, asserts the marker is recovered, then runs `Migrate` a second time and asserts the row's `tstamp` is preserved (proves the `WHERE NOT EXISTS` guard skips rather than re-inserts).
  - `TestMarkPre002Applied_FreshDBSkips` -- asserts the shim is a no-op on a database with no `goose_db_version` table yet.

## Why this fix and not the alternatives

The issue listed three options. Implementation candidate 1 (defensive shim in `migrate.go`) wins because:

- Smallest blast radius: 80 lines of new code, no schema change.
- Stays inside the new forward-only migrations philosophy. Option 2 (sentinel inside `002.sql`) would have re-introduced the runtime-conditional ALTER pattern goose was meant to replace. Option 3 (parallel runtime migration alongside numbered ones) mixes the two philosophies the codebase just retired.
- Idempotency is carried by the `WHERE NOT EXISTS` subquery: goose v3's tracker has only an autoincrement PK on `id`, with no unique constraint on `version_id`, so a bare `INSERT` would happily duplicate `version_id=2` rows on re-run. The shim's guard is correct against the actual schema (verified against `pressly/goose v3.27.1`).

## Test plan

- [x] `go test -race -run 'Migration002|Pre002|MarkPre002' ./internal/database/` -- all three tests pass; the recovery test logs the shim's info line exactly once across two `Migrate` calls.
- [x] `bash scripts/pre-push-gate.sh` -- all hard checks green (full test suite, lint, OpenAPI, generated files, raw-error-leak, patch coverage).
- [x] CodeRabbit pre-push review (one IMPORTANT finding addressed: dropped misleading `INSERT OR IGNORE` and corrected the comment to credit `WHERE NOT EXISTS` as the actual idempotency guard).
- [ ] CI green on this PR.

Closes #1310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database initialization to recognize older setups and avoid re-applying already-present migration changes, preventing redundant migration errors and ensuring idempotent startup behavior.
* **Tests**
  * Added migration-focused tests covering recovery from missing tracker entries, behavior on databases lacking specific columns, error propagation, and fresh-database no-op cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->