### PR TITLE
fix(scripts): patch-coverage rejects uncommitted work and prefers origin/main

### DIFF
--- a/scripts/patch-coverage.sh
+++ b/scripts/patch-coverage.sh
@@ -94,10 +94,11 @@ if [ -z "${BASE:-}" ]; then
 else
   base_ref="<BASE env var>"
 fi
-if ! git rev-parse --verify -q "${BASE}^{commit}" >/dev/null 2>&1; then
+if ! resolved_base=$(git rev-parse --verify -q "${BASE}^{commit}" 2>/dev/null); then
   echo "patch-coverage: BASE does not resolve to a commit: $BASE" >&2
   exit 2
 fi
+BASE="$resolved_base"
 echo "patch-coverage: BASE=${BASE:0:12} (${base_ref})"
 
 if [ ! -s "$COVER_OUT" ]; then

--- a/scripts/patch-coverage.sh
+++ b/scripts/patch-coverage.sh
@@ -57,21 +57,48 @@ if ! awk -v t="$THRESHOLD" 'BEGIN { exit !(t ~ /^[0-9]+(\.[0-9]+)?$/) }'; then
   exit 2
 fi
 
-# Resolve BASE. Prefer an explicit env var, otherwise fall back to
-# merge-base with main. Fail loudly if neither produces a usable commit
-# rather than silently comparing against a bogus ref (which would skip
-# every file and exit 0 -- a false pass).
+# Refuse to run with uncommitted changes. The diff range below is HEAD vs
+# BASE, so unstaged or staged-but-uncommitted edits are invisible -- a
+# gate run before `git commit` would silently false-pass on whatever
+# already happens to be in the diff range (commonly empty, or recently
+# merged upstream work whose coverage signal masks the real patch). Force
+# the caller to commit first so the gate's input matches the patch that
+# will actually be pushed. Untracked files are excluded by `git diff` and
+# do not trigger this guard; they cannot affect patch coverage anyway.
+if ! git diff --quiet HEAD 2>/dev/null; then
+  echo "patch-coverage: uncommitted changes detected; commit first so the gate sees the real patch." >&2
+  echo "Run \`git status\` to see the working tree; \`git diff HEAD\` for the changes." >&2
+  exit 2
+fi
+
+# Resolve BASE. Prefer an explicit env var; otherwise prefer `origin/main`
+# over the local `main` branch so a stale local main cannot silently
+# widen the diff range to include other contributors' already-merged work
+# (which dilutes the patch and can drown the real coverage signal under
+# their high-coverage files). Fall back to local `main` if origin is not
+# configured. Fail loudly if neither produces a usable commit rather than
+# silently comparing against a bogus ref (which would skip every file and
+# exit 0 -- a false pass).
+base_ref=""
 if [ -z "${BASE:-}" ]; then
-  if ! BASE=$(git merge-base main HEAD 2>/dev/null); then
-    echo "patch-coverage: could not resolve BASE (no 'main' branch and BASE not set)." >&2
+  if git rev-parse --verify -q origin/main >/dev/null 2>&1; then
+    base_ref="origin/main"
+  elif git rev-parse --verify -q main >/dev/null 2>&1; then
+    base_ref="main"
+  fi
+  if [ -z "$base_ref" ] || ! BASE=$(git merge-base "$base_ref" HEAD 2>/dev/null); then
+    echo "patch-coverage: could not resolve BASE (no 'origin/main' or 'main' branch and BASE not set)." >&2
     echo "Set BASE explicitly, e.g. BASE=\$(git merge-base origin/main HEAD)." >&2
     exit 2
   fi
+else
+  base_ref="<BASE env var>"
 fi
 if ! git rev-parse --verify -q "${BASE}^{commit}" >/dev/null 2>&1; then
   echo "patch-coverage: BASE does not resolve to a commit: $BASE" >&2
   exit 2
 fi
+echo "patch-coverage: BASE=${BASE:0:12} (${base_ref})"
 
 if [ ! -s "$COVER_OUT" ]; then
   echo "patch-coverage: profile not found or empty at $COVER_OUT" >&2


### PR DESCRIPTION
## Summary

- Closes #1314.
- Refuses to run when `git diff --quiet HEAD` reports uncommitted changes. The diff range below the BASE check is `BASE..HEAD`, so unstaged or staged-but-uncommitted edits are invisible. Running the gate before `git commit` therefore false-passed at 100% on PR #1313 by reporting on the lag between local `main` and `origin/main` (three unrelated files, all 100% covered). After commit + push, codecov diffed against `origin/main` server-side and reported the real 68.42%.
- BASE resolution now prefers `origin/main` over local `main`. A stale local main can otherwise widen the diff range to include other contributors' merged work and dilute the patch's coverage signal under their high-coverage files. Falls back to local `main` only when `origin/main` is unreachable.
- Echoes the resolved BASE SHA + ref label on each run (`patch-coverage: BASE=abc123def456 (origin/main)`) so a future operator can spot the bug pattern by inspection.

## Manual verification

T1 (clean tree, no BASE override) -> resolves `origin/main`, prints marker, exits 0:
```
patch-coverage: BASE=f9c215269781 (origin/main)
patch-coverage: no Go source changes in scope.
```

T2 (uncommitted changes on an unrelated file) -> exits 2 with clear message:
```
patch-coverage: uncommitted changes detected; commit first so the gate sees the real patch.
Run `git status` to see the working tree; `git diff HEAD` for the changes.
```

T3 (explicit `BASE` env override) -> labeled `<BASE env var>`:
```
patch-coverage: BASE=f9c215269781 (<BASE env var>)
```

## Test plan

- [x] T1/T2/T3 manual verification (above).
- [x] `bash scripts/pre-push-gate.sh` on this branch passes; BASE marker visible in output.
- [ ] CI green on this PR.

## Rationale notes

- Untracked files are excluded from the dirty check by `git diff` semantics; they cannot affect patch coverage anyway, so warning about them would be noise.
- The script never *fetches* origin/main. If origin is itself stale, the script is no worse off than today, and `pre-push-gate.sh` already runs after the user has presumably synced. Adding a fetch would introduce a surprising side-effect on a check command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a preflight guard to abort when there are uncommitted changes so patch checks reflect actual diffs.
  * Improved BASE resolution and messaging: prefers explicit base, falls back to main branches, requires a resolvable base, and emits clearer guidance when resolution fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->