### PR TITLE
feat(config): support TOML format alongside YAML; flip default to TOML

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -100,7 +100,7 @@ func main() {
 
 func run() error {
 	// Load configuration
-	configPath := os.Getenv("SW_CONFIG_PATH")
+	configPath, configPathSet := os.LookupEnv("SW_CONFIG_PATH")
 	if configPath == "" {
 		configPath = "/config/config.toml"
 	}
@@ -108,7 +108,21 @@ func run() error {
 	// First-run scaffolding: create a commented config.toml at configPath when
 	// the file is missing so admins have a documented starting point. A failure
 	// here is non-fatal; in-code defaults plus env vars are sufficient to boot.
-	scaffolded, scaffoldErr := config.EnsureScaffold(configPath)
+	//
+	// Only scaffold when the operator has explicitly opted in via
+	// SW_CONFIG_PATH. Native binary installs that boot with only SW_DB_PATH
+	// and SW_MUSIC_PATH would otherwise log a "could not write scaffold"
+	// warning every startup just because the container default /config is
+	// unwritable on a host filesystem. The container image sets
+	// SW_CONFIG_PATH explicitly, so the Docker first-run experience is
+	// preserved.
+	var (
+		scaffolded  bool
+		scaffoldErr error
+	)
+	if configPathSet && configPath != "" {
+		scaffolded, scaffoldErr = config.EnsureScaffold(configPath)
+	}
 
 	cfg, err := config.Load(configPath)
 	if err != nil {

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -102,8 +102,13 @@ func run() error {
 	// Load configuration
 	configPath := os.Getenv("SW_CONFIG_PATH")
 	if configPath == "" {
-		configPath = "/config/config.yaml"
+		configPath = "/config/config.toml"
 	}
+
+	// First-run scaffolding: create a commented config.toml at configPath when
+	// the file is missing so admins have a documented starting point. A failure
+	// here is non-fatal; in-code defaults plus env vars are sufficient to boot.
+	scaffolded, scaffoldErr := config.EnsureScaffold(configPath)
 
 	cfg, err := config.Load(configPath)
 	if err != nil {
@@ -118,6 +123,14 @@ func run() error {
 	logManager, logger := logging.NewManager(logCfg)
 	defer logManager.Close() //nolint:errcheck
 	slog.SetDefault(logger)
+
+	if scaffoldErr != nil {
+		logger.Warn("could not write first-run config scaffold",
+			"path", configPath, "error", scaffoldErr)
+	} else if scaffolded {
+		logger.Info("wrote first-run config scaffold",
+			"path", configPath)
+	}
 
 	// Open database
 	db, err := database.Open(cfg.Database.Path)
@@ -744,7 +757,7 @@ func resolveEncryptionKey(cfg *config.Config, logger *slog.Logger) (string, erro
 func resetCredentials() error {
 	configPath := os.Getenv("SW_CONFIG_PATH")
 	if configPath == "" {
-		configPath = "/config/config.yaml"
+		configPath = "/config/config.toml"
 	}
 
 	cfg, err := config.Load(configPath)
@@ -799,7 +812,7 @@ func resetCredentials() error {
 func resetPassword(username, password string) error {
 	configPath := os.Getenv("SW_CONFIG_PATH")
 	if configPath == "" {
-		configPath = "/config/config.yaml"
+		configPath = "/config/config.toml"
 	}
 
 	cfg, err := config.Load(configPath)

--- a/docs/site/src/getting-started/install-binary.md
+++ b/docs/site/src/getting-started/install-binary.md
@@ -86,11 +86,11 @@ The binary's built-in defaults assume a containerized layout (`/config`, `/music
 
 | Env var | What it controls | Example |
 |---|---|---|
-| `SW_CONFIG_PATH` | Path to `config.yaml` (file). Stillwater starts with built-in defaults if the file is missing or unset. | `~/.stillwater/config.yaml` |
+| `SW_CONFIG_PATH` | Path to `config.toml` (file). Stillwater starts with built-in defaults if the file is missing or unset. YAML files are also accepted for backward compatibility. | `~/.stillwater/config.toml` |
 | `SW_DB_PATH` | Path to the SQLite database (file). | `~/.stillwater/stillwater.db` |
 | `SW_MUSIC_PATH` | Music library directory. Stillwater needs read/write here for NFO writeback. | `/srv/music` |
 
-A first-time install only needs `SW_DB_PATH` and `SW_MUSIC_PATH`; you don't need a `config.yaml` until you want to override defaults beyond what env vars cover.
+A first-time install only needs `SW_DB_PATH` and `SW_MUSIC_PATH`; you don't need a `config.toml` until you want to override defaults beyond what env vars cover.
 
 ## Run it
 
@@ -212,32 +212,34 @@ A foreground binary stops when you log out. For a real install you want Stillwat
     - **NSSM** (the Non-Sucking Service Manager). Install NSSM, then `nssm install Stillwater "C:\Program Files\stillwater\stillwater.exe"` and configure the service environment variables through the NSSM GUI.
     - **Task Scheduler** with "At log on" trigger. Simpler, but not a true service; Stillwater runs only while the configured user is logged in.
 
-## Configure with a `config.yaml` (optional)
+## Configure with a `config.toml` (optional)
 
-Env vars cover most needs, but you can also supply a `config.yaml` for static configuration:
+Env vars cover most needs, but you can also supply a `config.toml` for static configuration:
 
-```yaml
-server:
-  port: 1973
-  base_path: /
+```toml
+[server]
+port = 1973
+base_path = "/"
 
-database:
-  path: /var/lib/stillwater/stillwater.db
+[database]
+path = "/var/lib/stillwater/stillwater.db"
 
-music:
-  library_path: /srv/music
+[music]
+library_path = "/srv/music"
 
-backup:
-  enabled: true
-  interval_hours: 24
-  retention_count: 7
+[backup]
+enabled = true
+interval_hours = 24
+retention_count = 7
 
-logging:
-  level: info
-  format: json
+[logging]
+level = "info"
+format = "json"
 ```
 
-Point Stillwater at it with `SW_CONFIG_PATH=/etc/stillwater/config.yaml`. Env vars override values from the file, so a config file plus a few environment overrides is a good production pattern.
+Point Stillwater at it with `SW_CONFIG_PATH=/etc/stillwater/config.toml`. Env vars override values from the file, so a config file plus a few environment overrides is a good production pattern.
+
+YAML configuration files (`.yaml` or `.yml`) remain supported for backward compatibility; the loader picks the parser by file extension.
 
 ## Upgrading
 
@@ -255,7 +257,7 @@ Stillwater runs schema migrations automatically on startup; you don't need to mi
 
 ## Backups
 
-Back up the SQLite database file (`SW_DB_PATH`), the encryption key (in the same directory by default), and your `config.yaml` if you have one. The simplest path is to back up the entire data directory:
+Back up the SQLite database file (`SW_DB_PATH`), the encryption key (in the same directory by default), and your `config.toml` if you have one. The simplest path is to back up the entire data directory:
 
 ```bash
 tar czf "stillwater-$(date +%F).tar.gz" -C ~/.stillwater .

--- a/docs/site/src/getting-started/install-docker-compose.md
+++ b/docs/site/src/getting-started/install-docker-compose.md
@@ -24,7 +24,7 @@ You'll need:
 
 One container running the Stillwater binary. Two storage paths:
 
-- `/config` (a Docker named volume): SQLite database, generated encryption key, configuration YAML, and any backups Stillwater writes itself.
+- `/config` (a Docker named volume): SQLite database, generated encryption key, optional `config.toml`, and any backups Stillwater writes itself.
 - `/music` (a bind mount to your host's music directory): the library Stillwater reads from and writes NFO files into.
 
 Stillwater listens on port `1973` inside the container. The compose file publishes it to `1973` on the host, so you'll reach the web UI at `http://localhost:1973` once it's up.

--- a/docs/site/src/reference/environment-variables.md
+++ b/docs/site/src/reference/environment-variables.md
@@ -2,11 +2,11 @@
 description: Every SW_ environment variable Stillwater honors at startup, with types, defaults, and descriptions.
 ---
 
-<!-- code: internal/config/config.go (Default, loadFromEnv, validate, Config struct hierarchy), cmd/stillwater/main.go (SW_CONFIG_PATH usage). Verified against main at the time of drafting. -->
+<!-- code: internal/config/config.go (Default, loadFromEnv, validate, Config struct hierarchy, detectFormat), cmd/stillwater/main.go (SW_CONFIG_PATH usage). Verified against main at the time of drafting. -->
 
 # Environment variables
 
-Stillwater is configured by a small YAML file plus environment-variable overrides. **Environment variables always win** over YAML values.
+Stillwater is configured by a small TOML file plus environment-variable overrides. **Environment variables always win** over file values. YAML configuration files (`.yaml` or `.yml`) remain accepted for backward compatibility.
 
 The table below is generated from the configuration definition; do not edit it by hand. Run `make generate-docs` after changing a configuration field.
 
@@ -28,49 +28,46 @@ The table below is generated from the configuration definition; do not edit it b
 | `SW_SESSION_SECRET` | string | unset | Long random string used to sign session cookies. When unset Stillwater generates one on first run and persists it in the config directory. |
 <!-- END GENERATED: env-reference -->
 
-`SW_CONFIG_PATH` is also honored at startup but lives outside the configuration struct: set it to point at a YAML config file. When unset, Stillwater attempts to read `/config/config.yaml`; if that file does not exist, it starts with defaults plus environment overrides only.
+`SW_CONFIG_PATH` is also honored at startup but lives outside the configuration struct: set it to point at a TOML or YAML config file. When unset, Stillwater attempts to read `/config/config.toml`; if that file does not exist, it starts with defaults plus environment overrides only. YAML files are still accepted for existing installs; the loader picks the parser from the file extension (`.toml` -> TOML; `.yaml` or `.yml` -> YAML).
 
-## YAML configuration file
+## TOML configuration file
 
-When `SW_CONFIG_PATH` points at a YAML file, Stillwater reads it on startup before applying environment-variable overrides. A complete example:
+When `SW_CONFIG_PATH` points at a config file, Stillwater reads it on startup before applying environment-variable overrides. A complete TOML example:
 
-```yaml
-server:
-  port: 1973
-  base_path: ""              # set to e.g. /stillwater for subfolder reverse-proxy deploys
+```toml
+[server]
+port = 1973
+base_path = ""              # set to e.g. /stillwater for subfolder reverse-proxy deploys
 
-database:
-  path: /config/stillwater.db
+[database]
+path = "/config/stillwater.db"
 
-auth:
-  session_secret: ""          # generate with: openssl rand -base64 64
+[auth]
+session_secret = ""          # generate with: openssl rand -base64 64
 
-encryption:
-  key: ""                     # generate with: openssl rand -base64 32
+[encryption]
+key = ""                     # generate with: openssl rand -base64 32
 
-music:
-  library_path: /music
+[music]
+library_path = "/music"
 
-scanner:
-  exclusions:
-    - "Various Artists"
-    - "Various"
-    - "VA"
-    - "Soundtrack"
-    - "OST"
+[scanner]
+exclusions = ["Various Artists", "Various", "VA", "Soundtrack", "OST"]
 
-backup:
-  path: ""                    # defaults to <config-dir>/backups when empty
-  retention_count: 7
-  interval_hours: 24
-  enabled: true
+[backup]
+path = ""                    # defaults to <config-dir>/backups when empty
+retention_count = 7
+interval_hours = 24
+enabled = true
 
-logging:
-  level: info
-  format: json
+[logging]
+level = "info"
+format = "json"
 ```
 
 You can ship the file with secrets blank and inject `SW_SESSION_SECRET` and `SW_ENCRYPTION_KEY` at runtime from your secrets manager.
+
+The same configuration in YAML (still supported for existing deployments) uses key: value syntax with two-space indentation under each top-level section, e.g. `server:` followed by an indented `port: 1973` line. Environment variables and field names are identical across both formats.
 
 ## Behavior notes
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/a-h/templ v0.3.1001 h1:yHDTgexACdJttyiyamcTHXr2QkIeVF1MukLy44EAhMY=
 github.com/a-h/templ v0.3.1001/go.mod h1:oCZcnKRf5jjsGpf2yELzQfodLphd2mwecwG4Crk5HBo=
 github.com/coreos/go-oidc/v3 v3.18.0 h1:V9orjXynvu5wiC9SemFTWnG4F45v403aIcjWo0d41+A=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"gopkg.in/yaml.v3"
+
+	"github.com/sydlexius/stillwater/internal/filesystem"
 )
 
 // Config holds all application configuration.
@@ -181,22 +183,18 @@ func EnsureScaffold(path string) (bool, error) {
 			return false, fmt.Errorf("creating config directory: %w", err)
 		}
 	}
-	// Atomic create-only: O_CREATE|O_EXCL avoids the TOCTOU window between
-	// a separate Stat and Write, and converges concurrent first-runs on a
-	// single scaffold (the loser sees ErrExist, treated as a no-op).
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644) //nolint:gosec // G306: config file is intentionally world-readable
-	if err != nil {
-		if errors.Is(err, fs.ErrExist) {
-			return false, nil
-		}
+	// Skip if the file already exists. A direct stat is sufficient: this
+	// runs once on first boot, the operator sequence does not produce
+	// concurrent scaffolders, and the alternative (O_EXCL on the destination)
+	// would skip the project's atomic-write contract that requires every
+	// file write to go through internal/filesystem's tmp/rename helper.
+	if _, err := os.Stat(path); err == nil {
+		return false, nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return false, fmt.Errorf("checking for existing config: %w", err)
+	}
+	if err := filesystem.WriteFileAtomic(path, []byte(scaffoldTOML), 0o644); err != nil {
 		return false, fmt.Errorf("writing config scaffold: %w", err)
-	}
-	if _, werr := f.Write([]byte(scaffoldTOML)); werr != nil {
-		_ = f.Close()
-		return false, fmt.Errorf("writing config scaffold: %w", werr)
-	}
-	if cerr := f.Close(); cerr != nil {
-		return false, fmt.Errorf("writing config scaffold: %w", cerr)
 	}
 	return true, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -224,6 +224,10 @@ func Load(path string) (*Config, error) {
 	return cfg, nil
 }
 
+// loadFromFile reads the config file at path and merges its contents into c
+// using the format detected from the extension (or sniffed from the first
+// non-comment byte for ambiguous filenames). A missing file is not an error;
+// the caller falls back to env-var overrides plus in-code defaults.
 func (c *Config) loadFromFile(path string) error {
 	data, err := os.ReadFile(path) //nolint:gosec // G304: path is from trusted config, not user input
 	if err != nil {
@@ -297,6 +301,9 @@ func detectFormat(path string, data []byte) configFormat {
 	return formatYAML
 }
 
+// loadFromEnv overlays environment variables onto c. Env-var values take
+// precedence over any file-loaded values per the API-first contract: an
+// operator can override one knob via env without rewriting the whole file.
 func (c *Config) loadFromEnv() {
 	if v := os.Getenv("SW_PORT"); v != "" {
 		if port, err := strconv.Atoi(v); err == nil {
@@ -349,6 +356,9 @@ func (c *Config) loadFromEnv() {
 	}
 }
 
+// validate enforces required fields and normalizes a few values that the
+// rest of the codebase assumes are well-formed (e.g. trimming a trailing
+// slash from BasePath so route registration is unambiguous).
 func (c *Config) validate() error {
 	if c.Server.Port < 1 || c.Server.Port > 65535 {
 		return fmt.Errorf("invalid port: %d", c.Server.Port)
@@ -357,8 +367,5 @@ func (c *Config) validate() error {
 		return fmt.Errorf("database path is required")
 	}
 	c.Server.BasePath = strings.TrimRight(c.Server.BasePath, "/")
-	if c.Server.BasePath == "" {
-		c.Server.BasePath = ""
-	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,24 +1,29 @@
 package config
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"gopkg.in/yaml.v3"
 )
 
 // Config holds all application configuration.
 type Config struct {
-	Server     ServerConfig     `yaml:"server"`
-	Database   DatabaseConfig   `yaml:"database"`
-	Auth       AuthConfig       `yaml:"auth"`
-	Encryption EncryptionConfig `yaml:"encryption"`
-	Music      MusicConfig      `yaml:"music"`
-	Scanner    ScannerConfig    `yaml:"scanner"`
-	Backup     BackupConfig     `yaml:"backup"`
-	Logging    LoggingConfig    `yaml:"logging"`
+	Server     ServerConfig     `yaml:"server" toml:"server"`
+	Database   DatabaseConfig   `yaml:"database" toml:"database"`
+	Auth       AuthConfig       `yaml:"auth" toml:"auth"`
+	Encryption EncryptionConfig `yaml:"encryption" toml:"encryption"`
+	Music      MusicConfig      `yaml:"music" toml:"music"`
+	Scanner    ScannerConfig    `yaml:"scanner" toml:"scanner"`
+	Backup     BackupConfig     `yaml:"backup" toml:"backup"`
+	Logging    LoggingConfig    `yaml:"logging" toml:"logging"`
 }
 
 // ServerConfig holds HTTP server settings.
@@ -29,49 +34,49 @@ type Config struct {
 //     sentence is acceptable when it captures a constraint or runtime caveat
 //   - default: rendered default; "unset" or "" when there is no default
 type ServerConfig struct {
-	Port            int    `yaml:"port" env:"SW_PORT" default:"1973" desc:"TCP port the HTTP server listens on. Numeric values outside 1-65535 are rejected at startup."`
-	BasePath        string `yaml:"base_path" env:"SW_BASE_PATH" default:"/" desc:"URL prefix for subfolder reverse-proxy deployments (for example /stillwater). When set from the environment the Settings UI marks the field read-only."`
-	BasePathFromEnv bool   `yaml:"-"`
+	Port            int    `yaml:"port" toml:"port" env:"SW_PORT" default:"1973" desc:"TCP port the HTTP server listens on. Numeric values outside 1-65535 are rejected at startup."`
+	BasePath        string `yaml:"base_path" toml:"base_path" env:"SW_BASE_PATH" default:"/" desc:"URL prefix for subfolder reverse-proxy deployments (for example /stillwater). When set from the environment the Settings UI marks the field read-only."`
+	BasePathFromEnv bool   `yaml:"-" toml:"-"`
 }
 
 // DatabaseConfig holds SQLite settings.
 type DatabaseConfig struct {
-	Path string `yaml:"path" env:"SW_DB_PATH" default:"/config/stillwater.db" desc:"Filesystem path to the SQLite database file."`
+	Path string `yaml:"path" toml:"path" env:"SW_DB_PATH" default:"/config/stillwater.db" desc:"Filesystem path to the SQLite database file."`
 }
 
 // AuthConfig holds authentication settings.
 type AuthConfig struct {
-	SessionSecret string `yaml:"session_secret" env:"SW_SESSION_SECRET" default:"unset" desc:"Long random string used to sign session cookies. When unset Stillwater generates one on first run and persists it in the config directory."` //nolint:gosec // G117: not a hardcoded secret, this is a config field
+	SessionSecret string `yaml:"session_secret" toml:"session_secret" env:"SW_SESSION_SECRET" default:"unset" desc:"Long random string used to sign session cookies. When unset Stillwater generates one on first run and persists it in the config directory."` //nolint:gosec // G117: not a hardcoded secret, this is a config field
 }
 
 // EncryptionConfig holds encryption key settings.
 type EncryptionConfig struct {
-	Key string `yaml:"key" env:"SW_ENCRYPTION_KEY" default:"unset" desc:"Key used to encrypt provider API keys at rest. When unset Stillwater generates one on first run and persists it in the config directory."`
+	Key string `yaml:"key" toml:"key" env:"SW_ENCRYPTION_KEY" default:"unset" desc:"Key used to encrypt provider API keys at rest. When unset Stillwater generates one on first run and persists it in the config directory."`
 }
 
 // MusicConfig holds music library path settings.
 type MusicConfig struct {
-	LibraryPath string `yaml:"library_path" env:"SW_MUSIC_PATH" default:"/music" desc:"Default music library path used as a starting point when no library has been added through the UI."`
+	LibraryPath string `yaml:"library_path" toml:"library_path" env:"SW_MUSIC_PATH" default:"/music" desc:"Default music library path used as a starting point when no library has been added through the UI."`
 }
 
 // ScannerConfig holds scanner behavior settings.
 type ScannerConfig struct {
-	Depth      int      `yaml:"depth"`
-	Exclusions []string `yaml:"exclusions" env:"SW_SCANNER_EXCLUSIONS" default:"Various Artists, Various, VA, Soundtrack, OST" desc:"Comma-separated artist directory names the scanner skips. Whitespace around each token is trimmed."`
+	Depth      int      `yaml:"depth" toml:"depth"`
+	Exclusions []string `yaml:"exclusions" toml:"exclusions" env:"SW_SCANNER_EXCLUSIONS" default:"Various Artists, Various, VA, Soundtrack, OST" desc:"Comma-separated artist directory names the scanner skips. Whitespace around each token is trimmed."`
 }
 
 // BackupConfig holds database backup settings.
 type BackupConfig struct {
-	Path           string `yaml:"path" env:"SW_BACKUP_PATH" default:"" desc:"Override the directory where automated database backups are written. When empty Stillwater writes to a backups/ subfolder of the config directory."`
-	RetentionCount int    `yaml:"retention_count" env:"SW_BACKUP_RETENTION" default:"7" desc:"Number of recent backups to keep. Must be a positive integer; non-positive or non-numeric values are silently ignored."`
-	IntervalHours  int    `yaml:"interval_hours" env:"SW_BACKUP_INTERVAL" default:"24" desc:"Hours between automated backups. Must be a positive integer; non-positive or non-numeric values are silently ignored."`
-	Enabled        bool   `yaml:"enabled" env:"SW_BACKUP_ENABLED" default:"true" desc:"Set to true or 1 to enable automated backups. Any other value disables them."`
+	Path           string `yaml:"path" toml:"path" env:"SW_BACKUP_PATH" default:"" desc:"Override the directory where automated database backups are written. When empty Stillwater writes to a backups/ subfolder of the config directory."`
+	RetentionCount int    `yaml:"retention_count" toml:"retention_count" env:"SW_BACKUP_RETENTION" default:"7" desc:"Number of recent backups to keep. Must be a positive integer; non-positive or non-numeric values are silently ignored."`
+	IntervalHours  int    `yaml:"interval_hours" toml:"interval_hours" env:"SW_BACKUP_INTERVAL" default:"24" desc:"Hours between automated backups. Must be a positive integer; non-positive or non-numeric values are silently ignored."`
+	Enabled        bool   `yaml:"enabled" toml:"enabled" env:"SW_BACKUP_ENABLED" default:"true" desc:"Set to true or 1 to enable automated backups. Any other value disables them."`
 }
 
 // LoggingConfig holds logging settings.
 type LoggingConfig struct {
-	Level  string `yaml:"level" env:"SW_LOG_LEVEL" default:"info" desc:"Log level at startup. One of trace, debug, info, warn, error. The runtime can also adjust the live level from the Logs settings tab."`
-	Format string `yaml:"format" env:"SW_LOG_FORMAT" default:"json" desc:"Log output format. Use json for log aggregators or text for friendlier console output."`
+	Level  string `yaml:"level" toml:"level" env:"SW_LOG_LEVEL" default:"info" desc:"Log level at startup. One of trace, debug, info, warn, error. The runtime can also adjust the live level from the Logs settings tab."`
+	Format string `yaml:"format" toml:"format" env:"SW_LOG_FORMAT" default:"json" desc:"Log output format. Use json for log aggregators or text for friendlier console output."`
 }
 
 // Default returns a Config with sensible defaults.
@@ -108,8 +113,101 @@ func Default() *Config {
 	}
 }
 
-// Load reads config from a YAML file (if it exists) and overrides with
+// scaffoldTOML is the first-run config.toml content. Every field is commented
+// out so the file documents the surface without overriding the in-code defaults
+// or env-var values that may already be set. Users uncomment + edit the lines
+// they want to pin.
+const scaffoldTOML = `# Stillwater configuration
+# Every field below is commented out; Stillwater applies the in-code default
+# until you uncomment a line. Environment variables (SW_*) still override
+# whatever this file sets, so the precedence order is:
+#   built-in default < this file < SW_* environment variable
+
+[server]
+# port = 1973
+# base_path = "/"
+
+[database]
+# path = "/config/stillwater.db"
+
+[auth]
+# session_secret is generated automatically on first run when unset.
+# session_secret = ""
+
+[encryption]
+# key is generated automatically on first run when unset.
+# key = ""
+
+[music]
+# library_path = "/music"
+
+[scanner]
+# depth = 1
+# exclusions = ["Various Artists", "Various", "VA", "Soundtrack", "OST"]
+
+[backup]
+# path = ""
+# retention_count = 7
+# interval_hours = 24
+# enabled = true
+
+[logging]
+# level = "info"
+# format = "json"
+`
+
+// EnsureScaffold writes a default config.toml at path if the file does not
+// already exist. It returns true when a new file was created. An empty path
+// or an existing file is treated as a no-op (false, nil). Missing parent
+// directories are created so the function works against a fresh data dir.
+//
+// Errors writing the file are returned to the caller so startup can decide
+// whether to surface a warning or proceed with built-in defaults.
+func EnsureScaffold(path string) (bool, error) {
+	if path == "" {
+		return false, nil
+	}
+	// Skip scaffolding for YAML paths: a TOML scaffold under a .yaml/.yml
+	// filename would be unparsable by the YAML loader on first boot. Users
+	// who configure SW_CONFIG_PATH to a YAML file are presumed to manage
+	// their own config; the policy lives here so callers stay simple.
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yaml", ".yml":
+		return false, nil
+	}
+
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			return false, fmt.Errorf("creating config directory: %w", err)
+		}
+	}
+	// Atomic create-only: O_CREATE|O_EXCL avoids the TOCTOU window between
+	// a separate Stat and Write, and converges concurrent first-runs on a
+	// single scaffold (the loser sees ErrExist, treated as a no-op).
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644) //nolint:gosec // G306: config file is intentionally world-readable
+	if err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("writing config scaffold: %w", err)
+	}
+	if _, werr := f.Write([]byte(scaffoldTOML)); werr != nil {
+		_ = f.Close()
+		return false, fmt.Errorf("writing config scaffold: %w", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		return false, fmt.Errorf("writing config scaffold: %w", cerr)
+	}
+	return true, nil
+}
+
+// Load reads config from a TOML or YAML file (if it exists) and overrides with
 // environment variables. Environment variables take precedence.
+//
+// Format detection: files with a .toml extension are parsed as TOML; .yaml or
+// .yml are parsed as YAML. When the extension is missing or ambiguous the
+// loader sniffs the first non-comment, non-whitespace byte: '[' or a key=value
+// pair triggers TOML parsing, otherwise YAML.
 func Load(path string) (*Config, error) {
 	cfg := Default()
 
@@ -136,7 +234,69 @@ func (c *Config) loadFromFile(path string) error {
 		}
 		return err
 	}
-	return yaml.Unmarshal(data, c)
+
+	switch detectFormat(path, data) {
+	case formatTOML:
+		if err := toml.Unmarshal(data, c); err != nil {
+			return fmt.Errorf("parsing TOML: %w", err)
+		}
+		return nil
+	case formatYAML:
+		if err := yaml.Unmarshal(data, c); err != nil {
+			return fmt.Errorf("parsing YAML: %w", err)
+		}
+		return nil
+	}
+	// Unreachable; detectFormat always returns one of the two formats.
+	return nil
+}
+
+type configFormat int
+
+const (
+	formatYAML configFormat = iota
+	formatTOML
+)
+
+// detectFormat picks a parser based on the file extension and, when the
+// extension is ambiguous (anything other than .toml/.yaml/.yml), the first
+// non-comment, non-whitespace byte of the file. TOML files always start with
+// '[' (a table header) or a bareword key followed by '='. YAML keys end with
+// ':' or the document is a list; in both cases the first significant byte
+// will not match the TOML markers below.
+func detectFormat(path string, data []byte) configFormat {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".toml":
+		return formatTOML
+	case ".yaml", ".yml":
+		return formatYAML
+	}
+	// Sniff: find the first non-comment, non-whitespace line.
+	for _, raw := range bytes.Split(data, []byte("\n")) {
+		line := bytes.TrimSpace(raw)
+		if len(line) == 0 {
+			continue
+		}
+		// Skip comments. '#' is valid in both YAML and TOML; '//' is invalid
+		// in both but cheap to skip defensively.
+		if line[0] == '#' || bytes.HasPrefix(line, []byte("//")) {
+			continue
+		}
+		// TOML signals: a table header '[...]' or a 'key = value' assignment.
+		if line[0] == '[' {
+			return formatTOML
+		}
+		if idxEq := bytes.IndexByte(line, '='); idxEq > 0 {
+			// TOML uses '=' between key and value. YAML uses ':' so a line
+			// containing '=' before any ':' is almost certainly TOML.
+			idxColon := bytes.IndexByte(line, ':')
+			if idxColon < 0 || idxEq < idxColon {
+				return formatTOML
+			}
+		}
+		break
+	}
+	return formatYAML
 }
 
 func (c *Config) loadFromEnv() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -195,6 +196,264 @@ database:
 	}
 }
 
+func TestLoad_FromTOML(t *testing.T) {
+	clearSWEnv(t)
+	dir := t.TempDir()
+	tomlPath := filepath.Join(dir, "config.toml")
+	err := os.WriteFile(tomlPath, []byte(`
+[server]
+port = 8080
+base_path = "/app"
+
+[database]
+path = "/tmp/test.db"
+
+[logging]
+level = "debug"
+`), 0o644)
+	if err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	cfg, err := Load(tomlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.Server.Port != 8080 {
+		t.Errorf("Server.Port = %d, want 8080", cfg.Server.Port)
+	}
+	if cfg.Server.BasePath != "/app" {
+		t.Errorf("Server.BasePath = %q, want /app", cfg.Server.BasePath)
+	}
+	if cfg.Database.Path != "/tmp/test.db" {
+		t.Errorf("Database.Path = %q, want /tmp/test.db", cfg.Database.Path)
+	}
+	if cfg.Logging.Level != "debug" {
+		t.Errorf("Logging.Level = %q, want debug", cfg.Logging.Level)
+	}
+}
+
+// TestLoad_TOMLAndYAMLEquivalent asserts that the two supported file formats
+// parse to the same Config when expressing the same configuration. This is
+// the round-trip contract documented in #1272.
+func TestLoad_TOMLAndYAMLEquivalent(t *testing.T) {
+	clearSWEnv(t)
+	dir := t.TempDir()
+
+	yamlPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+server:
+  port: 9000
+  base_path: /sw
+database:
+  path: /var/lib/x.db
+music:
+  library_path: /srv/music
+scanner:
+  exclusions:
+    - "Various Artists"
+    - "OST"
+backup:
+  enabled: true
+  interval_hours: 12
+  retention_count: 5
+logging:
+  level: warn
+  format: text
+`), 0o644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	tomlPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(tomlPath, []byte(`
+[server]
+port = 9000
+base_path = "/sw"
+
+[database]
+path = "/var/lib/x.db"
+
+[music]
+library_path = "/srv/music"
+
+[scanner]
+exclusions = ["Various Artists", "OST"]
+
+[backup]
+enabled = true
+interval_hours = 12
+retention_count = 5
+
+[logging]
+level = "warn"
+format = "text"
+`), 0o644); err != nil {
+		t.Fatalf("write toml: %v", err)
+	}
+
+	yamlCfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load yaml: %v", err)
+	}
+	tomlCfg, err := Load(tomlPath)
+	if err != nil {
+		t.Fatalf("Load toml: %v", err)
+	}
+
+	// Trim base path to match validate() behavior consistently.
+	if yamlCfg.Server.Port != tomlCfg.Server.Port {
+		t.Errorf("Port mismatch: yaml=%d toml=%d", yamlCfg.Server.Port, tomlCfg.Server.Port)
+	}
+	if yamlCfg.Server.BasePath != tomlCfg.Server.BasePath {
+		t.Errorf("BasePath mismatch: yaml=%q toml=%q", yamlCfg.Server.BasePath, tomlCfg.Server.BasePath)
+	}
+	if yamlCfg.Database.Path != tomlCfg.Database.Path {
+		t.Errorf("DB Path mismatch: yaml=%q toml=%q", yamlCfg.Database.Path, tomlCfg.Database.Path)
+	}
+	if yamlCfg.Music.LibraryPath != tomlCfg.Music.LibraryPath {
+		t.Errorf("LibraryPath mismatch")
+	}
+	if len(yamlCfg.Scanner.Exclusions) != len(tomlCfg.Scanner.Exclusions) {
+		t.Fatalf("Exclusions length mismatch: yaml=%d toml=%d",
+			len(yamlCfg.Scanner.Exclusions), len(tomlCfg.Scanner.Exclusions))
+	}
+	for i := range yamlCfg.Scanner.Exclusions {
+		if yamlCfg.Scanner.Exclusions[i] != tomlCfg.Scanner.Exclusions[i] {
+			t.Errorf("Exclusions[%d] mismatch: yaml=%q toml=%q",
+				i, yamlCfg.Scanner.Exclusions[i], tomlCfg.Scanner.Exclusions[i])
+		}
+	}
+	if yamlCfg.Backup != tomlCfg.Backup {
+		t.Errorf("Backup mismatch: yaml=%+v toml=%+v", yamlCfg.Backup, tomlCfg.Backup)
+	}
+	if yamlCfg.Logging != tomlCfg.Logging {
+		t.Errorf("Logging mismatch: yaml=%+v toml=%+v", yamlCfg.Logging, tomlCfg.Logging)
+	}
+}
+
+// TestLoad_FormatSniffByContent ensures the loader picks the right parser
+// when the path has neither .toml nor .yaml/.yml extension.
+func TestLoad_FormatSniffByContent(t *testing.T) {
+	clearSWEnv(t)
+	dir := t.TempDir()
+
+	tomlSniffPath := filepath.Join(dir, "config.cfg")
+	if err := os.WriteFile(tomlSniffPath, []byte(`
+# this is a TOML file with an ambiguous extension
+[server]
+port = 7777
+
+[database]
+path = "/tmp/sniff.db"
+`), 0o644); err != nil {
+		t.Fatalf("write sniff toml: %v", err)
+	}
+
+	cfg, err := Load(tomlSniffPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Server.Port != 7777 {
+		t.Errorf("Server.Port = %d, want 7777 (TOML sniff)", cfg.Server.Port)
+	}
+	if cfg.Database.Path != "/tmp/sniff.db" {
+		t.Errorf("Database.Path = %q, want /tmp/sniff.db (TOML sniff)", cfg.Database.Path)
+	}
+
+	yamlSniffPath := filepath.Join(dir, "config.conf")
+	if err := os.WriteFile(yamlSniffPath, []byte(`
+# YAML with ambiguous extension
+server:
+  port: 6666
+database:
+  path: /tmp/yamlsniff.db
+`), 0o644); err != nil {
+		t.Fatalf("write sniff yaml: %v", err)
+	}
+
+	cfg2, err := Load(yamlSniffPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg2.Server.Port != 6666 {
+		t.Errorf("Server.Port = %d, want 6666 (YAML sniff)", cfg2.Server.Port)
+	}
+	if cfg2.Database.Path != "/tmp/yamlsniff.db" {
+		t.Errorf("Database.Path = %q, want /tmp/yamlsniff.db (YAML sniff)", cfg2.Database.Path)
+	}
+}
+
+func TestLoad_MalformedTOML(t *testing.T) {
+	clearSWEnv(t)
+	dir := t.TempDir()
+	tomlPath := filepath.Join(dir, "config.toml")
+	// Unterminated string is a hard TOML parse error.
+	if err := os.WriteFile(tomlPath, []byte(`[server]`+"\nport = \"oops\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Load(tomlPath); err == nil {
+		t.Fatal("expected parse error on malformed TOML")
+	}
+}
+
+func TestLoad_MalformedYAML(t *testing.T) {
+	clearSWEnv(t)
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "config.yaml")
+	// Tab indent is invalid in YAML.
+	if err := os.WriteFile(yamlPath, []byte("server:\n\tport: 8080\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Load(yamlPath); err == nil {
+		t.Fatal("expected parse error on malformed YAML")
+	}
+}
+
+// TestLoadFromEnv_AllRemaining covers the env-var branches that the existing
+// tests do not already exercise (session secret, encryption key, music path,
+// backup overrides, log format).
+func TestLoadFromEnv_AllRemaining(t *testing.T) {
+	clearSWEnv(t)
+	t.Setenv("SW_SESSION_SECRET", "shh")
+	t.Setenv("SW_ENCRYPTION_KEY", "kk")
+	t.Setenv("SW_MUSIC_PATH", "/music2")
+	t.Setenv("SW_BACKUP_PATH", "/bk")
+	t.Setenv("SW_BACKUP_RETENTION", "9")
+	t.Setenv("SW_BACKUP_INTERVAL", "6")
+	t.Setenv("SW_BACKUP_ENABLED", "false")
+	t.Setenv("SW_LOG_FORMAT", "text")
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Auth.SessionSecret != "shh" {
+		t.Errorf("SessionSecret = %q", cfg.Auth.SessionSecret)
+	}
+	if cfg.Encryption.Key != "kk" {
+		t.Errorf("Encryption.Key = %q", cfg.Encryption.Key)
+	}
+	if cfg.Music.LibraryPath != "/music2" {
+		t.Errorf("LibraryPath = %q", cfg.Music.LibraryPath)
+	}
+	if cfg.Backup.Path != "/bk" {
+		t.Errorf("Backup.Path = %q", cfg.Backup.Path)
+	}
+	if cfg.Backup.RetentionCount != 9 {
+		t.Errorf("Backup.RetentionCount = %d", cfg.Backup.RetentionCount)
+	}
+	if cfg.Backup.IntervalHours != 6 {
+		t.Errorf("Backup.IntervalHours = %d", cfg.Backup.IntervalHours)
+	}
+	if cfg.Backup.Enabled {
+		t.Error("Backup.Enabled should be false (env said false)")
+	}
+	if cfg.Logging.Format != "text" {
+		t.Errorf("Logging.Format = %q", cfg.Logging.Format)
+	}
+}
+
 func TestLoadFromEnv_ScannerExclusions(t *testing.T) {
 	clearSWEnv(t)
 	t.Setenv("SW_SCANNER_EXCLUSIONS", "Various Artists, Soundtrack, OST")
@@ -212,5 +471,101 @@ func TestLoadFromEnv_ScannerExclusions(t *testing.T) {
 	}
 	if cfg.Scanner.Exclusions[1] != "Soundtrack" {
 		t.Errorf("Exclusions[1] = %q, want Soundtrack", cfg.Scanner.Exclusions[1])
+	}
+}
+
+func TestEnsureScaffold_CreatesMissingFile(t *testing.T) {
+	clearSWEnv(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	created, err := EnsureScaffold(path)
+	if err != nil {
+		t.Fatalf("EnsureScaffold: %v", err)
+	}
+	if !created {
+		t.Fatal("EnsureScaffold returned created=false on missing file")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile after scaffold: %v", err)
+	}
+	if !strings.Contains(string(data), "[server]") || !strings.Contains(string(data), "# port = 1973") {
+		t.Errorf("scaffold content missing expected sections; got:\n%s", data)
+	}
+	// The scaffold must parse as valid TOML so a Load round-trip succeeds.
+	if _, err := Load(path); err != nil {
+		t.Fatalf("Load after scaffold: %v", err)
+	}
+}
+
+func TestEnsureScaffold_NoOpWhenFileExists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	existing := []byte("[server]\nport = 9999\n")
+	if err := os.WriteFile(path, existing, 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	created, err := EnsureScaffold(path)
+	if err != nil {
+		t.Fatalf("EnsureScaffold: %v", err)
+	}
+	if created {
+		t.Error("EnsureScaffold returned created=true for existing file")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != string(existing) {
+		t.Errorf("existing file was rewritten; got %q, want %q", got, existing)
+	}
+}
+
+func TestEnsureScaffold_CreatesParentDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "subdir", "config.toml")
+
+	created, err := EnsureScaffold(path)
+	if err != nil {
+		t.Fatalf("EnsureScaffold: %v", err)
+	}
+	if !created {
+		t.Fatal("created=false")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("scaffold not created at nested path: %v", err)
+	}
+}
+
+func TestEnsureScaffold_EmptyPathNoOp(t *testing.T) {
+	created, err := EnsureScaffold("")
+	if err != nil {
+		t.Errorf("EnsureScaffold(\"\"): %v", err)
+	}
+	if created {
+		t.Error("EnsureScaffold(\"\") returned created=true")
+	}
+}
+
+// TestEnsureScaffold_SkipsYAMLPath verifies that EnsureScaffold treats a
+// .yaml/.yml path as a no-op. Writing TOML content under a YAML filename
+// would force the loader's extension-based parser selection to fail on
+// first boot, so the policy is to leave YAML deployments untouched.
+func TestEnsureScaffold_SkipsYAMLPath(t *testing.T) {
+	for _, ext := range []string{".yaml", ".yml"} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config"+ext)
+		created, err := EnsureScaffold(path)
+		if err != nil {
+			t.Fatalf("EnsureScaffold(%s): %v", ext, err)
+		}
+		if created {
+			t.Errorf("EnsureScaffold(%s) returned created=true; want false", ext)
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("EnsureScaffold(%s) wrote file; want no file: stat err=%v", ext, err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **#1272:** Add `github.com/BurntSushi/toml` dependency. Mirror every `yaml:` struct tag in `internal/config/config.go` with a `toml:` counterpart. Loader picks the parser by file extension (`.toml` -> TOML; `.yaml`/`.yml` -> YAML); on ambiguous extensions sniffs the first non-comment byte (`[` or `key=` -> TOML, otherwise YAML). YAML support is unchanged; existing deployments keep working.
- **#1273:** First-run scaffolding -- new `config.EnsureScaffold(path)` writes a documented, fully-commented `config.toml` at `SW_CONFIG_PATH` when the file is missing. Every field commented out so the scaffold documents the surface without overriding in-code defaults or `SW_*` env vars. Default `SW_CONFIG_PATH` flipped from `/config/config.yaml` to `/config/config.toml` in `cmd/stillwater/main.go`. User-facing docs (install-binary, install-docker-compose, environment-variables) updated to TOML examples; YAML kept as a backward-compat note.

Release notes are auto-generated by goreleaser from conventional-commit prefixes; no `CHANGELOG.md` added.

## Test plan

- [x] `internal/config/config_test.go`: round-trip TOML, format-sniff, malformed-parse, env-var coverage, plus four new `TestEnsureScaffold_*` cases (creates missing file; no-op when file exists; creates parent directories; empty path is no-op)
- [x] `bash scripts/pre-push-gate.sh` clean; patch coverage 75.47% on `internal/config/config.go`
- [x] UAT 1: empty data dir -> `config.toml` scaffolded with the documented template; `wrote first-run config scaffold` info log emitted
- [x] UAT 2: hand-written `config.toml` with `port = 8080` -> `server starting addr=":8080"`
- [x] UAT 3 (backward compat): existing `config.yaml` with `port: 8081` -> `server starting addr=":8081"`; no auto-toml created in the YAML data dir

Closes #1272
Closes #1273

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default configuration now prefers TOML while retaining YAML compatibility. Optional first-run scaffolding can create a commented config.toml and logs outcomes; CLI reset actions now respect the new default config path when configured.

* **Documentation**
  * Install and environment guides updated with TOML examples, SW_CONFIG_PATH behavior, parser selection notes, and updated backup references.

* **Tests**
  * Added tests covering TOML/YAML loading, format detection, malformed files, and scaffold behavior.

* **Chores**
  * Added TOML parsing dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->