### PR TITLE
fix(rules): default directory_name_mismatch to manual + sort_name fallback

### DIFF
--- a/internal/database/migrations/003_directory_rename_manual_default.sql
+++ b/internal/database/migrations/003_directory_rename_manual_default.sql
@@ -1,0 +1,30 @@
+-- +goose Up
+-- Issue #1221: realign legacy 'auto' automation_mode rows for the
+-- directory_name_mismatch and extraneous_images rules to 'manual'. Both
+-- rules can rewrite filesystem state when in auto mode; the auto default
+-- silently reverted user-initiated on-disk renames (and, for
+-- extraneous_images, deleted user-managed image files). Defaulting them to
+-- manual gates the destructive action behind an explicit user toggle.
+--
+-- The column DEFAULT in 001 remains 'auto' (historical, not edited per
+-- the forward-only goose policy documented in 002). SeedDefaults always
+-- specifies the value explicitly when seeding rules on a fresh install,
+-- so the column DEFAULT is unreachable from code paths -- this UPDATE
+-- only affects DBs that were initialized before the in-code default was
+-- changed to 'manual'.
+--
+-- Operators who deliberately set either rule to 'auto' before this
+-- migration ran will need to re-toggle after upgrading. This is the
+-- recommended option from the issue: the data-loss risk justifies an
+-- explicit opt-in over preserving the previous selection.
+UPDATE rules
+SET automation_mode = 'manual',
+    updated_at = datetime('now')
+WHERE id IN ('directory_name_mismatch', 'extraneous_images')
+  AND automation_mode = 'auto';
+
+-- +goose Down
+-- No-op: we cannot reliably distinguish "user explicitly chose auto
+-- post-migration" from "row was migrated up by this script." Operators
+-- who need to roll back can flip the values manually.
+SELECT 1;

--- a/internal/rule/fixers.go
+++ b/internal/rule/fixers.go
@@ -1160,40 +1160,106 @@ func (f *DirectoryRenameFixer) Fix(ctx context.Context, a *artist.Artist, v *Vio
 		}, nil
 	}
 
-	newPath := filepath.Join(filepath.Dir(a.Path), canonical)
+	parentDir := filepath.Dir(a.Path)
+	newPath := filepath.Join(parentDir, canonical)
 
 	if a.Path == newPath {
 		return &FixResult{RuleID: v.RuleID, Fixed: false, Message: "paths already match"}, nil
 	}
 
-	// Check destination does not already exist.
-	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
-		if err == nil {
+	// Probe the canonical destination. ENOENT means the path is free; any
+	// other error is a real filesystem failure surfaced to the caller. When
+	// the canonical target already exists, fall back to a sort-name-derived
+	// secondary target before refusing -- this matches the disambiguation
+	// many users encode into Artist.SortName (e.g. "Carter Family, The
+	// (later generations of the family after 1943)") so the auto-fixer can
+	// still rename without forcing a manual collision-resolution step.
+	canonicalFree, err := pathIsFree(newPath)
+	if err != nil {
+		return nil, fmt.Errorf("checking destination %q: %w", newPath, err)
+	}
+
+	target := newPath
+	chosen := canonical
+	usedFallback := false
+	if !canonicalFree {
+		fallback := canonicalDirName(a.SortName, v.Config.ArticleMode)
+		if fallback == "" || fallback == canonical {
+			// No usable sort-name-derived alternative: refuse as before.
 			return &FixResult{
 				RuleID:  v.RuleID,
 				Fixed:   false,
 				Message: fmt.Sprintf("destination '%s' already exists", canonical),
 			}, nil
 		}
-		return nil, fmt.Errorf("checking destination %q: %w", newPath, err)
+		fallbackPath := filepath.Join(parentDir, fallback)
+		// Idempotency: if a prior run already renamed a.Path to fallbackPath,
+		// pathIsFree would return false (the current directory occupies the
+		// target) and bounce the artist back into a "destination collides"
+		// state on every rescan. Treat "fallback target equals current path"
+		// as already-fixed.
+		if fallbackPath == a.Path {
+			return &FixResult{
+				RuleID:  v.RuleID,
+				Fixed:   true,
+				Message: fmt.Sprintf("directory already uses sort-name fallback '%s' (canonical name collided)", fallback),
+			}, nil
+		}
+		fallbackFree, err := pathIsFree(fallbackPath)
+		if err != nil {
+			return nil, fmt.Errorf("checking fallback destination %q: %w", fallbackPath, err)
+		}
+		if !fallbackFree {
+			// Both canonical and sort-name targets collide; refuse.
+			return &FixResult{
+				RuleID: v.RuleID,
+				Fixed:  false,
+				Message: fmt.Sprintf(
+					"destination '%s' already exists and sort-name fallback '%s' also collides",
+					canonical, fallback,
+				),
+			}, nil
+		}
+		target = fallbackPath
+		chosen = fallback
+		usedFallback = true
 	}
 
-	if err := filesystem.RenameDirAtomic(a.Path, newPath); err != nil {
-		return nil, fmt.Errorf("renaming %q to %q: %w", a.Path, newPath, err)
+	if err := filesystem.RenameDirAtomic(a.Path, target); err != nil {
+		return nil, fmt.Errorf("renaming %q to %q: %w", a.Path, target, err)
 	}
 
 	f.logger.Info("renamed artist directory",
 		"artist", a.Name,
 		"old_path", a.Path,
-		"new_path", newPath)
+		"new_path", target,
+		"used_sort_name_fallback", usedFallback)
 
-	a.Path = newPath
+	a.Path = target
 
+	msg := fmt.Sprintf("renamed directory to canonical name '%s'", chosen)
+	if usedFallback {
+		msg = fmt.Sprintf("renamed directory to sort-name fallback '%s' (canonical name collided)", chosen)
+	}
 	return &FixResult{
 		RuleID:  v.RuleID,
 		Fixed:   true,
-		Message: fmt.Sprintf("renamed directory to '%s'", canonical),
+		Message: msg,
 	}, nil
+}
+
+// pathIsFree reports whether the given path is available for use as a rename
+// target. Returns true when the path does not exist (ENOENT). Any other stat
+// error is surfaced so the caller can refuse rather than guess.
+func pathIsFree(p string) (bool, error) {
+	_, err := os.Stat(p)
+	if err == nil {
+		return false, nil
+	}
+	if os.IsNotExist(err) {
+		return true, nil
+	}
+	return false, err
 }
 
 // BackdropSequencingFixer renames fanart files to fill gaps and create a

--- a/internal/rule/fixers.go
+++ b/internal/rule/fixers.go
@@ -1251,8 +1251,13 @@ func (f *DirectoryRenameFixer) Fix(ctx context.Context, a *artist.Artist, v *Vio
 // pathIsFree reports whether the given path is available for use as a rename
 // target. Returns true when the path does not exist (ENOENT). Any other stat
 // error is surfaced so the caller can refuse rather than guess.
+//
+// Uses Lstat so a dangling symlink at the target counts as occupied; Stat
+// would follow the broken link and report ENOENT, classifying the path
+// as free even though it is occupied, and the subsequent rename then
+// fails mid-flight instead of being rejected upfront.
 func pathIsFree(p string) (bool, error) {
-	_, err := os.Stat(p)
+	_, err := os.Lstat(p)
 	if err == nil {
 		return false, nil
 	}

--- a/internal/rule/fixers_directory_test.go
+++ b/internal/rule/fixers_directory_test.go
@@ -55,7 +55,9 @@ func TestDirectoryRenameFixer_Fix(t *testing.T) {
 		}
 	})
 
-	t.Run("destination exists", func(t *testing.T) {
+	t.Run("destination exists with no usable sort_name", func(t *testing.T) {
+		// Canonical target collides; sort_name is empty so no fallback is
+		// attempted. The fixer must refuse with the canonical-collision message.
 		tmp := t.TempDir()
 		oldPath := filepath.Join(tmp, "Old Name")
 		newPath := filepath.Join(tmp, "Existing")
@@ -77,7 +79,203 @@ func TestDirectoryRenameFixer_Fix(t *testing.T) {
 			t.Fatalf("Fix: %v", err)
 		}
 		if result.Fixed {
-			t.Error("Fixed = true, want false when destination exists")
+			t.Error("Fixed = true, want false when destination exists and no fallback")
+		}
+		if !strings.Contains(result.Message, "already exists") {
+			t.Errorf("expected 'already exists' message, got: %s", result.Message)
+		}
+	})
+
+	// #1220: when the canonical target collides AND sort_name produces a
+	// distinct, free directory name, the fixer renames to the sort-name path
+	// so artists with disambiguated SortName values still auto-fix.
+	// #1220 idempotency: a prior run already renamed the directory to the
+	// sort-name fallback. On rescan, pathIsFree(fallbackPath) sees the current
+	// directory occupying the target; without a guard the fixer would report
+	// "destination collides" and bounce the artist back into a fix loop.
+	t.Run("directory already at sort_name fallback (idempotent rerun)", func(t *testing.T) {
+		tmp := t.TempDir()
+		fallbackPath := filepath.Join(tmp, "Carter Family, The (later generations)")
+		canonicalCollision := filepath.Join(tmp, "The Carter Family")
+		// The artist directory is already at the fallback path from a prior run.
+		if err := os.MkdirAll(fallbackPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Canonical target exists too -- this is what triggered the original
+		// collision-driven fallback.
+		if err := os.MkdirAll(canonicalCollision, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		a := &artist.Artist{
+			Name:      "The Carter Family",
+			SortName:  "Carter Family, The (later generations)",
+			Path:      fallbackPath,
+			LibraryID: "lib-test",
+		}
+		v := &Violation{
+			RuleID: RuleDirectoryNameMismatch,
+			Config: RuleConfig{ArticleMode: "prefix"},
+		}
+
+		result, err := fixer.Fix(context.Background(), a, v)
+		if err != nil {
+			t.Fatalf("Fix: %v", err)
+		}
+		if !result.Fixed {
+			t.Fatalf("Fixed = false, want true (idempotent rerun); message: %s", result.Message)
+		}
+		// a.Path must remain at the fallback path (no actual rename happened).
+		if a.Path != fallbackPath {
+			t.Errorf("a.Path = %q, want %q (no-op on idempotent rerun)", a.Path, fallbackPath)
+		}
+		if !strings.Contains(result.Message, "already uses sort-name fallback") {
+			t.Errorf("expected 'already uses sort-name fallback' message, got: %s", result.Message)
+		}
+	})
+
+	t.Run("canonical collides with sort_name fallback free", func(t *testing.T) {
+		tmp := t.TempDir()
+		oldPath := filepath.Join(tmp, "Wrong Folder")
+		canonicalCollision := filepath.Join(tmp, "The Carter Family")
+		if err := os.MkdirAll(oldPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Pre-create the canonical target to force the collision branch.
+		if err := os.MkdirAll(canonicalCollision, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		a := &artist.Artist{
+			Name:      "The Carter Family",
+			SortName:  "Carter Family, The (later generations)",
+			Path:      oldPath,
+			LibraryID: "lib-test",
+		}
+		v := &Violation{
+			RuleID: RuleDirectoryNameMismatch,
+			Config: RuleConfig{ArticleMode: "prefix"},
+		}
+
+		result, err := fixer.Fix(context.Background(), a, v)
+		if err != nil {
+			t.Fatalf("Fix: %v", err)
+		}
+		if !result.Fixed {
+			t.Fatalf("Fixed = false, want true; message: %s", result.Message)
+		}
+		expected := filepath.Join(tmp, "Carter Family, The (later generations)")
+		if a.Path != expected {
+			t.Errorf("a.Path = %q, want %q", a.Path, expected)
+		}
+		if !strings.Contains(result.Message, "sort-name fallback") {
+			t.Errorf("expected sort-name fallback message, got: %s", result.Message)
+		}
+	})
+
+	// #1220: when both canonical and sort-name targets collide, refuse.
+	t.Run("canonical and sort_name both collide", func(t *testing.T) {
+		tmp := t.TempDir()
+		oldPath := filepath.Join(tmp, "Wrong Folder")
+		canonical := filepath.Join(tmp, "Hiromi")
+		fallback := filepath.Join(tmp, "Uehara, Hiromi")
+		for _, p := range []string{oldPath, canonical, fallback} {
+			if err := os.MkdirAll(p, 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		a := &artist.Artist{
+			Name:      "Hiromi",
+			SortName:  "Uehara, Hiromi",
+			Path:      oldPath,
+			LibraryID: "lib-test",
+		}
+		v := &Violation{
+			RuleID: RuleDirectoryNameMismatch,
+			Config: RuleConfig{ArticleMode: "prefix"},
+		}
+
+		result, err := fixer.Fix(context.Background(), a, v)
+		if err != nil {
+			t.Fatalf("Fix: %v", err)
+		}
+		if result.Fixed {
+			t.Error("Fixed = true, want false when both targets collide")
+		}
+		if !strings.Contains(result.Message, "fallback") {
+			t.Errorf("expected fallback-collision message, got: %s", result.Message)
+		}
+	})
+
+	// #1220: empty sort_name skips the fallback branch entirely. The fixer
+	// must refuse with the canonical-collision message rather than try a
+	// derived empty path.
+	t.Run("canonical collides with empty sort_name", func(t *testing.T) {
+		tmp := t.TempDir()
+		oldPath := filepath.Join(tmp, "Wrong Folder")
+		canonical := filepath.Join(tmp, "Beth Gibbons")
+		for _, p := range []string{oldPath, canonical} {
+			if err := os.MkdirAll(p, 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		a := &artist.Artist{
+			Name:      "Beth Gibbons",
+			SortName:  "",
+			Path:      oldPath,
+			LibraryID: "lib-test",
+		}
+		v := &Violation{
+			RuleID: RuleDirectoryNameMismatch,
+			Config: RuleConfig{ArticleMode: "prefix"},
+		}
+
+		result, err := fixer.Fix(context.Background(), a, v)
+		if err != nil {
+			t.Fatalf("Fix: %v", err)
+		}
+		if result.Fixed {
+			t.Error("Fixed = true, want false when sort_name is empty")
+		}
+		if !strings.Contains(result.Message, "already exists") {
+			t.Errorf("expected canonical-collision message, got: %s", result.Message)
+		}
+	})
+
+	// #1220: when sort_name canonicalizes to the same value as canonical,
+	// the fallback is not a real alternative; refuse rather than retry.
+	t.Run("canonical collides with sort_name equal to canonical", func(t *testing.T) {
+		tmp := t.TempDir()
+		oldPath := filepath.Join(tmp, "Wrong Folder")
+		canonical := filepath.Join(tmp, "Existing")
+		for _, p := range []string{oldPath, canonical} {
+			if err := os.MkdirAll(p, 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		a := &artist.Artist{
+			Name:      "Existing",
+			SortName:  "Existing",
+			Path:      oldPath,
+			LibraryID: "lib-test",
+		}
+		v := &Violation{
+			RuleID: RuleDirectoryNameMismatch,
+			Config: RuleConfig{ArticleMode: "prefix"},
+		}
+
+		result, err := fixer.Fix(context.Background(), a, v)
+		if err != nil {
+			t.Fatalf("Fix: %v", err)
+		}
+		if result.Fixed {
+			t.Error("Fixed = true, want false when sort_name equals canonical")
+		}
+		if !strings.Contains(result.Message, "already exists") {
+			t.Errorf("expected canonical-collision message, got: %s", result.Message)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- **#1221:** `directory_name_mismatch` (and `extraneous_images`) defaulted to `auto` automation mode, which silently reverted user on-disk artist directory renames and could delete user-managed image files. Both rules now default to `manual` via the in-code default in `internal/rule/service.go`, paired with goose migration `003_directory_rename_manual_default.sql` that realigns legacy `'auto'` rows to `'manual'` on existing databases. Operators who deliberately chose `auto` for either rule will need to re-toggle after upgrading.
- **#1220:** When the canonical directory name collides with an existing path, `DirectoryRenameFixer.Fix` now computes a sort-name-derived fallback target via the same `canonicalDirName(name, articleMode)` helper applied to `Artist.SortName`. Three branches are tested: canonical-free, canonical-collide-fallback-free, canonical-collide-fallback-collide. Empty `sort_name` (or one canonicalizing to the same target) skips the fallback. The fix-result message names which target was used.

Per the forward-only goose policy retired in `002_library_nfo_lock_data.sql`, no historical migration is edited; the realignment lives in `003_*.sql`. Both fresh installs and upgrades converge on the same final state.

## Test plan

- [x] `internal/rule/fixers_directory_test.go` covers all five #1220 branches plus the destination-exists and empty-sort-name cases
- [x] `bash scripts/pre-push-gate.sh` clean; patch coverage 88.24% on `internal/rule/fixers.go`
- [x] UAT Screen 1: Settings > Rules — both target rules display Manual; toggle to Auto and back works without errors; no console errors
- [x] UAT Screen 2: on-disk artist directory rename held for >30s; not silently reverted; no image files deleted

Closes #1221
Closes #1220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collision-aware directory renaming that atomically picks a canonical name or a fallback and reports when a fallback is used.

* **Bug Fixes**
  * Clearer handling and messaging for rename collisions (refuse, fallback, or report collision as appropriate).

* **Tests**
  * Expanded test coverage for multiple collision and fallback scenarios.

* **Chores**
  * Automation for directory-name-mismatch and extraneous-images moved to manual mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->