### PR TITLE
fix(settings): preserve auth provider defaults + cross-instance token restore

### DIFF
--- a/api/bruno/settings/import-settings-admin-fallback.bru
+++ b/api/bruno/settings/import-settings-admin-fallback.bru
@@ -52,6 +52,6 @@ tests {
   test("either users_imported or ownership_reassigned should fire on cross-instance restore", function() {
     var users = res.body.users_imported || 0;
     var reassigned = res.body.ownership_reassigned || 0;
-    expect(users + reassigned).to.be.at.least(0);
+    expect(users + reassigned).to.be.at.least(1);
   });
 }

--- a/api/bruno/settings/import-settings-admin-fallback.bru
+++ b/api/bruno/settings/import-settings-admin-fallback.bru
@@ -1,0 +1,57 @@
+meta {
+  name: Import Settings (admin-fallback)
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{apiBase}}/settings/import
+  body: json
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "passphrase": "round-trip-test-passphrase",
+    "envelope": {{lastExportedEnvelope}},
+    "admin_fallback_tokens": true
+  }
+}
+
+docs {
+  Cross-instance scenario for #1283. Use this against an envelope that
+  was exported from a DIFFERENT Stillwater instance whose user set does
+  not match the target. With admin_fallback_tokens=true, API tokens
+  whose original owner is absent on the target are reassigned to the
+  importing admin instead of skipped. The reassignment count appears in
+  the response under ownership_reassigned.
+
+  Pre-flight: run "Export Settings" on the source instance, copy the
+  envelope into a Bruno variable named lastExportedEnvelope, then run
+  this request on the target instance.
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("ImportResult exposes ownership_reassigned counter", function() {
+    expect(res.body).to.have.property("ownership_reassigned");
+  });
+
+  test("ImportResult exposes users_imported counter", function() {
+    expect(res.body).to.have.property("users_imported");
+  });
+
+  test("either users_imported or ownership_reassigned should fire on cross-instance restore", function() {
+    var users = res.body.users_imported || 0;
+    var reassigned = res.body.ownership_reassigned || 0;
+    expect(users + reassigned).to.be.at.least(0);
+  });
+}

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -42,6 +42,8 @@ The encrypted settings export/import bundle (`internal/settingsio`) is the porta
 
 2. **Cross-instance ownership-bearing rows carry their own owners.** As of envelope version 1.3, the payload includes a `users` block. On import, users that already exist on the target are left untouched (the operator's setup wins); users absent on the target are recreated so downstream rows (api_tokens, user_preferences) can attribute back to them via the username -> user_id remap. An opt-in `admin_fallback_tokens` flag exists for environments that prefer to attribute orphan tokens to the importing admin instead of recreating users; the reassignment count surfaces in the import result so it cannot be silent.
 
+   Security constraints on the import path: recreated users land with `is_protected=0` (the bootstrap-admin protection bit cannot be smuggled across instances) and any role outside `administrator | operator | admin` coerces to `operator` (least privilege; an unknown future role must not silently grant elevated access). The `admin_fallback_tokens` opt is a trust-boundary tradeoff: reassigning an orphan token to the importing admin can effectively raise its privileges if the original owner had a lower role on the source, so the flag is opt-in per import and only appropriate for migrations between instances under the same operator's control.
+
 Envelope versions:
 
 - `1.0`: original (settings, connections, platform profiles, webhooks, provider keys, priorities)

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -33,3 +33,20 @@ Check last-modified timestamp before writing. If changed externally, warn instea
 ## Scanner exclusions
 
 Default skip list: "Various Artists", "Various", "VA", "Soundtrack", "OST". Excluded directories appear greyed out and unfetchable. Classical music directories get special handling.
+
+## Portable settings contract
+
+The encrypted settings export/import bundle (`internal/settingsio`) is the portability contract for cross-instance restore. Two rules govern what it carries:
+
+1. **Settings exported via the blanket KV dump must have a guaranteed DB row.** Code that reads a value via `getStringSetting(..., fallback)` and silently falls back to a hard-coded default when the row is absent will not export that value. The render path for a settings page is therefore responsible for seeding canonical defaults on first view (idempotent `INSERT OR IGNORE`) so an "I never touched this" instance still round-trips faithfully. The auth-provider Settings page does this for every `auth.providers.*` key it reads.
+
+2. **Cross-instance ownership-bearing rows carry their own owners.** As of envelope version 1.3, the payload includes a `users` block. On import, users that already exist on the target are left untouched (the operator's setup wins); users absent on the target are recreated so downstream rows (api_tokens, user_preferences) can attribute back to them via the username -> user_id remap. An opt-in `admin_fallback_tokens` flag exists for environments that prefer to attribute orphan tokens to the importing admin instead of recreating users; the reassignment count surfaces in the import result so it cannot be silent.
+
+Envelope versions:
+
+- `1.0`: original (settings, connections, platform profiles, webhooks, provider keys, priorities)
+- `1.1`: adds rules, scraper configs, user preferences, plaintext summary
+- `1.2`: adds libraries (connection refs remapped by type+url) and api_tokens (token_hash + metadata, never plaintext)
+- `1.3`: adds users so cross-instance restore can recreate absent owners before the api_tokens / user_preferences username remap
+
+Older envelopes remain importable. The `password_hash` inside the users block is a bcrypt digest -- never plaintext -- and only crosses the wire inside the passphrase-encrypted payload.

--- a/docs/site/src/how-to/export-import-settings.md
+++ b/docs/site/src/how-to/export-import-settings.md
@@ -2,7 +2,7 @@
 description: Move your Stillwater configuration to another instance with an encrypted bundle.
 ---
 
-<!-- code: internal/settingsio/export.go (Payload, CurrentEnvelopeVersion 1.1, ConnectionExport, RuleExport, PriorityExport, UserPrefsExport, pbkdf2Iterations 600_000), internal/api/router.go (POST /api/v1/settings/export, /api/v1/settings/import), web/templates/settings.templ maintenance tab (export passphrase + import upload). Future: W2.D adds Libraries + APITokens to Payload, bumps to 1.2 (#1186, #1189). -->
+<!-- code: internal/settingsio/export.go (Payload, CurrentEnvelopeVersion 1.3, ConnectionExport, RuleExport, PriorityExport, UserPrefsExport, UserExport, ImportOptions.AdminFallbackTokens, pbkdf2Iterations 600_000), internal/settingsio/users.go, internal/settingsio/tokens.go (admin-fallback path), internal/api/router.go (POST /api/v1/settings/export, /api/v1/settings/import), web/templates/settings.templ maintenance tab (export passphrase + import upload + admin-fallback checkbox). -->
 
 # Export and import settings
 
@@ -27,6 +27,8 @@ The export includes everything that lives in Stillwater's database that you'd wa
 - **Rules** -- enable state, automation mode, and config for each rule. Names and descriptions are *not* exported (the receiving instance keeps its own current copy).
 - **Scraper configurations** -- custom scraper YAMLs you've added.
 - **User preferences** -- per-user UI prefs.
+- **Users** -- usernames, roles, and stored password hashes for local accounts plus federated identity references (provider type and external id). Password hashes are bcrypt digests, never plaintext. The user list is included so that a backup taken on instance A can be restored on instance B without losing the API tokens or user preferences that are owned by users on A whose names B has not seen before.
+- **API tokens** -- the stored hash, scopes, and ownership metadata. The plaintext token value is not stored in the database and so is never carried in the bundle.
 
 What's **not** in the bundle:
 
@@ -76,6 +78,19 @@ For each item in the bundle:
 - **Item types not in the bundle** are left untouched on the receiving instance.
 
 So an import on a fresh instance fully populates it; an import on an instance with existing config merges -- the bundle's view wins where things overlap.
+
+### How users are handled
+
+Users get a softer treatment than other items because their state on the receiving instance often reflects local choices (rotated passwords, role changes) that should not be silently overwritten:
+
+- **Users present on the receiving instance with the same username** are left exactly as they are. The bundle's row is ignored. This means an admin who has rotated their password on the target keeps the new password, even if the source is older.
+- **Users absent on the receiving instance** are recreated from the bundle so any of their API tokens or preferences in the same import can attribute back to them.
+
+### When the source's owner is missing on the target
+
+If an API token's original owner is not in the bundle (e.g., the bundle came from an older Stillwater that did not include users) and is also not present on the receiving instance, the import treats the token as orphaned. By default, orphaned tokens are skipped and the result reports them under `api_tokens_skipped` so you can see what was lost.
+
+There is an optional **Reassign orphan tokens to me** checkbox on the import form for the case where you would rather inherit those tokens than lose them. With it checked, orphan tokens are reattributed to the admin running the import; the result reports the count under `ownership_reassigned` so the change is visible. Enable it deliberately -- it is silent ownership transfer if you forget you ticked it.
 
 ## Common workflows
 

--- a/docs/site/src/how-to/export-import-settings.md
+++ b/docs/site/src/how-to/export-import-settings.md
@@ -27,7 +27,7 @@ The export includes everything that lives in Stillwater's database that you'd wa
 - **Rules** -- enable state, automation mode, and config for each rule. Names and descriptions are *not* exported (the receiving instance keeps its own current copy).
 - **Scraper configurations** -- custom scraper YAMLs you've added.
 - **User preferences** -- per-user UI prefs.
-- **Users** -- usernames, roles, and stored password hashes for local accounts plus federated identity references (provider type and external id). Password hashes are bcrypt digests, never plaintext. The user list is included so that a backup taken on instance A can be restored on instance B without losing the API tokens or user preferences that are owned by users on A whose names B has not seen before.
+- **Users** -- usernames and roles for every account, plus stored password hashes for local (non-federated) accounts and, separately, federated identity references (provider type and external id) for federated accounts. Federated identities have no password hashes. Password hashes are bcrypt digests, never plaintext. The user list is included so that a backup taken on instance A can be restored on instance B without losing the API tokens or user preferences that are owned by users on A whose names B has not seen before.
 - **API tokens** -- the stored hash, scopes, and ownership metadata. The plaintext token value is not stored in the database and so is never carried in the bundle.
 
 What's **not** in the bundle:

--- a/internal/api/handlers_platform.go
+++ b/internal/api/handlers_platform.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/filesystem"
@@ -314,6 +315,15 @@ func (r *Router) handleSettingsPage(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	// Seed canonical defaults for tracked auth-provider keys before reading
+	// them, so that values matching the code default still produce a real
+	// row in the settings table (and therefore survive an export/import
+	// round trip). Without this, a user who views the page, sees Operator
+	// already selected, and moves on never fires a DB write -- the key
+	// stays absent, the export carries nothing, and the target instance
+	// renders its own default which may differ from the source's (#1188).
+	r.seedAuthProviderDefaults(req.Context())
+
 	authProvidersData := templates.AuthProvidersData{
 		BasePath:              r.basePath,
 		LocalEnabled:          r.getBoolSetting(req.Context(), "auth.providers.local.enabled", true),
@@ -483,4 +493,66 @@ func (r *Router) buildUpdatesTabData(ctx context.Context) templates.UpdatesTabDa
 	data.PendingVersion = status.PendingVersion
 
 	return data
+}
+
+// authProviderDefaults is the canonical list of auth.providers.* settings
+// keys that the Settings > Auth Providers page reads, paired with their
+// code defaults. seedAuthProviderDefaults inserts a row at this default
+// for any key that has no row yet, so a "user looked at the page and
+// accepted the defaults" instance round-trips faithfully through
+// export/import (#1188).
+//
+// Boolean-shaped keys are stored as the strings "true" / "false" to match
+// the parsing in getBoolSetting (which treats "true" or "1" as true).
+var authProviderDefaults = []struct {
+	Key     string
+	Default string
+}{
+	// Local provider is always on; persist that fact so disabling it on the
+	// source can be exported (the toggle is currently disabled in the UI but
+	// the storage shape is symmetric).
+	{"auth.providers.local.enabled", "true"},
+
+	// Emby provider.
+	{"auth.providers.emby.enabled", "false"},
+	{"auth.providers.emby.auto_provision", "false"},
+	{"auth.providers.emby.guard_rail", "admin"},
+	{"auth.providers.emby.default_role", "operator"},
+
+	// Jellyfin provider.
+	{"auth.providers.jellyfin.enabled", "false"},
+	{"auth.providers.jellyfin.auto_provision", "false"},
+	{"auth.providers.jellyfin.guard_rail", "admin"},
+	{"auth.providers.jellyfin.default_role", "operator"},
+
+	// OIDC provider. Optional URL/string fields are NOT seeded with empty
+	// strings: an "unset" OIDC issuer URL must remain absent (not present-
+	// but-empty) so the export omits it cleanly. Only the role default is
+	// seeded because it matches the same UI-default-masks-absent-row hazard
+	// as the Emby/Jellyfin selects.
+	{"auth.providers.oidc.enabled", "false"},
+	{"auth.providers.oidc.auto_provision", "false"},
+	{"auth.providers.oidc.default_role", "operator"},
+}
+
+// seedAuthProviderDefaults writes each canonical default to the settings
+// table only when the key has no row yet. INSERT OR IGNORE keeps the call
+// idempotent across page renders -- a key that has been changed (or even
+// re-set to the default explicitly) keeps its existing row.
+//
+// Errors are logged but not returned; the page must still render even if
+// the seed fails (e.g. because the DB is briefly read-only during a
+// maintenance window). The follow-up render will read the in-memory
+// fallbacks via getStringSetting / getBoolSetting, which preserves the
+// pre-#1188 behavior.
+func (r *Router) seedAuthProviderDefaults(ctx context.Context) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, d := range authProviderDefaults {
+		if _, err := r.db.ExecContext(ctx,
+			`INSERT OR IGNORE INTO settings (key, value, updated_at) VALUES (?, ?, ?)`,
+			d.Key, d.Default, now,
+		); err != nil {
+			r.logger.Warn("seeding auth provider default", "key", d.Key, "error", err)
+		}
+	}
 }

--- a/internal/api/handlers_settings_io.go
+++ b/internal/api/handlers_settings_io.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/settingsio"
 )
 
@@ -85,6 +86,12 @@ func (r *Router) handleSettingsImport(w http.ResponseWriter, req *http.Request) 
 
 	var envelope settingsio.Envelope
 	var passphrase string
+	// adminFallbackTokens is the opt-in for #1283. When true, api_tokens
+	// whose original owner is absent on the target (after the envelope's
+	// Users block has been applied) are reassigned to the importing admin
+	// rather than skipped. The form field is "admin_fallback_tokens" and
+	// the JSON field is the same; "1", "true", and "on" are accepted.
+	var adminFallbackTokens bool
 
 	ct := req.Header.Get("Content-Type")
 	if strings.HasPrefix(ct, "application/json") {
@@ -101,8 +108,9 @@ func (r *Router) handleSettingsImport(w http.ResponseWriter, req *http.Request) 
 
 		// Expect {"passphrase": "...", "envelope": {...}}
 		var payload struct {
-			Passphrase string              `json:"passphrase"`
-			Envelope   settingsio.Envelope `json:"envelope"`
+			Passphrase          string              `json:"passphrase"`
+			Envelope            settingsio.Envelope `json:"envelope"`
+			AdminFallbackTokens bool                `json:"admin_fallback_tokens"`
 		}
 		if err := json.Unmarshal(body, &payload); err != nil {
 			writeImportErr(http.StatusBadRequest, "invalid JSON")
@@ -110,6 +118,7 @@ func (r *Router) handleSettingsImport(w http.ResponseWriter, req *http.Request) 
 		}
 		envelope = payload.Envelope
 		passphrase = payload.Passphrase
+		adminFallbackTokens = payload.AdminFallbackTokens
 	} else {
 		// Multipart form upload
 		if err := req.ParseMultipartForm(maxImportSize); err != nil {
@@ -118,6 +127,13 @@ func (r *Router) handleSettingsImport(w http.ResponseWriter, req *http.Request) 
 		}
 
 		passphrase = req.FormValue("passphrase")
+		// HTML checkboxes submit "on" when checked; accept the common
+		// truthy variants so a JSON-style form value (some HTMX form
+		// helpers emit "true") is interpreted the same way.
+		switch req.FormValue("admin_fallback_tokens") {
+		case "1", "true", "on":
+			adminFallbackTokens = true
+		}
 
 		file, _, err := req.FormFile("file")
 		if err != nil {
@@ -146,7 +162,21 @@ func (r *Router) handleSettingsImport(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	result, err := r.settingsIOService.Import(req.Context(), &envelope, passphrase)
+	// Resolve the importing admin from the session so admin-fallback (if
+	// requested) has a valid user_id to reassign tokens to. The settings
+	// import endpoint is admin-only via middleware, so a missing user id
+	// here means the request bypassed the auth chain -- treat that as a
+	// hard refusal rather than silently disabling the fallback.
+	importingAdminID := middleware.UserIDFromContext(req.Context())
+	if adminFallbackTokens && importingAdminID == "" {
+		writeImportErr(http.StatusUnauthorized, "admin-fallback requires an authenticated session")
+		return
+	}
+
+	result, err := r.settingsIOService.ImportWithOptions(req.Context(), &envelope, passphrase, settingsio.ImportOptions{
+		AdminFallbackTokens:  adminFallbackTokens,
+		ImportingAdminUserID: importingAdminID,
+	})
 	if err != nil {
 		r.logger.Error("settings import failed", "error", err)
 		// Build a safe user-facing message: never expose raw internal errors.
@@ -176,13 +206,23 @@ func (r *Router) handleSettingsImport(w http.ResponseWriter, req *http.Request) 
 		w.Header().Set("Content-Type", "text/html")
 		// Local name avoids shadowing the html stdlib import used in
 		// writeImportErr above.
+		// Append users + token-reassignment counts only when non-zero so the
+		// happy path stays compact for instances that don't exercise the
+		// cross-instance restore code path.
+		extras := ""
+		if result.UsersImported > 0 {
+			extras += fmt.Sprintf(" %d users recreated.", result.UsersImported)
+		}
+		if result.OwnershipReassigned > 0 {
+			extras += fmt.Sprintf(" %d API tokens reassigned to the importing admin.", result.OwnershipReassigned)
+		}
 		fragment := fmt.Sprintf(
 			`<div class="text-sm text-green-600 dark:text-green-400">`+
 				`Import complete: %d settings, %d connections, %d profiles, %d webhooks, %d provider keys, %d priorities,`+
-				` %d rules, %d scraper configs, %d preferences.`+
+				` %d rules, %d scraper configs, %d preferences.%s`+
 				`</div>`,
 			result.Settings, result.Connections, result.Profiles, result.Webhooks, result.ProviderKeys, result.Priorities,
-			result.Rules, result.ScraperConfigs, result.UserPreferences,
+			result.Rules, result.ScraperConfigs, result.UserPreferences, extras,
 		)
 		w.Write([]byte(fragment)) //nolint:errcheck,gosec // G705: all format args are %d (integers)
 		return

--- a/internal/api/handlers_settings_seed_test.go
+++ b/internal/api/handlers_settings_seed_test.go
@@ -100,6 +100,9 @@ func TestSeedAuthProviderDefaults_Idempotent(t *testing.T) {
 			}
 			first[k] = rowState{v, u}
 		}
+		if err := rows.Err(); err != nil {
+			t.Fatalf("first rows iteration: %v", err)
+		}
 	}()
 
 	// Second seed call.
@@ -127,5 +130,8 @@ func TestSeedAuthProviderDefaults_Idempotent(t *testing.T) {
 		if prev.updated != u {
 			t.Errorf("%s: updated_at drifted across idempotent seed (INSERT OR IGNORE should not touch existing row): %q -> %q", k, prev.updated, u)
 		}
+	}
+	if err := rows2.Err(); err != nil {
+		t.Fatalf("second rows iteration: %v", err)
 	}
 }

--- a/internal/api/handlers_settings_seed_test.go
+++ b/internal/api/handlers_settings_seed_test.go
@@ -1,0 +1,131 @@
+package api
+
+import (
+	"context"
+	"testing"
+)
+
+// TestSeedAuthProviderDefaults_FreshDB confirms that calling
+// seedAuthProviderDefaults on a fresh DB writes a row at the canonical
+// default for every key the page reads. This is the integration point for
+// #1188: a value matching the code default must produce a real settings
+// row so the export carries it.
+func TestSeedAuthProviderDefaults_FreshDB(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+	ctx := context.Background()
+
+	// Pre-condition: the settings table has no auth.providers.* row at all.
+	var preCount int
+	if err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM settings WHERE key LIKE 'auth.providers.%'`).Scan(&preCount); err != nil {
+		t.Fatalf("pre-count: %v", err)
+	}
+	if preCount != 0 {
+		t.Fatalf("expected fresh DB, got %d rows", preCount)
+	}
+
+	r.seedAuthProviderDefaults(ctx)
+
+	// Every entry in authProviderDefaults must now have a row at the
+	// declared default. We iterate the package-level slice so the test
+	// stays in lock-step with the seed list.
+	for _, d := range authProviderDefaults {
+		var got string
+		if err := r.db.QueryRowContext(ctx,
+			`SELECT value FROM settings WHERE key = ?`, d.Key).Scan(&got); err != nil {
+			t.Errorf("%s: row missing after seed: %v", d.Key, err)
+			continue
+		}
+		if got != d.Default {
+			t.Errorf("%s: got %q, want default %q", d.Key, got, d.Default)
+		}
+	}
+}
+
+// TestSeedAuthProviderDefaults_RespectExistingRows confirms that an
+// existing row (e.g. user already changed the value) is NOT overwritten
+// by a subsequent seed call. INSERT OR IGNORE is the load-bearing piece
+// here -- a seed that clobbered user choices would be a regression worse
+// than the original bug.
+func TestSeedAuthProviderDefaults_RespectExistingRows(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+	ctx := context.Background()
+
+	// Manually set Emby default_role to administrator (the non-default).
+	if _, err := r.db.ExecContext(ctx,
+		`INSERT INTO settings (key, value, updated_at) VALUES (?, ?, datetime('now'))`,
+		"auth.providers.emby.default_role", "administrator"); err != nil {
+		t.Fatalf("seeding existing row: %v", err)
+	}
+
+	r.seedAuthProviderDefaults(ctx)
+
+	var got string
+	if err := r.db.QueryRowContext(ctx,
+		`SELECT value FROM settings WHERE key = ?`,
+		"auth.providers.emby.default_role").Scan(&got); err != nil {
+		t.Fatalf("post-seed query: %v", err)
+	}
+	if got != "administrator" {
+		t.Errorf("seed clobbered existing row: got %q, want administrator", got)
+	}
+}
+
+// TestSeedAuthProviderDefaults_Idempotent confirms a second seed call is a
+// no-op (no spurious updated_at churn for callers that watch the settings
+// table for changes).
+func TestSeedAuthProviderDefaults_Idempotent(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+	ctx := context.Background()
+
+	r.seedAuthProviderDefaults(ctx)
+
+	// Capture timestamps after first seed.
+	type rowState struct{ value, updated string }
+	first := map[string]rowState{}
+	func() {
+		rows, err := r.db.QueryContext(ctx,
+			`SELECT key, value, updated_at FROM settings WHERE key LIKE 'auth.providers.%'`)
+		if err != nil {
+			t.Fatalf("first read: %v", err)
+		}
+		defer rows.Close() //nolint:errcheck
+		for rows.Next() {
+			var k, v, u string
+			if err := rows.Scan(&k, &v, &u); err != nil {
+				t.Fatalf("scan: %v", err)
+			}
+			first[k] = rowState{v, u}
+		}
+	}()
+
+	// Second seed call.
+	r.seedAuthProviderDefaults(ctx)
+
+	rows2, err := r.db.QueryContext(ctx,
+		`SELECT key, value, updated_at FROM settings WHERE key LIKE 'auth.providers.%'`)
+	if err != nil {
+		t.Fatalf("second read: %v", err)
+	}
+	defer rows2.Close() //nolint:errcheck
+	for rows2.Next() {
+		var k, v, u string
+		if err := rows2.Scan(&k, &v, &u); err != nil {
+			t.Fatalf("scan2: %v", err)
+		}
+		prev, ok := first[k]
+		if !ok {
+			t.Errorf("second seed introduced new key: %s", k)
+			continue
+		}
+		if prev.value != v {
+			t.Errorf("%s: value drifted across idempotent seed: %q -> %q", k, prev.value, v)
+		}
+		if prev.updated != u {
+			t.Errorf("%s: updated_at drifted across idempotent seed (INSERT OR IGNORE should not touch existing row): %q -> %q", k, prev.updated, u)
+		}
+	}
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -187,6 +187,92 @@ components:
                 type: string
                 enum: [genres, styles, moods]
           additionalProperties: false
+    PortableSettingsEnvelope:
+      type: object
+      description: |
+        Outer JSON wrapper for an exported settings file. The encrypted
+        configuration payload lives in `data` (base64 nonce+ciphertext, decrypted
+        with `salt` + the import passphrase via PBKDF2). `summary` carries
+        plaintext per-section row counts so an operator can sanity-check the
+        export shape without decrypting. Used as the import request payload
+        and the export response body, so the contract stays in sync across
+        directions.
+      required: [version, app_version, created_at, salt, data]
+      properties:
+        version:
+          type: string
+          description: |
+            Envelope format version. Current writer emits `1.3`; importer
+            accepts `1.0`-`1.3`. Each minor bump adds optional fields without
+            breaking older readers (1.1: rules/scraper_configs/user_preferences;
+            1.2: libraries/api_tokens; 1.3: users).
+        app_version:
+          type: string
+          description: Application version that produced the export.
+        created_at:
+          type: string
+          format: date-time
+          description: When the export was created (UTC, RFC 3339).
+        salt:
+          type: string
+          description: Base64-encoded PBKDF2 salt used to derive the symmetric key from the passphrase.
+        data:
+          type: string
+          description: Base64-encoded ciphertext (nonce + AES-GCM payload) of the inner Payload struct.
+        summary:
+          type: object
+          description: |
+            Plaintext per-section row counts for sanity-checking without
+            decryption. Same shape as the import response, so the same fields
+            cover both export-side ("rows packed") and import-side
+            ("rows applied") semantics.
+          required: [settings, connections, platform_profiles, webhooks, provider_keys, priorities, rules, scraper_configs, user_preferences]
+          properties:
+            settings:
+              type: integer
+              description: Number of plain-KV settings rows.
+            connections:
+              type: integer
+              description: Number of platform connections.
+            platform_profiles:
+              type: integer
+              description: Number of platform profiles.
+            webhooks:
+              type: integer
+              description: Number of outbound webhooks.
+            provider_keys:
+              type: integer
+              description: Number of provider API key rows.
+            priorities:
+              type: integer
+              description: Number of provider-priority entries.
+            rules:
+              type: integer
+              description: Number of rule configurations (envelope >= 1.1).
+            scraper_configs:
+              type: integer
+              description: Number of scraper configuration scopes (envelope >= 1.1).
+            user_preferences:
+              type: integer
+              description: Number of user-preference rows (envelope >= 1.1).
+            libraries:
+              type: integer
+              description: Number of libraries (envelope >= 1.2).
+            libraries_skipped:
+              type: integer
+              description: Number of libraries skipped because the source-side connection has no equivalent on the target instance.
+            api_tokens:
+              type: integer
+              description: Number of API tokens (envelope >= 1.2). Token plaintexts are never carried; only the stored hash + metadata.
+            api_tokens_skipped:
+              type: integer
+              description: Number of API tokens skipped (e.g. owner absent on target and admin-fallback not requested).
+            users_imported:
+              type: integer
+              description: Number of users recreated from the envelope's Users block (envelope >= 1.3). Pre-existing users on the target are NOT counted.
+            ownership_reassigned:
+              type: integer
+              description: Number of API tokens whose owner was absent on the target and were reassigned to the importing admin via admin_fallback_tokens=true.
     Status:
       type: object
       properties:
@@ -8159,48 +8245,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required: [version, app_version, created_at, salt, data, summary]
-                properties:
-                  version:
-                    type: string
-                    description: Export format version number.
-                  app_version:
-                    type: string
-                    description: Application version that created this export.
-                  created_at:
-                    type: string
-                    format: date-time
-                    description: When the export was created (UTC, RFC 3339).
-                  salt:
-                    type: string
-                    description: Encryption salt for the settings payload.
-                  data:
-                    type: string
-                    description: Encrypted settings payload.
-                  summary:
-                    type: object
-                    description: Plaintext section counts for sanity-checking without decryption.
-                    required: [settings, connections, platform_profiles, webhooks, provider_keys, priorities, rules, scraper_configs, user_preferences]
-                    properties:
-                      settings:
-                        type: integer
-                      connections:
-                        type: integer
-                      platform_profiles:
-                        type: integer
-                      webhooks:
-                        type: integer
-                      provider_keys:
-                        type: integer
-                      priorities:
-                        type: integer
-                      rules:
-                        type: integer
-                      scraper_configs:
-                        type: integer
-                      user_preferences:
-                        type: integer
+                $ref: "#/components/schemas/PortableSettingsEnvelope"
         "400":
           description: Missing passphrase
           content:
@@ -8235,7 +8280,7 @@ paths:
                 passphrase:
                   type: string
                 envelope:
-                  type: object
+                  $ref: "#/components/schemas/PortableSettingsEnvelope"
                 admin_fallback_tokens:
                   type: boolean
                   description: Opt-in. When true, API tokens whose original owner is absent on the target after the envelope's Users block has been applied are reassigned to the importing admin instead of skipped. The reassignment count surfaces in the response under ownership_reassigned.

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -8236,6 +8236,9 @@ paths:
                   type: string
                 envelope:
                   type: object
+                admin_fallback_tokens:
+                  type: boolean
+                  description: Opt-in. When true, API tokens whose original owner is absent on the target after the envelope's Users block has been applied are reassigned to the importing admin instead of skipped. The reassignment count surfaces in the response under ownership_reassigned.
               required: [passphrase, envelope]
           multipart/form-data:
             schema:
@@ -8246,6 +8249,9 @@ paths:
                 file:
                   type: string
                   format: binary
+                admin_fallback_tokens:
+                  type: string
+                  description: Opt-in. Truthy values ("1", "true", "on") request the same admin-fallback behavior as the JSON field of the same name.
               required: [passphrase, file]
       responses:
         "200":
@@ -8283,6 +8289,24 @@ paths:
                   user_preferences:
                     type: integer
                     description: Number of user preference entries imported.
+                  libraries:
+                    type: integer
+                    description: Number of libraries imported (envelope >= 1.2).
+                  libraries_skipped:
+                    type: integer
+                    description: Number of libraries skipped because the source-side connection has no equivalent on the target instance.
+                  api_tokens:
+                    type: integer
+                    description: Number of API tokens imported (envelope >= 1.2).
+                  api_tokens_skipped:
+                    type: integer
+                    description: Number of API tokens skipped (e.g. owner absent on target and admin-fallback not requested).
+                  users_imported:
+                    type: integer
+                    description: Number of users recreated from the envelope's Users block (envelope >= 1.3). Users that already existed on the target are NOT counted.
+                  ownership_reassigned:
+                    type: integer
+                    description: Number of API tokens whose owner was absent on the target and were reassigned to the importing admin via admin_fallback_tokens=true.
             text/html:
               schema:
                 type: string

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -8260,7 +8260,7 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [settings, connections, platform_profiles, webhooks, provider_keys, priorities, rules, scraper_configs, user_preferences]
+                required: [settings, connections, platform_profiles, webhooks, provider_keys, priorities, rules, scraper_configs, user_preferences, libraries, libraries_skipped, api_tokens, api_tokens_skipped, users_imported, ownership_reassigned]
                 properties:
                   settings:
                     type: integer

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -187,25 +187,24 @@ components:
                 type: string
                 enum: [genres, styles, moods]
           additionalProperties: false
-    PortableSettingsEnvelope:
+    PortableSettingsEnvelopeImport:
       type: object
       description: |
-        Outer JSON wrapper for an exported settings file. The encrypted
-        configuration payload lives in `data` (base64 nonce+ciphertext, decrypted
-        with `salt` + the import passphrase via PBKDF2). `summary` carries
-        plaintext per-section row counts so an operator can sanity-check the
-        export shape without decrypting. Used as the import request payload
-        and the export response body, so the contract stays in sync across
-        directions.
+        Import-side wrapper for a previously exported settings file. The shape
+        is intentionally permissive: the importer accepts envelope versions
+        1.0-1.3, and earlier versions do not carry the per-section counters
+        that current writers emit. Required fields are limited to the core
+        crypto envelope (version + app_version + created_at + salt + data);
+        the optional `summary` block is informational only on the import path.
       required: [version, app_version, created_at, salt, data]
       properties:
         version:
           type: string
           description: |
-            Envelope format version. Current writer emits `1.3`; importer
-            accepts `1.0`-`1.3`. Each minor bump adds optional fields without
-            breaking older readers (1.1: rules/scraper_configs/user_preferences;
-            1.2: libraries/api_tokens; 1.3: users).
+            Envelope format version. Importer accepts `1.0`-`1.3`. Each minor
+            bump adds optional fields without breaking older readers (1.1:
+            rules/scraper_configs/user_preferences; 1.2: libraries/api_tokens;
+            1.3: users).
         app_version:
           type: string
           description: Application version that produced the export.
@@ -223,10 +222,65 @@ components:
           type: object
           description: |
             Plaintext per-section row counts for sanity-checking without
-            decryption. Same shape as the import response, so the same fields
-            cover both export-side ("rows packed") and import-side
-            ("rows applied") semantics.
-          required: [settings, connections, platform_profiles, webhooks, provider_keys, priorities, rules, scraper_configs, user_preferences]
+            decryption. Optional on import: legacy envelopes pre-1.2 do not
+            carry libraries/api_tokens/users counters, so all section fields
+            are optional here. The export-side schema is the strict counterpart.
+          properties:
+            settings: { type: integer }
+            connections: { type: integer }
+            platform_profiles: { type: integer }
+            webhooks: { type: integer }
+            provider_keys: { type: integer }
+            priorities: { type: integer }
+            rules: { type: integer }
+            scraper_configs: { type: integer }
+            user_preferences: { type: integer }
+            libraries: { type: integer }
+            libraries_skipped: { type: integer }
+            api_tokens: { type: integer }
+            api_tokens_skipped: { type: integer }
+            users_imported: { type: integer }
+            ownership_reassigned: { type: integer }
+    PortableSettingsEnvelopeExport:
+      type: object
+      description: |
+        Export-side wrapper produced by the current writer (envelope version
+        1.3). Strict shape: every counter the writer emits is marked required
+        so generated clients can rely on the field's presence without
+        defensive null checks. The import-side schema is the permissive
+        counterpart that accepts older envelope versions.
+      required: [version, app_version, created_at, salt, data, summary]
+      properties:
+        version:
+          type: string
+          description: |
+            Envelope format version. Current writer emits `1.3`. Each minor
+            bump adds optional fields without breaking older readers (1.1:
+            rules/scraper_configs/user_preferences; 1.2: libraries/api_tokens;
+            1.3: users).
+        app_version:
+          type: string
+          description: Application version that produced the export.
+        created_at:
+          type: string
+          format: date-time
+          description: When the export was created (UTC, RFC 3339).
+        salt:
+          type: string
+          description: Base64-encoded PBKDF2 salt used to derive the symmetric key from the passphrase.
+        data:
+          type: string
+          description: Base64-encoded ciphertext (nonce + AES-GCM payload) of the inner Payload struct.
+        summary:
+          type: object
+          description: |
+            Plaintext per-section row counts for sanity-checking without
+            decryption. All counters the current writer emits are required.
+          required:
+            [settings, connections, platform_profiles, webhooks, provider_keys, priorities,
+             rules, scraper_configs, user_preferences,
+             libraries, libraries_skipped, api_tokens, api_tokens_skipped,
+             users_imported, ownership_reassigned]
           properties:
             settings:
               type: integer
@@ -8245,7 +8299,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PortableSettingsEnvelope"
+                $ref: "#/components/schemas/PortableSettingsEnvelopeExport"
         "400":
           description: Missing passphrase
           content:
@@ -8280,7 +8334,7 @@ paths:
                 passphrase:
                   type: string
                 envelope:
-                  $ref: "#/components/schemas/PortableSettingsEnvelope"
+                  $ref: "#/components/schemas/PortableSettingsEnvelopeImport"
                 admin_fallback_tokens:
                   type: boolean
                   description: Opt-in. When true, API tokens whose original owner is absent on the target after the envelope's Users block has been applied are reassigned to the importing admin instead of skipped. The reassignment count surfaces in the response under ownership_reassigned.

--- a/internal/settingsio/export.go
+++ b/internal/settingsio/export.go
@@ -448,6 +448,13 @@ func (s *Service) Import(ctx context.Context, env *Envelope, passphrase string) 
 // ImportWithOptions decrypts and applies settings from an Envelope, honoring
 // the supplied ImportOptions. See ImportOptions for the available knobs.
 func (s *Service) ImportWithOptions(ctx context.Context, env *Envelope, passphrase string, opts ImportOptions) (*ImportResult, error) {
+	// Reject nil envelope before touching any field. The HTTP handler is the
+	// only documented caller and constructs env from a decoded JSON body, but
+	// the receiver is exported and a nil pass would otherwise panic in the
+	// middle of the import path -- worse than a clean 400.
+	if env == nil {
+		return nil, fmt.Errorf("nil envelope")
+	}
 	if env.Data == "" {
 		return nil, fmt.Errorf("empty export data")
 	}

--- a/internal/settingsio/export.go
+++ b/internal/settingsio/export.go
@@ -35,7 +35,11 @@ const pbkdf2Iterations = 600_000
 //   - "1.1": adds rules, scraper_configs, user_preferences, plaintext summary
 //   - "1.2": adds libraries (connection refs remapped by type+url) and api_tokens
 //     (token_hash + metadata only; never plaintext)
-const CurrentEnvelopeVersion = "1.2"
+//   - "1.3": adds users block so cross-instance restore can recreate absent
+//     owners before remapping api_tokens / user_preferences (#1283). The
+//     password_hash inside Users is a bcrypt digest -- never plaintext --
+//     and only crosses the wire inside the passphrase-encrypted envelope.
+const CurrentEnvelopeVersion = "1.3"
 
 // supportedEnvelopeVersions lists the envelope versions Import will accept.
 // Older versions are accepted for backward compatibility (their newer fields
@@ -44,6 +48,7 @@ var supportedEnvelopeVersions = map[string]bool{
 	"1.0": true,
 	"1.1": true,
 	"1.2": true,
+	"1.3": true,
 }
 
 // ErrWrongPassphrase is returned by Import when the AES-GCM tag verification
@@ -82,6 +87,7 @@ type Payload struct {
 	UserPreferences    []UserPrefsExport     `json:"user_preferences,omitempty"`
 	Libraries          []LibraryExport       `json:"libraries,omitempty"`
 	APITokens          []APITokenExport      `json:"api_tokens,omitempty"`
+	Users              []UserExport          `json:"users,omitempty"`
 }
 
 // ConnectionExport is a connection with its API key decrypted for export.
@@ -149,6 +155,38 @@ type ImportResult struct {
 	LibrariesSkipped int `json:"libraries_skipped,omitempty"`
 	APITokens        int `json:"api_tokens"`
 	APITokensSkipped int `json:"api_tokens_skipped,omitempty"`
+	// UsersImported counts user rows recreated from the envelope on import
+	// because they were absent on the target instance (#1283). Users that
+	// already existed on the target are NOT counted -- their rows are left
+	// untouched so the operator's local setup wins over the envelope.
+	UsersImported int `json:"users_imported,omitempty"`
+	// OwnershipReassigned counts api_tokens whose original owner is absent
+	// on the target AND who were attributed to the importing admin via the
+	// admin-fallback opt-in. This is a deliberate ownership change and is
+	// surfaced in the result so it cannot be silent (#1283).
+	OwnershipReassigned int `json:"ownership_reassigned,omitempty"`
+}
+
+// ImportOptions controls optional behaviors at import time. The zero value
+// reproduces the historical behavior: tokens whose owning username is absent
+// on the target are skipped (their count surfaces via APITokensSkipped) and
+// no automatic ownership reassignment occurs.
+type ImportOptions struct {
+	// AdminFallbackTokens, when true, attributes api_tokens whose original
+	// username remains absent on the target (after the envelope's Users
+	// block has been applied) to ImportingAdminUserID. Each reassignment
+	// increments ImportResult.OwnershipReassigned so the audit is visible
+	// to the operator.
+	//
+	// This is opt-in because silent ownership reassignment surprises
+	// operators who rely on the historical "skip unknown owner" semantics
+	// for cross-environment exports (e.g. prod -> staging clones).
+	AdminFallbackTokens bool
+
+	// ImportingAdminUserID is the user_id to attribute reassigned tokens to
+	// when AdminFallbackTokens is true. The HTTP handler resolves it from
+	// the authenticated session before calling ImportWithOptions.
+	ImportingAdminUserID string
 }
 
 // Service handles settings export and import.
@@ -343,6 +381,18 @@ func (s *Service) Export(ctx context.Context, passphrase string) (*Envelope, err
 	}
 	payload.APITokens = tokens
 
+	// Collect users so the import side can recreate any owner that is
+	// absent on the target instance, before remapping api_tokens and
+	// user_preferences (#1283). Without this, a backup whose admin had a
+	// different username than the target's admin would silently lose every
+	// API token. Users that already exist on the target are NOT modified
+	// on import; this block is restore data, not authoritative state.
+	users, err := s.exportUsers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("exporting users: %w", err)
+	}
+	payload.Users = users
+
 	// Marshal and encrypt payload
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -374,6 +424,11 @@ func (s *Service) Export(ctx context.Context, passphrase string) (*Envelope, err
 			UserPreferences: countUserPreferences(payload.UserPreferences),
 			Libraries:       len(payload.Libraries),
 			APITokens:       len(payload.APITokens),
+			// UsersImported in the export Summary reports the count of user
+			// rows the envelope is carrying (not yet imported). The import
+			// path increments this same field with the count of users
+			// actually inserted on the target.
+			UsersImported: len(payload.Users),
 		},
 	}
 
@@ -382,7 +437,17 @@ func (s *Service) Export(ctx context.Context, passphrase string) (*Envelope, err
 
 // Import decrypts and applies settings from an Envelope using the given
 // passphrase. The passphrase must match the one used during export.
+//
+// This is a thin wrapper around ImportWithOptions that preserves the
+// historical default (no admin-fallback for token ownership). New callers
+// that need to opt into admin-fallback should call ImportWithOptions directly.
 func (s *Service) Import(ctx context.Context, env *Envelope, passphrase string) (*ImportResult, error) {
+	return s.ImportWithOptions(ctx, env, passphrase, ImportOptions{})
+}
+
+// ImportWithOptions decrypts and applies settings from an Envelope, honoring
+// the supplied ImportOptions. See ImportOptions for the available knobs.
+func (s *Service) ImportWithOptions(ctx context.Context, env *Envelope, passphrase string, opts ImportOptions) (*ImportResult, error) {
 	if env.Data == "" {
 		return nil, fmt.Errorf("empty export data")
 	}
@@ -583,6 +648,15 @@ func (s *Service) Import(ctx context.Context, env *Envelope, passphrase string) 
 		}
 	}
 
+	// Import users from the envelope FIRST (before user_preferences and
+	// api_tokens) so absent owners are recreated and their downstream rows
+	// can attribute back to them via the username -> user_id lookup. Users
+	// that already exist on the target are left untouched; the operator's
+	// existing setup wins over the envelope (#1283).
+	if err := s.importUsers(ctx, payload.Users, result); err != nil {
+		return nil, fmt.Errorf("importing users: %w", err)
+	}
+
 	// Import user preferences. Preferences are matched by username; rows for users
 	// that do not exist on this instance are silently skipped.
 	if err := s.importUserPreferences(ctx, payload.UserPreferences, result); err != nil {
@@ -595,9 +669,12 @@ func (s *Service) Import(ctx context.Context, env *Envelope, passphrase string) 
 		return nil, fmt.Errorf("importing libraries: %w", err)
 	}
 
-	// Import API tokens. Must run AFTER user_preferences so the username ->
-	// user_id lookup sees the final user set on the target instance.
-	if err := s.importAPITokens(ctx, payload.APITokens, result); err != nil {
+	// Import API tokens. Must run AFTER importUsers so the username ->
+	// user_id lookup sees the final user set on the target instance,
+	// including any users just recreated from the envelope. The opts
+	// parameter controls the admin-fallback opt-in behavior for tokens
+	// whose original owner is still absent after user import.
+	if err := s.importAPITokens(ctx, payload.APITokens, result, opts); err != nil {
 		return nil, fmt.Errorf("importing api tokens: %w", err)
 	}
 

--- a/internal/settingsio/export.go
+++ b/internal/settingsio/export.go
@@ -459,6 +459,16 @@ func (s *Service) ImportWithOptions(ctx context.Context, env *Envelope, passphra
 		return nil, fmt.Errorf("empty export data")
 	}
 
+	// Reject misconfigured admin-fallback up front. The HTTP handler resolves
+	// ImportingAdminUserID from the session, so an empty value here means the
+	// caller asked for fallback but supplied no fallback target. Silently
+	// dropping every orphan token (the prior behavior) hides the misconfig
+	// behind an APITokensSkipped count; failing fast surfaces it as the
+	// configuration error it is.
+	if opts.AdminFallbackTokens && opts.ImportingAdminUserID == "" {
+		return nil, fmt.Errorf("admin_fallback_tokens=true requires a non-empty ImportingAdminUserID")
+	}
+
 	// Reject envelope formats this binary does not understand. An empty Version
 	// is treated as legacy "1.0" so older exports without an explicit field
 	// continue to import.

--- a/internal/settingsio/export_authprovider_test.go
+++ b/internal/settingsio/export_authprovider_test.go
@@ -1,0 +1,186 @@
+package settingsio
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// canonicalAuthKeys mirrors authProviderDefaults from internal/api but is
+// expressed here as the test contract: every auth.providers.* setting that
+// the Settings > Auth Providers UI reads MUST round-trip through
+// Export -> wipe -> Import unchanged. The list is deliberately duplicated
+// here (rather than imported from internal/api) because a regression that
+// drops a key from the seed list AND the test list at the same time would
+// be invisible -- duplicating the contract makes drift loud.
+var canonicalAuthKeys = []string{
+	"auth.providers.local.enabled",
+	"auth.providers.emby.enabled",
+	"auth.providers.emby.auto_provision",
+	"auth.providers.emby.guard_rail",
+	"auth.providers.emby.default_role",
+	"auth.providers.jellyfin.enabled",
+	"auth.providers.jellyfin.auto_provision",
+	"auth.providers.jellyfin.guard_rail",
+	"auth.providers.jellyfin.default_role",
+	"auth.providers.oidc.enabled",
+	"auth.providers.oidc.auto_provision",
+	"auth.providers.oidc.default_role",
+}
+
+// nonDefaultValue returns a value for the given canonical auth key that is
+// guaranteed to differ from the code default. The mapping mirrors the UI's
+// "the other allowed value" for each key.
+func nonDefaultValue(key string) string {
+	switch key {
+	case "auth.providers.local.enabled",
+		"auth.providers.emby.enabled",
+		"auth.providers.emby.auto_provision",
+		"auth.providers.jellyfin.enabled",
+		"auth.providers.jellyfin.auto_provision",
+		"auth.providers.oidc.enabled",
+		"auth.providers.oidc.auto_provision":
+		// Booleans default to "true" or "false"; flip to the opposite.
+		// local.enabled defaults to true; everything else defaults to false.
+		if key == "auth.providers.local.enabled" {
+			return "false"
+		}
+		return "true"
+	case "auth.providers.emby.guard_rail",
+		"auth.providers.jellyfin.guard_rail":
+		return "any_user"
+	case "auth.providers.emby.default_role",
+		"auth.providers.jellyfin.default_role",
+		"auth.providers.oidc.default_role":
+		return "administrator"
+	}
+	return "non-default"
+}
+
+// TestRoundTrip_AuthProviderKeys_NonDefaults seeds every canonical
+// auth.providers.* key on the source instance with a non-default value,
+// runs Export -> Import on a fresh target, and asserts the value on
+// target equals the value on source. This is the regression test for
+// #1188: the user-reported symptom was Default role flipping from
+// Operator to Administrator after restore; the harness here pins every
+// key so a future regression is caught at the contract level rather than
+// per-key.
+func TestRoundTrip_AuthProviderKeys_NonDefaults(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+
+	// Seed each canonical key with its non-default value directly via the
+	// settings KV table. This simulates a user who actually fired the
+	// onchange handler and persisted a row.
+	now := time.Now().UTC().Format(time.RFC3339)
+	want := make(map[string]string, len(canonicalAuthKeys))
+	for _, key := range canonicalAuthKeys {
+		v := nonDefaultValue(key)
+		want[key] = v
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
+			 ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+			key, v, now); err != nil {
+			t.Fatalf("seeding %s: %v", key, err)
+		}
+	}
+
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+	envelope, err := svc.Export(ctx, "test-passphrase")
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	// Fresh target instance with an empty settings table.
+	db2 := setupTestDB(t)
+	provSettings2, connSvc2, platSvc2, whSvc2 := newTestServices(t, db2)
+	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2)
+	if _, err := svc2.Import(ctx, envelope, "test-passphrase"); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	for _, key := range canonicalAuthKeys {
+		var got string
+		if err := db2.QueryRowContext(ctx,
+			`SELECT value FROM settings WHERE key = ?`, key).Scan(&got); err != nil {
+			t.Fatalf("reading %s on target: %v", key, err)
+		}
+		if got != want[key] {
+			t.Errorf("key %s: got %q, want %q", key, got, want[key])
+		}
+	}
+}
+
+// TestRoundTrip_AuthProviderKeys_SeededDefaults verifies that, when the
+// source instance has had its defaults seeded (the seedAuthProviderDefaults
+// call from the Settings page render), every canonical key has a real row
+// to export, even if no user has touched the UI since first install.
+//
+// This pins the #1188 root-cause fix: pre-fix, a value matching the code
+// default never had a row, so the export carried nothing for that key.
+// Post-fix, the seed writes a row with the default value on first render,
+// so the export carries a copy of the default that import faithfully
+// re-applies on the target.
+func TestRoundTrip_AuthProviderKeys_SeededDefaults(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+
+	// Simulate the page-render seed: insert the canonical defaults via
+	// INSERT OR IGNORE. We hard-code the expected default values here
+	// (not re-imported from internal/api) so a drift between this test
+	// and the live seed list is loud rather than silent.
+	defaults := map[string]string{
+		"auth.providers.local.enabled":           "true",
+		"auth.providers.emby.enabled":            "false",
+		"auth.providers.emby.auto_provision":     "false",
+		"auth.providers.emby.guard_rail":         "admin",
+		"auth.providers.emby.default_role":       "operator",
+		"auth.providers.jellyfin.enabled":        "false",
+		"auth.providers.jellyfin.auto_provision": "false",
+		"auth.providers.jellyfin.guard_rail":     "admin",
+		"auth.providers.jellyfin.default_role":   "operator",
+		"auth.providers.oidc.enabled":            "false",
+		"auth.providers.oidc.auto_provision":     "false",
+		"auth.providers.oidc.default_role":       "operator",
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	for k, v := range defaults {
+		if _, err := db.ExecContext(ctx,
+			`INSERT OR IGNORE INTO settings (key, value, updated_at) VALUES (?, ?, ?)`,
+			k, v, now); err != nil {
+			t.Fatalf("seeding default %s: %v", k, err)
+		}
+	}
+
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+	envelope, err := svc.Export(ctx, "test-passphrase")
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	db2 := setupTestDB(t)
+	provSettings2, connSvc2, platSvc2, whSvc2 := newTestServices(t, db2)
+	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2)
+	if _, err := svc2.Import(ctx, envelope, "test-passphrase"); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	// Every canonical key must have a row on target with the default
+	// value. The pre-#1188 bug manifested as "row absent on target,
+	// reader falls back to code default" -- that path is now gone.
+	for k, v := range defaults {
+		var got string
+		if err := db2.QueryRowContext(ctx,
+			`SELECT value FROM settings WHERE key = ?`, k).Scan(&got); err != nil {
+			t.Errorf("reading %s on target: %v (key may be absent -- the #1188 regression)", k, err)
+			continue
+		}
+		if got != v {
+			t.Errorf("key %s: got %q, want %q (default drift across round-trip)", k, got, v)
+		}
+	}
+}

--- a/internal/settingsio/export_authprovider_test.go
+++ b/internal/settingsio/export_authprovider_test.go
@@ -54,7 +54,11 @@ func nonDefaultValue(key string) string {
 		"auth.providers.oidc.default_role":
 		return "administrator"
 	}
-	return "non-default"
+	// Panic instead of returning a placeholder. A new entry in
+	// canonicalAuthKeys without a matching switch arm here is a test bug:
+	// the placeholder would silently equal the code default for some types,
+	// hiding the very drift this helper exists to catch.
+	panic("nonDefaultValue: unmapped canonical auth key: " + key)
 }
 
 // TestRoundTrip_AuthProviderKeys_NonDefaults seeds every canonical
@@ -146,6 +150,17 @@ func TestRoundTrip_AuthProviderKeys_SeededDefaults(t *testing.T) {
 		"auth.providers.oidc.enabled":            "false",
 		"auth.providers.oidc.auto_provision":     "false",
 		"auth.providers.oidc.default_role":       "operator",
+	}
+	// Parity guard: a new entry in canonicalAuthKeys with no matching default
+	// here would silently skip seeding for that key, masking the very drift
+	// the SeededDefaults round-trip exists to catch.
+	if len(defaults) != len(canonicalAuthKeys) {
+		t.Fatalf("defaults/canonical key count mismatch: defaults=%d canonical=%d", len(defaults), len(canonicalAuthKeys))
+	}
+	for _, k := range canonicalAuthKeys {
+		if _, ok := defaults[k]; !ok {
+			t.Fatalf("missing default for canonical auth key %q", k)
+		}
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	for k, v := range defaults {

--- a/internal/settingsio/export_test.go
+++ b/internal/settingsio/export_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -857,6 +858,26 @@ func TestImport_EmptyData(t *testing.T) {
 	_, err := svc.Import(ctx, env, "any-passphrase")
 	if err == nil {
 		t.Error("expected error for empty data")
+	}
+}
+
+// TestImport_NilEnvelope covers the explicit nil-envelope guard at the top of
+// ImportWithOptions. The HTTP handler always passes a decoded body, but the
+// function is exported so a nil pass from another caller is a real possibility;
+// failing fast prevents a partial import from panicking on env.Data.
+func TestImport_NilEnvelope(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	_, err := svc.Import(ctx, nil, "any-passphrase")
+	if err == nil {
+		t.Fatal("expected error for nil envelope, got nil")
+	}
+	if !strings.Contains(err.Error(), "nil envelope") {
+		t.Errorf("error must reference 'nil envelope'; got: %v", err)
 	}
 }
 

--- a/internal/settingsio/export_test.go
+++ b/internal/settingsio/export_test.go
@@ -925,8 +925,10 @@ func TestRoundTrip_LibrariesAndTokens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Export: %v", err)
 	}
-	if envelope.Version != "1.2" {
-		t.Errorf("envelope version: got %q, want 1.2", envelope.Version)
+	// Envelope version was bumped to 1.3 when the Users block was added
+	// (#1283). Older versions remain importable; see TestImport_LegacyEnvelopeWithoutUsers.
+	if envelope.Version != "1.3" {
+		t.Errorf("envelope version: got %q, want 1.3", envelope.Version)
 	}
 	if envelope.Summary == nil {
 		t.Fatal("expected non-nil export summary")
@@ -1048,8 +1050,16 @@ func TestRoundTrip_LibrariesAndTokens(t *testing.T) {
 	if res3.Libraries != 2 {
 		t.Errorf("target #2 libraries imported: got %d, want 2 (connection imported alongside)", res3.Libraries)
 	}
-	if res3.APITokens != 0 || res3.APITokensSkipped != 1 {
-		t.Errorf("target #2 tokens: imported=%d skipped=%d, want 0/1 (no matching user)", res3.APITokens, res3.APITokensSkipped)
+	// As of envelope v1.3 (#1283), the envelope carries its own users so
+	// target #2 recreates "tokenowner" and the token round-trips even
+	// though target #2 had no matching user pre-import. This is the whole
+	// point of the v1.3 fix; the previous "skipped=1, imported=0" assertion
+	// is what the bug looked like before the fix.
+	if res3.APITokens != 1 || res3.APITokensSkipped != 0 {
+		t.Errorf("target #2 tokens: imported=%d skipped=%d, want 1/0 (envelope users recreated owner)", res3.APITokens, res3.APITokensSkipped)
+	}
+	if res3.UsersImported < 1 {
+		t.Errorf("target #2 users imported: got %d, want >=1 (tokenowner)", res3.UsersImported)
 	}
 
 	// --- Target #3: idempotency. Re-importing into target #1 must not

--- a/internal/settingsio/tokens.go
+++ b/internal/settingsio/tokens.go
@@ -103,12 +103,21 @@ func (s *Service) importAPITokens(ctx context.Context, tokens []APITokenExport, 
 				probeErr := s.db.QueryRowContext(ctx,
 					`SELECT id FROM users WHERE id = ?`, opts.ImportingAdminUserID,
 				).Scan(&adminProbe)
-				if probeErr != nil {
+				switch {
+				case errors.Is(probeErr, sql.ErrNoRows):
+					// Genuine "admin deleted between resolution and import":
+					// skip the token, do not fail the whole import.
 					slog.Warn("import: admin-fallback configured but admin id missing on target; skipping token",
 						"token_name", te.Name, "username", te.Username,
-						"admin_id", opts.ImportingAdminUserID, "probe_error", probeErr)
+						"admin_id", opts.ImportingAdminUserID)
 					result.APITokensSkipped++
 					continue
+				case probeErr != nil:
+					// A real DB error (connectivity, locking, EIO) must not
+					// be silently swallowed as "admin missing"; that turns a
+					// transient outage into a quiet bulk-token loss. Fail
+					// fast so the operator sees the underlying cause.
+					return fmt.Errorf("probing importing admin %q for token fallback: %w", opts.ImportingAdminUserID, probeErr)
 				}
 				slog.Info("import: reassigning api token to importing admin (admin-fallback)",
 					"token_name", te.Name,

--- a/internal/settingsio/tokens.go
+++ b/internal/settingsio/tokens.go
@@ -64,10 +64,19 @@ func (s *Service) exportAPITokens(ctx context.Context) ([]APITokenExport, error)
 }
 
 // importAPITokens upserts API tokens by token_hash (which is UNIQUE in the
-// schema). The owning user is resolved by username; if no matching user
-// exists on the target instance, the token is skipped with a warning so a
-// minor user-set drift does not abort the whole import.
-func (s *Service) importAPITokens(ctx context.Context, tokens []APITokenExport, result *ImportResult) error {
+// schema). The owning user is resolved by username on the target instance.
+//
+// Resolution order (#1283):
+//  1. Username found on target (either pre-existing OR just recreated from
+//     the envelope's Users block) -> token attributes back to that user.
+//  2. Username absent AND opts.AdminFallbackTokens=true -> token is
+//     attributed to opts.ImportingAdminUserID and OwnershipReassigned is
+//     incremented in the result so the operator can see the audit count.
+//  3. Username absent AND admin-fallback is off (the historical default) ->
+//     token is skipped and APITokensSkipped is incremented; this preserves
+//     the prior behavior for callers that prefer a quiet skip over a silent
+//     ownership change (e.g. prod->staging clones).
+func (s *Service) importAPITokens(ctx context.Context, tokens []APITokenExport, result *ImportResult, opts ImportOptions) error {
 	for _, te := range tokens {
 		if te.TokenHash == "" {
 			// A blank hash cannot satisfy authentication and would collide
@@ -82,12 +91,38 @@ func (s *Service) importAPITokens(ctx context.Context, tokens []APITokenExport, 
 		err := s.db.QueryRowContext(ctx,
 			`SELECT id FROM users WHERE username = ?`, te.Username,
 		).Scan(&userID)
-		if errors.Is(err, sql.ErrNoRows) {
-			slog.Warn("import: skipping api token whose owner is absent on target",
-				"token_name", te.Name, "username", te.Username)
-			result.APITokensSkipped++
-			continue
-		} else if err != nil {
+		switch {
+		case err == nil:
+			// Owner found (pre-existing or just recreated from envelope).
+		case errors.Is(err, sql.ErrNoRows):
+			if opts.AdminFallbackTokens && opts.ImportingAdminUserID != "" {
+				// Verify the importing admin still exists on the target.
+				// A tampered or stale opt would otherwise insert a token
+				// with a dangling user_id FK.
+				var adminProbe string
+				probeErr := s.db.QueryRowContext(ctx,
+					`SELECT id FROM users WHERE id = ?`, opts.ImportingAdminUserID,
+				).Scan(&adminProbe)
+				if probeErr != nil {
+					slog.Warn("import: admin-fallback configured but admin id missing on target; skipping token",
+						"token_name", te.Name, "username", te.Username,
+						"admin_id", opts.ImportingAdminUserID, "probe_error", probeErr)
+					result.APITokensSkipped++
+					continue
+				}
+				slog.Info("import: reassigning api token to importing admin (admin-fallback)",
+					"token_name", te.Name,
+					"original_username", te.Username,
+					"new_owner_id", opts.ImportingAdminUserID)
+				userID = opts.ImportingAdminUserID
+				result.OwnershipReassigned++
+			} else {
+				slog.Warn("import: skipping api token whose owner is absent on target",
+					"token_name", te.Name, "username", te.Username)
+				result.APITokensSkipped++
+				continue
+			}
+		default:
 			return fmt.Errorf("looking up user %q for token %q: %w", te.Username, te.Name, err)
 		}
 

--- a/internal/settingsio/tokens_test.go
+++ b/internal/settingsio/tokens_test.go
@@ -3,6 +3,7 @@ package settingsio
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -203,6 +204,35 @@ func TestImport_CrossInstance_FallbackOff_NoUsers(t *testing.T) {
 	}
 	if res.OwnershipReassigned != 0 {
 		t.Errorf("ownership reassigned: got %d, want 0", res.OwnershipReassigned)
+	}
+}
+
+// TestImport_AdminFallback_RejectsEmptyAdminID checks that the import path
+// fails fast when admin-fallback is enabled but ImportingAdminUserID is
+// empty. The prior behavior silently routed every orphan token through the
+// owner-absent skip branch, hiding the misconfiguration behind an
+// APITokensSkipped count instead of surfacing it as a configuration error.
+func TestImport_AdminFallback_RejectsEmptyAdminID(t *testing.T) {
+	hash := "bcrypt-token-hash-empty-admin"
+	srcSvc, ctx := seedTokenSource(t, hash)
+	envelope, err := srcSvc.Export(ctx, "pp")
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	db2 := setupTestDB(t)
+	provSettings2, connSvc2, platSvc2, whSvc2 := newTestServices(t, db2)
+	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2)
+
+	_, err = svc2.ImportWithOptions(ctx, envelope, "pp", ImportOptions{
+		AdminFallbackTokens:  true,
+		ImportingAdminUserID: "",
+	})
+	if err == nil {
+		t.Fatal("expected error for AdminFallbackTokens=true with empty ImportingAdminUserID, got nil")
+	}
+	if !strings.Contains(err.Error(), "ImportingAdminUserID") {
+		t.Errorf("error must reference ImportingAdminUserID; got: %v", err)
 	}
 }
 

--- a/internal/settingsio/tokens_test.go
+++ b/internal/settingsio/tokens_test.go
@@ -1,0 +1,268 @@
+package settingsio
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// reencodePassphrase is the fixed passphrase used by every test in this
+// file. Threading it through mustReencodeWithoutUsers as a parameter
+// would be more flexible but unparam flags the duplication; a package-
+// level constant keeps the call sites short and the linter happy.
+const reencodePassphrase = "pp"
+
+// mustReencodeWithoutUsers strips the Users block from an envelope and
+// re-encrypts the payload so the modified envelope still decrypts. This
+// simulates either a legacy v1.2 envelope or an export from a binary that
+// has no Users awareness.
+func mustReencodeWithoutUsers(t *testing.T, env *Envelope) *Envelope {
+	t.Helper()
+	plaintext, err := decryptWithPassphrase(env.Data, env.Salt, reencodePassphrase)
+	if err != nil {
+		t.Fatalf("mustReencodeWithoutUsers: decrypt: %v", err)
+	}
+	var p Payload
+	if err := json.Unmarshal(plaintext, &p); err != nil {
+		t.Fatalf("mustReencodeWithoutUsers: unmarshal: %v", err)
+	}
+	p.Users = nil
+	out, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("mustReencodeWithoutUsers: marshal: %v", err)
+	}
+	data, salt, err := encryptWithPassphrase(out, reencodePassphrase)
+	if err != nil {
+		t.Fatalf("mustReencodeWithoutUsers: encrypt: %v", err)
+	}
+	env.Data = data
+	env.Salt = salt
+	return env
+}
+
+// seedTokenSource builds a "source" instance that has user "alice" with an
+// API token whose hash is `hash`. The function returns the source service
+// + the underlying DB so callers can extend the seed.
+func seedTokenSource(t *testing.T, hash string) (*Service, context.Context) {
+	t.Helper()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO users (id, username, password_hash, role, auth_provider, is_active, created_at, updated_at)
+		VALUES ('u-alice', 'alice', 'bcrypt-hash-stub', 'administrator', 'local', 1, ?, ?)
+	`, now, now); err != nil {
+		t.Fatalf("seeding source user: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO api_tokens (id, name, token_hash, scopes, user_id, created_at, status)
+		VALUES ('t-alice-1', 'Alice Token', ?, 'read,write', 'u-alice', ?, 'active')
+	`, hash, now); err != nil {
+		t.Fatalf("seeding source token: %v", err)
+	}
+
+	return NewService(db, provSettings, connSvc, platSvc, whSvc), ctx
+}
+
+// TestImport_CrossInstance_RecreatesAbsentUser_ForToken pins the #1283
+// happy path: instance B had never heard of "alice", but the envelope
+// from instance A carries her user record; on import, B recreates alice
+// and her token round-trips with the user_id remap into the new local id.
+func TestImport_CrossInstance_RecreatesAbsentUser_ForToken(t *testing.T) {
+	hash := "bcrypt-token-hash-cross-instance"
+	srcSvc, ctx := seedTokenSource(t, hash)
+
+	envelope, err := srcSvc.Export(ctx, "pp")
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	// Target B: NO alice user exists locally pre-import.
+	db2 := setupTestDB(t)
+	provSettings2, connSvc2, platSvc2, whSvc2 := newTestServices(t, db2)
+	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2)
+
+	res, err := svc2.Import(ctx, envelope, "pp")
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	// The token MUST have been imported (not skipped). Pre-#1283 this
+	// would have been APITokensSkipped=1, APITokens=0.
+	if res.APITokens != 1 || res.APITokensSkipped != 0 {
+		t.Errorf("tokens: got imported=%d skipped=%d, want 1/0", res.APITokens, res.APITokensSkipped)
+	}
+	// Alice must have been recreated on target.
+	if res.UsersImported < 1 {
+		t.Errorf("users imported: got %d, want >=1", res.UsersImported)
+	}
+	if res.OwnershipReassigned != 0 {
+		t.Errorf("ownership reassigned: got %d, want 0 (envelope carried user, no fallback needed)", res.OwnershipReassigned)
+	}
+
+	// The token must be attributed to the freshly-recreated alice on target.
+	var aliceID, tokenUserID string
+	if err := db2.QueryRowContext(ctx,
+		`SELECT id FROM users WHERE username = 'alice'`).Scan(&aliceID); err != nil {
+		t.Fatalf("looking up alice on target: %v", err)
+	}
+	if err := db2.QueryRowContext(ctx,
+		`SELECT user_id FROM api_tokens WHERE token_hash = ?`, hash).Scan(&tokenUserID); err != nil {
+		t.Fatalf("looking up token user_id: %v", err)
+	}
+	if tokenUserID != aliceID {
+		t.Errorf("token user_id: got %q, want %q (alice's new id)", tokenUserID, aliceID)
+	}
+}
+
+// TestImport_CrossInstance_AdminFallback_NoUsersInEnvelope pins the
+// admin-fallback path: the envelope is synthesized to look like a v1.2
+// payload (no Users block), and the target opts into AdminFallbackTokens.
+// Alice's token reassigns to the importing admin and OwnershipReassigned
+// is incremented exactly once.
+func TestImport_CrossInstance_AdminFallback_NoUsersInEnvelope(t *testing.T) {
+	hash := "bcrypt-token-hash-admin-fallback"
+	srcSvc, ctx := seedTokenSource(t, hash)
+
+	envelope, err := srcSvc.Export(ctx, "pp")
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	// Strip the envelope's Users block to simulate either a legacy v1.2
+	// envelope or an operator who deliberately wants admin-fallback. We
+	// re-encrypt the trimmed payload with the same passphrase so the
+	// envelope still decrypts on import.
+	envelope = mustReencodeWithoutUsers(t, envelope)
+
+	// Target: admin user exists locally; alice does NOT.
+	db2 := setupTestDB(t)
+	provSettings2, connSvc2, platSvc2, whSvc2 := newTestServices(t, db2)
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db2.ExecContext(ctx, `
+		INSERT INTO users (id, username, password_hash, role, auth_provider, is_active, created_at, updated_at)
+		VALUES ('u-target-admin', 'admin-b', 'bcrypt-hash-stub', 'administrator', 'local', 1, ?, ?)
+	`, now, now); err != nil {
+		t.Fatalf("seeding target admin: %v", err)
+	}
+	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2)
+
+	res, err := svc2.ImportWithOptions(ctx, envelope, "pp", ImportOptions{
+		AdminFallbackTokens:  true,
+		ImportingAdminUserID: "u-target-admin",
+	})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	if res.APITokens != 1 || res.APITokensSkipped != 0 {
+		t.Errorf("tokens: got imported=%d skipped=%d, want 1/0", res.APITokens, res.APITokensSkipped)
+	}
+	if res.OwnershipReassigned != 1 {
+		t.Errorf("ownership reassigned: got %d, want 1", res.OwnershipReassigned)
+	}
+
+	// The token's user_id must be the importing admin, not alice's old id.
+	var tokenUserID string
+	if err := db2.QueryRowContext(ctx,
+		`SELECT user_id FROM api_tokens WHERE token_hash = ?`, hash).Scan(&tokenUserID); err != nil {
+		t.Fatalf("looking up token user_id: %v", err)
+	}
+	if tokenUserID != "u-target-admin" {
+		t.Errorf("reassigned user_id: got %q, want u-target-admin", tokenUserID)
+	}
+}
+
+// TestImport_CrossInstance_FallbackOff_NoUsers preserves the historical
+// skip semantics: with admin-fallback off and no Users block, alice's
+// token is silently skipped (APITokensSkipped=1) just as it was pre-#1283.
+// This guards against an accidental default-on rollout.
+func TestImport_CrossInstance_FallbackOff_NoUsers(t *testing.T) {
+	hash := "bcrypt-token-hash-fallback-off"
+	srcSvc, ctx := seedTokenSource(t, hash)
+
+	envelope, err := srcSvc.Export(ctx, "pp")
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	envelope = mustReencodeWithoutUsers(t, envelope)
+
+	db2 := setupTestDB(t)
+	provSettings2, connSvc2, platSvc2, whSvc2 := newTestServices(t, db2)
+	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2)
+
+	// Default Import (no opts) must skip the token.
+	res, err := svc2.Import(ctx, envelope, "pp")
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.APITokens != 0 || res.APITokensSkipped != 1 {
+		t.Errorf("tokens: got imported=%d skipped=%d, want 0/1", res.APITokens, res.APITokensSkipped)
+	}
+	if res.OwnershipReassigned != 0 {
+		t.Errorf("ownership reassigned: got %d, want 0", res.OwnershipReassigned)
+	}
+}
+
+// TestImport_AdminFallback_RejectsBogusAdminID guards the FK integrity:
+// even when admin-fallback is requested, an ImportingAdminUserID that
+// does not exist on the target must NOT result in a token row with a
+// dangling user_id. The token is skipped instead.
+func TestImport_AdminFallback_RejectsBogusAdminID(t *testing.T) {
+	hash := "bcrypt-token-hash-bogus-admin"
+	srcSvc, ctx := seedTokenSource(t, hash)
+	envelope, err := srcSvc.Export(ctx, "pp")
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	envelope = mustReencodeWithoutUsers(t, envelope)
+
+	db2 := setupTestDB(t)
+	provSettings2, connSvc2, platSvc2, whSvc2 := newTestServices(t, db2)
+	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2)
+
+	res, err := svc2.ImportWithOptions(ctx, envelope, "pp", ImportOptions{
+		AdminFallbackTokens:  true,
+		ImportingAdminUserID: "does-not-exist",
+	})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.APITokens != 0 || res.APITokensSkipped != 1 {
+		t.Errorf("tokens: got imported=%d skipped=%d, want 0/1 (bogus admin id must skip)", res.APITokens, res.APITokensSkipped)
+	}
+	if res.OwnershipReassigned != 0 {
+		t.Errorf("ownership reassigned: got %d, want 0", res.OwnershipReassigned)
+	}
+}
+
+// TestImport_LegacyEnvelopeWithoutUsers verifies a synthesized v1.2
+// envelope (lacking Users) still imports under default options: tokens
+// for absent owners skip, like before.
+func TestImport_LegacyEnvelopeWithoutUsers(t *testing.T) {
+	hash := "legacy-envelope-hash"
+	srcSvc, ctx := seedTokenSource(t, hash)
+	envelope, err := srcSvc.Export(ctx, "pp")
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	envelope = mustReencodeWithoutUsers(t, envelope)
+	envelope.Version = "1.2"
+
+	db2 := setupTestDB(t)
+	provSettings2, connSvc2, platSvc2, whSvc2 := newTestServices(t, db2)
+	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2)
+
+	res, err := svc2.Import(ctx, envelope, "pp")
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if res.APITokensSkipped != 1 {
+		t.Errorf("legacy envelope: got skipped=%d, want 1", res.APITokensSkipped)
+	}
+	if res.UsersImported != 0 {
+		t.Errorf("legacy envelope: got users_imported=%d, want 0", res.UsersImported)
+	}
+}

--- a/internal/settingsio/users.go
+++ b/internal/settingsio/users.go
@@ -14,7 +14,6 @@ package settingsio
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -93,29 +92,18 @@ func (s *Service) importUsers(ctx context.Context, users []UserExport, result *I
 	if len(users) == 0 {
 		return nil
 	}
+	if result == nil {
+		// Counter writes below dereference result unconditionally; reject a
+		// nil caller up front rather than panicking partway through the
+		// import (which would leave the DB in a partially-applied state).
+		return errors.New("importUsers requires non-nil ImportResult")
+	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, u := range users {
 		if u.Username == "" {
 			slog.Warn("import: skipping user with empty username")
 			continue
 		}
-		// Probe for existing row first. We do not UPDATE on conflict because
-		// overwriting the operator's password_hash or role with the source
-		// instance's older snapshot is far worse than leaving the target's
-		// row alone; the only data loss case (user does not exist on target)
-		// is what this import path is designed to fix.
-		var existingID string
-		err := s.db.QueryRowContext(ctx,
-			`SELECT id FROM users WHERE username = ?`, u.Username,
-		).Scan(&existingID)
-		if err == nil {
-			// Already exists: keep target's row; do not overwrite.
-			continue
-		}
-		if !errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("looking up user %q: %w", u.Username, err)
-		}
-
 		role := u.Role
 		if role != "administrator" && role != "operator" && role != "admin" {
 			// Unknown role -- coerce to operator (least privilege). Auth
@@ -136,8 +124,16 @@ func (s *Service) importUsers(ctx context.Context, users []UserExport, result *I
 			createdAt = now
 		}
 		id := uuid.New().String()
-		if _, err := s.db.ExecContext(ctx, `
-			INSERT INTO users (
+		// INSERT OR IGNORE: a probe-then-insert flow would race against a
+		// concurrent import or interactive create on the same username,
+		// failing the whole import with a UNIQUE-violation when the
+		// intended semantic is "if the row already exists, leave it
+		// alone." The IGNORE branch matches the prior probe behavior
+		// (do not overwrite the operator's password_hash or role), and
+		// gating UsersImported++ on RowsAffected() == 1 keeps the audit
+		// counter honest when a concurrent insert wins the race.
+		res, err := s.db.ExecContext(ctx, `
+			INSERT OR IGNORE INTO users (
 				id, username, display_name, password_hash, role,
 				auth_provider, provider_id, is_active, is_protected,
 				invited_by, created_at, updated_at
@@ -146,10 +142,17 @@ func (s *Service) importUsers(ctx context.Context, users []UserExport, result *I
 			id, u.Username, u.DisplayName, u.PasswordHash, role,
 			authProvider, u.ProviderID, isActive,
 			createdAt, now,
-		); err != nil {
+		)
+		if err != nil {
 			return fmt.Errorf("inserting user %q: %w", u.Username, err)
 		}
-		result.UsersImported++
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("reading insert result for user %q: %w", u.Username, err)
+		}
+		if affected == 1 {
+			result.UsersImported++
+		}
 	}
 	return nil
 }

--- a/internal/settingsio/users.go
+++ b/internal/settingsio/users.go
@@ -1,0 +1,155 @@
+// Package settingsio: cross-instance user export/import.
+//
+// Users are exported by username (the only key that is portable across
+// instances; ids are uuid-per-instance). On import, users that already exist
+// on the target are left untouched -- the operator's existing setup wins
+// over the envelope. Users absent on the target are recreated so that
+// downstream rows (api tokens, user preferences) can attribute back to them
+// without a fallback.
+//
+// This file lives alongside tokens.go and libraries.go to keep the per-domain
+// export/import helpers physically together; the dispatch from Service.Export /
+// Service.Import is in export.go.
+package settingsio
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// UserExport carries a single user row in a form portable across instances.
+// Internal ids (id, invited_by) are intentionally omitted because they are
+// regenerated per-instance; downstream rows (api_tokens, user_preferences)
+// remap by username instead.
+//
+// PasswordHash is preserved for local-auth users so credentials survive a
+// restore. The hash is a bcrypt digest, never plaintext, and it only crosses
+// the wire inside the passphrase-encrypted envelope. Federated-only users
+// have an empty hash (their schema row already stores ”).
+type UserExport struct {
+	Username     string `json:"username"`
+	DisplayName  string `json:"display_name,omitempty"`
+	PasswordHash string `json:"password_hash,omitempty"`
+	Role         string `json:"role"`
+	AuthProvider string `json:"auth_provider,omitempty"`
+	ProviderID   string `json:"provider_id,omitempty"`
+	IsActive     bool   `json:"is_active"`
+	IsProtected  bool   `json:"is_protected,omitempty"`
+	CreatedAt    string `json:"created_at"`
+}
+
+// exportUsers reads every users row in a form portable across instances.
+// The bootstrap admin row is included in the dump but its is_protected flag
+// is preserved; on import the target's existing protected row is what
+// survives because import skips users whose username already exists.
+func (s *Service) exportUsers(ctx context.Context) ([]UserExport, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT username, display_name, password_hash, role, auth_provider,
+		       provider_id, is_active, is_protected, created_at
+		FROM users
+		ORDER BY created_at, username
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("querying users: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	var out []UserExport
+	for rows.Next() {
+		var row UserExport
+		var isActive, isProtected int
+		if err := rows.Scan(
+			&row.Username, &row.DisplayName, &row.PasswordHash, &row.Role,
+			&row.AuthProvider, &row.ProviderID, &isActive, &isProtected, &row.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scanning user row: %w", err)
+		}
+		row.IsActive = isActive != 0
+		row.IsProtected = isProtected != 0
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating user rows: %w", err)
+	}
+	return out, nil
+}
+
+// importUsers inserts users from the envelope that are absent on the target,
+// keyed by username. Existing users are left untouched: the operator's local
+// setup (potentially with a rotated password or different role) wins over
+// the envelope's snapshot. is_protected is forced to 0 on insert so the
+// envelope cannot smuggle in a second protected row that would conflict
+// with the target's bootstrap admin.
+//
+// Returns the number of inserted users so the caller can record an audit
+// count; rows that already existed are not counted.
+func (s *Service) importUsers(ctx context.Context, users []UserExport, result *ImportResult) error {
+	if len(users) == 0 {
+		return nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, u := range users {
+		if u.Username == "" {
+			slog.Warn("import: skipping user with empty username")
+			continue
+		}
+		// Probe for existing row first. We do not UPDATE on conflict because
+		// overwriting the operator's password_hash or role with the source
+		// instance's older snapshot is far worse than leaving the target's
+		// row alone; the only data loss case (user does not exist on target)
+		// is what this import path is designed to fix.
+		var existingID string
+		err := s.db.QueryRowContext(ctx,
+			`SELECT id FROM users WHERE username = ?`, u.Username,
+		).Scan(&existingID)
+		if err == nil {
+			// Already exists: keep target's row; do not overwrite.
+			continue
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("looking up user %q: %w", u.Username, err)
+		}
+
+		role := u.Role
+		if role != "administrator" && role != "operator" && role != "admin" {
+			// Unknown role -- coerce to operator (least privilege). Auth
+			// material must fail closed: a tampered or future-version role
+			// must not silently grant Administrator.
+			role = "operator"
+		}
+		authProvider := u.AuthProvider
+		if authProvider == "" {
+			authProvider = "local"
+		}
+		isActive := 0
+		if u.IsActive {
+			isActive = 1
+		}
+		createdAt := u.CreatedAt
+		if createdAt == "" {
+			createdAt = now
+		}
+		id := uuid.New().String()
+		if _, err := s.db.ExecContext(ctx, `
+			INSERT INTO users (
+				id, username, display_name, password_hash, role,
+				auth_provider, provider_id, is_active, is_protected,
+				invited_by, created_at, updated_at
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?, ?)
+		`,
+			id, u.Username, u.DisplayName, u.PasswordHash, role,
+			authProvider, u.ProviderID, isActive,
+			createdAt, now,
+		); err != nil {
+			return fmt.Errorf("inserting user %q: %w", u.Username, err)
+		}
+		result.UsersImported++
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- **#1188 -- Auth provider settings round-trip fidelity:** Auth provider Default role used `selected?={ value == "" }` patterns, so absent settings rows fell back to the first option (often Administrator) instead of the documented in-code default (Operator). Added seed-on-render: when the auth provider settings page loads and a tracked key has no `settings` row, the canonical default is INSERT OR IGNORE'd. The export/import round-trip now preserves the seeded value rather than dropping it.
- **#1283 -- Cross-instance token restore (Option 3, combined):** Settings export envelope bumped to **v1.3** with a new `Users` block. On import:
  - Users in the envelope are recreated on the target if absent (never overwriting existing rows; password/role of existing users wins).
  - For tokens whose owning username remains absent after the user-recreation pass, an opt-in `admin_fallback_tokens` flag attributes them to the importing admin and increments an `OwnershipReassigned` counter on `ImportResult`.
  - Default behavior (no flag) preserves the historical "skip on missing owner" path; older v1.0/1.1/1.2 envelopes still import.
- Bcrypt password hashes carried in the envelope's encrypted payload only (documented in `docs/architecture-decisions.md` portable-settings contract).
- Imported users have `is_protected=0` forced on insert (prevents envelope-smuggled second protected admin) and unknown roles coerce to `operator` (least privilege).

## Audit findings (grep sweep)

`selected?={ ... == "" }` and `onchange="saveProviderSetting(...)"` patterns: only the 4 lines in `settings_auth_providers.templ` are user-portability-relevant; all addressed by seed-on-render. Other matches in `compliance.templ`/`artists.templ`/`preferences.templ` are URL-param or per-user state, out of scope.

## Test plan

- [x] `internal/settingsio/export_authprovider_test.go` (new): for every canonical auth key, set non-default + default, run Export -> clear DB -> Import, assert target equals source.
- [x] `internal/settingsio/tokens_test.go`: cross-instance happy path (envelope users), admin-fallback path, fallback-off legacy skip, bogus-admin-id rejection, legacy v1.2 envelope.
- [x] `internal/api/handlers_settings_seed_test.go` (new): seed on fresh DB / respect existing rows / idempotent.
- [x] `api/bruno/settings/import-settings-admin-fallback.bru` (new): cross-instance scenario.
- [x] `bash scripts/pre-push-gate.sh` clean; patch coverage 78.80%.
- [x] UAT Screen (a): fresh install -> Settings > Auth shows Operator as Default role for Emby/Jellyfin/OIDC; no console errors.

Cross-instance UAT (Screens b + c) deferred to bot CI + the new tokens_test.go integration coverage; the cross-instance path requires a second running instance and the unit tests exercise the same code paths.

## Envelope versioning

`CurrentEnvelopeVersion` 1.2 -> 1.3. `supportedEnvelopeVersions` retains 1.0, 1.1, 1.2 for backward compat. Older envelopes have no Users block; their tokens go through the historical skip path unless `admin_fallback_tokens=true` is opted in.

Closes #1188
Closes #1283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Envelope bumped to v1.3: includes Users and API tokens; import accepts admin_fallback_tokens, supports admin-fallback ownership reassignment, and returns users_imported and ownership_reassigned counters. Also seeds canonical auth-provider defaults on settings pages.

* **Documentation**
  * Added portable settings contract and updated export/import guides with envelope v1.3, user handling, orphan token behavior, reassignment option, and UI guidance.

* **Tests**
  * Added comprehensive tests for user export/import, token import (including admin-fallback), auth-provider seeding, and an HTTP import scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->