### PR TITLE
fix(image): distinguish ENOENT in FindExistingImage; rerun rules after fetch

### DIFF
--- a/docs/site/src/how-to/fetch-and-crop-images.md
+++ b/docs/site/src/how-to/fetch-and-crop-images.md
@@ -98,6 +98,10 @@ To delete many at once:
 
 When you want to compare what's currently saved against the candidates from providers, the comparison view shows the current image and N candidates side by side, all at the same display size, with a "select this" button on each. Useful for picking between visually similar options.
 
+## What happens after a successful fetch
+
+Once a fetch or upload writes a new image, Stillwater reruns the artist's image rules immediately. Violations like "missing thumb" or "missing fanart" disappear from the artist's row and the dashboard the moment the slot is populated, instead of waiting for the next scheduled rule scan.
+
 ## Skip rule violations during a fetch
 
 If a fetch returns nothing satisfactory and the rule has "select best candidate" turned on, Stillwater picks the highest-resolution candidate and saves it -- even if it doesn't meet the threshold. The result still flags as a violation, but you've at least populated the slot.

--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -194,6 +194,10 @@ func (r *Router) handleImageUpload(w http.ResponseWriter, req *http.Request) {
 			})
 		}
 		r.InvalidateHealthCache()
+		// Re-evaluate rules after a successful image write so image-related
+		// violations (missing thumbnail, fanart count, etc.) auto-clear in
+		// auto mode without waiting for the next scheduled scan. See #1028.
+		r.runRulesAfterRefresh(req.Context(), a)
 		// Skip platform sync for fanart appends: platforms only support a single
 		// backdrop image, and the primary (fanart.jpg) was already synced when
 		// first saved. Re-syncing here would re-push the primary, not the new
@@ -231,6 +235,9 @@ func (r *Router) handleImageUpload(w http.ResponseWriter, req *http.Request) {
 		})
 	}
 	r.InvalidateHealthCache()
+	// Re-evaluate rules after a successful image write so image-related
+	// violations auto-clear in auto mode. See #1028.
+	r.runRulesAfterRefresh(req.Context(), a)
 
 	syncCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
 	defer cancel()
@@ -350,6 +357,8 @@ func (r *Router) handleImageFetch(w http.ResponseWriter, req *http.Request) {
 		r.enforceCacheLimitIfNeeded(req.Context(), a)
 		r.updateArtistFanartCount(req.Context(), a)
 		r.InvalidateHealthCache()
+		// Re-evaluate rules after a successful image write. See #1028.
+		r.runRulesAfterRefresh(req.Context(), a)
 
 		if r.eventBus != nil {
 			r.eventBus.Publish(event.Event{
@@ -399,6 +408,8 @@ func (r *Router) handleImageFetch(w http.ResponseWriter, req *http.Request) {
 		})
 	}
 	r.InvalidateHealthCache()
+	// Re-evaluate rules after a successful image write. See #1028.
+	r.runRulesAfterRefresh(req.Context(), a)
 
 	syncCtx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
 	defer cancel()
@@ -1079,11 +1090,22 @@ func (r *Router) handleServeImage(w http.ResponseWriter, req *http.Request) {
 	}
 
 	patterns := r.getActiveNamingConfig(req.Context(), imageType)
-	filePath, found := img.FindExistingImage(dir, patterns)
+	// Strict variant: a non-ENOENT stat error must NOT clear the exists_flag.
+	// A permission-denied or unmounted-filesystem hiccup that returned EACCES
+	// or EIO would otherwise drop a flag that is still correct on disk. See #1161.
+	filePath, found, statErr := img.FindExistingImageStrict(dir, patterns)
+	if statErr != nil {
+		r.logger.Warn("serve image: stat error probing artist dir; preserving exists_flag",
+			slog.String("artist_id", a.ID),
+			slog.String("image_type", imageType),
+			slog.String("error", statErr.Error()))
+		http.NotFound(w, req)
+		return
+	}
 	if !found {
-		// If the DB flag says the image exists but the file is gone, clear
-		// the stale flag so subsequent UI renders show a placeholder instead
-		// of a broken image tag. This is best-effort and non-blocking.
+		// If the DB flag says the image exists but the file is genuinely gone
+		// (every probe returned ENOENT), clear the stale flag so subsequent UI
+		// renders show a placeholder instead of a broken image tag. Best-effort.
 		if imageExistsFlag(a, imageType) {
 			go func() { //nolint:gosec // Background context is intentional: this goroutine outlives the request.
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) //nolint:gosec
@@ -1291,7 +1313,15 @@ func (r *Router) handleDeleteImage(w http.ResponseWriter, req *http.Request) {
 	patterns := r.getActiveNamingConfig(req.Context(), imageType)
 	deleted, deleteFailed := deleteImageFiles(r.fileRemover, r.imageDir(a), patterns, r.logger)
 
-	if _, found := img.FindExistingImage(r.imageDir(a), patterns); !found {
+	// Strict variant: only clear the exists_flag when every probe returned
+	// ENOENT (file genuinely gone). A transient stat error means we cannot
+	// confirm absence and must leave the flag alone. See #1161.
+	if _, found, statErr := img.FindExistingImageStrict(r.imageDir(a), patterns); statErr != nil {
+		r.logger.Warn("delete image: post-delete stat error; preserving exists_flag",
+			slog.String("artist_id", a.ID),
+			slog.String("image_type", imageType),
+			slog.String("error", statErr.Error()))
+	} else if !found {
 		r.clearArtistImageFlag(req.Context(), a, imageType)
 	}
 	if r.eventBus != nil {
@@ -2120,9 +2150,18 @@ func (r *Router) handleRandomBackdrop(w http.ResponseWriter, req *http.Request) 
 			continue
 		}
 
-		filePath, found := img.FindExistingImage(dir, patterns)
+		// Strict variant: only clear the exists_flag when every probe returned
+		// ENOENT. A transient stat error must skip this artist without
+		// touching the flag (see #1161).
+		filePath, found, statErr := img.FindExistingImageStrict(dir, patterns)
+		if statErr != nil {
+			r.logger.Warn("random backdrop: stat error probing artist dir; preserving exists_flag",
+				slog.String("artist_id", a.ID),
+				slog.String("error", statErr.Error()))
+			continue
+		}
 		if !found {
-			// File is gone despite exists_flag=1; clear the stale flag and keep looking.
+			// File is genuinely gone despite exists_flag=1; clear the stale flag and keep looking.
 			if err := r.artistService.ClearImageFlag(req.Context(), a.ID, "fanart", 0); err != nil {
 				r.logger.Warn("failed to clear stale backdrop flag",
 					slog.String("artist_id", a.ID),

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -10,6 +10,7 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -2117,6 +2118,89 @@ func TestHandleImageUpload_RerunsRulesAfterWrite(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Error("RunForArtist was not invoked after successful image upload")
+	}
+}
+
+// stubRoundTripper returns a fixed response without touching the network.
+// Used to replace Router.ssrfClient.Transport in fetch-path tests so the
+// handler runs end-to-end without an actual HTTP request.
+type stubRoundTripper struct {
+	body []byte
+}
+
+func (s *stubRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"image/jpeg"}},
+		Body:       io.NopCloser(bytes.NewReader(s.body)),
+		Request:    req,
+	}, nil
+}
+
+// TestHandleImageFetch_RerunsRulesAfterWrite mirrors
+// TestHandleImageUpload_RerunsRulesAfterWrite for the fetch path. The PR's
+// runRulesAfterRefresh hook is wired into BOTH save paths; covering only one
+// would let a regression in the fetch handler's call site land unnoticed.
+//
+// example.com resolves to a public IP so isPrivateURL passes; the stub
+// RoundTripper short-circuits the actual HTTP request so no network is
+// involved at test time.
+func TestHandleImageFetch_RerunsRulesAfterWrite(t *testing.T) {
+	t.Parallel()
+	called := make(chan string, 1)
+	stub := &stubPipeline{
+		runForArtistFn: func(_ context.Context, a *artist.Artist) (*rule.RunResult, error) {
+			select {
+			case called <- a.ID:
+			default:
+			}
+			return &rule.RunResult{}, nil
+		},
+	}
+	r, artistSvc := testRouterWithStubPipeline(t, stub)
+	platSvc := platform.NewService(r.db)
+	r.platformService = platSvc
+	r.publisher = publish.New(publish.Deps{
+		ArtistService:      r.artistService,
+		ConnectionService:  r.connectionService,
+		NFOSnapshotService: r.nfoSnapshotService,
+		PlatformService:    platSvc,
+		ImageCacheDir:      r.imageCacheDir,
+		Logger:             r.logger,
+	})
+
+	// Encode a 1:1 JPEG and serve it via the stubbed Transport so the fetch
+	// path runs without a real network round trip.
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, image.NewRGBA(image.Rect(0, 0, 500, 500)), nil); err != nil {
+		t.Fatalf("encoding JPEG: %v", err)
+	}
+	r.ssrfClient = &http.Client{Transport: &stubRoundTripper{body: buf.Bytes()}}
+
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Fetch Rerun Rules", SortName: "Fetch Rerun Rules", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	body := strings.NewReader(`{"url":"https://example.com/test.jpg","type":"thumb"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fetch?skip_crop=true", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+
+	r.handleImageFetch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	select {
+	case got := <-called:
+		if got != a.ID {
+			t.Errorf("RunForArtist called with %q, want %q", got, a.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("RunForArtist was not invoked after successful image fetch")
 	}
 }
 

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -2172,18 +2172,24 @@ func TestHandleServeImage_PreservesFlagOnStatError(t *testing.T) {
 		t.Errorf("expected 404 on stat error, got %d", w.Code)
 	}
 
-	// Wait briefly so any (incorrect) async clear would have time to run.
-	time.Sleep(200 * time.Millisecond)
-
 	// Restore permissions so the DB read can use the path freely (defensive).
 	_ = os.Chmod(parent, 0o755)
 
-	updated, err := artistSvc.GetByID(ctx, a.ID)
-	if err != nil {
-		t.Fatalf("GetByID: %v", err)
-	}
-	if !updated.ThumbExists {
-		t.Error("ThumbExists must remain true after a non-ENOENT stat error; otherwise transient FS hiccups corrupt flags")
+	// The serve handler clears stale flags from a goroutine with a 5s
+	// timeout. A short sleep can let the test pass even if a buggy code path
+	// schedules the clear with extra latency, so poll past the goroutine's
+	// own deadline and assert the flag stays true the whole window. Any flip
+	// to false at any point is a regression.
+	deadline := time.Now().Add(6 * time.Second)
+	for time.Now().Before(deadline) {
+		updated, err := artistSvc.GetByID(ctx, a.ID)
+		if err != nil {
+			t.Fatalf("GetByID: %v", err)
+		}
+		if !updated.ThumbExists {
+			t.Fatal("ThumbExists must remain true after a non-ENOENT stat error; otherwise transient FS hiccups corrupt flags")
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/sydlexius/stillwater/internal/platform"
 	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/internal/publish"
+	"github.com/sydlexius/stillwater/internal/rule"
 )
 
 // testRouterWithPlatform returns a Router that includes a platform service,
@@ -2039,4 +2041,352 @@ func TestSortImageResults(t *testing.T) {
 				imgs[0].URL, imgs[1].URL, imgs[2].URL, imgs[3].URL)
 		}
 	})
+}
+
+// TestHandleImageUpload_RerunsRulesAfterWrite verifies that a successful image
+// upload triggers a best-effort rule re-evaluation so image violations
+// (missing thumbnail, etc.) auto-clear without waiting for the next scheduled
+// scan. See issue #1028.
+func TestHandleImageUpload_RerunsRulesAfterWrite(t *testing.T) {
+	t.Parallel()
+	called := make(chan string, 1)
+	stub := &stubPipeline{
+		runForArtistFn: func(_ context.Context, a *artist.Artist) (*rule.RunResult, error) {
+			select {
+			case called <- a.ID:
+			default:
+			}
+			return &rule.RunResult{}, nil
+		},
+	}
+	r, artistSvc := testRouterWithStubPipeline(t, stub)
+	// Wire a platform service + publisher so the upload path resolves naming
+	// config and runs to completion.
+	platSvc := platform.NewService(r.db)
+	r.platformService = platSvc
+	r.publisher = publish.New(publish.Deps{
+		ArtistService:      r.artistService,
+		ConnectionService:  r.connectionService,
+		NFOSnapshotService: r.nfoSnapshotService,
+		PlatformService:    platSvc,
+		ImageCacheDir:      r.imageCacheDir,
+		Logger:             r.logger,
+	})
+
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Rerun Rules", SortName: "Rerun Rules", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	if err := mw.WriteField("type", "thumb"); err != nil {
+		t.Fatalf("writing field: %v", err)
+	}
+	partHeader := make(map[string][]string)
+	partHeader["Content-Disposition"] = []string{`form-data; name="file"; filename="thumb.jpg"`}
+	partHeader["Content-Type"] = []string{"image/jpeg"}
+	fw, err := mw.CreatePart(partHeader)
+	if err != nil {
+		t.Fatalf("CreatePart: %v", err)
+	}
+	// Use a roughly-1:1 image so it does not trigger the needs_crop branch.
+	testImg := image.NewRGBA(image.Rect(0, 0, 500, 500))
+	if err := jpeg.Encode(fw, testImg, nil); err != nil {
+		t.Fatalf("encoding JPEG: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("closing multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/upload?skip_crop=true", &body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+
+	r.handleImageUpload(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	select {
+	case got := <-called:
+		if got != a.ID {
+			t.Errorf("RunForArtist called with %q, want %q", got, a.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("RunForArtist was not invoked after successful image upload")
+	}
+}
+
+// TestHandleServeImage_PreservesFlagOnStatError verifies that when the artist
+// directory cannot be stat-walked (EACCES from an unreadable parent dir), the
+// serve handler returns 404 but does NOT clear the exists_flag. Without the
+// strict variant of FindExistingImage, a single permission-denied directory
+// would silently drop every flag for artists under it on each request. See
+// issue #1161.
+func TestHandleServeImage_PreservesFlagOnStatError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o000 semantics are Unix-specific")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses permission bits; cannot trigger EACCES")
+	}
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	ctx := context.Background()
+
+	// Create an artist whose Path is a child of a directory we will make
+	// unreadable. The serve handler will then hit EACCES when stat-ing files.
+	parent := t.TempDir()
+	child := filepath.Join(parent, "stat-error-artist")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	a := &artist.Artist{Name: "Stat Error", SortName: "Stat Error", Path: child}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// Place a real thumb so the flag is set, then drop the parent's exec bit so
+	// traversal fails with EACCES (the file is still on disk, but unreachable).
+	writeJPEG(t, filepath.Join(child, "folder.jpg"), 500, 500)
+	r.setArtistImageFlag(ctx, a, "thumb", true)
+	if !a.ThumbExists {
+		t.Fatal("ThumbExists should be true after setting flag")
+	}
+	if err := os.Chmod(parent, 0o000); err != nil {
+		t.Fatalf("Chmod parent: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	url := fmt.Sprintf("/api/v1/artists/%s/images/thumb/file", a.ID)
+	req := httptest.NewRequest("GET", url, nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "thumb")
+	w := httptest.NewRecorder()
+	r.handleServeImage(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 on stat error, got %d", w.Code)
+	}
+
+	// Wait briefly so any (incorrect) async clear would have time to run.
+	time.Sleep(200 * time.Millisecond)
+
+	// Restore permissions so the DB read can use the path freely (defensive).
+	_ = os.Chmod(parent, 0o755)
+
+	updated, err := artistSvc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if !updated.ThumbExists {
+		t.Error("ThumbExists must remain true after a non-ENOENT stat error; otherwise transient FS hiccups corrupt flags")
+	}
+}
+
+// TestHandleDeleteImage_PreservesFlagOnStatError verifies that when the delete
+// path's post-delete probe encounters a non-ENOENT stat error (here EACCES from
+// an unreadable parent directory), the exists_flag is NOT cleared. Without the
+// strict variant, a transient permission-denied stat would silently drop a
+// flag whose underlying file may still be on disk. See issue #1161.
+func TestHandleDeleteImage_PreservesFlagOnStatError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o000 semantics are Unix-specific")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses permission bits; cannot trigger EACCES")
+	}
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	ctx := context.Background()
+
+	parent := t.TempDir()
+	child := filepath.Join(parent, "delete-stat-error")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	a := &artist.Artist{Name: "Delete Stat Error", SortName: "Delete Stat Error", Path: child}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// Place a thumb and set the flag, then drop the parent's exec bit so the
+	// post-delete strict probe hits EACCES rather than ENOENT.
+	writeJPEG(t, filepath.Join(child, "folder.jpg"), 500, 500)
+	r.setArtistImageFlag(ctx, a, "thumb", true)
+	if !a.ThumbExists {
+		t.Fatal("ThumbExists should be true after setting flag")
+	}
+	if err := os.Chmod(parent, 0o000); err != nil {
+		t.Fatalf("Chmod parent: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	url := fmt.Sprintf("/api/v1/artists/%s/images/thumb", a.ID)
+	req := httptest.NewRequest(http.MethodDelete, url, nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "thumb")
+	w := httptest.NewRecorder()
+	r.handleDeleteImage(w, req)
+
+	// Restore permissions so subsequent DB reads / cleanup are unaffected.
+	_ = os.Chmod(parent, 0o755)
+
+	updated, err := artistSvc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if !updated.ThumbExists {
+		t.Error("ThumbExists must remain true after a non-ENOENT post-delete stat error")
+	}
+}
+
+// TestHandleRandomBackdrop_PreservesFlagOnStatError verifies that the random
+// backdrop endpoint does not clear the fanart exists_flag when probing the
+// artist directory hits a non-ENOENT stat error (EACCES). Without the strict
+// variant, a single unreadable parent dir would silently drop the flag for
+// every artist under it on each request. See issue #1161.
+func TestHandleRandomBackdrop_PreservesFlagOnStatError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o000 semantics are Unix-specific")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses permission bits; cannot trigger EACCES")
+	}
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	ctx := context.Background()
+
+	parent := t.TempDir()
+	child := filepath.Join(parent, "backdrop-stat-error")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	a := &artist.Artist{Name: "Backdrop Stat Error", SortName: "Backdrop Stat Error", Path: child}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// Seed the fanart flag (file present on disk) then drop parent permissions.
+	writeJPEG(t, filepath.Join(child, "fanart.jpg"), 100, 56)
+	if _, err := r.db.ExecContext(ctx,
+		`INSERT INTO artist_images (id, artist_id, image_type, slot_index, exists_flag)
+		 VALUES (lower(hex(randomblob(16))), ?, 'fanart', 0, 1)
+		 ON CONFLICT (artist_id, image_type, slot_index) DO UPDATE SET exists_flag = 1`,
+		a.ID); err != nil {
+		t.Fatalf("seeding artist_images: %v", err)
+	}
+	if err := os.Chmod(parent, 0o000); err != nil {
+		t.Fatalf("Chmod parent: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	req := httptest.NewRequest("GET", "/api/v1/images/random-backdrop", nil)
+	w := httptest.NewRecorder()
+	r.handleRandomBackdrop(w, req)
+
+	// Endpoint returns 404 because all candidates were skipped due to stat error.
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 when all candidates skipped, got %d", w.Code)
+	}
+
+	// Restore permissions so subsequent DB queries are unaffected.
+	_ = os.Chmod(parent, 0o755)
+
+	images, err := artistSvc.GetImagesForArtist(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetImagesForArtist: %v", err)
+	}
+	var sawFanart bool
+	for _, im := range images {
+		if im.ImageType == "fanart" && im.SlotIndex == 0 {
+			sawFanart = true
+			if !im.Exists {
+				t.Error("fanart exists_flag must remain true after a non-ENOENT stat error")
+			}
+		}
+	}
+	if !sawFanart {
+		t.Error("expected to find fanart row in artist_images")
+	}
+}
+
+// TestHandleImageUpload_FanartAppend_RerunsRules verifies that the fanart
+// append branch (a.FanartExists == true) of handleImageUpload also calls
+// RunForArtist after a successful write. The primary path is covered by
+// TestHandleImageUpload_RerunsRulesAfterWrite. See #1028.
+func TestHandleImageUpload_FanartAppend_RerunsRules(t *testing.T) {
+	t.Parallel()
+	called := make(chan string, 1)
+	stub := &stubPipeline{
+		runForArtistFn: func(_ context.Context, a *artist.Artist) (*rule.RunResult, error) {
+			select {
+			case called <- a.ID:
+			default:
+			}
+			return &rule.RunResult{}, nil
+		},
+	}
+	r, artistSvc := testRouterWithStubPipeline(t, stub)
+	platSvc := platform.NewService(r.db)
+	r.platformService = platSvc
+	r.publisher = publish.New(publish.Deps{
+		ArtistService:      r.artistService,
+		ConnectionService:  r.connectionService,
+		NFOSnapshotService: r.nfoSnapshotService,
+		PlatformService:    platSvc,
+		ImageCacheDir:      r.imageCacheDir,
+		Logger:             r.logger,
+	})
+
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Fanart Append", SortName: "Fanart Append", Path: dir, FanartExists: true}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	// Seed a primary fanart so the append branch produces fanart2.jpg.
+	writeJPEG(t, filepath.Join(dir, "fanart.jpg"), 1920, 1080)
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	if err := mw.WriteField("type", "fanart"); err != nil {
+		t.Fatalf("writing field: %v", err)
+	}
+	partHeader := make(map[string][]string)
+	partHeader["Content-Disposition"] = []string{`form-data; name="file"; filename="fanart.jpg"`}
+	partHeader["Content-Type"] = []string{"image/jpeg"}
+	fw, err := mw.CreatePart(partHeader)
+	if err != nil {
+		t.Fatalf("CreatePart: %v", err)
+	}
+	// 16:9 aspect to satisfy fanart geometry without triggering needs_crop.
+	testImg := image.NewRGBA(image.Rect(0, 0, 1920, 1080))
+	if err := jpeg.Encode(fw, testImg, nil); err != nil {
+		t.Fatalf("encoding JPEG: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("closing multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/upload?skip_crop=true", &body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+
+	r.handleImageUpload(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	select {
+	case got := <-called:
+		if got != a.ID {
+			t.Errorf("RunForArtist called with %q, want %q", got, a.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("RunForArtist was not invoked after successful fanart append")
+	}
 }

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -2326,6 +2326,15 @@ func TestHandleDeleteImage_PreservesFlagOnStatError(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.handleDeleteImage(w, req)
 
+	// Pin the handler-contract status so a regression that returns a
+	// non-2xx for this EACCES-on-post-probe path is caught here, not just
+	// "ThumbExists stayed true." StatusOK is the contract for delete: the
+	// remove itself reports success and the flag-preservation is the
+	// follow-on probe behavior, not the response.
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
 	// Restore permissions so subsequent DB reads / cleanup are unaffected.
 	_ = os.Chmod(parent, 0o755)
 

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -2183,7 +2183,11 @@ func TestHandleImageFetch_RerunsRulesAfterWrite(t *testing.T) {
 		t.Fatalf("creating artist: %v", err)
 	}
 
-	body := strings.NewReader(`{"url":"https://example.com/test.jpg","type":"thumb"}`)
+	// Use a public IP literal rather than a hostname so isPrivateURL's DNS
+	// lookup is skipped: in offline / locked-down CI a hostname lookup can
+	// fail and isPrivateURL fails closed (returns true), which would block
+	// the fetch path before the stub transport ever runs.
+	body := strings.NewReader(`{"url":"https://8.8.8.8/test.jpg","type":"thumb"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fetch?skip_crop=true", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("id", a.ID)

--- a/internal/image/naming.go
+++ b/internal/image/naming.go
@@ -1,6 +1,8 @@
 package image
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -103,11 +105,33 @@ var AllSlots = []string{"thumb", "fanart", "logo", "banner"}
 // For each configured pattern it first checks the exact filename, then probes
 // alternate supported extensions (.jpg, .png) to handle cases where the saved
 // format differs from the configured name (e.g. a PNG crop saved over folder.jpg).
+//
+// This is a thin wrapper over FindExistingImageStrict that discards the error.
+// Callers that branch on `found == false` to drive destructive state (clearing
+// flags, deleting rows, overwriting NFOs) MUST call FindExistingImageStrict
+// instead so transient stat errors (EACCES, EIO, ESTALE, ELOOP) are not
+// silently treated as "file absent". See issue #1161.
 func FindExistingImage(dir string, patterns []string) (string, bool) {
+	path, found, _ := FindExistingImageStrict(dir, patterns)
+	return path, found
+}
+
+// FindExistingImageStrict is the same as FindExistingImage but surfaces the
+// first non-fs.ErrNotExist stat error encountered. Callers that act
+// destructively on `found == false` should use this variant: an error means
+// "we don't know whether the file is absent" and the caller should refuse to
+// proceed (skip the destructive write, log, retry next cycle).
+//
+// On a clean miss (every probe returned fs.ErrNotExist), the result is
+// ("", false, nil). On a hit, the result is (path, true, nil). On the first
+// non-ENOENT error, the result is ("", false, err) and probing stops.
+func FindExistingImageStrict(dir string, patterns []string) (string, bool, error) {
 	for _, pattern := range patterns {
 		p := filepath.Join(dir, pattern)
 		if _, err := os.Stat(p); err == nil { //nolint:gosec // path from trusted naming patterns
-			return p, true
+			return p, true, nil
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return "", false, err
 		}
 		// Check alternate extensions in case the format changed after save.
 		base := strings.TrimSuffix(pattern, filepath.Ext(pattern))
@@ -117,9 +141,11 @@ func FindExistingImage(dir string, patterns []string) (string, bool) {
 			}
 			alt := filepath.Join(dir, base+ext)
 			if _, err := os.Stat(alt); err == nil { //nolint:gosec // path from trusted naming patterns
-				return alt, true
+				return alt, true, nil
+			} else if !errors.Is(err, fs.ErrNotExist) {
+				return "", false, err
 			}
 		}
 	}
-	return "", false
+	return "", false, nil
 }

--- a/internal/image/naming_test.go
+++ b/internal/image/naming_test.go
@@ -1,6 +1,11 @@
 package image
 
 import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -138,6 +143,209 @@ func TestAllSlots(t *testing.T) {
 		if AllSlots[i] != s {
 			t.Errorf("AllSlots[%d] = %q, want %q", i, AllSlots[i], s)
 		}
+	}
+}
+
+// TestFindExistingImageStrict_FilePresent verifies that a present file is
+// returned with found=true and no error (the success path).
+func TestFindExistingImageStrict_FilePresent(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "folder.jpg")
+	if err := os.WriteFile(target, []byte("img"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, found, err := FindExistingImageStrict(dir, []string{"folder.jpg"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true, got false")
+	}
+	if got != target {
+		t.Errorf("got %q, want %q", got, target)
+	}
+}
+
+// TestFindExistingImageStrict_FileAbsent verifies that ENOENT is treated as a
+// clean miss: found=false, err=nil. This is the only "not present" signal
+// callers should trust for destructive actions.
+func TestFindExistingImageStrict_FileAbsent(t *testing.T) {
+	dir := t.TempDir()
+	got, found, err := FindExistingImageStrict(dir, []string{"folder.jpg"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Errorf("expected found=false, got true (path=%q)", got)
+	}
+}
+
+// TestFindExistingImageStrict_DirAbsent verifies that probing a missing
+// directory surfaces as ENOENT (clean miss, no error).
+func TestFindExistingImageStrict_DirAbsent(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does-not-exist")
+	_, found, err := FindExistingImageStrict(dir, []string{"folder.jpg"})
+	if err != nil {
+		t.Fatalf("ENOENT must surface as nil error, got %v", err)
+	}
+	if found {
+		t.Error("expected found=false on missing dir")
+	}
+}
+
+// TestFindExistingImageStrict_AlternateExtension verifies the alt-extension
+// probe path: configured pattern is folder.jpg but actual file is folder.png.
+func TestFindExistingImageStrict_AlternateExtension(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "folder.png")
+	if err := os.WriteFile(target, []byte("img"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, found, err := FindExistingImageStrict(dir, []string{"folder.jpg"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true via alternate extension")
+	}
+	if got != target {
+		t.Errorf("got %q, want %q", got, target)
+	}
+}
+
+// TestFindExistingImageStrict_PermissionDenied verifies that a stat error
+// other than fs.ErrNotExist (here EACCES from an unreadable parent dir) is
+// surfaced to the caller and probing stops. Without this, transient FS errors
+// would silently masquerade as "file absent" and drive destructive writes.
+func TestFindExistingImageStrict_PermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o000 semantics are Unix-specific")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses permission bits; cannot trigger EACCES")
+	}
+	parent := t.TempDir()
+	child := filepath.Join(parent, "artist")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Chmod(parent, 0o000); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	_, found, err := FindExistingImageStrict(child, []string{"folder.jpg"})
+	if err == nil {
+		t.Fatal("expected non-nil error from permission-denied stat")
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("error must NOT be fs.ErrNotExist (got %v)", err)
+	}
+	if found {
+		t.Error("expected found=false when error surfaces")
+	}
+}
+
+// TestFindExistingImage_LooseWrapper verifies the loose wrapper preserves
+// the legacy 2-return shape and treats every error as "not found". Callers
+// that depend on this behavior (read-only consumers) must continue to work.
+func TestFindExistingImage_LooseWrapper(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "folder.jpg")
+	if err := os.WriteFile(target, []byte("img"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, found := FindExistingImage(dir, []string{"folder.jpg"})
+	if !found || got != target {
+		t.Errorf("FindExistingImage(present)=(%q,%v), want (%q,true)", got, found, target)
+	}
+	got, found = FindExistingImage(filepath.Join(t.TempDir(), "missing"), []string{"folder.jpg"})
+	if found || got != "" {
+		t.Errorf("FindExistingImage(absent)=(%q,%v), want (\"\",false)", got, found)
+	}
+}
+
+// TestFindExistingImageStrict_PermissionDeniedAltExt covers the alt-extension
+// branch's EACCES short-circuit. The primary pattern's stat must surface as
+// ENOENT (so the loop continues into the alt-extension probes) while the
+// alt-extension stat then returns a non-ENOENT error. Without this branch,
+// callers driving destructive state on `found == false` could silently treat
+// EACCES on an alt-named file as "absent".
+func TestFindExistingImageStrict_PermissionDeniedAltExt(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o000 semantics are Unix-specific")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses permission bits; cannot trigger EACCES")
+	}
+	// Layout:
+	//   parent/                (0o755 throughout)
+	//     visible/             (0o755) -- the dir we probe with patterns
+	//   We make `visible` itself unreadable AFTER creating folder.png inside,
+	//   so the alt-extension probe (folder.png) gets EACCES, but the primary
+	//   probe (folder.jpg) also gets EACCES -- which is fine, the function
+	//   returns the first non-ENOENT error encountered.
+	//
+	// To exercise specifically the alt-extension branch, we instead use a
+	// pattern whose primary file is genuinely absent in a readable dir, then
+	// place an unreadable subdir for the alt extension. But Stat does not
+	// recurse, so a single dir with a stat-blocked file is what we need.
+	// We achieve that by making the parent dir traversable but the file's
+	// containing dir unreadable for `folder.png` only via a separate sub-path.
+	//
+	// Simpler approach: use a probe directory whose parent has exec bit
+	// cleared. Stat on `dir/folder.jpg` returns EACCES, but errors.Is(err,
+	// fs.ErrNotExist) is false on most systems for a directory traversal
+	// failure, so the function returns immediately on the primary pattern.
+	// That covers the primary-pattern EACCES branch already tested.
+	//
+	// To hit the *alt-extension* branch specifically, we need the primary
+	// stat to return ENOENT and the alt stat to return EACCES. This is
+	// achievable on Linux/macOS by making the dir traversable + readable
+	// (so ENOENT is returned for missing names) but creating the alt file
+	// with mode that makes Stat fail. Stat itself only needs parent
+	// traversal, not file read perms, so we cannot block Stat with file
+	// mode bits alone.
+	//
+	// Workaround: create a *symlink* whose target is inside an unreadable
+	// directory. Stat follows symlinks; if the target's parent is
+	// unreadable, Stat returns EACCES rather than ENOENT.
+	parent := t.TempDir()
+	probeDir := filepath.Join(parent, "probe")
+	if err := os.MkdirAll(probeDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll probe: %v", err)
+	}
+	hidden := filepath.Join(parent, "hidden")
+	if err := os.MkdirAll(hidden, 0o755); err != nil {
+		t.Fatalf("MkdirAll hidden: %v", err)
+	}
+	target := filepath.Join(hidden, "folder.png")
+	if err := os.WriteFile(target, []byte("img"), 0o644); err != nil {
+		t.Fatalf("WriteFile target: %v", err)
+	}
+	// Symlink probe/folder.png -> hidden/folder.png. Then chmod hidden to
+	// 0o000 so Stat (which follows symlinks) fails with EACCES on the alt
+	// extension probe. The primary pattern (folder.jpg) does not exist in
+	// probeDir and returns ENOENT, so the loop falls through to the alt
+	// extension probe.
+	link := filepath.Join(probeDir, "folder.png")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	if err := os.Chmod(hidden, 0o000); err != nil {
+		t.Fatalf("Chmod hidden: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(hidden, 0o755) })
+
+	_, found, err := FindExistingImageStrict(probeDir, []string{"folder.jpg"})
+	if err == nil {
+		t.Fatal("expected non-nil error from alt-extension EACCES probe")
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("error must NOT be fs.ErrNotExist (got %v)", err)
+	}
+	if found {
+		t.Error("expected found=false when error surfaces")
 	}
 }
 

--- a/internal/image/naming_test.go
+++ b/internal/image/naming_test.go
@@ -265,6 +265,37 @@ func TestFindExistingImage_LooseWrapper(t *testing.T) {
 	}
 }
 
+// TestFindExistingImage_LooseWrapper_StatErrorReturnsNotFound locks in the
+// loose wrapper's swallow-all-errors contract on the EACCES path. The strict
+// variant surfaces the error; the loose wrapper must continue to return
+// ("", false) for read-only consumers that have no use for the error and
+// cannot regress to a strict signature without churning every caller.
+func TestFindExistingImage_LooseWrapper_StatErrorReturnsNotFound(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o000 semantics are Unix-specific")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses permission bits; cannot trigger EACCES")
+	}
+	parent := t.TempDir()
+	child := filepath.Join(parent, "artist")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Chmod(parent, 0o000); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) })
+
+	got, found := FindExistingImage(child, []string{"folder.jpg"})
+	if found {
+		t.Error("expected found=false on permission-denied stat")
+	}
+	if got != "" {
+		t.Errorf("expected got=\"\" on permission-denied stat, got %q", got)
+	}
+}
+
 // TestFindExistingImageStrict_PermissionDeniedAltExt covers the alt-extension
 // branch's EACCES short-circuit. The primary pattern's stat must surface as
 // ENOENT (so the loop continues into the alt-extension probes) while the

--- a/internal/maintenance/maintenance.go
+++ b/internal/maintenance/maintenance.go
@@ -213,6 +213,17 @@ func (s *Service) ScanExistsFlags(ctx context.Context) error {
 		// as a clean miss. Without this distinction, a single flaky filesystem
 		// could clear every exists_flag under it. See issue #1161.
 		patterns := img.FileNamesForType(img.DefaultFileNames, imageType)
+		if len(patterns) == 0 {
+			// Unknown imageType: FindExistingImageStrict(dir, nil) reports
+			// found=false, err=nil, which would clear exists_flag without ever
+			// probing the filesystem. Skip so the "only clear on definitive
+			// absence" guarantee is preserved.
+			s.logger.Warn("exists_flag scan: unknown image type, skipping",
+				slog.String("artist_id", artistID),
+				slog.String("image_type", imageType))
+			skipped++
+			continue
+		}
 		_, found, statErr := img.FindExistingImageStrict(dir, patterns)
 		if statErr != nil {
 			s.logger.Warn("exists_flag scan: stat error probing artist dir, skipping",

--- a/internal/maintenance/maintenance.go
+++ b/internal/maintenance/maintenance.go
@@ -3,9 +3,7 @@ package maintenance
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -209,21 +207,22 @@ func (s *Service) ScanExistsFlags(ctx context.Context) error {
 			continue
 		}
 
-		// Stat the directory before asking FindExistingImage to probe files
-		// inside it. FindExistingImage collapses any stat error to "not found",
-		// so without this guard a permission-denied directory or an unmounted
-		// NFS share would clear every flag under it.
-		if _, statErr := os.Stat(dir); statErr != nil && !errors.Is(statErr, fs.ErrNotExist) {
-			s.logger.Warn("exists_flag scan: cannot stat artist dir, skipping",
+		// Use the strict variant: a transient stat error (EACCES on a
+		// permission-denied dir, EIO/ESTALE on an unmounted NFS share) means
+		// "we don't know whether the file is absent" and must NOT be treated
+		// as a clean miss. Without this distinction, a single flaky filesystem
+		// could clear every exists_flag under it. See issue #1161.
+		patterns := img.FileNamesForType(img.DefaultFileNames, imageType)
+		_, found, statErr := img.FindExistingImageStrict(dir, patterns)
+		if statErr != nil {
+			s.logger.Warn("exists_flag scan: stat error probing artist dir, skipping",
 				slog.String("artist_id", artistID),
 				slog.String("dir", dir),
 				slog.Any("error", statErr))
 			skipped++
 			continue
 		}
-
-		patterns := img.FileNamesForType(img.DefaultFileNames, imageType)
-		if _, found := img.FindExistingImage(dir, patterns); !found {
+		if !found {
 			stale = append(stale, staleRow{artistID, imageType, slotIndex})
 		}
 	}


### PR DESCRIPTION
## Summary

Two issues bundled in a W2.B M46.5 PR:

- **#1161**: \`img.FindExistingImage\` collapsed every \`os.Stat\` error to \`found=false\`, so callers driving destructive writes (clearing \`exists_flag\`, deleting flag rows) silently corrupted state on transient EACCES / EIO / ESTALE / ELOOP. Adds \`FindExistingImageStrict\` returning \`(string, bool, error)\` per option A in the issue. The legacy \`FindExistingImage\` becomes a thin wrapper for read-only consumers that do not branch destructively.
- **#1028**: \`handleImageFetch\` and \`handleImageUpload\` did not call \`RunForArtist\` after a successful image write. Image violations (missing thumb, missing fanart, etc.) only auto-cleared on the next scheduled scan. Adds best-effort \`runRulesAfterRefresh\` calls after every successful image-write path in both handlers.

## Caller audit (FindExistingImage)

Per #1161 acceptance criteria, every caller was audited for "uses \`found == false\` to drive destructive action." Strict variant adopted only where destructive.

| File:line | Caller | Decision | Rationale |
|---|---|---|---|
| \`internal/maintenance/maintenance.go:226\` | \`ScanExistsFlags\` | **Strict** | Clears \`exists_flag\`. Pre-stat directory guard removed (now redundant per #1161 ACs). |
| \`internal/api/handlers_image.go:618\` | \`handleImageCrop\` provenance read | Loose | Read-only; falls back to fresh metadata on miss. Not destructive. |
| \`internal/api/handlers_image.go:947\` | \`setArtistImageFlag\` (exists=true) | Loose | Falls back to default flags on miss; not destructive. |
| \`internal/api/handlers_image.go:1086\` | \`handleServeImage\` stale-flag clear | **Strict** | Calls \`ClearImageFlag\` on miss. Destructive. |
| \`internal/api/handlers_image.go:1163\` | \`handleImageInfo\` | Loose | Returns 404 on miss; not destructive. |
| \`internal/api/handlers_image.go:1304\` | \`handleDeleteImage\` post-delete check | **Strict** | Calls \`clearArtistImageFlag\` on miss. Destructive. |
| \`internal/api/handlers_image.go:1547\` | \`handleLogoTrim\` | Loose | Returns 404 on miss; not destructive. |
| \`internal/api/handlers_image.go:2143\` | \`handleRandomBackdrop\` | **Strict** | Calls \`ClearImageFlag\` on miss. Destructive. |
| \`internal/api/handlers_push.go:205\` | platform image push | Loose | Skips upload on miss with logged warning. Not destructive. |
| \`internal/api/handlers_connection_library.go:906\` | library scan | Loose | Skips download when image already exists; miss continues. Not destructive. |
| \`internal/publish/publisher.go:383\` | \`SyncImageToPlatforms\` | Loose | Returns warning on miss; not destructive. |
| \`internal/rule/fixers.go\`, \`internal/rule/checkers.go\` | rule engine | Loose | W2.A territory; out of scope for this PR. Verified no destructive use of \`found==false\` (rule engine reads file presence to compute violations, does not write back). |

The loose wrapper now short-circuits on the first non-ENOENT error rather than continuing to probe alternate extensions. This is a behavior change but a safer one: every loose-caller's miss-path is "skip and 404" or "skip and warn", which is the right response when the filesystem is flaky.

## Post-fetch rule rerun (#1028)

\`runRulesAfterRefresh\` (defined in \`handlers_refresh.go\`, unchanged) is now invoked after the four success paths in \`handleImageUpload\` + \`handleImageFetch\`:

- upload, fanart-append branch
- upload, primary-save branch
- fetch, fanart-append branch
- fetch, primary-save branch

Mirrors the existing pattern in \`handlers_refresh.go\`: detached context, 30s timeout, errors logged but not propagated.

## Tests

- \`internal/image/naming_test.go\` -- new tests cover file-present, file-absent, dir-absent, alternate-extension success, EACCES (Unix-only via chmod 0o000 trick), and the loose wrapper preservation.
- \`internal/maintenance/maintenance_test.go\` -- existing \`TestScanExistsFlagsStatErrorSkips\` continues to assert flag preservation under EACCES; the in-place pre-stat guard was removed but the equivalent guard now lives inside FindExistingImageStrict.
- \`internal/api/handlers_image_test.go\` -- new \`TestHandleServeImage_PreservesFlagOnStatError\` regression test verifies a permission-denied parent directory does NOT clear \`thumb_exists\`. New \`TestHandleImageUpload_RerunsRulesAfterWrite\` integration test verifies \`RunForArtist\` is invoked via the stub pipeline.

## Verification

- \`make fmt\` clean
- \`make lint\` clean
- \`bash scripts/pre-push-gate.sh\` clean (patch coverage 70.18% across the diff)

Closes #1161
Closes #1028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve image-exists flags when transient filesystem errors occur; flags are only cleared after definitive absence.
  * Safer, non-blocking handling of stale flags to avoid blocking responses.

* **Improvements**
  * Automatic re-evaluation of image rules after successful image writes (upload, fetch, crop, fanart append) to speed self-healing and platform sync.
  * More robust, strict presence probing across image flows to reduce false negatives.
  * Provenance metadata for saved images is recorded and cleared correctly on delete.

* **Tests**
  * Added extensive tests for rule re-runs, strict existence checks, provenance, and backlog/serve/delete flows.

* **Documentation**
  * Added guidance on immediate post-fetch/upload rule re-evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->