### PR TITLE
refactor(artists): drop legacy library_id, add lower-name index, fix history datetime

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -959,9 +959,15 @@ func readPasswordNoEcho() (string, error) {
 	return strings.TrimSpace(line), nil
 }
 
-// backfillDefaultLibrary ensures at least one library exists and all artists
-// have a library_id set. Returns the default library ID for the scanner.
+// backfillDefaultLibrary ensures at least one library exists. Returns the
+// default library ID for the scanner. Assignment of "orphaned" artists
+// (artists without a membership row) is no longer performed here: the
+// legacy artists.library_id column was dropped in migration 004 and
+// artist_libraries is the authoritative membership record. Newly
+// scanned artists pick up a membership via Service.Create's
+// AddDerivingSource path.
 func backfillDefaultLibrary(ctx context.Context, libService *library.Service, musicPath string, db *sql.DB, logger *slog.Logger) string {
+	_ = db // legacy parameter retained for call-site stability
 	libs, err := libService.List(ctx)
 	if err != nil {
 		logger.Error("listing libraries for backfill", "error", err)
@@ -1007,27 +1013,7 @@ func backfillDefaultLibrary(ctx context.Context, libService *library.Service, mu
 		defaultID = lib.ID
 	}
 
-	// Assign orphaned artists (library_id IS NULL) to the default library
-	count := assignOrphanedArtists(ctx, db, defaultID, logger)
-	if count > 0 {
-		logger.Info("assigned orphaned artists to library",
-			slog.String("library_id", defaultID),
-			slog.Int64("count", count))
-	}
-
 	return defaultID
-}
-
-// assignOrphanedArtists sets library_id on all artists where it is currently NULL.
-func assignOrphanedArtists(ctx context.Context, db *sql.DB, libraryID string, logger *slog.Logger) int64 {
-	result, err := db.ExecContext(ctx,
-		`UPDATE artists SET library_id = ? WHERE library_id IS NULL`, libraryID)
-	if err != nil {
-		logger.Error("assigning orphaned artists", "error", err)
-		return 0
-	}
-	n, _ := result.RowsAffected()
-	return n
 }
 
 // loadDBLoggingConfig reads logging settings from the DB and reconfigures the

--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1104,29 +1105,32 @@ func (r *Router) manualLibraries(ctx context.Context) []library.Library {
 // or exact name, stores the platform ID on it, and backfills the mapping to
 // any matching filesystem-library artist. Returns the connection-library
 // artist for the caller to update image flags, or nil if no match found.
+//
+// The lookup prefers an artist that already holds a membership in connLib
+// (so a transitional state with one artist row per library still resolves
+// to the connection-side row, not the filesystem-side row). It falls back
+// to an unscoped MBID-then-name lookup, which is the right answer once the
+// duplicate-collapse migration has merged the rows.
 func (r *Router) resolveAndBackfillPlatformID(
 	ctx context.Context,
 	mbid, name, connectionID, platformArtistID string,
 	connLib *library.Library,
 	manualLibs []library.Library,
 ) *artist.Artist {
-	var a *artist.Artist
-	var lookupErr error
-	if mbid != "" {
-		a, lookupErr = r.artistService.GetByMBIDAndLibrary(ctx, mbid, connLib.ID)
-	}
-	if a == nil && lookupErr == nil {
-		a, lookupErr = r.artistService.GetByNameAndLibrary(ctx, name, connLib.ID)
-	}
-	if lookupErr != nil {
-		r.logger.Warn("scan artist lookup", "name", name, "mbid", mbid, "platform", connLib.Source, "error", lookupErr)
-		return nil
+	a := r.findArtistInLibrary(ctx, mbid, name, connLib.ID)
+	if a == nil {
+		var lookupErr error
+		a, lookupErr = r.artistService.FindByMBIDOrNameUnscoped(ctx, mbid, name)
+		if lookupErr != nil {
+			r.logger.Warn("scan artist lookup", "name", name, "mbid", mbid, "platform", connLib.Source, "error", lookupErr)
+			return nil
+		}
 	}
 	if a == nil {
 		return nil
 	}
 
-	// Store platform ID on the connection-library artist.
+	// Store platform ID on the resolved artist.
 	if setErr := r.artistService.SetPlatformID(ctx, a.ID, connectionID, platformArtistID); setErr != nil {
 		r.logger.Warn("storing platform id during scan", "name", a.Name, "platform", connLib.Source, "error", setErr)
 	}
@@ -1134,6 +1138,71 @@ func (r *Router) resolveAndBackfillPlatformID(
 	// Backfill to filesystem-library artists.
 	r.backfillPlatformIDToManualLibs(ctx, mbid, name, connectionID, platformArtistID, a.ID, manualLibs)
 
+	return a
+}
+
+// findArtistInLibrary looks up an artist by MBID then case-insensitive
+// name, restricted to artists that are members of libraryID. Returns nil
+// if no match exists. Used by resolveAndBackfillPlatformID to prefer the
+// connection-library artist over a sibling-library artist that shares the
+// same identity (transitional duplicate-row state under M:N).
+func (r *Router) findArtistInLibrary(ctx context.Context, mbid, name, libraryID string) *artist.Artist {
+	if mbid != "" {
+		if a := r.lookupByMBIDInLibrary(ctx, mbid, libraryID); a != nil {
+			return a
+		}
+	}
+	if name == "" {
+		return nil
+	}
+	return r.lookupByNameInLibrary(ctx, name, libraryID)
+}
+
+func (r *Router) lookupByMBIDInLibrary(ctx context.Context, mbid, libraryID string) *artist.Artist {
+	var artistID string
+	err := r.db.QueryRowContext(ctx, `
+		SELECT a.id FROM artists a
+		JOIN artist_libraries al ON al.artist_id = a.id
+		JOIN artist_provider_ids p ON p.artist_id = a.id
+		WHERE al.library_id = ?
+		  AND p.provider = 'musicbrainz' AND p.provider_id = ?
+		LIMIT 1
+	`, libraryID, mbid).Scan(&artistID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		r.logger.Warn("library-scoped mbid lookup", "mbid", mbid, "library_id", libraryID, "error", err)
+		return nil
+	}
+	a, err := r.artistService.GetByID(ctx, artistID)
+	if err != nil {
+		r.logger.Warn("loading library-scoped artist by id", "artist_id", artistID, "error", err)
+		return nil
+	}
+	return a
+}
+
+func (r *Router) lookupByNameInLibrary(ctx context.Context, name, libraryID string) *artist.Artist {
+	var artistID string
+	err := r.db.QueryRowContext(ctx, `
+		SELECT a.id FROM artists a
+		JOIN artist_libraries al ON al.artist_id = a.id
+		WHERE al.library_id = ? AND LOWER(a.name) = LOWER(?)
+		LIMIT 1
+	`, libraryID, name).Scan(&artistID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		r.logger.Warn("library-scoped name lookup", "name", name, "library_id", libraryID, "error", err)
+		return nil
+	}
+	a, err := r.artistService.GetByID(ctx, artistID)
+	if err != nil {
+		r.logger.Warn("loading library-scoped artist by id", "artist_id", artistID, "error", err)
+		return nil
+	}
 	return a
 }
 

--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -1179,12 +1179,18 @@ func (r *Router) findArtistInLibrary(ctx context.Context, mbid, name, libraryID 
 // back; this function never silently swallows a DB error as "not found".
 func (r *Router) lookupByMBIDInLibrary(ctx context.Context, mbid, libraryID string) (*artist.Artist, error) {
 	var artistID string
+	// ORDER BY datetime(created_at), a.id makes the LIMIT 1 deterministic when
+	// multiple artists share the same library + MBID. datetime() normalizes
+	// mixed timestamp formats (legacy SQLite "YYYY-MM-DD HH:MM:SS" vs RFC3339
+	// "T"-separator) so chronological order survives the mixed-format reality
+	// of production data; a.id is the deterministic tie-breaker.
 	err := r.db.QueryRowContext(ctx, `
 		SELECT a.id FROM artists a
 		JOIN artist_libraries al ON al.artist_id = a.id
 		JOIN artist_provider_ids p ON p.artist_id = a.id
 		WHERE al.library_id = ?
 		  AND p.provider = 'musicbrainz' AND p.provider_id = ?
+		ORDER BY datetime(a.created_at), a.id
 		LIMIT 1
 	`, libraryID, mbid).Scan(&artistID)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1205,10 +1211,14 @@ func (r *Router) lookupByMBIDInLibrary(ctx context.Context, mbid, libraryID stri
 // to (nil, nil).
 func (r *Router) lookupByNameInLibrary(ctx context.Context, name, libraryID string) (*artist.Artist, error) {
 	var artistID string
+	// Same determinism rationale as lookupByMBIDInLibrary: order by the
+	// chronologically normalized created_at, then a.id, so duplicate-name
+	// rows in the same library always resolve to the same artist.
 	err := r.db.QueryRowContext(ctx, `
 		SELECT a.id FROM artists a
 		JOIN artist_libraries al ON al.artist_id = a.id
 		WHERE al.library_id = ? AND LOWER(a.name) = LOWER(?)
+		ORDER BY datetime(a.created_at), a.id
 		LIMIT 1
 	`, libraryID, name).Scan(&artistID)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -1117,7 +1117,15 @@ func (r *Router) resolveAndBackfillPlatformID(
 	connLib *library.Library,
 	manualLibs []library.Library,
 ) *artist.Artist {
-	a := r.findArtistInLibrary(ctx, mbid, name, connLib.ID)
+	// Library-scoped lookup: distinguish "not found" (a == nil, err == nil)
+	// from a real DB/load failure (err != nil). Falling back to the unscoped
+	// match on a real error during the duplicate-row transition could attach
+	// the platform ID to a sibling-library artist instead of failing safely.
+	a, err := r.findArtistInLibrary(ctx, mbid, name, connLib.ID)
+	if err != nil {
+		r.logger.Warn("scan artist library-scoped lookup", "name", name, "mbid", mbid, "platform", connLib.Source, "error", err)
+		return nil
+	}
 	if a == nil {
 		var lookupErr error
 		a, lookupErr = r.artistService.FindByMBIDOrNameUnscoped(ctx, mbid, name)
@@ -1146,19 +1154,30 @@ func (r *Router) resolveAndBackfillPlatformID(
 // if no match exists. Used by resolveAndBackfillPlatformID to prefer the
 // connection-library artist over a sibling-library artist that shares the
 // same identity (transitional duplicate-row state under M:N).
-func (r *Router) findArtistInLibrary(ctx context.Context, mbid, name, libraryID string) *artist.Artist {
+// findArtistInLibrary returns (artist, nil) on a hit, (nil, nil) on a genuine
+// "no match" result, and (nil, err) on a real DB/load failure. Callers must
+// distinguish the latter so they do not silently fall back to an unscoped
+// lookup that could attach IDs to the wrong sibling-library artist.
+func (r *Router) findArtistInLibrary(ctx context.Context, mbid, name, libraryID string) (*artist.Artist, error) {
 	if mbid != "" {
-		if a := r.lookupByMBIDInLibrary(ctx, mbid, libraryID); a != nil {
-			return a
+		a, err := r.lookupByMBIDInLibrary(ctx, mbid, libraryID)
+		if err != nil {
+			return nil, err
+		}
+		if a != nil {
+			return a, nil
 		}
 	}
 	if name == "" {
-		return nil
+		return nil, nil
 	}
 	return r.lookupByNameInLibrary(ctx, name, libraryID)
 }
 
-func (r *Router) lookupByMBIDInLibrary(ctx context.Context, mbid, libraryID string) *artist.Artist {
+// lookupByMBIDInLibrary returns (nil, nil) when no row matches and (nil, err)
+// when the query or follow-up load fails. The caller decides whether to fall
+// back; this function never silently swallows a DB error as "not found".
+func (r *Router) lookupByMBIDInLibrary(ctx context.Context, mbid, libraryID string) (*artist.Artist, error) {
 	var artistID string
 	err := r.db.QueryRowContext(ctx, `
 		SELECT a.id FROM artists a
@@ -1169,21 +1188,22 @@ func (r *Router) lookupByMBIDInLibrary(ctx context.Context, mbid, libraryID stri
 		LIMIT 1
 	`, libraryID, mbid).Scan(&artistID)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil
+		return nil, nil
 	}
 	if err != nil {
-		r.logger.Warn("library-scoped mbid lookup", "mbid", mbid, "library_id", libraryID, "error", err)
-		return nil
+		return nil, fmt.Errorf("library-scoped mbid lookup (mbid=%s library=%s): %w", mbid, libraryID, err)
 	}
 	a, err := r.artistService.GetByID(ctx, artistID)
 	if err != nil {
-		r.logger.Warn("loading library-scoped artist by id", "artist_id", artistID, "error", err)
-		return nil
+		return nil, fmt.Errorf("loading library-scoped artist by id (%s): %w", artistID, err)
 	}
-	return a
+	return a, nil
 }
 
-func (r *Router) lookupByNameInLibrary(ctx context.Context, name, libraryID string) *artist.Artist {
+// lookupByNameInLibrary mirrors lookupByMBIDInLibrary's error contract: a
+// real DB/load failure surfaces to the caller, only sql.ErrNoRows collapses
+// to (nil, nil).
+func (r *Router) lookupByNameInLibrary(ctx context.Context, name, libraryID string) (*artist.Artist, error) {
 	var artistID string
 	err := r.db.QueryRowContext(ctx, `
 		SELECT a.id FROM artists a
@@ -1192,18 +1212,16 @@ func (r *Router) lookupByNameInLibrary(ctx context.Context, name, libraryID stri
 		LIMIT 1
 	`, libraryID, name).Scan(&artistID)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil
+		return nil, nil
 	}
 	if err != nil {
-		r.logger.Warn("library-scoped name lookup", "name", name, "library_id", libraryID, "error", err)
-		return nil
+		return nil, fmt.Errorf("library-scoped name lookup (name=%s library=%s): %w", name, libraryID, err)
 	}
 	a, err := r.artistService.GetByID(ctx, artistID)
 	if err != nil {
-		r.logger.Warn("loading library-scoped artist by id", "artist_id", artistID, "error", err)
-		return nil
+		return nil, fmt.Errorf("loading library-scoped artist by id (%s): %w", artistID, err)
 	}
-	return a
+	return a, nil
 }
 
 // scanFromEmby pages through Emby artists and updates image existence flags.

--- a/internal/api/handlers_connection_library_test.go
+++ b/internal/api/handlers_connection_library_test.go
@@ -341,7 +341,7 @@ func TestPopulateFromEmby_ImportsMetadataFields(t *testing.T) {
 	}
 
 	// Retrieve the artist and verify metadata was mapped.
-	a, err := r.artistService.GetByNameAndLibrary(ctx, "Radiohead", lib.ID)
+	a, err := r.artistService.GetByName(ctx, "Radiohead")
 	if err != nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -419,7 +419,7 @@ func TestPopulateFromJellyfin_ImportsMetadataFields(t *testing.T) {
 		t.Fatalf("created = %d, want 1", result.Created)
 	}
 
-	a, err := r.artistService.GetByNameAndLibrary(ctx, "Bjork", lib.ID)
+	a, err := r.artistService.GetByName(ctx, "Bjork")
 	if err != nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -599,7 +599,7 @@ func TestPopulateFromEmby_DownloadsImages(t *testing.T) {
 	}
 
 	// Verify artist record has path and thumb flag set.
-	a, err := router.artistService.GetByNameAndLibrary(ctx, "Radiohead", lib.ID)
+	a, err := router.artistService.GetByName(ctx, "Radiohead")
 	if err != nil || a == nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -749,7 +749,7 @@ func TestPopulateFromEmby_UsesImageCacheWhenNoPath(t *testing.T) {
 	}
 
 	// Verify the image was saved to the cache directory, not an artist path.
-	a, err := router.artistService.GetByNameAndLibrary(ctx, "NoPath Artist", lib.ID)
+	a, err := router.artistService.GetByName(ctx, "NoPath Artist")
 	if err != nil || a == nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -862,7 +862,7 @@ func TestPopulateFromJellyfin_DownloadsImages(t *testing.T) {
 		t.Errorf("expected image file in %s, got: %v", artistDir, entries)
 	}
 
-	a, err := router.artistService.GetByNameAndLibrary(ctx, "Bjork", lib.ID)
+	a, err := router.artistService.GetByName(ctx, "Bjork")
 	if err != nil || a == nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -977,7 +977,7 @@ func TestPopulateFromEmby_DownloadsImagesForExistingArtist(t *testing.T) {
 	}
 
 	// Verify the flag was set.
-	a, err := router.artistService.GetByNameAndLibrary(ctx, "Radiohead", lib.ID)
+	a, err := router.artistService.GetByName(ctx, "Radiohead")
 	if err != nil || a == nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -1083,7 +1083,7 @@ func TestPopulateFromEmby_PlatformPathNotStoredWhenPathless(t *testing.T) {
 		t.Fatalf("created = %d, want 1", result.Created)
 	}
 
-	a, err := router.artistService.GetByNameAndLibrary(ctx, "Radiohead", lib.ID)
+	a, err := router.artistService.GetByName(ctx, "Radiohead")
 	if err != nil || a == nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -1146,7 +1146,7 @@ func TestPopulateFromEmby_PlatformPathStoredWhenUnderLibraryRoot(t *testing.T) {
 		t.Fatalf("created = %d, want 1", result.Created)
 	}
 
-	a, err := router.artistService.GetByNameAndLibrary(ctx, "Radiohead", lib.ID)
+	a, err := router.artistService.GetByName(ctx, "Radiohead")
 	if err != nil || a == nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -1202,7 +1202,7 @@ func TestPopulateFromEmby_PlatformPathRejectedWhenOutsideLibraryRoot(t *testing.
 		t.Fatalf("created = %d, want 1", result.Created)
 	}
 
-	a, err := router.artistService.GetByNameAndLibrary(ctx, "Radiohead", lib.ID)
+	a, err := router.artistService.GetByName(ctx, "Radiohead")
 	if err != nil || a == nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -1277,7 +1277,7 @@ func TestPopulateFromEmby_BackfillsMBID(t *testing.T) {
 	}
 
 	// Verify MBID was backfilled.
-	a, err := router.artistService.GetByNameAndLibrary(ctx, "Radiohead", lib.ID)
+	a, err := router.artistService.GetByName(ctx, "Radiohead")
 	if err != nil || a == nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -1530,7 +1530,7 @@ func TestPopulateFromEmby_DownloadsMultipleBackdrops(t *testing.T) {
 		t.Errorf("expected fanart1.jpg to exist: %v", err)
 	}
 
-	a, err := router.artistService.GetByNameAndLibrary(ctx, "Radiohead", lib.ID)
+	a, err := router.artistService.GetByName(ctx, "Radiohead")
 	if err != nil || a == nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -1703,7 +1703,7 @@ func TestPopulateFromJellyfin_DownloadsMultipleBackdrops(t *testing.T) {
 		t.Errorf("expected fanart1.jpg to exist: %v", err)
 	}
 
-	a, err := router.artistService.GetByNameAndLibrary(ctx, "Bjork", lib.ID)
+	a, err := router.artistService.GetByName(ctx, "Bjork")
 	if err != nil || a == nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -1934,7 +1934,7 @@ func TestScanFromEmby_FanartExistsFromBackdropImageTags(t *testing.T) {
 		t.Errorf("updated = %d, want 1", updated)
 	}
 
-	got, err := router.artistService.GetByMBIDAndLibrary(ctx, "mbid-scan-001", lib.ID)
+	got, err := router.artistService.GetByMBID(ctx, "mbid-scan-001")
 	if err != nil || got == nil {
 		t.Fatalf("looking up artist after scan: %v", err)
 	}
@@ -2010,7 +2010,7 @@ func TestScanFromJellyfin_FanartExistsFromBackdropImageTags(t *testing.T) {
 		t.Errorf("updated = %d, want 1", updated)
 	}
 
-	got, err := router.artistService.GetByMBIDAndLibrary(ctx, "mbid-scan-002", lib.ID)
+	got, err := router.artistService.GetByMBID(ctx, "mbid-scan-002")
 	if err != nil || got == nil {
 		t.Fatalf("looking up artist after scan: %v", err)
 	}
@@ -2107,7 +2107,7 @@ func TestPopulateFromEmby_NonKodiBackdropNaming(t *testing.T) {
 		t.Errorf("expected backdrop2.jpg to exist: %v", err)
 	}
 
-	a, err := router.artistService.GetByNameAndLibrary(ctx, "Sigur Ros", lib.ID)
+	a, err := router.artistService.GetByName(ctx, "Sigur Ros")
 	if err != nil || a == nil {
 		t.Fatalf("looking up artist: %v", err)
 	}
@@ -2531,14 +2531,9 @@ func TestScanFromEmby_BackfillsCaseInsensitiveName(t *testing.T) {
 	if fsPlatformID != "" {
 		t.Errorf("filesystem artist platform ID = %q, want empty (UNIQUE index forbids duplicate mapping)", fsPlatformID)
 	}
-	embyArtistRow, err := router.artistService.GetByNameAndLibrary(ctx, "VERIDIA", embyLib.ID)
-	if err != nil {
-		t.Fatalf("GetByNameAndLibrary (emby): %v", err)
-	}
-	if embyArtistRow == nil {
-		t.Fatal("scanFromEmby should have created the Emby-library artist row")
-	}
-	embyPlatformID, err := router.artistService.GetPlatformID(ctx, embyArtistRow.ID, "conn-emby-1")
+	// The scan resolves the Emby-library artist via membership; assert
+	// that the platform mapping landed on that row directly.
+	embyPlatformID, err := router.artistService.GetPlatformID(ctx, embyArtist.ID, "conn-emby-1")
 	if err != nil {
 		t.Fatalf("GetPlatformID (emby): %v", err)
 	}

--- a/internal/api/handlers_connection_library_test.go
+++ b/internal/api/handlers_connection_library_test.go
@@ -2774,6 +2774,181 @@ func TestFindArtistInLibrary_NoMatchReturnsNil(t *testing.T) {
 	}
 }
 
+// TestFindArtistInLibrary_CrossLibraryMissReturnsNil pins the M:N scoping
+// guarantee: an artist that exists with the requested MBID/name BUT only in
+// a different library must NOT match the lookup. Without the al.library_id
+// filter on artist_libraries, the JOIN would surface the wrong artist and
+// the per-library scoping behavior would silently regress.
+func TestFindArtistInLibrary_CrossLibraryMissReturnsNil(t *testing.T) {
+	t.Parallel()
+	router := testRouterForLibraryOps(t)
+	ctx := context.Background()
+
+	// Two libraries on two different connections; the search target is
+	// embyLib but every artist we plant lives in otherLib only.
+	addTestConnection(t, router, "conn-emby-1", "Emby Server", "emby")
+	addTestConnection(t, router, "conn-emby-2", "Other Emby", "emby")
+
+	embyLib := &library.Library{
+		Name:         "Emby Music",
+		Type:         library.TypeRegular,
+		Source:       library.SourceEmby,
+		ConnectionID: "conn-emby-1",
+		ExternalID:   "emby-lib-1",
+	}
+	if err := router.libraryService.Create(ctx, embyLib); err != nil {
+		t.Fatalf("creating emby library: %v", err)
+	}
+	otherLib := &library.Library{
+		Name:         "Other Music",
+		Type:         library.TypeRegular,
+		Source:       library.SourceEmby,
+		ConnectionID: "conn-emby-2",
+		ExternalID:   "emby-lib-2",
+	}
+	if err := router.libraryService.Create(ctx, otherLib); err != nil {
+		t.Fatalf("creating other library: %v", err)
+	}
+
+	// Artist 1: matches by MBID, but only in otherLib.
+	mbidArtist := &artist.Artist{
+		Name:      "MBID Only",
+		SortName:  "MBID Only",
+		LibraryID: otherLib.ID,
+		Path:      t.TempDir(),
+	}
+	if err := router.artistService.Create(ctx, mbidArtist); err != nil {
+		t.Fatalf("creating mbid artist: %v", err)
+	}
+	if _, err := router.db.ExecContext(ctx, `
+		INSERT INTO artist_provider_ids (artist_id, provider, provider_id)
+		VALUES (?, 'musicbrainz', ?)
+	`, mbidArtist.ID, "22222222-2222-2222-2222-222222222222"); err != nil {
+		t.Fatalf("inserting provider id: %v", err)
+	}
+
+	// Artist 2: matches by name, but only in otherLib.
+	nameArtist := &artist.Artist{
+		Name:      "Name Only",
+		SortName:  "Name Only",
+		LibraryID: otherLib.ID,
+		Path:      t.TempDir(),
+	}
+	if err := router.artistService.Create(ctx, nameArtist); err != nil {
+		t.Fatalf("creating name artist: %v", err)
+	}
+
+	// MBID lookup scoped to embyLib must miss even though the MBID exists
+	// in otherLib. Without the library_id filter on artist_libraries, the
+	// JOIN would return the otherLib artist and silently violate scoping.
+	got, err := router.findArtistInLibrary(ctx,
+		"22222222-2222-2222-2222-222222222222", "", embyLib.ID)
+	if err != nil {
+		t.Fatalf("findArtistInLibrary by mbid: %v", err)
+	}
+	if got != nil {
+		t.Errorf("MBID cross-library lookup returned %+v, want nil", got)
+	}
+
+	// Name lookup scoped to embyLib must also miss.
+	got, err = router.findArtistInLibrary(ctx, "", "Name Only", embyLib.ID)
+	if err != nil {
+		t.Fatalf("findArtistInLibrary by name: %v", err)
+	}
+	if got != nil {
+		t.Errorf("name cross-library lookup returned %+v, want nil", got)
+	}
+}
+
+// TestFindArtistInLibrary_DeterministicOrdering pins the
+// ORDER BY datetime(a.created_at), a.id determinism for both lookup paths.
+// Two artists in the same library share the same MBID (and the same name)
+// but were inserted with mixed-format created_at timestamps. The lookup
+// must always return the chronologically older row, even though the legacy
+// "YYYY-MM-DD HH:MM:SS" form sorts AFTER an "T"-separated RFC3339 form
+// under raw TEXT comparison.
+func TestFindArtistInLibrary_DeterministicOrdering(t *testing.T) {
+	t.Parallel()
+	router := testRouterForLibraryOps(t)
+	ctx := context.Background()
+
+	addTestConnection(t, router, "conn-emby-1", "Emby Server", "emby")
+	embyLib := &library.Library{
+		Name:         "Emby Music",
+		Type:         library.TypeRegular,
+		Source:       library.SourceEmby,
+		ConnectionID: "conn-emby-1",
+		ExternalID:   "emby-lib-1",
+	}
+	if err := router.libraryService.Create(ctx, embyLib); err != nil {
+		t.Fatalf("creating emby library: %v", err)
+	}
+
+	// olderArtist: RFC3339 timestamp at 00:30Z (earlier).
+	// newerArtist: legacy SQLite timestamp at 23:00 (later).
+	// Raw TEXT comparison would order "2024-01-15 23:00:00" BEFORE
+	// "2024-01-15T00:30:00Z" because ' ' (0x20) < 'T' (0x54), so without
+	// datetime() normalization the wrong row would win.
+	olderID := "older-artist"
+	newerID := "newer-artist"
+	mbid := "33333333-3333-3333-3333-333333333333"
+	dupName := "Duplicate Band"
+
+	for _, row := range []struct {
+		id, createdAt string
+	}{
+		{olderID, "2024-01-15T00:30:00Z"}, // RFC3339, chronologically EARLIER
+		{newerID, "2024-01-15 23:00:00"},  // legacy SQLite, chronologically LATER
+	} {
+		if _, err := router.db.ExecContext(ctx,
+			`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			row.id, dupName, dupName, t.TempDir(), row.createdAt, row.createdAt); err != nil {
+			t.Fatalf("inserting %s: %v", row.id, err)
+		}
+		if _, err := router.db.ExecContext(ctx,
+			`INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+			 VALUES (?, ?, 'manual', ?)`,
+			row.id, embyLib.ID, row.createdAt); err != nil {
+			t.Fatalf("seeding membership for %s: %v", row.id, err)
+		}
+		if _, err := router.db.ExecContext(ctx,
+			`INSERT INTO artist_provider_ids (artist_id, provider, provider_id)
+			 VALUES (?, 'musicbrainz', ?)`,
+			row.id, mbid); err != nil {
+			t.Fatalf("inserting provider id for %s: %v", row.id, err)
+		}
+	}
+
+	// MBID lookup: must return the chronologically older RFC3339 row.
+	got, err := router.findArtistInLibrary(ctx, mbid, "", embyLib.ID)
+	if err != nil {
+		t.Fatalf("findArtistInLibrary by mbid: %v", err)
+	}
+	if got == nil || got.ID != olderID {
+		var gotID string
+		if got != nil {
+			gotID = got.ID
+		}
+		t.Errorf("MBID lookup ID = %q, want %q (datetime() must normalize mixed formats)",
+			gotID, olderID)
+	}
+
+	// Name lookup: same determinism guarantee.
+	got, err = router.findArtistInLibrary(ctx, "", dupName, embyLib.ID)
+	if err != nil {
+		t.Fatalf("findArtistInLibrary by name: %v", err)
+	}
+	if got == nil || got.ID != olderID {
+		var gotID string
+		if got != nil {
+			gotID = got.ID
+		}
+		t.Errorf("name lookup ID = %q, want %q (datetime() must normalize mixed formats)",
+			gotID, olderID)
+	}
+}
+
 func TestBackfillPlatformIDToManualLibs_SkipsWhenNoMatch(t *testing.T) {
 	t.Parallel()
 	router := testRouterForLibraryOps(t)

--- a/internal/api/handlers_connection_library_test.go
+++ b/internal/api/handlers_connection_library_test.go
@@ -2568,6 +2568,81 @@ func TestResolveAndBackfillPlatformID_NilWhenNoConnectionMatch(t *testing.T) {
 	}
 }
 
+// TestResolveAndBackfillPlatformID_StopsOnScopedLookupError verifies that a
+// real DB/load failure inside the library-scoped lookup short-circuits the
+// resolver: the unscoped fallback must NOT run, no platform-id mapping is
+// stored, and the function returns nil. This guards the safety contract that
+// callers rely on during the M:N transitional state -- a transient scoped
+// query error must never silently fall back to an unscoped match that could
+// attach the platform id to a sibling-library artist.
+//
+// The test forces the scoped query to fail by dropping the artist_libraries
+// table after seeding everything else. The unscoped path (GetByMBID against
+// the artists + artist_provider_ids tables) remains functional, so if the
+// short-circuit ever regresses, the unscoped match would resolve and
+// SetPlatformID would land a mapping -- the assertion below would catch it.
+func TestResolveAndBackfillPlatformID_StopsOnScopedLookupError(t *testing.T) {
+	t.Parallel()
+	router := testRouterForLibraryOps(t)
+	ctx := context.Background()
+
+	addTestConnection(t, router, "conn-emby-1", "Emby Server", "emby")
+
+	embyLib := &library.Library{
+		Name:         "Emby Music",
+		Type:         library.TypeRegular,
+		Source:       library.SourceEmby,
+		ConnectionID: "conn-emby-1",
+		ExternalID:   "emby-lib-1",
+	}
+	if err := router.libraryService.Create(ctx, embyLib); err != nil {
+		t.Fatalf("creating emby library: %v", err)
+	}
+
+	// Seed an artist + MBID mapping that the UNSCOPED lookup would resolve.
+	// If short-circuit breaks, this artist gets a platform mapping and the
+	// final assertion fails.
+	const mbid = "11111111-1111-1111-1111-111111111111"
+	unscopedArtist := &artist.Artist{
+		Name:          "Backstop Artist",
+		SortName:      "Backstop Artist",
+		MusicBrainzID: mbid,
+		Path:          "/music/backstop",
+	}
+	if err := router.artistService.Create(ctx, unscopedArtist); err != nil {
+		t.Fatalf("creating unscoped artist: %v", err)
+	}
+
+	// Force the scoped query to fail without breaking the unscoped path.
+	// lookupByMBIDInLibrary joins artist_libraries; dropping it makes that
+	// query error. GetByMBID (used by the unscoped fallback) hits artists +
+	// artist_provider_ids only and is unaffected.
+	if _, err := router.db.ExecContext(ctx, `DROP TABLE artist_libraries`); err != nil {
+		t.Fatalf("dropping artist_libraries: %v", err)
+	}
+
+	a := router.resolveAndBackfillPlatformID(ctx,
+		mbid, "Backstop Artist",
+		"conn-emby-1", "emby-backstop-001", embyLib, nil)
+	if a != nil {
+		t.Errorf("expected nil, got %+v", a)
+	}
+
+	// If the unscoped fallback ran, SetPlatformID would have stored a row
+	// mapping unscopedArtist.ID -> emby-backstop-001 for conn-emby-1. Read
+	// the mapping directly via the DB so we do not depend on service-layer
+	// queries that also touch artist_libraries (which we just dropped).
+	var count int
+	if err := router.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_platform_ids WHERE artist_id = ? AND connection_id = ?`,
+		unscopedArtist.ID, "conn-emby-1").Scan(&count); err != nil {
+		t.Fatalf("counting platform ids: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 platform-id rows after short-circuit, got %d", count)
+	}
+}
+
 // TestFindArtistInLibrary_HitByMBID covers the success path of
 // lookupByMBIDInLibrary: an artist with an MBID provider row AND a membership
 // in the target library is returned. Pins the M:N membership-join behavior

--- a/internal/api/handlers_connection_library_test.go
+++ b/internal/api/handlers_connection_library_test.go
@@ -369,6 +369,12 @@ func TestPopulateFromEmby_ImportsMetadataFields(t *testing.T) {
 	if a.MusicBrainzID != "a74b1b7f-71a5-4011-9441-d0b5e4122711" {
 		t.Errorf("MusicBrainzID = %q, want expected MBID", a.MusicBrainzID)
 	}
+	// M:N membership: populate switched from a library-scoped lookup to
+	// an unscoped GetByName, so this assertion is what now guarantees the
+	// artist_libraries join row was actually inserted alongside the
+	// artists row. A regression that creates only the artist would still
+	// satisfy GetByName above.
+	assertArtistInLibrary(t, r, ctx, a.ID, lib.ID)
 }
 
 func TestPopulateFromJellyfin_ImportsMetadataFields(t *testing.T) {
@@ -438,6 +444,7 @@ func TestPopulateFromJellyfin_ImportsMetadataFields(t *testing.T) {
 	if a.Formed != "1965-11-21T00:00:00.0000000Z" {
 		t.Errorf("Formed = %q, want 1965 date", a.Formed)
 	}
+	assertArtistInLibrary(t, r, ctx, a.ID, lib.ID)
 }
 
 func TestPopulateLibrary_ConflictWhenRunning(t *testing.T) {
@@ -508,6 +515,28 @@ func createTestJPEGForHandler(t *testing.T) []byte {
 		t.Fatalf("encoding test jpeg: %v", err)
 	}
 	return buf.Bytes()
+}
+
+// assertArtistInLibrary fails the test unless the artist holds an
+// artist_libraries membership row for the given library. Populate/scan
+// happy-path tests now look up the artist via the unscoped GetByName /
+// GetByMBID path, so this helper is what guarantees the M:N membership
+// was actually inserted -- not just the artists row. A regression that
+// drops the membership insert would still satisfy the unscoped lookup
+// but fail here.
+func assertArtistInLibrary(t *testing.T, r *Router, ctx context.Context, artistID, libraryID string) {
+	t.Helper()
+	memberships, err := r.artistService.LibrariesForArtist(ctx, artistID)
+	if err != nil {
+		t.Fatalf("LibrariesForArtist(%s): %v", artistID, err)
+	}
+	for _, m := range memberships {
+		if m.LibraryID == libraryID {
+			return
+		}
+	}
+	t.Errorf("artist %s missing artist_libraries membership for library %s; got %+v",
+		artistID, libraryID, memberships)
 }
 
 func TestPopulateFromEmby_DownloadsImages(t *testing.T) {
@@ -609,6 +638,7 @@ func TestPopulateFromEmby_DownloadsImages(t *testing.T) {
 	if !a.ThumbExists {
 		t.Error("expected ThumbExists to be true")
 	}
+	assertArtistInLibrary(t, router, ctx, a.ID, lib.ID)
 }
 
 func TestPopulateFromEmby_SkipsExistingImage(t *testing.T) {
@@ -771,6 +801,7 @@ func TestPopulateFromEmby_UsesImageCacheWhenNoPath(t *testing.T) {
 	if !found {
 		t.Errorf("expected image in cache dir %s, got: %v", cacheDir, entries)
 	}
+	assertArtistInLibrary(t, router, ctx, a.ID, lib.ID)
 }
 
 func TestPopulateFromJellyfin_DownloadsImages(t *testing.T) {
@@ -872,6 +903,7 @@ func TestPopulateFromJellyfin_DownloadsImages(t *testing.T) {
 	if !a.ThumbExists {
 		t.Error("expected ThumbExists to be true")
 	}
+	assertArtistInLibrary(t, router, ctx, a.ID, lib.ID)
 }
 
 func TestPopulateFromEmby_DownloadsImagesForExistingArtist(t *testing.T) {
@@ -984,6 +1016,10 @@ func TestPopulateFromEmby_DownloadsImagesForExistingArtist(t *testing.T) {
 	if !a.ThumbExists {
 		t.Error("expected ThumbExists to be true")
 	}
+	// Pre-existing artist was created with this library; membership must
+	// still be present after populate's skip path. A regression that
+	// dropped membership on the skip code-path would fail here.
+	assertArtistInLibrary(t, router, ctx, a.ID, lib.ID)
 }
 
 func TestValidatedArtistPath(t *testing.T) {
@@ -1090,6 +1126,7 @@ func TestPopulateFromEmby_PlatformPathNotStoredWhenPathless(t *testing.T) {
 	if a.Path != "" {
 		t.Errorf("artist path = %q, want empty (pathless library should not store platform path)", a.Path)
 	}
+	assertArtistInLibrary(t, router, ctx, a.ID, lib.ID)
 }
 
 func TestPopulateFromEmby_PlatformPathStoredWhenUnderLibraryRoot(t *testing.T) {
@@ -1153,6 +1190,7 @@ func TestPopulateFromEmby_PlatformPathStoredWhenUnderLibraryRoot(t *testing.T) {
 	if a.Path != artistDir {
 		t.Errorf("artist path = %q, want %q", a.Path, artistDir)
 	}
+	assertArtistInLibrary(t, router, ctx, a.ID, lib.ID)
 }
 
 func TestPopulateFromEmby_PlatformPathRejectedWhenOutsideLibraryRoot(t *testing.T) {
@@ -1209,6 +1247,7 @@ func TestPopulateFromEmby_PlatformPathRejectedWhenOutsideLibraryRoot(t *testing.
 	if a.Path != "" {
 		t.Errorf("artist path = %q, want empty (path outside library root should be rejected)", a.Path)
 	}
+	assertArtistInLibrary(t, router, ctx, a.ID, lib.ID)
 }
 
 func TestPopulateFromEmby_BackfillsMBID(t *testing.T) {
@@ -1284,6 +1323,9 @@ func TestPopulateFromEmby_BackfillsMBID(t *testing.T) {
 	if a.MusicBrainzID != "a74b1b7f-71a5-4011-9441-d0b5e4122711" {
 		t.Errorf("MusicBrainzID = %q, want backfilled MBID", a.MusicBrainzID)
 	}
+	// MBID-backfill code path is an UPDATE, not a CREATE; the membership
+	// recorded at pre-create time must still be present afterwards.
+	assertArtistInLibrary(t, router, ctx, a.ID, lib.ID)
 }
 
 func TestPopulateFromEmby_SkipsOnMBIDConflict(t *testing.T) {
@@ -1537,6 +1579,7 @@ func TestPopulateFromEmby_DownloadsMultipleBackdrops(t *testing.T) {
 	if a.FanartCount != 2 {
 		t.Errorf("FanartCount = %d, want 2", a.FanartCount)
 	}
+	assertArtistInLibrary(t, router, ctx, a.ID, lib.ID)
 }
 
 func TestPopulateFromEmby_SkipsExistingBackdrop(t *testing.T) {
@@ -1710,6 +1753,7 @@ func TestPopulateFromJellyfin_DownloadsMultipleBackdrops(t *testing.T) {
 	if a.FanartCount != 2 {
 		t.Errorf("FanartCount = %d, want 2", a.FanartCount)
 	}
+	assertArtistInLibrary(t, router, ctx, a.ID, lib.ID)
 }
 
 func TestPopulateFromEmby_NoBackdropsWhenTagsEmpty(t *testing.T) {
@@ -2114,6 +2158,7 @@ func TestPopulateFromEmby_NonKodiBackdropNaming(t *testing.T) {
 	if a.FanartCount != 2 {
 		t.Errorf("FanartCount = %d, want 2", a.FanartCount)
 	}
+	assertArtistInLibrary(t, router, ctx, a.ID, lib.ID)
 }
 
 func TestImportLibraries_AutoPopulate(t *testing.T) {

--- a/internal/api/handlers_connection_library_test.go
+++ b/internal/api/handlers_connection_library_test.go
@@ -2568,6 +2568,137 @@ func TestResolveAndBackfillPlatformID_NilWhenNoConnectionMatch(t *testing.T) {
 	}
 }
 
+// TestFindArtistInLibrary_HitByMBID covers the success path of
+// lookupByMBIDInLibrary: an artist with an MBID provider row AND a membership
+// in the target library is returned. Pins the M:N membership-join behavior
+// after the legacy artists.library_id column was dropped.
+func TestFindArtistInLibrary_HitByMBID(t *testing.T) {
+	t.Parallel()
+	router := testRouterForLibraryOps(t)
+	ctx := context.Background()
+
+	addTestConnection(t, router, "conn-emby-1", "Emby Server", "emby")
+
+	embyLib := &library.Library{
+		Name:         "Emby Music",
+		Type:         library.TypeRegular,
+		Source:       library.SourceEmby,
+		ConnectionID: "conn-emby-1",
+		ExternalID:   "emby-lib-1",
+	}
+	if err := router.libraryService.Create(ctx, embyLib); err != nil {
+		t.Fatalf("creating emby library: %v", err)
+	}
+
+	a := &artist.Artist{
+		Name:      "Veridia",
+		SortName:  "Veridia",
+		LibraryID: embyLib.ID,
+		Path:      t.TempDir(),
+	}
+	if err := router.artistService.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	// Attach an MBID provider row so the MBID lookup matches.
+	if _, err := router.db.ExecContext(ctx, `
+		INSERT INTO artist_provider_ids (artist_id, provider, provider_id)
+		VALUES (?, 'musicbrainz', ?)
+	`, a.ID, "11111111-1111-1111-1111-111111111111"); err != nil {
+		t.Fatalf("inserting provider id: %v", err)
+	}
+
+	got, err := router.findArtistInLibrary(ctx, "11111111-1111-1111-1111-111111111111", "Veridia", embyLib.ID)
+	if err != nil {
+		t.Fatalf("findArtistInLibrary: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected hit, got nil")
+	}
+	if got.ID != a.ID {
+		t.Errorf("got.ID = %q, want %q", got.ID, a.ID)
+	}
+}
+
+// TestFindArtistInLibrary_HitByName covers the case-insensitive fallback path
+// (lookupByNameInLibrary) when no MBID is provided.
+func TestFindArtistInLibrary_HitByName(t *testing.T) {
+	t.Parallel()
+	router := testRouterForLibraryOps(t)
+	ctx := context.Background()
+
+	addTestConnection(t, router, "conn-emby-1", "Emby Server", "emby")
+
+	embyLib := &library.Library{
+		Name:         "Emby Music",
+		Type:         library.TypeRegular,
+		Source:       library.SourceEmby,
+		ConnectionID: "conn-emby-1",
+		ExternalID:   "emby-lib-1",
+	}
+	if err := router.libraryService.Create(ctx, embyLib); err != nil {
+		t.Fatalf("creating emby library: %v", err)
+	}
+
+	a := &artist.Artist{
+		Name:      "Mixed Case Band",
+		SortName:  "Mixed Case Band",
+		LibraryID: embyLib.ID,
+		Path:      t.TempDir(),
+	}
+	if err := router.artistService.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// Lookup with a different case should still match (LOWER on both sides).
+	got, err := router.findArtistInLibrary(ctx, "", "MIXED CASE BAND", embyLib.ID)
+	if err != nil {
+		t.Fatalf("findArtistInLibrary: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected hit, got nil")
+	}
+	if got.ID != a.ID {
+		t.Errorf("got.ID = %q, want %q", got.ID, a.ID)
+	}
+}
+
+// TestFindArtistInLibrary_NoMatchReturnsNil verifies the (nil, nil) "genuine
+// no match" contract that callers depend on to fall back to unscoped lookup.
+func TestFindArtistInLibrary_NoMatchReturnsNil(t *testing.T) {
+	t.Parallel()
+	router := testRouterForLibraryOps(t)
+	ctx := context.Background()
+
+	addTestConnection(t, router, "conn-emby-1", "Emby Server", "emby")
+	embyLib := &library.Library{
+		Name:         "Emby Music",
+		Type:         library.TypeRegular,
+		Source:       library.SourceEmby,
+		ConnectionID: "conn-emby-1",
+		ExternalID:   "emby-lib-1",
+	}
+	if err := router.libraryService.Create(ctx, embyLib); err != nil {
+		t.Fatalf("creating emby library: %v", err)
+	}
+
+	got, err := router.findArtistInLibrary(ctx, "00000000-0000-0000-0000-000000000000", "Nobody", embyLib.ID)
+	if err != nil {
+		t.Fatalf("findArtistInLibrary: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+
+	// MBID empty + no name => early return (nil, nil) without query.
+	got, err = router.findArtistInLibrary(ctx, "", "", embyLib.ID)
+	if err != nil {
+		t.Fatalf("findArtistInLibrary empty: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for empty inputs, got %+v", got)
+	}
+}
+
 func TestBackfillPlatformIDToManualLibs_SkipsWhenNoMatch(t *testing.T) {
 	t.Parallel()
 	router := testRouterForLibraryOps(t)

--- a/internal/api/handlers_library_test.go
+++ b/internal/api/handlers_library_test.go
@@ -31,6 +31,9 @@ func testRouterWithLibrary(t *testing.T) (*Router, *library.Service, *artist.Ser
 	if err := database.Migrate(db); err != nil {
 		t.Fatalf("running migrations: %v", err)
 	}
+	if err := database.EnableForeignKeys(db); err != nil {
+		t.Fatalf("enabling foreign keys: %v", err)
+	}
 	t.Cleanup(func() { _ = db.Close() })
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1231,7 +1231,8 @@ components:
         library_id:
           type: string
           description: ID of the artist's primary library, derived from the
-            artist_libraries membership table (oldest membership wins).
+            artist_libraries membership table (oldest membership wins;
+            ties are resolved by lowest library_id).
             Empty when the artist has no library memberships.
         nfo_exists:
           type: boolean

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1230,7 +1230,9 @@ components:
           description: Filesystem path to the artist directory. Empty for pathless (platform-only) artists.
         library_id:
           type: string
-          description: ID of the library this artist belongs to.
+          description: ID of the artist's primary library, derived from the
+            artist_libraries membership table (oldest membership wins).
+            Empty when the artist has no library memberships.
         nfo_exists:
           type: boolean
           description: Whether an NFO file exists on disk for this artist.

--- a/internal/artist/count_test.go
+++ b/internal/artist/count_test.go
@@ -219,3 +219,77 @@ func TestCount_ConsistentWithList(t *testing.T) {
 		})
 	}
 }
+
+// TestCount_WithLibraryFlyoutFilters covers the M:N membership EXISTS/NOT
+// EXISTS clauses emitted by buildWhereClause for the per-library include and
+// exclude flyout filters (Filters["library_<id>"] = include|exclude). After
+// the legacy library_id column was dropped in migration 004, these clauses
+// must filter via artist_libraries; this test pins the M:N behavior so it
+// cannot silently regress.
+func TestCount_WithLibraryFlyoutFilters(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedLibraries(t, db, "lib-a", "lib-b", "lib-c")
+
+	// art-a only in lib-a; art-b only in lib-b; art-ab in BOTH lib-a + lib-b;
+	// art-c only in lib-c. Capture the generated IDs from Create so the
+	// membership rows reference the real artist row.
+	artistIDs := map[string]string{}
+	for _, name := range []string{"art-a", "art-b", "art-ab", "art-c"} {
+		a := testArtist(name, "/music/"+name)
+		if err := svc.Create(ctx, a); err != nil {
+			t.Fatalf("Create %s: %v", name, err)
+		}
+		artistIDs[name] = a.ID
+	}
+	for _, link := range []struct{ name, libID string }{
+		{"art-a", "lib-a"},
+		{"art-b", "lib-b"},
+		{"art-ab", "lib-a"},
+		{"art-ab", "lib-b"},
+		{"art-c", "lib-c"},
+	} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artist_libraries (artist_id, library_id, source) VALUES (?, ?, 'filesystem')`,
+			artistIDs[link.name], link.libID); err != nil {
+			t.Fatalf("insert artist_libraries (%s, %s): %v", link.name, link.libID, err)
+		}
+	}
+
+	// Include lib-a OR lib-b: art-a, art-b, art-ab match (3).
+	includeAB, err := svc.Count(ctx, CountParams{
+		Filters: map[string]string{"library_lib-a": "include", "library_lib-b": "include"},
+	})
+	if err != nil {
+		t.Fatalf("Count include lib-a + lib-b: %v", err)
+	}
+	if includeAB != 3 {
+		t.Errorf("include lib-a + lib-b count = %d, want 3", includeAB)
+	}
+
+	// Exclude lib-c: drop art-c, leaving 3.
+	excludeC, err := svc.Count(ctx, CountParams{
+		Filters: map[string]string{"library_lib-c": "exclude"},
+	})
+	if err != nil {
+		t.Fatalf("Count exclude lib-c: %v", err)
+	}
+	if excludeC != 3 {
+		t.Errorf("exclude lib-c count = %d, want 3", excludeC)
+	}
+
+	// Include lib-a, exclude lib-b: only art-a (art-ab is in both, so the
+	// exclude clause drops it).
+	mixed, err := svc.Count(ctx, CountParams{
+		Filters: map[string]string{"library_lib-a": "include", "library_lib-b": "exclude"},
+	})
+	if err != nil {
+		t.Fatalf("Count include lib-a exclude lib-b: %v", err)
+	}
+	if mixed != 1 {
+		t.Errorf("include lib-a exclude lib-b count = %d, want 1 (art-a only)", mixed)
+	}
+}

--- a/internal/artist/count_test.go
+++ b/internal/artist/count_test.go
@@ -48,6 +48,8 @@ func TestCount_WithLibraryFilter(t *testing.T) {
 	svc := NewService(db)
 	ctx := context.Background()
 
+	seedLibraries(t, db, "lib-1", "lib-2")
+
 	a1 := testArtist("Alpha", "/music/Alpha")
 	a1.LibraryID = "lib-1"
 	a2 := testArtist("Bravo", "/music/Bravo")
@@ -135,6 +137,8 @@ func TestCount_ConsistentWithList(t *testing.T) {
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
+
+	seedLibraries(t, db, "lib-1", "lib-2")
 
 	a1 := testArtist("Alpha", "/music/Alpha")
 	a1.LibraryID = "lib-1"

--- a/internal/artist/history_test.go
+++ b/internal/artist/history_test.go
@@ -348,16 +348,13 @@ func TestHistoryService_RecordUsesContextHistoryID(t *testing.T) {
 	}
 }
 
-// TestHistoryService_ListGlobalOrderMixedTimestampFormats verifies that
-// ListGlobal returns rows in true chronological order even when created_at
-// values are stored in different formats. SQLite's metadata_changes column
-// holds RFC 3339 strings for new rows ("2024-01-15T10:00:00Z") but legacy
-// rows wrote the SQLite default ("2024-01-15 11:00:00"). Lexicographic sort
-// puts the space-separated form after any RFC 3339 form ('T' < ' ' is false:
-// ' ' = 0x20, 'T' = 0x54), so a raw ORDER BY mc.created_at would invert
-// real-world ordering. The query wraps both the WHERE bounds and the
-// ORDER BY in datetime() to normalise both representations.
-func TestHistoryService_ListGlobalOrderMixedTimestampFormats(t *testing.T) {
+// TestHistoryService_ListGlobalOrderRFC3339 verifies that ListGlobal
+// returns rows in true chronological order. Migration 004 normalised any
+// pre-existing space-separator legacy rows to RFC3339, so the production
+// table holds a single uniform format and a plain TEXT ORDER BY is
+// monotonic without datetime() normalization. This test guards the order
+// against an accidental sort regression.
+func TestHistoryService_ListGlobalOrderRFC3339(t *testing.T) {
 	t.Parallel()
 	svc := setupHistoryTestDB(t)
 	ctx := context.Background()
@@ -370,14 +367,14 @@ func TestHistoryService_ListGlobalOrderMixedTimestampFormats(t *testing.T) {
 		t.Fatalf("inserting artist: %v", err)
 	}
 
-	// Insert three rows directly so we can control the created_at format.
-	// Expected DESC order (newest first): newer-rfc, middle-sqlite, oldest-rfc.
+	// Three RFC3339 rows; expected DESC order (newest first):
+	// newer, middle, oldest.
 	rows := []struct {
 		id, createdAt string
 	}{
-		{"oldest-rfc", "2024-01-15T08:00:00Z"},
-		{"middle-sqlite", "2024-01-15 09:00:00"}, // legacy SQLite format
-		{"newer-rfc", "2024-01-15T10:00:00Z"},
+		{"oldest", "2024-01-15T08:00:00Z"},
+		{"middle", "2024-01-15T09:00:00Z"},
+		{"newer", "2024-01-15T10:00:00Z"},
 	}
 	for _, r := range rows {
 		if _, err := db.ExecContext(ctx,
@@ -400,7 +397,7 @@ func TestHistoryService_ListGlobalOrderMixedTimestampFormats(t *testing.T) {
 		t.Fatalf("len(changes) = %d, want 3", len(changes))
 	}
 
-	want := []string{"newer-rfc", "middle-sqlite", "oldest-rfc"}
+	want := []string{"newer", "middle", "oldest"}
 	got := []string{changes[0].ID, changes[1].ID, changes[2].ID}
 	for i := range want {
 		if got[i] != want[i] {

--- a/internal/artist/hydrate_library_test.go
+++ b/internal/artist/hydrate_library_test.go
@@ -84,6 +84,57 @@ func TestHydratePrimaryLibrary_PicksOldestMembership(t *testing.T) {
 	}
 }
 
+// TestHydratePrimaryLibrary_TieBreaksOnLibraryID pins the documented
+// secondary ORDER BY library_id tie-breaker. Two memberships are seeded
+// with timestamps that normalize under datetime() to the IDENTICAL
+// instant; without the secondary library_id ASC sort, SQLite is free to
+// return either row, and the previous test would still pass if the
+// ORDER BY clause dropped its second key.
+func TestHydratePrimaryLibrary_TieBreaksOnLibraryID(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	// Library IDs chosen so lexicographic ordering is unambiguous:
+	// lib-aaa-tie sorts before lib-zzz-tie.
+	seedLibraries(t, db, "lib-aaa-tie", "lib-zzz-tie")
+
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		 VALUES ('a-tie', 'Tie', 'Tie', '/music/Tie', datetime('now'), datetime('now'))`); err != nil {
+		t.Fatalf("seeding artist: %v", err)
+	}
+
+	// Both timestamps normalize to the same datetime() instant
+	// ("2026-02-01 12:00:00"), so the primary ORDER BY key is a tie.
+	// Insert lib-zzz-tie FIRST so neither natural insertion order nor
+	// reverse insertion order accidentally selects the documented winner.
+	rows := []struct {
+		libID, addedAt string
+	}{
+		{"lib-zzz-tie", "2026-02-01T12:00:00Z"}, // RFC3339 form
+		{"lib-aaa-tie", "2026-02-01 12:00:00"},  // SQLite form -> same instant
+	}
+	for _, r := range rows {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+			 VALUES ('a-tie', ?, 'manual', ?)`,
+			r.libID, r.addedAt); err != nil {
+			t.Fatalf("seeding membership %s: %v", r.libID, err)
+		}
+	}
+
+	a := &Artist{ID: "a-tie"}
+	if err := svc.hydratePrimaryLibrary(ctx, a); err != nil {
+		t.Fatalf("hydratePrimaryLibrary: %v", err)
+	}
+	if a.LibraryID != "lib-aaa-tie" {
+		t.Errorf("LibraryID = %q, want lib-aaa-tie (secondary ORDER BY library_id ASC must break datetime() ties)",
+			a.LibraryID)
+	}
+}
+
 // TestHydratePrimaryLibrariesBatch covers the batch hydration path: a
 // mix of artists with zero, one, and many memberships. Each artist's
 // LibraryID must reflect its own oldest membership independently.
@@ -93,13 +144,16 @@ func TestHydratePrimaryLibrariesBatch(t *testing.T) {
 	svc := NewService(db)
 	ctx := context.Background()
 
-	seedLibraries(t, db, "lib-a", "lib-b", "lib-c")
+	seedLibraries(t, db, "lib-a", "lib-b", "lib-c", "lib-aaa-tie", "lib-zzz-tie")
 
-	// Three artists:
+	// Four artists:
 	//   a-1: single membership in lib-a.
 	//   a-2: two memberships, lib-b should win (older).
 	//   a-3: zero memberships (orphan).
-	for _, id := range []string{"a-1", "a-2", "a-3"} {
+	//   a-4: two memberships whose timestamps normalize to the SAME
+	//        datetime() instant; lib-aaa-tie must win on the secondary
+	//        ORDER BY library_id ASC tie-breaker.
+	for _, id := range []string{"a-1", "a-2", "a-3", "a-4"} {
 		if _, err := db.ExecContext(ctx,
 			`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
 			 VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
@@ -113,6 +167,11 @@ func TestHydratePrimaryLibrariesBatch(t *testing.T) {
 		// same datetime() normalization concern.
 		{"a-2", "lib-c", "2026-03-01T00:00:00Z"}, // RFC3339, later
 		{"a-2", "lib-b", "2026-01-01 00:00:00"},  // SQLite, earlier -> wins
+		// a-4 tie pair: both rows normalize to "2026-02-01 12:00:00"
+		// under SQLite's datetime(). Insert lib-zzz-tie first so neither
+		// insertion order accidentally selects the documented winner.
+		{"a-4", "lib-zzz-tie", "2026-02-01T12:00:00Z"},
+		{"a-4", "lib-aaa-tie", "2026-02-01 12:00:00"},
 	}
 	for _, m := range memberships {
 		if _, err := db.ExecContext(ctx,
@@ -127,6 +186,7 @@ func TestHydratePrimaryLibrariesBatch(t *testing.T) {
 		{ID: "a-1"},
 		{ID: "a-2"},
 		{ID: "a-3", LibraryID: "stale-caller-value"},
+		{ID: "a-4"},
 	}
 	if err := svc.hydratePrimaryLibrariesBatch(ctx, artists); err != nil {
 		t.Fatalf("hydratePrimaryLibrariesBatch: %v", err)
@@ -142,6 +202,12 @@ func TestHydratePrimaryLibrariesBatch(t *testing.T) {
 	if artists[2].LibraryID != "" {
 		t.Errorf("a-3 LibraryID = %q, want \"\" (zero memberships must clear LibraryID per OpenAPI contract)",
 			artists[2].LibraryID)
+	}
+	// a-4 pins the secondary ORDER BY library_id ASC tie-breaker for the
+	// batch path: identical datetime() instant, lower library_id wins.
+	if artists[3].LibraryID != "lib-aaa-tie" {
+		t.Errorf("a-4 LibraryID = %q, want lib-aaa-tie (batch path must apply secondary library_id ASC tie-breaker)",
+			artists[3].LibraryID)
 	}
 }
 

--- a/internal/artist/hydrate_library_test.go
+++ b/internal/artist/hydrate_library_test.go
@@ -7,9 +7,11 @@ import (
 )
 
 // TestHydratePrimaryLibrary_NoMembership covers the artist-with-zero-rows
-// branch: the artist exists but has no artist_libraries entry. The helper
-// must leave LibraryID untouched and return no error so callers like
-// GetByID don't fail for orphaned rows.
+// branch: the artist exists but has no artist_libraries entry. Per the
+// OpenAPI contract on Artist.library_id ("empty when the artist has no
+// library memberships"), the helper must CLEAR LibraryID rather than
+// preserve any caller-set value, so orphaned rows never leak a stale
+// library reference into API responses.
 func TestHydratePrimaryLibrary_NoMembership(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
@@ -25,13 +27,13 @@ func TestHydratePrimaryLibrary_NoMembership(t *testing.T) {
 		t.Fatalf("seeding orphan artist: %v", err)
 	}
 
-	a := &Artist{ID: "orphan-1", LibraryID: "should-not-change"}
+	a := &Artist{ID: "orphan-1", LibraryID: "stale-caller-value"}
 	if err := svc.hydratePrimaryLibrary(ctx, a); err != nil {
 		t.Fatalf("hydratePrimaryLibrary: %v", err)
 	}
-	if a.LibraryID != "should-not-change" {
-		t.Errorf("LibraryID = %q, want %q (no membership must leave field untouched)",
-			a.LibraryID, "should-not-change")
+	if a.LibraryID != "" {
+		t.Errorf("LibraryID = %q, want \"\" (zero memberships must clear LibraryID per OpenAPI contract)",
+			a.LibraryID)
 	}
 }
 
@@ -124,7 +126,7 @@ func TestHydratePrimaryLibrariesBatch(t *testing.T) {
 	artists := []Artist{
 		{ID: "a-1"},
 		{ID: "a-2"},
-		{ID: "a-3", LibraryID: "preserved"},
+		{ID: "a-3", LibraryID: "stale-caller-value"},
 	}
 	if err := svc.hydratePrimaryLibrariesBatch(ctx, artists); err != nil {
 		t.Fatalf("hydratePrimaryLibrariesBatch: %v", err)
@@ -135,9 +137,11 @@ func TestHydratePrimaryLibrariesBatch(t *testing.T) {
 	if artists[1].LibraryID != "lib-b" {
 		t.Errorf("a-2 LibraryID = %q, want lib-b (oldest by datetime() across formats)", artists[1].LibraryID)
 	}
-	if artists[2].LibraryID != "preserved" {
-		t.Errorf("a-3 LibraryID = %q, want %q (no membership must leave field untouched)",
-			artists[2].LibraryID, "preserved")
+	// a-3 has no memberships: the batch path must CLEAR LibraryID per the
+	// OpenAPI contract, matching the single-artist hydration behavior.
+	if artists[2].LibraryID != "" {
+		t.Errorf("a-3 LibraryID = %q, want \"\" (zero memberships must clear LibraryID per OpenAPI contract)",
+			artists[2].LibraryID)
 	}
 }
 

--- a/internal/artist/hydrate_library_test.go
+++ b/internal/artist/hydrate_library_test.go
@@ -1,0 +1,209 @@
+package artist
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestHydratePrimaryLibrary_NoMembership covers the artist-with-zero-rows
+// branch: the artist exists but has no artist_libraries entry. The helper
+// must leave LibraryID untouched and return no error so callers like
+// GetByID don't fail for orphaned rows.
+func TestHydratePrimaryLibrary_NoMembership(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	// Insert an artist row directly without going through Service.Create
+	// so no membership row is recorded.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+		"orphan-1", "Orphan", "Orphan", "/music/Orphan"); err != nil {
+		t.Fatalf("seeding orphan artist: %v", err)
+	}
+
+	a := &Artist{ID: "orphan-1", LibraryID: "should-not-change"}
+	if err := svc.hydratePrimaryLibrary(ctx, a); err != nil {
+		t.Fatalf("hydratePrimaryLibrary: %v", err)
+	}
+	if a.LibraryID != "should-not-change" {
+		t.Errorf("LibraryID = %q, want %q (no membership must leave field untouched)",
+			a.LibraryID, "should-not-change")
+	}
+}
+
+// TestHydratePrimaryLibrary_PicksOldestMembership covers the "oldest
+// added_at wins" rule with explicit chronological ordering. The helper
+// must select the earliest membership even when timestamps are stored in
+// mixed SQLite + RFC3339 formats (the wrap-with-datetime() fix).
+func TestHydratePrimaryLibrary_PicksOldestMembership(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedLibraries(t, db, "lib-old", "lib-mid", "lib-new")
+
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		 VALUES ('a-multi', 'Multi', 'Multi', '/music/Multi', datetime('now'), datetime('now'))`); err != nil {
+		t.Fatalf("seeding artist: %v", err)
+	}
+
+	// Three memberships, mixed timestamp formats. lib-old is the
+	// chronologically earliest; raw TEXT ordering would put 'T'-separated
+	// RFC3339 rows after ' '-separated SQLite ones, so without datetime()
+	// normalization the wrong row could win.
+	rows := []struct {
+		libID, addedAt string
+	}{
+		{"lib-mid", "2026-02-01T00:00:00Z"}, // RFC3339, middle
+		{"lib-old", "2026-01-01 00:00:00"},  // SQLite, earliest
+		{"lib-new", "2026-03-01T00:00:00Z"}, // RFC3339, latest
+	}
+	for _, r := range rows {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+			 VALUES ('a-multi', ?, 'manual', ?)`,
+			r.libID, r.addedAt); err != nil {
+			t.Fatalf("seeding membership %s: %v", r.libID, err)
+		}
+	}
+
+	a := &Artist{ID: "a-multi"}
+	if err := svc.hydratePrimaryLibrary(ctx, a); err != nil {
+		t.Fatalf("hydratePrimaryLibrary: %v", err)
+	}
+	if a.LibraryID != "lib-old" {
+		t.Errorf("LibraryID = %q, want lib-old (datetime() must normalize mixed formats)", a.LibraryID)
+	}
+}
+
+// TestHydratePrimaryLibrariesBatch covers the batch hydration path: a
+// mix of artists with zero, one, and many memberships. Each artist's
+// LibraryID must reflect its own oldest membership independently.
+func TestHydratePrimaryLibrariesBatch(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedLibraries(t, db, "lib-a", "lib-b", "lib-c")
+
+	// Three artists:
+	//   a-1: single membership in lib-a.
+	//   a-2: two memberships, lib-b should win (older).
+	//   a-3: zero memberships (orphan).
+	for _, id := range []string{"a-1", "a-2", "a-3"} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))`,
+			id, id, id, "/music/"+id); err != nil {
+			t.Fatalf("seeding %s: %v", id, err)
+		}
+	}
+	memberships := []struct{ artist, lib, addedAt string }{
+		{"a-1", "lib-a", "2026-02-01T00:00:00Z"},
+		// a-2 in two formats again to keep batch path covered for the
+		// same datetime() normalization concern.
+		{"a-2", "lib-c", "2026-03-01T00:00:00Z"}, // RFC3339, later
+		{"a-2", "lib-b", "2026-01-01 00:00:00"},  // SQLite, earlier -> wins
+	}
+	for _, m := range memberships {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+			 VALUES (?, ?, 'manual', ?)`,
+			m.artist, m.lib, m.addedAt); err != nil {
+			t.Fatalf("seeding membership for %s: %v", m.artist, err)
+		}
+	}
+
+	artists := []Artist{
+		{ID: "a-1"},
+		{ID: "a-2"},
+		{ID: "a-3", LibraryID: "preserved"},
+	}
+	if err := svc.hydratePrimaryLibrariesBatch(ctx, artists); err != nil {
+		t.Fatalf("hydratePrimaryLibrariesBatch: %v", err)
+	}
+	if artists[0].LibraryID != "lib-a" {
+		t.Errorf("a-1 LibraryID = %q, want lib-a", artists[0].LibraryID)
+	}
+	if artists[1].LibraryID != "lib-b" {
+		t.Errorf("a-2 LibraryID = %q, want lib-b (oldest by datetime() across formats)", artists[1].LibraryID)
+	}
+	if artists[2].LibraryID != "preserved" {
+		t.Errorf("a-3 LibraryID = %q, want %q (no membership must leave field untouched)",
+			artists[2].LibraryID, "preserved")
+	}
+}
+
+// TestHydratePrimaryLibrariesBatch_Empty is the trivial guard: passing
+// no artists must be a no-op that never touches the DB.
+func TestHydratePrimaryLibrariesBatch_Empty(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+
+	if err := svc.hydratePrimaryLibrariesBatch(context.Background(), nil); err != nil {
+		t.Fatalf("nil slice: %v", err)
+	}
+	if err := svc.hydratePrimaryLibrariesBatch(context.Background(), []Artist{}); err != nil {
+		t.Fatalf("empty slice: %v", err)
+	}
+}
+
+// TestHydratePrimaryLibrary_DecoratedRepo verifies the dbProvider interface
+// path: a repo wrapper that EMBEDS *sqliteArtistRepo (the decorator
+// pattern used by NewServiceWithRepos callers) must continue to expose
+// the underlying *sql.DB and let hydration succeed. The previous
+// concrete-type assertion silently disabled hydration here, leaving
+// LibraryID empty.
+func TestHydratePrimaryLibrary_DecoratedRepo(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	seedLibraries(t, db, "lib-dec")
+
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		 VALUES ('a-dec', 'Dec', 'Dec', '/music/Dec', datetime('now'), datetime('now'))`); err != nil {
+		t.Fatalf("seeding artist: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+		 VALUES ('a-dec', 'lib-dec', 'manual', ?)`,
+		time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("seeding membership: %v", err)
+	}
+
+	// Build a Service with a decorator that wraps the real
+	// sqliteArtistRepo. Method promotion exposes DB() so the dbProvider
+	// type assertion in hydratePrimaryLibrary still succeeds even though
+	// the field type is no longer the concrete *sqliteArtistRepo.
+	inner := newSQLiteArtistRepo(db)
+	svc := NewService(db)
+	svc.artists = &decoratorRepo{sqliteArtistRepo: inner}
+
+	a := &Artist{ID: "a-dec"}
+	if err := svc.hydratePrimaryLibrary(ctx, a); err != nil {
+		t.Fatalf("hydratePrimaryLibrary: %v", err)
+	}
+	if a.LibraryID != "lib-dec" {
+		t.Errorf("decorated repo LibraryID = %q, want lib-dec (interface-based hydration must work through wrappers)",
+			a.LibraryID)
+	}
+}
+
+// decoratorRepo embeds *sqliteArtistRepo so it both satisfies Repository
+// (via method promotion) and inherits the DB() accessor used by the
+// unexported dbProvider interface in service.go.
+type decoratorRepo struct {
+	*sqliteArtistRepo
+}
+
+// Compile-time guard: decoratorRepo satisfies Repository through promotion.
+var _ Repository = (*decoratorRepo)(nil)

--- a/internal/artist/platform_ids_test.go
+++ b/internal/artist/platform_ids_test.go
@@ -2,7 +2,6 @@ package artist
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"testing"
 
@@ -305,50 +304,6 @@ func addMembership(t *testing.T, svc *Service, artistID, libraryID, source strin
 	}
 }
 
-// setupPlatformPresenceTestWithDB is a sibling of setupPlatformPresenceTest
-// that also returns the underlying *sql.DB. Several legacy-fallback tests
-// need to insert rows (e.g. artists with only artists.library_id and no
-// artist_libraries membership) that Service.Create cannot produce.
-func setupPlatformPresenceTestWithDB(t *testing.T) (*Service, *sql.DB) {
-	t.Helper()
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatal(err)
-	}
-	// See setupPlatformPresenceTest: mirror production FK enforcement.
-	if err := database.EnableForeignKeys(db); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { db.Close() })
-
-	ctx := context.Background()
-	for _, q := range []string{
-		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
-			VALUES ('conn-1', 'Test Emby', 'emby', 'http://emby:8096', 'enc-key', 1, 'ok', datetime('now'), datetime('now'))`,
-		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
-			VALUES ('conn-2', 'Test Jellyfin', 'jellyfin', 'http://jf:8096', 'enc-key', 1, 'ok', datetime('now'), datetime('now'))`,
-		`INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
-			VALUES ('conn-3', 'Test Lidarr', 'lidarr', 'http://lidarr:8686', 'enc-key', 1, 'ok', datetime('now'), datetime('now'))`,
-		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
-			VALUES ('lib-emby', 'lib-emby', '/music', 'regular', 'import', 'conn-1', datetime('now'), datetime('now'))`,
-		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
-			VALUES ('lib-jelly', 'lib-jelly', '/music', 'regular', 'import', 'conn-2', datetime('now'), datetime('now'))`,
-		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
-			VALUES ('lib-lidarr', 'lib-lidarr', '/music', 'regular', 'import', 'conn-3', datetime('now'), datetime('now'))`,
-		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
-			VALUES ('lib-fs', 'lib-fs', '/music', 'regular', 'manual', NULL, datetime('now'), datetime('now'))`,
-	} {
-		if _, err := db.ExecContext(ctx, q); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	return NewService(db), db
-}
-
 func TestGetPlatformPresenceForArtists(t *testing.T) {
 	t.Parallel()
 	svc := setupPlatformPresenceTest(t)
@@ -496,86 +451,9 @@ func TestGetPlatformPresenceForArtists_AllPlatforms(t *testing.T) {
 	}
 }
 
-// TestGetPlatformPresenceForArtists_LegacyLibraryIDFallback exercises the
-// hybrid OR-fallback added for the M:N transition. An artist row that
-// still carries only the legacy artists.library_id column (no
-// artist_libraries membership) must still surface its presence; the
-// fallback branch goes away once the column drop in #1214 lands.
-func TestGetPlatformPresenceForArtists_LegacyLibraryIDFallback(t *testing.T) {
-	t.Parallel()
-	svc, db := setupPlatformPresenceTestWithDB(t)
-	ctx := context.Background()
-
-	// Create an artist directly via SQL so artist.Service.Create does
-	// not auto-populate artist_libraries. The artists.library_id column
-	// is the only thing pointing at lib-emby for this row.
-	if _, err := db.ExecContext(ctx, `
-		INSERT INTO artists (id, name, sort_name, library_id, path, created_at, updated_at)
-		VALUES ('a-legacy-emby', 'Legacy Emby', 'Legacy Emby', 'lib-emby',
-			'/music/legacy', datetime('now'), datetime('now'))
-	`); err != nil {
-		t.Fatalf("seeding legacy artist: %v", err)
-	}
-
-	// Same shape but pointing at a filesystem (NULL connection_id) library.
-	if _, err := db.ExecContext(ctx, `
-		INSERT INTO artists (id, name, sort_name, library_id, path, created_at, updated_at)
-		VALUES ('a-legacy-fs', 'Legacy FS', 'Legacy FS', 'lib-fs',
-			'/music/legacy-fs', datetime('now'), datetime('now'))
-	`); err != nil {
-		t.Fatalf("seeding legacy fs artist: %v", err)
-	}
-
-	result, err := svc.GetPlatformPresenceForArtists(ctx,
-		[]string{"a-legacy-emby", "a-legacy-fs"})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pe := result["a-legacy-emby"]
-	if !pe.HasEmby {
-		t.Error("legacy emby artist: expected HasEmby=true via library_id fallback")
-	}
-	if pe.HasFilesystem {
-		t.Error("legacy emby artist: expected HasFilesystem=false")
-	}
-
-	pf := result["a-legacy-fs"]
-	if !pf.HasFilesystem {
-		t.Error("legacy fs artist: expected HasFilesystem=true via library_id fallback")
-	}
-	if pf.HasEmby || pf.HasJellyfin || pf.HasLidarr {
-		t.Errorf("legacy fs artist: expected platform flags all false, got %+v", pf)
-	}
-}
-
-// TestGetPlatformPresenceForArtists_MembershipAndLegacyDeDuplicate verifies
-// that an artist with BOTH an artist_libraries row AND a legacy
-// artists.library_id pointing at the same library is reported once per
-// presence kind (the UNION + GROUP-equivalent semantics dedupe).
-func TestGetPlatformPresenceForArtists_MembershipAndLegacyDeDuplicate(t *testing.T) {
-	t.Parallel()
-	svc, db := setupPlatformPresenceTestWithDB(t)
-	ctx := context.Background()
-
-	if _, err := db.ExecContext(ctx, `
-		INSERT INTO artists (id, name, sort_name, library_id, path, created_at, updated_at)
-		VALUES ('a-both', 'BothPaths', 'BothPaths', 'lib-emby',
-			'/music/both', datetime('now'), datetime('now'))
-	`); err != nil {
-		t.Fatalf("seeding artist: %v", err)
-	}
-	addMembership(t, svc, "a-both", "lib-emby", "emby")
-
-	result, err := svc.GetPlatformPresenceForArtists(ctx, []string{"a-both"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	p := result["a-both"]
-	if !p.HasEmby {
-		t.Error("expected HasEmby=true")
-	}
-	if p.HasFilesystem || p.HasJellyfin || p.HasLidarr {
-		t.Errorf("expected only HasEmby, got %+v", p)
-	}
-}
+// Note: the previous TestGetPlatformPresenceForArtists_LegacyLibraryIDFallback
+// and *_MembershipAndLegacyDeDuplicate tests covered the hybrid OR-fallback
+// for the legacy artists.library_id column. Migration 004 dropped the column
+// and the corresponding UNION branch in GetPresenceForArtists, so the
+// fallback shape is no longer reachable. Membership-only coverage remains in
+// TestGetPlatformPresenceForArtists* above.

--- a/internal/artist/repository.go
+++ b/internal/artist/repository.go
@@ -18,17 +18,9 @@ type Repository interface {
 	GetByName(ctx context.Context, name string) (*Artist, error)
 
 	// FindByMBIDOrNameUnscoped performs unscoped MBID-then-name lookup,
-	// matching the dedupe priority used by connection populates. Replaces
-	// the library-scoped FindByMBIDOrName.
+	// matching the dedupe priority used by connection populates.
 	FindByMBIDOrNameUnscoped(ctx context.Context, mbid, name string) (*Artist, error)
 
-	// Deprecated: use GetByMBID. The library-scoped variant remains while
-	// legacy populate paths are migrated; remove with the M:N cleanup.
-	GetByMBIDAndLibrary(ctx context.Context, mbid, libraryID string) (*Artist, error)
-	// Deprecated: use GetByName. See GetByMBIDAndLibrary above.
-	GetByNameAndLibrary(ctx context.Context, name, libraryID string) (*Artist, error)
-	// Deprecated: use FindByMBIDOrNameUnscoped. See GetByMBIDAndLibrary above.
-	FindByMBIDOrName(ctx context.Context, mbid, name, libraryID string) (*Artist, error)
 	GetByPath(ctx context.Context, path string) (*Artist, error)
 	List(ctx context.Context, params ListParams) ([]Artist, int, error)
 	// Count returns the total number of artists matching the given filters

--- a/internal/artist/scan.go
+++ b/internal/artist/scan.go
@@ -9,10 +9,13 @@ import (
 
 // artistColumns is the ordered list of columns for SELECT queries.
 // Provider IDs are stored in artist_provider_ids, image metadata in artist_images.
+// Library membership lives in artist_libraries; Artist.LibraryID is hydrated
+// post-scan via Service.hydratePrimaryLibrary so call sites that read the
+// runtime-only field still see a value derived from the M:N table.
 const artistColumns = `id, name, sort_name, type, gender, origin, disambiguation,
 	genres, styles, moods,
 	years_active, born, formed, died, disbanded, biography,
-	path, library_id, nfo_exists,
+	path, nfo_exists,
 	health_score, health_evaluated_at, dirty_since, rules_evaluated_at, is_excluded, exclusion_reason, is_classical,
 	locked, lock_source, locked_at, locked_fields,
 	metadata_sources,
@@ -34,7 +37,6 @@ type scannedArtist struct {
 	genres            string
 	styles            string
 	moods             string
-	libraryID         sql.NullString
 	metadataSources   string
 	healthEvaluatedAt sql.NullString
 	dirtySince        sql.NullString
@@ -56,7 +58,7 @@ func (s *scannedArtist) scanPtrs() []any {
 		&s.a.ID, &s.a.Name, &s.a.SortName, &s.a.Type, &s.a.Gender, &s.a.Origin, &s.a.Disambiguation,
 		&s.genres, &s.styles, &s.moods,
 		&s.a.YearsActive, &s.a.Born, &s.a.Formed, &s.a.Died, &s.a.Disbanded, &s.a.Biography,
-		&s.a.Path, &s.libraryID, &s.nfo,
+		&s.a.Path, &s.nfo,
 		&s.a.HealthScore, &s.healthEvaluatedAt, &s.dirtySince, &s.rulesEvaluatedAt, &s.isExcluded, &s.a.ExclusionReason, &s.isClassical,
 		&s.locked, &s.a.LockSource, &s.lockedAt, &s.lockedFields,
 		&s.metadataSources,
@@ -67,9 +69,6 @@ func (s *scannedArtist) scanPtrs() []any {
 
 // apply converts intermediate scan values into the Artist struct fields.
 func (s *scannedArtist) apply() {
-	if s.libraryID.Valid {
-		s.a.LibraryID = s.libraryID.String
-	}
 	s.a.Genres = UnmarshalStringSlice(s.genres)
 	s.a.Styles = UnmarshalStringSlice(s.styles)
 	s.a.Moods = UnmarshalStringSlice(s.moods)
@@ -216,18 +215,14 @@ func buildWhereClause(params ListParams) (string, []any) {
 	}
 
 	if params.LibraryID != "" {
-		// Match either via the M:N membership table or the legacy
-		// library_id column, so artists created before the membership
-		// rollout still appear in per-library queries until phase 7
-		// drops the column.
-		conditions = append(conditions, `(
-			EXISTS (
-				SELECT 1 FROM artist_libraries al
-				WHERE al.artist_id = artists.id AND al.library_id = ?
-			)
-			OR artists.library_id = ?
+		// Match via the M:N membership table. The legacy artists.library_id
+		// column was dropped in migration 004; artist_libraries is the
+		// authoritative membership record.
+		conditions = append(conditions, `EXISTS (
+			SELECT 1 FROM artist_libraries al
+			WHERE al.artist_id = artists.id AND al.library_id = ?
 		)`)
-		args = append(args, params.LibraryID, params.LibraryID)
+		args = append(args, params.LibraryID)
 	}
 
 	switch params.Filter {
@@ -360,37 +355,25 @@ func buildWhereClause(params ListParams) (string, []any) {
 	}
 	if len(libIncludes) > 0 {
 		ph := strings.Repeat("?,", len(libIncludes))
-		// Union semantics: match if the artist has membership in ANY of
-		// the included libraries OR the legacy column points at one.
-		// Drop the legacy branch in the column-removal phase.
-		conditions = append(conditions, `(
-			EXISTS (
-				SELECT 1 FROM artist_libraries al
-				WHERE al.artist_id = artists.id
-				  AND al.library_id IN (`+ph[:len(ph)-1]+`)
-			)
-			OR artists.library_id IN (`+ph[:len(ph)-1]+`)
+		// Match artists with membership in ANY of the included libraries.
+		conditions = append(conditions, `EXISTS (
+			SELECT 1 FROM artist_libraries al
+			WHERE al.artist_id = artists.id
+			  AND al.library_id IN (`+ph[:len(ph)-1]+`)
 		)`)
-		for _, id := range libIncludes {
-			args = append(args, id)
-		}
 		for _, id := range libIncludes {
 			args = append(args, id)
 		}
 	}
 	if len(libExcludes) > 0 {
 		ph := strings.Repeat("?,", len(libExcludes))
-		// Drop artists with membership OR legacy pointer in any excluded
-		// library. Artists with neither pass through (nothing to exclude),
-		// matching the prior "IS NULL OR NOT IN" semantic.
+		// Drop artists with membership in any excluded library. Artists
+		// with no membership in the excluded set pass through.
 		conditions = append(conditions, `NOT EXISTS (
 			SELECT 1 FROM artist_libraries al
 			WHERE al.artist_id = artists.id
 			  AND al.library_id IN (`+ph[:len(ph)-1]+`)
-		) AND (artists.library_id IS NULL OR artists.library_id NOT IN (`+ph[:len(ph)-1]+`))`)
-		for _, id := range libExcludes {
-			args = append(args, id)
-		}
+		)`)
 		for _, id := range libExcludes {
 			args = append(args, id)
 		}

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -1157,6 +1157,9 @@ func (s *Service) Search(ctx context.Context, query string) ([]Artist, error) {
 	if err := s.hydrateImagesBatch(ctx, artists); err != nil {
 		return nil, err
 	}
+	if err := s.hydratePrimaryLibrariesBatch(ctx, artists); err != nil {
+		return nil, err
+	}
 	return artists, nil
 }
 
@@ -1317,6 +1320,9 @@ func (s *Service) SearchWithAliases(ctx context.Context, query string) ([]Artist
 		return nil, err
 	}
 	if err := s.hydrateImagesBatch(ctx, artists); err != nil {
+		return nil, err
+	}
+	if err := s.hydratePrimaryLibrariesBatch(ctx, artists); err != nil {
 		return nil, err
 	}
 	return artists, nil

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -1454,6 +1454,11 @@ type dbProvider interface {
 // continue to see a value derived from the M:N table. A repository that
 // does not expose a *sql.DB is a silent no-op so tests using fake repos
 // without a real DB are unaffected.
+//
+// Per the OpenAPI contract on Artist.library_id, the field is empty when
+// the artist has no library memberships. We therefore CLEAR LibraryID for
+// orphaned artists so callers do not see stale values left over from a
+// previous hydration or a bare struct literal.
 func (s *Service) hydratePrimaryLibrary(ctx context.Context, a *Artist) error {
 	if a == nil || a.ID == "" {
 		return nil
@@ -1476,6 +1481,10 @@ func (s *Service) hydratePrimaryLibrary(ctx context.Context, a *Artist) error {
 		`SELECT library_id FROM artist_libraries WHERE artist_id = ? ORDER BY datetime(added_at), library_id LIMIT 1`,
 		a.ID).Scan(&libID)
 	if errors.Is(err, sql.ErrNoRows) {
+		// Zero memberships: clear LibraryID per the OpenAPI contract so
+		// readers do not observe a stale caller-set value for an orphaned
+		// artist.
+		a.LibraryID = ""
 		return nil
 	}
 	if err != nil {
@@ -1488,7 +1497,9 @@ func (s *Service) hydratePrimaryLibrary(ctx context.Context, a *Artist) error {
 // hydratePrimaryLibrariesBatch populates LibraryID on a slice of artists
 // in a single query so List does not fan out to N round-trips. The same
 // "earliest added_at" rule applies per artist. Artists without any
-// membership row keep their zero-valued LibraryID.
+// membership row have LibraryID CLEARED to "" per the OpenAPI contract;
+// any caller-set value on an orphaned artist would otherwise leak into
+// API responses.
 func (s *Service) hydratePrimaryLibrariesBatch(ctx context.Context, artists []Artist) error {
 	if len(artists) == 0 {
 		return nil
@@ -1542,6 +1553,11 @@ func (s *Service) hydratePrimaryLibrariesBatch(ctx context.Context, artists []Ar
 	for i := range artists {
 		if lid, ok := libByArtist[artists[i].ID]; ok {
 			artists[i].LibraryID = lid
+		} else {
+			// Zero memberships: clear LibraryID per the OpenAPI contract.
+			// Without this, a caller-set value on an orphaned artist would
+			// survive batch hydration and leak into List responses.
+			artists[i].LibraryID = ""
 		}
 	}
 	return nil

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -1430,27 +1430,44 @@ func (s *Service) hydrateProviderIDs(ctx context.Context, a *Artist) error {
 	return nil
 }
 
+// dbProvider is the minimal interface hydratePrimaryLibrary needs from the
+// repository: a handle to the underlying *sql.DB so it can issue the
+// membership lookup. Decorated/wrapped repositories (NewServiceWithRepos)
+// satisfy this contract by either embedding *sqliteArtistRepo or
+// re-exposing DB(); fake repos used in unit tests omit it and the
+// hydration becomes a silent no-op.
+type dbProvider interface {
+	DB() *sql.DB
+}
+
 // hydratePrimaryLibrary populates a.LibraryID from artist_libraries by
 // picking the earliest membership row (oldest added_at). The legacy
 // artists.library_id column was dropped in migration 004; readers that
 // still rely on Artist.LibraryID (rule engine shared-fs detection,
 // compliance CSV export, library-name display in artist detail pages)
-// continue to see a value derived from the M:N table. A nil or unset
-// repository is a silent no-op so tests using fake repos without a real
-// DB are unaffected.
+// continue to see a value derived from the M:N table. A repository that
+// does not expose a *sql.DB is a silent no-op so tests using fake repos
+// without a real DB are unaffected.
 func (s *Service) hydratePrimaryLibrary(ctx context.Context, a *Artist) error {
 	if a == nil || a.ID == "" {
 		return nil
 	}
-	// Use the underlying *sql.DB through the repo when available; fall back
-	// to a no-op when no DB is wired (e.g. tests with fake repos).
-	repo, ok := s.artists.(*sqliteArtistRepo)
+	// Use the underlying *sql.DB through the dbProvider interface so wrapped
+	// repos (decorators that embed *sqliteArtistRepo) still hydrate correctly.
+	provider, ok := s.artists.(dbProvider)
 	if !ok {
 		return nil
 	}
+	db := provider.DB()
+	if db == nil {
+		return nil
+	}
+	// added_at can hold mixed SQLite ("YYYY-MM-DD HH:MM:SS") and RFC3339
+	// timestamps from different writers, so wrap with datetime() to compare
+	// chronologically rather than lexicographically.
 	var libID string
-	err := repo.db.QueryRowContext(ctx,
-		`SELECT library_id FROM artist_libraries WHERE artist_id = ? ORDER BY added_at, library_id LIMIT 1`,
+	err := db.QueryRowContext(ctx,
+		`SELECT library_id FROM artist_libraries WHERE artist_id = ? ORDER BY datetime(added_at), library_id LIMIT 1`,
 		a.ID).Scan(&libID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil
@@ -1470,8 +1487,12 @@ func (s *Service) hydratePrimaryLibrariesBatch(ctx context.Context, artists []Ar
 	if len(artists) == 0 {
 		return nil
 	}
-	repo, ok := s.artists.(*sqliteArtistRepo)
+	provider, ok := s.artists.(dbProvider)
 	if !ok {
+		return nil
+	}
+	db := provider.DB()
+	if db == nil {
 		return nil
 	}
 	placeholders := make([]string, len(artists))
@@ -1482,17 +1503,20 @@ func (s *Service) hydratePrimaryLibrariesBatch(ctx context.Context, artists []Ar
 	}
 	// Window-style "first per group" via NOT EXISTS so we get exactly one
 	// row per artist_id (the one with the smallest added_at, ties broken
-	// by library_id).
+	// by library_id). Wrap added_at with datetime() to normalize the mixed
+	// "YYYY-MM-DD HH:MM:SS" + RFC3339 formats present in production data;
+	// raw TEXT comparison would order RFC3339 (T separator) after SQLite
+	// (space separator) and pick the wrong "earliest" membership.
 	//nolint:gosec // G202: placeholders is a literal "?,?,..." string built by joining "?" literals; no user input.
 	query := `SELECT al.artist_id, al.library_id FROM artist_libraries al
 		WHERE al.artist_id IN (` + strings.Join(placeholders, ",") + `)
 		AND NOT EXISTS (
 			SELECT 1 FROM artist_libraries al2
 			WHERE al2.artist_id = al.artist_id
-			AND (al2.added_at < al.added_at
-				OR (al2.added_at = al.added_at AND al2.library_id < al.library_id))
+			AND (datetime(al2.added_at) < datetime(al.added_at)
+				OR (datetime(al2.added_at) = datetime(al.added_at) AND al2.library_id < al.library_id))
 		)`
-	rows, err := repo.db.QueryContext(ctx, query, args...)
+	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("batch hydrating primary library: %w", err)
 	}

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -331,6 +331,9 @@ func (s *Service) GetByID(ctx context.Context, id string) (*Artist, error) {
 	if err := s.hydrateImages(ctx, a); err != nil {
 		return nil, err
 	}
+	if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
+		return nil, err
+	}
 	return a, nil
 }
 
@@ -344,6 +347,9 @@ func (s *Service) GetByMBID(ctx context.Context, mbid string) (*Artist, error) {
 		return nil, err
 	}
 	if err := s.hydrateImages(ctx, a); err != nil {
+		return nil, err
+	}
+	if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -363,36 +369,7 @@ func (s *Service) GetByProviderID(ctx context.Context, provider, id string) (*Ar
 	if err := s.hydrateImages(ctx, a); err != nil {
 		return nil, err
 	}
-	return a, nil
-}
-
-// GetByNameAndLibrary retrieves an artist by name within a specific library.
-// Returns nil, nil when no match is found.
-func (s *Service) GetByNameAndLibrary(ctx context.Context, name, libraryID string) (*Artist, error) {
-	a, err := s.artists.GetByNameAndLibrary(ctx, name, libraryID)
-	if err != nil || a == nil {
-		return a, err
-	}
-	if err := s.hydrateProviderIDs(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydrateImages(ctx, a); err != nil {
-		return nil, err
-	}
-	return a, nil
-}
-
-// GetByMBIDAndLibrary retrieves an artist by MusicBrainz ID within a specific library.
-// Returns nil, nil when no match is found.
-func (s *Service) GetByMBIDAndLibrary(ctx context.Context, mbid, libraryID string) (*Artist, error) {
-	a, err := s.artists.GetByMBIDAndLibrary(ctx, mbid, libraryID)
-	if err != nil || a == nil {
-		return a, err
-	}
-	if err := s.hydrateProviderIDs(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydrateImages(ctx, a); err != nil {
+	if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -412,6 +389,9 @@ func (s *Service) GetByName(ctx context.Context, name string) (*Artist, error) {
 	if err := s.hydrateImages(ctx, a); err != nil {
 		return nil, err
 	}
+	if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
+		return nil, err
+	}
 	return a, nil
 }
 
@@ -428,6 +408,9 @@ func (s *Service) FindByMBIDOrNameUnscoped(ctx context.Context, mbid, name strin
 		return nil, err
 	}
 	if err := s.hydrateImages(ctx, a); err != nil {
+		return nil, err
+	}
+	if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -470,26 +453,6 @@ func (s *Service) CountLibrariesForArtist(ctx context.Context, artistID string) 
 	return s.memberships.CountForArtist(ctx, artistID)
 }
 
-// FindByMBIDOrName finds an artist by MBID first, then falls back to
-// case-insensitive name match, both scoped to the given library.
-// Returns nil, nil when no match is found.
-//
-// Deprecated: use FindByMBIDOrNameUnscoped. Removed alongside the
-// artists.library_id column when the legacy scoped repo surface goes.
-func (s *Service) FindByMBIDOrName(ctx context.Context, mbid, name, libraryID string) (*Artist, error) {
-	a, err := s.artists.FindByMBIDOrName(ctx, mbid, name, libraryID)
-	if err != nil || a == nil {
-		return a, err
-	}
-	if err := s.hydrateProviderIDs(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydrateImages(ctx, a); err != nil {
-		return nil, err
-	}
-	return a, nil
-}
-
 // GetByPath retrieves an artist by filesystem path, including provider IDs and image metadata.
 func (s *Service) GetByPath(ctx context.Context, path string) (*Artist, error) {
 	a, err := s.artists.GetByPath(ctx, path)
@@ -500,6 +463,9 @@ func (s *Service) GetByPath(ctx context.Context, path string) (*Artist, error) {
 		return nil, err
 	}
 	if err := s.hydrateImages(ctx, a); err != nil {
+		return nil, err
+	}
+	if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -516,6 +482,9 @@ func (s *Service) List(ctx context.Context, params ListParams) ([]Artist, int, e
 		return nil, 0, err
 	}
 	if err := s.hydrateImagesBatch(ctx, artists); err != nil {
+		return nil, 0, err
+	}
+	if err := s.hydratePrimaryLibrariesBatch(ctx, artists); err != nil {
 		return nil, 0, err
 	}
 	return artists, total, nil
@@ -1458,6 +1427,93 @@ func (s *Service) hydrateProviderIDs(ctx context.Context, a *Artist) error {
 		return fmt.Errorf("hydrating provider IDs: %w", err)
 	}
 	applyProviderIDs(a, ids)
+	return nil
+}
+
+// hydratePrimaryLibrary populates a.LibraryID from artist_libraries by
+// picking the earliest membership row (oldest added_at). The legacy
+// artists.library_id column was dropped in migration 004; readers that
+// still rely on Artist.LibraryID (rule engine shared-fs detection,
+// compliance CSV export, library-name display in artist detail pages)
+// continue to see a value derived from the M:N table. A nil or unset
+// repository is a silent no-op so tests using fake repos without a real
+// DB are unaffected.
+func (s *Service) hydratePrimaryLibrary(ctx context.Context, a *Artist) error {
+	if a == nil || a.ID == "" {
+		return nil
+	}
+	// Use the underlying *sql.DB through the repo when available; fall back
+	// to a no-op when no DB is wired (e.g. tests with fake repos).
+	repo, ok := s.artists.(*sqliteArtistRepo)
+	if !ok {
+		return nil
+	}
+	var libID string
+	err := repo.db.QueryRowContext(ctx,
+		`SELECT library_id FROM artist_libraries WHERE artist_id = ? ORDER BY added_at, library_id LIMIT 1`,
+		a.ID).Scan(&libID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("hydrating primary library for artist %s: %w", a.ID, err)
+	}
+	a.LibraryID = libID
+	return nil
+}
+
+// hydratePrimaryLibrariesBatch populates LibraryID on a slice of artists
+// in a single query so List does not fan out to N round-trips. The same
+// "earliest added_at" rule applies per artist. Artists without any
+// membership row keep their zero-valued LibraryID.
+func (s *Service) hydratePrimaryLibrariesBatch(ctx context.Context, artists []Artist) error {
+	if len(artists) == 0 {
+		return nil
+	}
+	repo, ok := s.artists.(*sqliteArtistRepo)
+	if !ok {
+		return nil
+	}
+	placeholders := make([]string, len(artists))
+	args := make([]any, len(artists))
+	for i := range artists {
+		placeholders[i] = "?"
+		args[i] = artists[i].ID
+	}
+	// Window-style "first per group" via NOT EXISTS so we get exactly one
+	// row per artist_id (the one with the smallest added_at, ties broken
+	// by library_id).
+	//nolint:gosec // G202: placeholders is a literal "?,?,..." string built by joining "?" literals; no user input.
+	query := `SELECT al.artist_id, al.library_id FROM artist_libraries al
+		WHERE al.artist_id IN (` + strings.Join(placeholders, ",") + `)
+		AND NOT EXISTS (
+			SELECT 1 FROM artist_libraries al2
+			WHERE al2.artist_id = al.artist_id
+			AND (al2.added_at < al.added_at
+				OR (al2.added_at = al.added_at AND al2.library_id < al.library_id))
+		)`
+	rows, err := repo.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("batch hydrating primary library: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck
+
+	libByArtist := make(map[string]string, len(artists))
+	for rows.Next() {
+		var aid, lid string
+		if err := rows.Scan(&aid, &lid); err != nil {
+			return fmt.Errorf("scanning primary library row: %w", err)
+		}
+		libByArtist[aid] = lid
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating primary library rows: %w", err)
+	}
+	for i := range artists {
+		if lid, ok := libByArtist[artists[i].ID]; ok {
+			artists[i].LibraryID = lid
+		}
+	}
 	return nil
 }
 

--- a/internal/artist/service_test.go
+++ b/internal/artist/service_test.go
@@ -48,6 +48,26 @@ func setupTestDB(t *testing.T) *sql.DB {
 	return db
 }
 
+// seedLibraries inserts placeholder libraries rows so that Service.Create's
+// recordInitialMembership / AddDerivingSource path can land an
+// artist_libraries membership row. Idempotent via INSERT OR IGNORE.
+// Helper for tests that previously relied on the legacy artists.library_id
+// column without separately materializing the libraries row.
+func seedLibraries(t *testing.T, db *sql.DB, ids ...string) {
+	t.Helper()
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, err := db.ExecContext(context.Background(),
+			`INSERT OR IGNORE INTO libraries (id, name, type, source, created_at, updated_at)
+				VALUES (?, ?, 'regular', 'manual', datetime('now'), datetime('now'))`,
+			id, id); err != nil {
+			t.Fatalf("seeding library %s: %v", id, err)
+		}
+	}
+}
+
 func testArtist(name, path string) *Artist {
 	return &Artist{
 		Name:           name,
@@ -784,20 +804,15 @@ func TestLibraryID_NullOnEmpty(t *testing.T) {
 	}
 }
 
-func TestGetByNameAndLibrary(t *testing.T) {
+func TestGetByName_HydratesPrimaryLibrary(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
 
-	// Create two libraries
-	for _, q := range []string{
-		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-x', 'Library X', '/music/x', 'regular', datetime('now'), datetime('now'))`,
-		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-y', 'Library Y', '/music/y', 'regular', datetime('now'), datetime('now'))`,
-	} {
-		if _, err := db.ExecContext(ctx, q); err != nil {
-			t.Fatalf("creating library: %v", err)
-		}
+	if _, err := db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-x', 'Library X', '/music/x', 'regular', datetime('now'), datetime('now'))`); err != nil {
+		t.Fatalf("creating library: %v", err)
 	}
 
 	a := testArtist("Deftones", "/music/Deftones")
@@ -806,48 +821,36 @@ func TestGetByNameAndLibrary(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	// Found in correct library
-	got, err := svc.GetByNameAndLibrary(ctx, "Deftones", "lib-x")
+	got, err := svc.GetByName(ctx, "Deftones")
 	if err != nil {
-		t.Fatalf("GetByNameAndLibrary: %v", err)
+		t.Fatalf("GetByName: %v", err)
 	}
 	if got == nil || got.Name != "Deftones" {
 		t.Errorf("expected Deftones, got %v", got)
 	}
-
-	// Not found in different library
-	got, err = svc.GetByNameAndLibrary(ctx, "Deftones", "lib-y")
-	if err != nil {
-		t.Fatalf("GetByNameAndLibrary different lib: %v", err)
-	}
-	if got != nil {
-		t.Errorf("expected nil for different library, got %+v", got)
+	if got != nil && got.LibraryID != "lib-x" {
+		t.Errorf("LibraryID hydration = %q, want lib-x", got.LibraryID)
 	}
 
 	// Not found (wrong name)
-	got, err = svc.GetByNameAndLibrary(ctx, "Nonexistent", "lib-x")
+	got, err = svc.GetByName(ctx, "Nonexistent")
 	if err != nil {
-		t.Fatalf("GetByNameAndLibrary not found: %v", err)
+		t.Fatalf("GetByName not found: %v", err)
 	}
 	if got != nil {
 		t.Errorf("expected nil for nonexistent name, got %+v", got)
 	}
 }
 
-func TestGetByMBIDAndLibrary(t *testing.T) {
+func TestGetByMBID_HydratesPrimaryLibrary(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
 
-	// Create two libraries
-	for _, q := range []string{
-		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-m', 'Library M', '/music/m', 'regular', datetime('now'), datetime('now'))`,
-		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-n', 'Library N', '/music/n', 'regular', datetime('now'), datetime('now'))`,
-	} {
-		if _, err := db.ExecContext(ctx, q); err != nil {
-			t.Fatalf("creating library: %v", err)
-		}
+	if _, err := db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-m', 'Library M', '/music/m', 'regular', datetime('now'), datetime('now'))`); err != nil {
+		t.Fatalf("creating library: %v", err)
 	}
 
 	mbid := "a74b1b7f-71a5-4011-9441-d0b5e4122711"
@@ -858,28 +861,21 @@ func TestGetByMBIDAndLibrary(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	// Found in correct library
-	got, err := svc.GetByMBIDAndLibrary(ctx, mbid, "lib-m")
+	got, err := svc.GetByMBID(ctx, mbid)
 	if err != nil {
-		t.Fatalf("GetByMBIDAndLibrary: %v", err)
+		t.Fatalf("GetByMBID: %v", err)
 	}
 	if got == nil || got.Name != "Radiohead" {
 		t.Errorf("expected Radiohead, got %v", got)
 	}
-
-	// Not found in different library
-	got, err = svc.GetByMBIDAndLibrary(ctx, mbid, "lib-n")
-	if err != nil {
-		t.Fatalf("GetByMBIDAndLibrary different lib: %v", err)
-	}
-	if got != nil {
-		t.Errorf("expected nil for different library, got %+v", got)
+	if got != nil && got.LibraryID != "lib-m" {
+		t.Errorf("LibraryID hydration = %q, want lib-m", got.LibraryID)
 	}
 
 	// Not found (wrong MBID)
-	got, err = svc.GetByMBIDAndLibrary(ctx, "nonexistent-mbid", "lib-m")
+	got, err = svc.GetByMBID(ctx, "nonexistent-mbid")
 	if err != nil {
-		t.Fatalf("GetByMBIDAndLibrary not found: %v", err)
+		t.Fatalf("GetByMBID not found: %v", err)
 	}
 	if got != nil {
 		t.Errorf("expected nil for nonexistent MBID, got %+v", got)
@@ -1125,168 +1121,6 @@ func TestList_LibraryIDFilter(t *testing.T) {
 	}
 }
 
-func TestFindByMBIDOrName_ByMBID(t *testing.T) {
-	t.Parallel()
-	db := setupTestDB(t)
-	svc := NewService(db)
-	ctx := context.Background()
-
-	if _, err := db.ExecContext(ctx,
-		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
-	); err != nil {
-		t.Fatalf("creating library: %v", err)
-	}
-
-	mbid := "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
-	a := testArtist("Nirvana", "/music/Nirvana")
-	a.MusicBrainzID = mbid
-	a.LibraryID = "lib-manual"
-	if err := svc.Create(ctx, a); err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-
-	got, err := svc.FindByMBIDOrName(ctx, mbid, "Nirvana", "lib-manual")
-	if err != nil {
-		t.Fatalf("FindByMBIDOrName: %v", err)
-	}
-	if got == nil {
-		t.Fatal("expected artist, got nil")
-	}
-	if got.Name != "Nirvana" {
-		t.Errorf("Name = %q, want Nirvana", got.Name)
-	}
-	if got.MusicBrainzID != mbid {
-		t.Errorf("MusicBrainzID = %q, want %q", got.MusicBrainzID, mbid)
-	}
-}
-
-func TestFindByMBIDOrName_ByNameCaseInsensitive(t *testing.T) {
-	t.Parallel()
-	db := setupTestDB(t)
-	svc := NewService(db)
-	ctx := context.Background()
-
-	if _, err := db.ExecContext(ctx,
-		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
-	); err != nil {
-		t.Fatalf("creating library: %v", err)
-	}
-
-	a := testArtist("Veridia", "/music/Veridia")
-	a.LibraryID = "lib-manual"
-	if err := svc.Create(ctx, a); err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-
-	// Search with a different case; no MBID provided.
-	got, err := svc.FindByMBIDOrName(ctx, "", "VERIDIA", "lib-manual")
-	if err != nil {
-		t.Fatalf("FindByMBIDOrName: %v", err)
-	}
-	if got == nil {
-		t.Fatal("expected artist, got nil")
-	}
-	if got.Name != "Veridia" {
-		t.Errorf("Name = %q, want Veridia", got.Name)
-	}
-}
-
-func TestFindByMBIDOrName_MBIDPreferredOverName(t *testing.T) {
-	t.Parallel()
-	db := setupTestDB(t)
-	svc := NewService(db)
-	ctx := context.Background()
-
-	if _, err := db.ExecContext(ctx,
-		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
-	); err != nil {
-		t.Fatalf("creating library: %v", err)
-	}
-
-	mbid1 := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-	mbid2 := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
-
-	a1 := testArtist("Coldplay", "/music/Coldplay-1")
-	a1.MusicBrainzID = mbid1
-	a1.LibraryID = "lib-manual"
-	if err := svc.Create(ctx, a1); err != nil {
-		t.Fatalf("Create a1: %v", err)
-	}
-
-	a2 := testArtist("Coldplay", "/music/Coldplay-2")
-	a2.MusicBrainzID = mbid2
-	a2.LibraryID = "lib-manual"
-	if err := svc.Create(ctx, a2); err != nil {
-		t.Fatalf("Create a2: %v", err)
-	}
-
-	// Searching by mbid2 should return a2, not a1, even though both share the name.
-	got, err := svc.FindByMBIDOrName(ctx, mbid2, "Coldplay", "lib-manual")
-	if err != nil {
-		t.Fatalf("FindByMBIDOrName: %v", err)
-	}
-	if got == nil {
-		t.Fatal("expected artist, got nil")
-	}
-	if got.ID != a2.ID {
-		t.Errorf("ID = %q, want %q (a2)", got.ID, a2.ID)
-	}
-}
-
-func TestFindByMBIDOrName_NotFound(t *testing.T) {
-	t.Parallel()
-	db := setupTestDB(t)
-	svc := NewService(db)
-	ctx := context.Background()
-
-	if _, err := db.ExecContext(ctx,
-		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
-	); err != nil {
-		t.Fatalf("creating library: %v", err)
-	}
-
-	got, err := svc.FindByMBIDOrName(ctx, "nonexistent-mbid", "Nonexistent Artist", "lib-manual")
-	if err != nil {
-		t.Fatalf("FindByMBIDOrName: %v", err)
-	}
-	if got != nil {
-		t.Errorf("expected nil, got %+v", got)
-	}
-}
-
-func TestFindByMBIDOrName_RespectsLibraryScope(t *testing.T) {
-	t.Parallel()
-	db := setupTestDB(t)
-	svc := NewService(db)
-	ctx := context.Background()
-
-	for _, q := range []string{
-		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-manual', 'Manual', '/music', 'regular', datetime('now'), datetime('now'))`,
-		`INSERT OR IGNORE INTO libraries (id, name, path, type, created_at, updated_at) VALUES ('lib-emby', 'Emby', '/music/emby', 'regular', datetime('now'), datetime('now'))`,
-	} {
-		if _, err := db.ExecContext(ctx, q); err != nil {
-			t.Fatalf("creating library: %v", err)
-		}
-	}
-
-	mbid := "cccccccc-cccc-cccc-cccc-cccccccccccc"
-	a := testArtist("Muse", "/music/Muse")
-	a.MusicBrainzID = mbid
-	a.LibraryID = "lib-emby"
-	if err := svc.Create(ctx, a); err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-
-	// Artist is in the emby library; searching the manual library should return nil.
-	got, err := svc.FindByMBIDOrName(ctx, mbid, "Muse", "lib-manual")
-	if err != nil {
-		t.Fatalf("FindByMBIDOrName: %v", err)
-	}
-	if got != nil {
-		t.Errorf("expected nil for wrong library scope, got %+v", got)
-	}
-}
-
 func TestMigration018_OrphanCleanupAndBackfill(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
@@ -1366,12 +1200,14 @@ func TestMigration018_OrphanCleanupAndBackfill(t *testing.T) {
 		plat.created_at, plat.updated_at
 	FROM artist_platform_ids plat
 	JOIN artists conn_artist ON conn_artist.id = plat.artist_id
-	JOIN libraries conn_lib ON conn_lib.id = conn_artist.library_id AND conn_lib.source != 'manual'
+	JOIN artist_libraries conn_al ON conn_al.artist_id = conn_artist.id
+	JOIN libraries conn_lib ON conn_lib.id = conn_al.library_id AND conn_lib.source != 'manual'
 	JOIN artist_provider_ids conn_mbid ON conn_mbid.artist_id = conn_artist.id AND conn_mbid.provider = 'musicbrainz'
 	JOIN artist_provider_ids fs_mbid ON fs_mbid.provider = 'musicbrainz'
 		AND fs_mbid.provider_id = conn_mbid.provider_id AND fs_mbid.artist_id != conn_artist.id
 	JOIN artists fs_artist ON fs_artist.id = fs_mbid.artist_id
-	JOIN libraries fs_lib ON fs_lib.id = fs_artist.library_id AND fs_lib.source = 'manual'`)
+	JOIN artist_libraries fs_al ON fs_al.artist_id = fs_artist.id
+	JOIN libraries fs_lib ON fs_lib.id = fs_al.library_id AND fs_lib.source = 'manual'`)
 	if err != nil {
 		t.Fatalf("backfill: %v", err)
 	}

--- a/internal/artist/service_test.go
+++ b/internal/artist/service_test.go
@@ -532,6 +532,92 @@ func TestSearch(t *testing.T) {
 	}
 }
 
+// TestSearch_HydratesPrimaryLibrary asserts that Search populates LibraryID
+// from the artist_libraries membership table. Regression coverage for the
+// gap where Search/SearchWithAliases skipped hydratePrimaryLibrariesBatch
+// after the artists.library_id column was removed.
+func TestSearch_HydratesPrimaryLibrary(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedLibraries(t, db, "lib-search-a", "lib-search-b")
+
+	a1 := testArtist("Searchable One", "/music/Searchable One")
+	a1.LibraryID = "lib-search-a"
+	if err := svc.Create(ctx, a1); err != nil {
+		t.Fatalf("Create a1: %v", err)
+	}
+
+	a2 := testArtist("Searchable Two", "/music/Searchable Two")
+	a2.LibraryID = "lib-search-b"
+	if err := svc.Create(ctx, a2); err != nil {
+		t.Fatalf("Create a2: %v", err)
+	}
+
+	results, err := svc.Search(ctx, "Searchable")
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("search results = %d, want 2", len(results))
+	}
+	want := map[string]string{
+		a1.ID: "lib-search-a",
+		a2.ID: "lib-search-b",
+	}
+	for _, r := range results {
+		if got, ok := want[r.ID]; !ok {
+			t.Errorf("unexpected artist ID in results: %s", r.ID)
+		} else if r.LibraryID != got {
+			t.Errorf("Search result %q LibraryID = %q, want %q", r.Name, r.LibraryID, got)
+		}
+	}
+}
+
+// TestSearchWithAliases_HydratesPrimaryLibrary mirrors TestSearch_HydratesPrimaryLibrary
+// for the alias-aware search path.
+func TestSearchWithAliases_HydratesPrimaryLibrary(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedLibraries(t, db, "lib-alias-a", "lib-alias-b")
+
+	a1 := testArtist("Aliased One", "/music/Aliased One")
+	a1.LibraryID = "lib-alias-a"
+	if err := svc.Create(ctx, a1); err != nil {
+		t.Fatalf("Create a1: %v", err)
+	}
+
+	a2 := testArtist("Aliased Two", "/music/Aliased Two")
+	a2.LibraryID = "lib-alias-b"
+	if err := svc.Create(ctx, a2); err != nil {
+		t.Fatalf("Create a2: %v", err)
+	}
+
+	results, err := svc.SearchWithAliases(ctx, "Aliased")
+	if err != nil {
+		t.Fatalf("SearchWithAliases: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("search results = %d, want 2", len(results))
+	}
+	want := map[string]string{
+		a1.ID: "lib-alias-a",
+		a2.ID: "lib-alias-b",
+	}
+	for _, r := range results {
+		if got, ok := want[r.ID]; !ok {
+			t.Errorf("unexpected artist ID in results: %s", r.ID)
+		} else if r.LibraryID != got {
+			t.Errorf("SearchWithAliases result %q LibraryID = %q, want %q", r.Name, r.LibraryID, got)
+		}
+	}
+}
+
 func TestBandMembers_CRUD(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/internal/artist/service_test.go
+++ b/internal/artist/service_test.go
@@ -581,7 +581,11 @@ func TestSearch_HydratesPrimaryLibrary(t *testing.T) {
 }
 
 // TestSearchWithAliases_HydratesPrimaryLibrary mirrors TestSearch_HydratesPrimaryLibrary
-// for the alias-aware search path.
+// for the alias-aware search path. The query token MUST be unique to the
+// alias row (not present in any artists.name) so the test exercises the
+// alias-resolution code path, not the plain name-search fallback. Using
+// a name-matching query like "Aliased" would still pass even if
+// SearchWithAliases regressed to a plain name search.
 func TestSearchWithAliases_HydratesPrimaryLibrary(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
@@ -590,35 +594,42 @@ func TestSearchWithAliases_HydratesPrimaryLibrary(t *testing.T) {
 
 	seedLibraries(t, db, "lib-alias-a", "lib-alias-b")
 
-	a1 := testArtist("Aliased One", "/music/Aliased One")
+	a1 := testArtist("Radiohead", "/music/Radiohead")
 	a1.LibraryID = "lib-alias-a"
 	if err := svc.Create(ctx, a1); err != nil {
 		t.Fatalf("Create a1: %v", err)
 	}
 
-	a2 := testArtist("Aliased Two", "/music/Aliased Two")
+	a2 := testArtist("The Sugarcubes", "/music/The Sugarcubes")
 	a2.LibraryID = "lib-alias-b"
 	if err := svc.Create(ctx, a2); err != nil {
 		t.Fatalf("Create a2: %v", err)
 	}
 
-	results, err := svc.SearchWithAliases(ctx, "Aliased")
+	// Attach a unique alias token that does NOT appear in either
+	// artists.name row. Searching for this token forces the alias join
+	// path; a regression to plain name search would return zero rows.
+	const aliasToken = "OnlyAliasToken_xyz"
+	if _, err := svc.AddAlias(ctx, a1.ID, aliasToken, "manual"); err != nil {
+		t.Fatalf("AddAlias: %v", err)
+	}
+
+	results, err := svc.SearchWithAliases(ctx, aliasToken)
 	if err != nil {
 		t.Fatalf("SearchWithAliases: %v", err)
 	}
-	if len(results) != 2 {
-		t.Fatalf("search results = %d, want 2", len(results))
+	if len(results) != 1 {
+		t.Fatalf("search results = %d, want 1 (alias-only token must resolve to exactly one artist)", len(results))
 	}
-	want := map[string]string{
-		a1.ID: "lib-alias-a",
-		a2.ID: "lib-alias-b",
+	if results[0].ID != a1.ID {
+		t.Errorf("result ID = %q, want %q (alias must resolve to its owning artist)", results[0].ID, a1.ID)
 	}
-	for _, r := range results {
-		if got, ok := want[r.ID]; !ok {
-			t.Errorf("unexpected artist ID in results: %s", r.ID)
-		} else if r.LibraryID != got {
-			t.Errorf("SearchWithAliases result %q LibraryID = %q, want %q", r.Name, r.LibraryID, got)
-		}
+	// Pin the primary-library hydration on the alias-resolved row: this
+	// is the original assertion the test was added to cover, and it must
+	// still hold once the search reaches the artist via the alias join.
+	if results[0].LibraryID != "lib-alias-a" {
+		t.Errorf("SearchWithAliases result %q LibraryID = %q, want lib-alias-a (alias path must hydrate primary library)",
+			results[0].Name, results[0].LibraryID)
 	}
 }
 

--- a/internal/artist/service_test.go
+++ b/internal/artist/service_test.go
@@ -59,10 +59,14 @@ func seedLibraries(t *testing.T, db *sql.DB, ids ...string) {
 		if id == "" {
 			continue
 		}
+		// Include `path` to match the canonical insert shape used elsewhere
+		// in this file (e.g. line 152 and the other call sites). The column
+		// is non-NULL in some schema versions and the placeholder helps
+		// identify seeded libraries in debug dumps.
 		if _, err := db.ExecContext(context.Background(),
-			`INSERT OR IGNORE INTO libraries (id, name, type, source, created_at, updated_at)
-				VALUES (?, ?, 'regular', 'manual', datetime('now'), datetime('now'))`,
-			id, id); err != nil {
+			`INSERT OR IGNORE INTO libraries (id, name, path, type, source, created_at, updated_at)
+				VALUES (?, ?, ?, 'regular', 'manual', datetime('now'), datetime('now'))`,
+			id, id, "/test/library/"+id); err != nil {
 			t.Fatalf("seeding library %s: %v", id, err)
 		}
 	}

--- a/internal/artist/sqlite_artist.go
+++ b/internal/artist/sqlite_artist.go
@@ -69,6 +69,13 @@ func newSQLiteArtistRepo(db *sql.DB) *sqliteArtistRepo {
 	return &sqliteArtistRepo{db: db}
 }
 
+// DB satisfies the dbProvider interface used by Service.hydratePrimaryLibrary
+// (and its batch sibling) so wrapped repositories that embed *sqliteArtistRepo
+// continue to expose the underlying handle without a concrete type assertion.
+func (r *sqliteArtistRepo) DB() *sql.DB {
+	return r.db
+}
+
 func (r *sqliteArtistRepo) Create(ctx context.Context, a *Artist) error {
 	if a.ID == "" {
 		a.ID = uuid.New().String()

--- a/internal/artist/sqlite_artist.go
+++ b/internal/artist/sqlite_artist.go
@@ -82,17 +82,17 @@ func (r *sqliteArtistRepo) Create(ctx context.Context, a *Artist) error {
 			id, name, sort_name, type, gender, origin, disambiguation,
 			genres, styles, moods,
 			years_active, born, formed, died, disbanded, biography,
-			path, library_id, nfo_exists,
+			path, nfo_exists,
 			health_score, is_excluded, exclusion_reason, is_classical,
 			locked, lock_source, locked_at, locked_fields,
 			metadata_sources,
 			last_scanned_at, created_at, updated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		a.ID, a.Name, a.SortName, a.Type, a.Gender, a.Origin, a.Disambiguation,
 		MarshalStringSlice(a.Genres), MarshalStringSlice(a.Styles), MarshalStringSlice(a.Moods),
 		a.YearsActive, a.Born, a.Formed, a.Died, a.Disbanded, a.Biography,
-		a.Path, dbutil.NullableString(a.LibraryID), dbutil.BoolToInt(a.NFOExists),
+		a.Path, dbutil.BoolToInt(a.NFOExists),
 		a.HealthScore, dbutil.BoolToInt(a.IsExcluded), a.ExclusionReason, dbutil.BoolToInt(a.IsClassical),
 		dbutil.BoolToInt(a.Locked), a.LockSource, dbutil.FormatNullableTime(a.LockedAt),
 		MarshalStringSlice(a.LockedFields),
@@ -165,64 +165,6 @@ func (r *sqliteArtistRepo) FindByMBIDOrNameUnscoped(ctx context.Context, mbid, n
 		return nil, nil
 	}
 	return r.GetByName(ctx, name)
-}
-
-func (r *sqliteArtistRepo) GetByMBIDAndLibrary(ctx context.Context, mbid, libraryID string) (*Artist, error) {
-	row := r.db.QueryRowContext(ctx,
-		`SELECT `+artistColumns+` FROM artists
-		WHERE id IN (SELECT artist_id FROM artist_provider_ids WHERE provider = 'musicbrainz' AND provider_id = ?)
-		AND library_id = ?`, mbid, libraryID)
-	a, err := scanArtist(row)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("getting artist by mbid+library: %w", err)
-	}
-	return a, nil
-}
-
-func (r *sqliteArtistRepo) GetByNameAndLibrary(ctx context.Context, name, libraryID string) (*Artist, error) {
-	row := r.db.QueryRowContext(ctx,
-		`SELECT `+artistColumns+` FROM artists WHERE name = ? AND library_id = ?`, name, libraryID)
-	a, err := scanArtist(row)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("getting artist by name+library: %w", err)
-	}
-	return a, nil
-}
-
-func (r *sqliteArtistRepo) FindByMBIDOrName(ctx context.Context, mbid, name, libraryID string) (*Artist, error) {
-	// Try MBID match first (most reliable).
-	if mbid != "" {
-		row := r.db.QueryRowContext(ctx,
-			`SELECT `+artistColumns+` FROM artists
-			WHERE id IN (SELECT artist_id FROM artist_provider_ids WHERE provider = 'musicbrainz' AND provider_id = ?)
-			AND library_id = ?`, mbid, libraryID)
-		a, err := scanArtist(row)
-		if err == nil {
-			return a, nil
-		}
-		if !errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("finding artist by mbid+library: %w", err)
-		}
-		// No MBID match -- fall through to name match.
-	}
-
-	// Fall back to case-insensitive name match.
-	row := r.db.QueryRowContext(ctx,
-		`SELECT `+artistColumns+` FROM artists WHERE LOWER(name) = LOWER(?) AND library_id = ?`, name, libraryID)
-	a, err := scanArtist(row)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("finding artist by name+library: %w", err)
-	}
-	return a, nil
 }
 
 func (r *sqliteArtistRepo) GetByPath(ctx context.Context, path string) (*Artist, error) {
@@ -304,7 +246,7 @@ func (r *sqliteArtistRepo) Update(ctx context.Context, a *Artist) error {
 			name = ?, sort_name = ?, type = ?, gender = ?, origin = ?, disambiguation = ?,
 			genres = ?, styles = ?, moods = ?,
 			years_active = ?, born = ?, formed = ?, died = ?, disbanded = ?, biography = ?,
-			path = ?, library_id = ?, nfo_exists = ?,
+			path = ?, nfo_exists = ?,
 			health_score = ?, health_evaluated_at = ?, is_excluded = ?, exclusion_reason = ?, is_classical = ?,
 			locked = ?, lock_source = ?, locked_at = ?, locked_fields = ?,
 			metadata_sources = ?,
@@ -314,7 +256,7 @@ func (r *sqliteArtistRepo) Update(ctx context.Context, a *Artist) error {
 		a.Name, a.SortName, a.Type, a.Gender, a.Origin, a.Disambiguation,
 		MarshalStringSlice(a.Genres), MarshalStringSlice(a.Styles), MarshalStringSlice(a.Moods),
 		a.YearsActive, a.Born, a.Formed, a.Died, a.Disbanded, a.Biography,
-		a.Path, dbutil.NullableString(a.LibraryID), dbutil.BoolToInt(a.NFOExists),
+		a.Path, dbutil.BoolToInt(a.NFOExists),
 		a.HealthScore, dbutil.FormatNullableTime(a.HealthEvaluatedAt), dbutil.BoolToInt(a.IsExcluded), a.ExclusionReason, dbutil.BoolToInt(a.IsClassical),
 		dbutil.BoolToInt(a.Locked), a.LockSource, dbutil.FormatNullableTime(a.LockedAt),
 		MarshalStringSlice(a.LockedFields),
@@ -388,10 +330,14 @@ func (r *sqliteArtistRepo) Delete(ctx context.Context, id string) error {
 // ListPathsByLibrary returns a map of artist ID to filesystem path for all
 // artists in the given library that have a non-empty path. Uses artist ID
 // as the key (not name) to avoid collisions when multiple artists share
-// the same name.
+// the same name. Membership is resolved through artist_libraries (the
+// authoritative M:N table) since the legacy artists.library_id column
+// was dropped in migration 004.
 func (r *sqliteArtistRepo) ListPathsByLibrary(ctx context.Context, libraryID string) (map[string]string, error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, path FROM artists WHERE library_id = ? AND path != ''`,
+		`SELECT a.id, a.path FROM artists a
+		JOIN artist_libraries al ON al.artist_id = a.id
+		WHERE al.library_id = ? AND a.path != ''`,
 		libraryID)
 	if err != nil {
 		return nil, fmt.Errorf("listing artist paths for library %s: %w", libraryID, err)

--- a/internal/artist/sqlite_completeness.go
+++ b/internal/artist/sqlite_completeness.go
@@ -62,14 +62,11 @@ WHERE a.is_excluded = 0`
 	var args []any
 
 	if libraryID != "" {
-		query = baseQuery + ` AND (
-			EXISTS (
-				SELECT 1 FROM artist_libraries al
-				WHERE al.artist_id = a.id AND al.library_id = ?
-			)
-			OR a.library_id = ?
+		query = baseQuery + ` AND EXISTS (
+			SELECT 1 FROM artist_libraries al
+			WHERE al.artist_id = a.id AND al.library_id = ?
 		)`
-		args = []any{libraryID, libraryID}
+		args = []any{libraryID}
 	} else {
 		query = baseQuery
 	}
@@ -131,14 +128,11 @@ WHERE a.is_excluded = 0`
 	var args []any
 
 	if libraryID != "" {
-		query = baseQuery + ` AND (
-			EXISTS (
-				SELECT 1 FROM artist_libraries al
-				WHERE al.artist_id = a.id AND al.library_id = ?
-			)
-			OR a.library_id = ?
+		query = baseQuery + ` AND EXISTS (
+			SELECT 1 FROM artist_libraries al
+			WHERE al.artist_id = a.id AND al.library_id = ?
 		) ORDER BY a.health_score ASC LIMIT ?`
-		args = []any{libraryID, libraryID, limit}
+		args = []any{libraryID, limit}
 	} else {
 		query = baseQuery + " ORDER BY a.health_score ASC LIMIT ?"
 		args = []any{limit}

--- a/internal/artist/sqlite_completeness_test.go
+++ b/internal/artist/sqlite_completeness_test.go
@@ -130,6 +130,8 @@ func TestGetCompletenessRows_LibraryFilter(t *testing.T) {
 	svc := NewService(db)
 	ctx := context.Background()
 
+	seedLibraries(t, db, "lib-a", "lib-b")
+
 	libA := &Artist{
 		Name:      "Library A Artist",
 		SortName:  "Library A Artist",
@@ -320,6 +322,8 @@ func TestGetLowestCompleteness_LibraryFilter(t *testing.T) {
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
+
+	seedLibraries(t, db, "lib-a", "lib-b")
 
 	a1 := &Artist{
 		Name:        "Lib A Artist",

--- a/internal/artist/sqlite_health_stats.go
+++ b/internal/artist/sqlite_health_stats.go
@@ -108,14 +108,11 @@ WHERE a.is_excluded = 0`
 	var args []any
 
 	if libraryID != "" {
-		query = baseQuery + ` AND (
-			EXISTS (
-				SELECT 1 FROM artist_libraries al
-				WHERE al.artist_id = a.id AND al.library_id = ?
-			)
-			OR a.library_id = ?
+		query = baseQuery + ` AND EXISTS (
+			SELECT 1 FROM artist_libraries al
+			WHERE al.artist_id = a.id AND al.library_id = ?
 		)`
-		args = []any{libraryID, libraryID}
+		args = []any{libraryID}
 	} else {
 		query = baseQuery
 	}

--- a/internal/artist/sqlite_health_stats_test.go
+++ b/internal/artist/sqlite_health_stats_test.go
@@ -136,6 +136,8 @@ func TestHealthStats_LibraryFilter(t *testing.T) {
 	svc := NewService(db)
 	ctx := context.Background()
 
+	seedLibraries(t, db, "lib-1", "lib-2")
+
 	lib1 := &Artist{
 		Name:        "Library1 Artist",
 		SortName:    "Library1 Artist",

--- a/internal/artist/sqlite_history.go
+++ b/internal/artist/sqlite_history.go
@@ -75,17 +75,14 @@ func (r *sqliteHistoryRepo) List(ctx context.Context, artistID string, limit, of
 		return []MetadataChange{}, 0, nil
 	}
 
-	// Wrap created_at with datetime() so mixed-format timestamps (legacy
-	// "YYYY-MM-DD HH:MM:SS" rows and RFC 3339 rows) sort consistently. Without
-	// this, the space character (0x20) sorts before 'T' in a raw text
-	// comparison, causing legacy rows to appear out of chronological order
-	// relative to RFC 3339 rows. This mirrors the normalisation applied in
-	// ListGlobal() above.
+	// Migration 004 normalized any legacy "YYYY-MM-DD HH:MM:SS" rows to
+	// RFC3339, so a plain TEXT compare is monotonic again. Direct ORDER
+	// BY on created_at is index-friendly without a datetime() wrapper.
 	const q = `
 		SELECT id, artist_id, field, old_value, new_value, source, created_at
 		FROM metadata_changes
 		WHERE artist_id = ?
-		ORDER BY datetime(created_at) DESC, id DESC
+		ORDER BY created_at DESC, id DESC
 		LIMIT ? OFFSET ?`
 
 	rows, err := r.db.QueryContext(ctx, q, artistID, limit, offset)
@@ -149,17 +146,15 @@ func (r *sqliteHistoryRepo) ListGlobal(ctx context.Context, filter GlobalHistory
 		where = append(where, "("+strings.Join(sourceClauses, " OR ")+")")
 	}
 
-	// Date range bounds. datetime() normalises both the stored value and the
-	// bind parameter so that legacy rows using the "2006-01-02 15:04:05" space
-	// separator compare correctly against RFC 3339 bounds. Without this, the
-	// space character ('\x20') sorts before 'T', causing legacy rows to appear
-	// after any RFC 3339 bound in a lexicographic comparison.
+	// Migration 004 normalized legacy space-separator rows to RFC3339, so
+	// direct text compares are monotonic. Bind RFC3339 directly to keep
+	// the index on created_at usable.
 	if !filter.From.IsZero() {
-		where = append(where, "datetime(mc.created_at) >= datetime(?)")
+		where = append(where, "mc.created_at >= ?")
 		args = append(args, filter.From.UTC().Format(time.RFC3339))
 	}
 	if !filter.To.IsZero() {
-		where = append(where, "datetime(mc.created_at) <= datetime(?)")
+		where = append(where, "mc.created_at <= ?")
 		args = append(args, filter.To.UTC().Format(time.RFC3339))
 	}
 
@@ -180,16 +175,13 @@ func (r *sqliteHistoryRepo) ListGlobal(ctx context.Context, filter GlobalHistory
 		return []MetadataChangeWithArtist{}, 0, nil
 	}
 
-	// Fetch rows with artist name. ORDER BY uses datetime() to normalise mixed
-	// timestamp formats (RFC 3339 vs SQLite "YYYY-MM-DD HH:MM:SS") so legacy
-	// rows sort consistently with the datetime()-normalised WHERE bounds above.
-	// Otherwise the lexicographic 'T' vs ' ' difference would invert ordering.
+	// Plain TEXT ORDER BY on created_at is monotonic post-migration 004.
 	selectQ := `
 		SELECT mc.id, mc.artist_id, a.name, mc.field, mc.old_value, mc.new_value, mc.source, mc.created_at
 		FROM metadata_changes mc
 		JOIN artists a ON a.id = mc.artist_id
 		` + whereClause + `
-		ORDER BY datetime(mc.created_at) DESC, mc.id DESC
+		ORDER BY mc.created_at DESC, mc.id DESC
 		LIMIT ? OFFSET ?`
 
 	queryArgs := make([]any, len(args))

--- a/internal/artist/sqlite_image.go
+++ b/internal/artist/sqlite_image.go
@@ -274,16 +274,11 @@ func (r *sqliteImageRepo) NewestWriteTimesByArtist(ctx context.Context, libraryI
 		SELECT a.id, MAX(ai.last_written_at)
 		FROM artist_images ai
 		JOIN artists a ON ai.artist_id = a.id
-		WHERE (
-			EXISTS (
-				SELECT 1 FROM artist_libraries al
-				WHERE al.artist_id = a.id AND al.library_id = ?
-			)
-			OR a.library_id = ?
-		)
+		JOIN artist_libraries al ON al.artist_id = a.id
+		WHERE al.library_id = ?
 		AND ai.last_written_at != ''
 		GROUP BY a.id`,
-		libraryID, libraryID,
+		libraryID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("querying newest write times by artist for library %s: %w", libraryID, err)

--- a/internal/artist/sqlite_image_test.go
+++ b/internal/artist/sqlite_image_test.go
@@ -260,6 +260,16 @@ func TestNewestWriteTimesByArtist_NoWrites(t *testing.T) {
 	ctx := context.Background()
 	repo := newSQLiteImageRepo(db)
 
+	// Seed lib-empty so Service.Create's derive-source membership insert
+	// lands a real artist_libraries row (matches the membership-backed
+	// precondition the sibling TestNewestWriteTimesByArtist test enforces).
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO libraries (id, name, type, source, created_at, updated_at)
+			VALUES (?, ?, 'regular', 'manual', datetime('now'), datetime('now'))`,
+		"lib-empty", "lib-empty"); err != nil {
+		t.Fatalf("seeding library lib-empty: %v", err)
+	}
+
 	// Create an artist with an image but no provenance (empty last_written_at).
 	a := testArtist("Silent Artist", "/music/Silent")
 	a.LibraryID = "lib-empty"

--- a/internal/artist/sqlite_image_test.go
+++ b/internal/artist/sqlite_image_test.go
@@ -170,6 +170,17 @@ func TestNewestWriteTimesByArtist(t *testing.T) {
 	ctx := context.Background()
 	repo := newSQLiteImageRepo(db)
 
+	// Seed the two libraries the artists will belong to so Service.Create's
+	// derive-source membership insert lands a real artist_libraries row.
+	for _, lid := range []string{"lib-mtime", "lib-other"} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO libraries (id, name, type, source, created_at, updated_at)
+				VALUES (?, ?, 'regular', 'manual', datetime('now'), datetime('now'))`,
+			lid, lid); err != nil {
+			t.Fatalf("seeding library %s: %v", lid, err)
+		}
+	}
+
 	// Create two artists in the same library with different write times.
 	artistA := testArtist("Artist A", "/music/Artist A")
 	artistA.LibraryID = "lib-mtime"

--- a/internal/artist/sqlite_platform.go
+++ b/internal/artist/sqlite_platform.go
@@ -144,30 +144,17 @@ func (r *sqlitePlatformIDRepo) GetPresenceForArtists(ctx context.Context, artist
 	// with libraries.source in the GROUP BY (SQLite resolves the bare
 	// name to the table column, raising "ambiguous column" otherwise).
 	//
-	// Hybrid OR-fallback: UNION the membership-derived rows with the
-	// legacy artists.library_id projection so artists created by
-	// still-legacy writers (or older fixtures) without an
-	// artist_libraries row are still visible. The legacy branch goes
-	// away when #1214 drops the column.
+	// Membership-derived only. The legacy artists.library_id column was
+	// dropped in migration 004; artist_libraries is the authoritative
+	// presence record.
 	in := strings.Join(placeholders, ",")
-	query := `SELECT artist_id, presence_kind FROM (` + //nolint:gosec // G202: placeholders are "?" literals
-		`SELECT al.artist_id AS artist_id, ` +
+	query := `SELECT al.artist_id, ` + //nolint:gosec // G202: placeholders are "?" literals
 		`CASE WHEN l.connection_id IS NULL THEN 'filesystem' ELSE COALESCE(c.type, '') END AS presence_kind ` +
 		`FROM artist_libraries al ` +
 		`JOIN libraries l ON l.id = al.library_id ` +
 		`LEFT JOIN connections c ON c.id = l.connection_id ` +
-		`WHERE al.artist_id IN (` + in + `) ` +
-		`UNION ` +
-		`SELECT a.id AS artist_id, ` +
-		`CASE WHEN l.connection_id IS NULL THEN 'filesystem' ELSE COALESCE(c.type, '') END AS presence_kind ` +
-		`FROM artists a ` +
-		`JOIN libraries l ON l.id = a.library_id ` +
-		`LEFT JOIN connections c ON c.id = l.connection_id ` +
-		`WHERE a.id IN (` + in + `) ` +
-		`  AND a.library_id IS NOT NULL AND a.library_id <> ''` +
-		`)`
-	queryArgs := append(append([]any{}, args...), args...)
-	rows, err := r.db.QueryContext(ctx, query, queryArgs...)
+		`WHERE al.artist_id IN (` + in + `)`
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("batch getting platform presence: %w", err)
 	}

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -275,11 +275,34 @@ func seedLibrary(t *testing.T, db *sql.DB, id, source, connID string) {
 	}
 }
 
+// ensureLegacyLibraryIDColumn re-adds the (post-004 dropped)
+// artists.library_id column on a freshly migrated DB so the legacy backfill
+// and duplicate-collapse helpers can be exercised against a "pre-1004"
+// data shape. Idempotent: a no-op when the column is already present.
+// Lazy-called from seedArtistWithLibrary so individual tests do not need
+// to remember the setup step.
+func ensureLegacyLibraryIDColumn(t *testing.T, db *sql.DB) {
+	t.Helper()
+	has, err := columnExists(db, "artists", "library_id")
+	if err != nil {
+		t.Fatalf("checking for legacy library_id column: %v", err)
+	}
+	if has {
+		return
+	}
+	if _, err := db.ExecContext(context.Background(),
+		`ALTER TABLE artists ADD COLUMN library_id TEXT REFERENCES libraries(id) DEFAULT NULL`); err != nil {
+		t.Fatalf("re-adding legacy library_id column: %v", err)
+	}
+}
+
 // seedArtistWithLibrary inserts an artist tied to a specific library_id
 // (legacy path that the M:N migration backfills from). created_at lets the
-// test control the canonical-pick tie-breaker.
+// test control the canonical-pick tie-breaker. Lazy-installs the legacy
+// library_id column on first use.
 func seedArtistWithLibrary(t *testing.T, db *sql.DB, id, name, libraryID, createdAt string) {
 	t.Helper()
+	ensureLegacyLibraryIDColumn(t, db)
 	_, err := db.ExecContext(context.Background(), `
 		INSERT INTO artists (id, name, sort_name, path, library_id, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, datetime('now'))

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -997,6 +997,122 @@ func TestMarkPre002Applied_PropagatesErrorOnClosedDB(t *testing.T) {
 	}
 }
 
+// TestMigration004_NormalizesLegacyHistoryTimestamp covers the migration-
+// level timestamp conversion that protects history ordering on upgrades.
+// Before 004 a row could be written with the SQLite "YYYY-MM-DD HH:MM:SS"
+// space-separator format; the service-level history reader sorts by plain
+// TEXT, so a stray legacy row would lexically follow any RFC3339 row
+// ('T' (0x54) > ' ' (0x20)) and break chronological order. The 004
+// migration runs an UPDATE that rewrites those legacy rows to RFC3339.
+//
+// This test simulates the upgrade path: insert a legacy row directly
+// (bypassing the modern service writer which always emits RFC3339), then
+// re-run the UPDATE statement that 004 ships with, and assert the row is
+// normalized. We re-run the UPDATE rather than down-then-up the migration
+// because goose does not re-execute already-applied migrations, and the
+// behavioral contract under test is "the SQL works", not "goose replays
+// it".
+func TestMigration004_NormalizesLegacyHistoryTimestamp(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	// Seed an artist + a legacy-format change row + a clean RFC3339 row.
+	seedArtist(t, db, "a-mig", "MigArtist")
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO metadata_changes (id, artist_id, field, old_value, new_value, source, created_at)
+		VALUES ('legacy-1', 'a-mig', 'biography', '', 'v', 'manual', '2024-01-15 09:00:00')
+	`); err != nil {
+		t.Fatalf("seeding legacy row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO metadata_changes (id, artist_id, field, old_value, new_value, source, created_at)
+		VALUES ('rfc-1', 'a-mig', 'biography', '', 'v', 'manual', '2024-01-15T10:00:00Z')
+	`); err != nil {
+		t.Fatalf("seeding rfc3339 row: %v", err)
+	}
+
+	// Run the same normalization statement migration 004 executes. This
+	// is the contract under test; if the migration's pattern ever drifts
+	// (e.g. fails to match a legacy variant), this will catch it.
+	if _, err := db.ExecContext(ctx, `
+		UPDATE metadata_changes
+		SET created_at = REPLACE(created_at, ' ', 'T') || 'Z'
+		WHERE created_at LIKE '____-__-__ __:__:__'
+	`); err != nil {
+		t.Fatalf("running normalization: %v", err)
+	}
+
+	// Legacy row is now RFC3339.
+	var legacy string
+	if err := db.QueryRowContext(ctx,
+		`SELECT created_at FROM metadata_changes WHERE id = 'legacy-1'`).Scan(&legacy); err != nil {
+		t.Fatalf("reading legacy row: %v", err)
+	}
+	if legacy != "2024-01-15T09:00:00Z" {
+		t.Errorf("legacy row created_at = %q, want %q (migration must convert space separator to T and append Z)",
+			legacy, "2024-01-15T09:00:00Z")
+	}
+
+	// Already-RFC3339 row is unchanged.
+	var rfc string
+	if err := db.QueryRowContext(ctx,
+		`SELECT created_at FROM metadata_changes WHERE id = 'rfc-1'`).Scan(&rfc); err != nil {
+		t.Fatalf("reading rfc row: %v", err)
+	}
+	if rfc != "2024-01-15T10:00:00Z" {
+		t.Errorf("rfc row created_at = %q, want unchanged %q", rfc, "2024-01-15T10:00:00Z")
+	}
+
+	// Plain TEXT ORDER BY now produces chronological order. Without the
+	// migration the legacy row (' ' separator, lexically before 'T')
+	// would sort before the RFC3339 row even though it is one hour
+	// earlier in real time -- the same TEXT ordering happens to be
+	// "right" in this single case, but the load-bearing contract is that
+	// after normalization the table holds a single uniform format and
+	// further inserts (which always use RFC3339) interleave correctly.
+	rows, err := db.QueryContext(ctx,
+		`SELECT id FROM metadata_changes WHERE artist_id = 'a-mig' ORDER BY created_at ASC`)
+	if err != nil {
+		t.Fatalf("ordered query: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var got []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, id)
+	}
+	want := []string{"legacy-1", "rfc-1"}
+	if len(got) != len(want) {
+		t.Fatalf("rows = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("position %d: got %q, want %q (full order: %v)", i, got[i], want[i], got)
+		}
+	}
+
+	// Idempotency: re-running the UPDATE on already-normalized rows must
+	// be a no-op (LIKE pattern excludes the 'T'-separated rows).
+	res, err := db.ExecContext(ctx, `
+		UPDATE metadata_changes
+		SET created_at = REPLACE(created_at, ' ', 'T') || 'Z'
+		WHERE created_at LIKE '____-__-__ __:__:__'
+	`)
+	if err != nil {
+		t.Fatalf("re-running normalization: %v", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		t.Fatalf("RowsAffected: %v", err)
+	}
+	if affected != 0 {
+		t.Errorf("re-run affected %d rows, want 0 (already-normalized rows must not match)", affected)
+	}
+}
+
 // TestMarkPre002Applied_FreshDBSkips verifies that markPre002Applied is a
 // no-op on a database that has no goose_db_version table yet. Fresh-install
 // startup must not synthesize a tracker row before goose has had a chance to

--- a/internal/database/migrations/004_drop_library_id_and_perf.sql
+++ b/internal/database/migrations/004_drop_library_id_and_perf.sql
@@ -1,0 +1,72 @@
+-- +goose Up
+-- Issue #1214: drop the legacy artists.library_id column and its index.
+-- Membership of record now lives exclusively in artist_libraries (the M:N
+-- table introduced in #1004). Backfill any pre-1004 rows whose library_id
+-- column still carries a non-empty value before dropping the column, so a
+-- DB that has not yet had ensureArtistLibrariesMembership run also lands
+-- with full memberships.
+--
+-- Issue #1224: add a case-insensitive index on artist name to make
+-- LOWER(name) lookups (GetByName, FindByMBIDOrNameUnscoped) index-driven
+-- instead of running a full scan on the artists table.
+--
+-- Issue #1018: normalize legacy metadata_changes.created_at rows from the
+-- SQLite "YYYY-MM-DD HH:MM:SS" space-separator format to RFC3339
+-- ("YYYY-MM-DDTHH:MM:SSZ") so range comparisons work without datetime()
+-- wrappers.
+
+-- +goose StatementBegin
+-- Step 1: backfill artist_libraries from any remaining pre-1004 rows. The
+-- INSERT OR IGNORE preserves any existing memberships so an already-
+-- migrated DB is a no-op. The join through libraries skips rows whose
+-- library_id no longer references a real library.
+INSERT OR IGNORE INTO artist_libraries (artist_id, library_id, source, added_at)
+SELECT
+    a.id,
+    a.library_id,
+    CASE
+        WHEN c.type = 'emby'     THEN 'emby'
+        WHEN c.type = 'jellyfin' THEN 'jellyfin'
+        WHEN c.type = 'lidarr'   THEN 'lidarr'
+        ELSE 'filesystem'
+    END,
+    a.created_at
+FROM artists a
+JOIN libraries l ON l.id = a.library_id
+LEFT JOIN connections c ON c.id = l.connection_id
+WHERE a.library_id IS NOT NULL AND a.library_id != '';
+-- +goose StatementEnd
+
+-- Step 2: drop the supporting index. SQLite tolerates DROP INDEX IF NOT
+-- EXISTS only via IF EXISTS; this matches the column-drop's IF semantics.
+DROP INDEX IF EXISTS idx_artists_library_id;
+
+-- Step 3: drop the column. SQLite 3.35+ supports DROP COLUMN; modernc
+-- ships well past that.
+ALTER TABLE artists DROP COLUMN library_id;
+
+-- Step 4: case-insensitive lookup index for #1224. SQLite supports
+-- expression indexes; LOWER(name) lookups now hit this directly.
+CREATE INDEX IF NOT EXISTS idx_artists_name_lower ON artists(LOWER(name));
+
+-- +goose StatementBegin
+-- Step 5: normalize metadata_changes.created_at to RFC3339 for any legacy
+-- row stored in the "YYYY-MM-DD HH:MM:SS" space-separator format. The
+-- LIKE pattern matches "YYYY-MM-DD" + space + "HH:MM:SS" exactly: 10
+-- digits/dashes, one space, 8 digits/colons. Rows already in RFC3339
+-- format ("T" separator) skip the rewrite. The replace + 'Z' suffix is
+-- safe because legacy rows were always in UTC.
+UPDATE metadata_changes
+SET created_at = REPLACE(created_at, ' ', 'T') || 'Z'
+WHERE created_at LIKE '____-__-__ __:__:__';
+-- +goose StatementEnd
+
+-- +goose Down
+-- Restore the column (data loss acceptable: ensureArtistLibrariesMembership
+-- runs at startup and re-derives memberships from artist_libraries when
+-- needed). Drop the lower-name index. The metadata_changes normalization
+-- is one-way; callers that depend on legacy parsing have parseHistoryTimestamp
+-- which already handles both formats.
+ALTER TABLE artists ADD COLUMN library_id TEXT REFERENCES libraries(id) DEFAULT NULL;
+CREATE INDEX IF NOT EXISTS idx_artists_library_id ON artists(library_id);
+DROP INDEX IF EXISTS idx_artists_name_lower;

--- a/internal/database/query_plan_test.go
+++ b/internal/database/query_plan_test.go
@@ -55,16 +55,28 @@ func TestQueryPlans(t *testing.T) {
 			args:  []any{"Test Artist"},
 		},
 		"artist_list_by_library": {
-			query: "SELECT id, name FROM artists WHERE library_id = ? ORDER BY name ASC LIMIT ? OFFSET ?",
-			args:  []any{"lib-1", 50, 0},
+			query: `SELECT a.id, a.name FROM artists a
+				JOIN artist_libraries al ON al.artist_id = a.id
+				WHERE al.library_id = ? ORDER BY a.name ASC LIMIT ? OFFSET ?`,
+			args: []any{"lib-1", 50, 0},
 		},
 		"artist_list_with_search": {
 			query: "SELECT id, name FROM artists WHERE name LIKE ? ORDER BY name ASC LIMIT ? OFFSET ?",
 			args:  []any{"%test%", 50, 0},
 		},
 		"artist_count_by_library": {
-			query: "SELECT COUNT(*) FROM artists WHERE library_id = ?",
+			query: "SELECT COUNT(*) FROM artist_libraries WHERE library_id = ?",
 			args:  []any{"lib-1"},
+		},
+		"artist_by_lower_name": {
+			query: "SELECT id FROM artists WHERE LOWER(name) = LOWER(?)",
+			args:  []any{"Beatles"},
+		},
+		"history_range_rfc3339": {
+			query: `SELECT id FROM metadata_changes
+				WHERE artist_id = ? AND created_at >= ? AND created_at <= ?
+				ORDER BY created_at DESC LIMIT 50`,
+			args: []any{"test-id", "2024-01-01T00:00:00Z", "2024-12-31T23:59:59Z"},
 		},
 		"artist_search": {
 			query: "SELECT id, name FROM artists WHERE name LIKE ? ORDER BY name LIMIT 20",
@@ -80,9 +92,10 @@ func TestQueryPlans(t *testing.T) {
 			args: []any{"5b11f4ce-a62d-471e-81fc-a69a8278c7da"},
 		},
 		"artist_by_mbid_and_library": {
-			query: `SELECT id FROM artists
-				WHERE id IN (SELECT artist_id FROM artist_provider_ids WHERE provider = 'musicbrainz' AND provider_id = ?)
-				AND library_id = ?`,
+			query: `SELECT a.id FROM artists a
+				JOIN artist_libraries al ON al.artist_id = a.id
+				WHERE a.id IN (SELECT artist_id FROM artist_provider_ids WHERE provider = 'musicbrainz' AND provider_id = ?)
+				AND al.library_id = ?`,
 			args: []any{"5b11f4ce-a62d-471e-81fc-a69a8278c7da", "lib-1"},
 		},
 		"images_for_artist": {
@@ -138,8 +151,10 @@ func TestQueryPlans(t *testing.T) {
 			args:  []any{"2024-01-01"},
 		},
 		"artists_by_path_for_library": {
-			query: "SELECT id, path FROM artists WHERE library_id = ? AND path != ''",
-			args:  []any{"lib-1"},
+			query: `SELECT a.id, a.path FROM artists a
+				JOIN artist_libraries al ON al.artist_id = a.id
+				WHERE al.library_id = ? AND a.path != ''`,
+			args: []any{"lib-1"},
 		},
 		"locked_artists": {
 			query: "SELECT id, name FROM artists WHERE locked = 1",
@@ -207,7 +222,8 @@ func TestQueryPlans(t *testing.T) {
 			query: `SELECT a.id, MAX(ai.last_written_at)
 				FROM artist_images ai
 				JOIN artists a ON ai.artist_id = a.id
-				WHERE a.library_id = ? AND ai.last_written_at != ''
+				JOIN artist_libraries al ON al.artist_id = a.id
+				WHERE al.library_id = ? AND ai.last_written_at != ''
 				GROUP BY a.id`,
 			args: []any{"lib-1"},
 		},
@@ -226,6 +242,8 @@ func TestQueryPlans(t *testing.T) {
 		"artist_by_id":              true,
 		"artist_by_path":            true,
 		"artist_by_name":            true,
+		"artist_by_lower_name":      true,
+		"history_range_rfc3339":     true,
 		"provider_id_lookup":        true,
 		"api_token_lookup":          true,
 		"images_for_artist":         true,

--- a/internal/database/query_plan_test.go
+++ b/internal/database/query_plan_test.go
@@ -72,6 +72,19 @@ func TestQueryPlans(t *testing.T) {
 			query: "SELECT id FROM artists WHERE LOWER(name) = LOWER(?)",
 			args:  []any{"Beatles"},
 		},
+		// Library-scoped LOWER(name) lookup used by lookupByNameInLibrary
+		// in handlers_connection_library.go. The JOIN form filters by
+		// artist_libraries.library_id first then matches the case-insensitive
+		// name; pinning its plan here catches future regressions where the
+		// planner stops using the membership index.
+		"artist_by_lower_name_library": {
+			query: `SELECT a.id FROM artists a
+				JOIN artist_libraries al ON al.artist_id = a.id
+				WHERE al.library_id = ? AND LOWER(a.name) = LOWER(?)
+				ORDER BY datetime(a.created_at), a.id
+				LIMIT 1`,
+			args: []any{"lib-1", "Beatles"},
+		},
 		"history_range_rfc3339": {
 			query: `SELECT id FROM metadata_changes
 				WHERE artist_id = ? AND created_at >= ? AND created_at <= ?

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -207,28 +207,11 @@ func (s *Service) ClearConnectionID(ctx context.Context, connectionID string) er
 }
 
 // Delete removes a library by ID. Artists are preserved; their membership
-// rows in artist_libraries cascade-delete via the FK. this is
+// rows in artist_libraries cascade-delete via the FK. This is
 // the "unlink only" path, where the user wants to disconnect the library
 // but keep the artists (which may still be observed by other libraries).
-//
-// The legacy artists.library_id column is also cleared for any artist that
-// pointed at the deleted library, so older code paths that still read the
-// orphan column do not see a dangling FK. The column will be removed in
-// the final phase.
 func (s *Service) Delete(ctx context.Context, id string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("starting transaction: %w", err)
-	}
-	defer tx.Rollback() //nolint:errcheck
-
-	// Soft-deprecation cleanup for the orphan artists.library_id column.
-	if _, err := tx.ExecContext(ctx,
-		`UPDATE artists SET library_id = NULL WHERE library_id = ?`, id); err != nil {
-		return fmt.Errorf("clearing artist references: %w", err)
-	}
-
-	result, err := tx.ExecContext(ctx, `DELETE FROM libraries WHERE id = ?`, id)
+	result, err := s.db.ExecContext(ctx, `DELETE FROM libraries WHERE id = ?`, id)
 	if err != nil {
 		return fmt.Errorf("deleting library: %w", err)
 	}
@@ -236,28 +219,24 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 	if rows == 0 {
 		return fmt.Errorf("library not found: %s", id)
 	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("committing delete: %w", err)
-	}
 	return nil
 }
 
-// CountArtists returns the number of artists assigned to a library.
+// CountArtists returns the number of artists assigned to a library, as
+// recorded in artist_libraries.
 func (s *Service) CountArtists(ctx context.Context, libraryID string) (int, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM artists WHERE library_id = ?`, libraryID).Scan(&count)
+		`SELECT COUNT(*) FROM artist_libraries WHERE library_id = ?`, libraryID).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("counting artists for library: %w", err)
 	}
 	return count, nil
 }
 
-// collectUnlinkCandidates returns the union of artist IDs that hold a
-// membership row in the about-to-be-deleted library and artist IDs whose
-// legacy artists.library_id column points at it. Split out so the rows
-// scopes can use defer (sqlclosecheck-friendly).
+// collectUnlinkCandidates returns the artist IDs that currently hold a
+// membership row in the about-to-be-deleted library. Split out so the
+// rows scope can use defer (sqlclosecheck-friendly).
 func collectUnlinkCandidates(ctx context.Context, tx *sql.Tx, libraryID string) ([]string, error) {
 	candidates := []string{}
 	seen := make(map[string]bool)
@@ -281,45 +260,22 @@ func collectUnlinkCandidates(ctx context.Context, tx *sql.Tx, libraryID string) 
 	if err := memberRows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating memberships: %w", err)
 	}
-
-	legacyRows, err := tx.QueryContext(ctx,
-		`SELECT id FROM artists WHERE library_id = ?`, libraryID)
-	if err != nil {
-		return nil, fmt.Errorf("listing legacy library_id artists: %w", err)
-	}
-	defer legacyRows.Close() //nolint:errcheck
-	for legacyRows.Next() {
-		var aid string
-		if err := legacyRows.Scan(&aid); err != nil {
-			return nil, fmt.Errorf("scanning legacy artist row: %w", err)
-		}
-		if !seen[aid] {
-			candidates = append(candidates, aid)
-			seen[aid] = true
-		}
-	}
-	if err := legacyRows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating legacy artist rows: %w", err)
-	}
 	return candidates, nil
 }
 
 // DeleteWithArtists removes a library and prunes artists that have no
-// other home. Membership-based for the M:N model, with a fallback prune
-// for legacy connection-orphan rows that predate artist_libraries:
+// other home.
 //
 // - Membership prune: for each artist with a membership
 // in the deleted library, if zero memberships remain after the
 // cascade AND zero platform mappings exist, drop the artist row.
 // Artists with sibling-library memberships or live platform mappings
 // elsewhere survive.
-// - Connection-orphan prune (carryover): when the deleted
-// library was the last library on its connection, also drop artists
-// whose only platform mapping is on that connection and who had no
-// library_id assignment. These are legacy data shapes that the
-// migration backfill could not see (no library_id to copy from).
-// The "last library on connection" guard avoids deleting data that a
-// sibling library still legitimately references.
+// - Connection-orphan prune: when the deleted library was the last
+// library on its connection, also drop artists whose only platform
+// mapping is on that connection. The "last library on connection"
+// guard avoids deleting data that a sibling library still legitimately
+// references.
 //
 // Order matters: the membership snapshot is taken BEFORE the library
 // delete fires the cascade.
@@ -344,14 +300,6 @@ func (s *Service) DeleteWithArtists(ctx context.Context, id string) error {
 		return err
 	}
 
-	// Soft-deprecation cleanup: the orphan artists.library_id FK still
-	// blocks the library delete on legacy / test rows that point at it.
-	// Clear it before the delete; final phase removes the column.
-	if _, err := tx.ExecContext(ctx,
-		`UPDATE artists SET library_id = NULL WHERE library_id = ?`, id); err != nil {
-		return fmt.Errorf("clearing legacy library_id refs: %w", err)
-	}
-
 	// Drop the library. CASCADE removes its artist_libraries rows.
 	result, err := tx.ExecContext(ctx, `DELETE FROM libraries WHERE id = ?`, id)
 	if err != nil {
@@ -374,8 +322,8 @@ func (s *Service) DeleteWithArtists(ctx context.Context, id string) error {
 	}
 
 	// Candidate prune: an artist is a candidate iff it had explicit
-	// presence in the deleted library (membership row OR legacy library_id
-	// pointer). Keep it if it has any other home: a remaining membership
+	// presence in the deleted library (membership row). Keep it if it
+	// has any other home: a remaining membership
 	// in some other library, OR a platform mapping on a connection other
 	// than the deleted library's connection. Mappings on the SAME
 	// connection do not count as "other home" because the user has just
@@ -413,25 +361,14 @@ func (s *Service) DeleteWithArtists(ctx context.Context, id string) error {
 	}
 
 	// Connection-orphan sweep for artists never in candidateIDs (no
-	// membership row, no library_id pointer, but a mapping on the
-	// just-unlinked connection). Legacy case.
-	//
-	// The COALESCE(a.library_id, '') = '' guard is required during partial
-	// migration: the lines above only cleared library_id pointing at the
-	// library being deleted, so an artist can still legitimately reference
-	// some other surviving library through the legacy column. Without
-	// this guard, a connection-library unlink would silently delete those
-	// artists when their only artist_libraries row had not yet been
-	// backfilled.
+	// membership row, but a mapping on the just-unlinked connection).
 	if connOrphanPruneAllowed {
 		if _, err := tx.ExecContext(ctx, `
 			DELETE FROM artists
 			WHERE id IN (
 				SELECT ap.artist_id
 				FROM artist_platform_ids ap
-				JOIN artists a ON a.id = ap.artist_id
 				WHERE ap.connection_id = ?
-				 AND COALESCE(a.library_id, '') = ''
 				 AND ap.artist_id NOT IN (
 					SELECT artist_id FROM artist_libraries
 				 )
@@ -503,12 +440,16 @@ func (s *Service) ListByConnectionID(ctx context.Context, connectionID string) (
 	return libs, rows.Err()
 }
 
-// CountArtistsByConnectionID returns the total number of artists across all
-// libraries belonging to a connection.
+// CountArtistsByConnectionID returns the total number of distinct artists
+// across all libraries belonging to a connection. Membership of record
+// lives in artist_libraries.
 func (s *Service) CountArtistsByConnectionID(ctx context.Context, connectionID string) (int, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM artists WHERE library_id IN (SELECT id FROM libraries WHERE connection_id = ?)`,
+		`SELECT COUNT(DISTINCT al.artist_id)
+		FROM artist_libraries al
+		JOIN libraries l ON l.id = al.library_id
+		WHERE l.connection_id = ?`,
 		connectionID).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("counting artists for connection: %w", err)

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -222,12 +222,18 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
-// CountArtists returns the number of artists assigned to a library, as
-// recorded in artist_libraries.
+// CountArtists returns the number of distinct artists assigned to a
+// library. The PRIMARY KEY (artist_id, library_id) on artist_libraries
+// already guarantees one-row-per-artist for a given library, so
+// COUNT(DISTINCT artist_id) is mathematically equivalent to COUNT(*) on
+// today's schema. The DISTINCT spelling is kept because it expresses
+// the intent of the function literally and stays correct under any
+// future schema change that loosens the PK (for example, splitting the
+// PK into (artist_id, library_id, source)).
 func (s *Service) CountArtists(ctx context.Context, libraryID string) (int, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM artist_libraries WHERE library_id = ?`, libraryID).Scan(&count)
+		`SELECT COUNT(DISTINCT artist_id) FROM artist_libraries WHERE library_id = ?`, libraryID).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("counting artists for library: %w", err)
 	}

--- a/internal/library/service_test.go
+++ b/internal/library/service_test.go
@@ -223,16 +223,27 @@ func TestDelete_WithArtists(t *testing.T) {
 		t.Fatalf("Create library: %v", err)
 	}
 
-	// Insert an artist referencing this library
+	// Enable FKs so the artist_libraries -> libraries cascade actually
+	// fires when the library row is deleted.
+	if err := database.EnableForeignKeys(db); err != nil {
+		t.Fatalf("enabling foreign keys: %v", err)
+	}
+
+	// Insert an artist referencing this library via artist_libraries.
 	_, err := db.ExecContext(ctx, `
-		INSERT INTO artists (id, name, sort_name, path, library_id, created_at, updated_at)
-		VALUES ('art-1', 'Test Artist', 'Test Artist', '/music/test', ?, datetime('now'), datetime('now'))
-	`, lib.ID)
+		INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		VALUES ('art-1', 'Test Artist', 'Test Artist', '/music/test', datetime('now'), datetime('now'))
+	`)
 	if err != nil {
 		t.Fatalf("inserting artist: %v", err)
 	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artist_libraries (artist_id, library_id, source) VALUES ('art-1', ?, 'filesystem')`,
+		lib.ID); err != nil {
+		t.Fatalf("inserting artist_libraries: %v", err)
+	}
 
-	// Delete should succeed and dereference the artist.
+	// Delete should succeed; CASCADE removes the membership row.
 	if err := svc.Delete(ctx, lib.ID); err != nil {
 		t.Fatalf("Delete returned error: %v", err)
 	}
@@ -242,15 +253,20 @@ func TestDelete_WithArtists(t *testing.T) {
 		t.Error("library should not exist after delete")
 	}
 
-	// Artist should still exist but with a cleared library_id.
-	var libID *string
+	// Artist should still exist; membership row removed by FK CASCADE.
+	var name string
 	err = db.QueryRowContext(ctx,
-		`SELECT library_id FROM artists WHERE id = 'art-1'`).Scan(&libID)
+		`SELECT name FROM artists WHERE id = 'art-1'`).Scan(&name)
 	if err != nil {
 		t.Fatalf("querying artist: %v", err)
 	}
-	if libID != nil {
-		t.Errorf("artist library_id = %q, want NULL", *libID)
+	var memberCount int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_libraries WHERE artist_id = 'art-1'`).Scan(&memberCount); err != nil {
+		t.Fatalf("counting memberships: %v", err)
+	}
+	if memberCount != 0 {
+		t.Errorf("memberships after library delete = %d, want 0 (cascade)", memberCount)
 	}
 }
 
@@ -285,13 +301,18 @@ func TestCountArtists(t *testing.T) {
 		t.Errorf("count = %d, want 0", count)
 	}
 
-	// Add an artist
+	// Add an artist with a membership.
 	_, err = db.ExecContext(ctx, `
-		INSERT INTO artists (id, name, sort_name, path, library_id, created_at, updated_at)
-		VALUES ('art-2', 'Artist 2', 'Artist 2', '/music/art2', ?, datetime('now'), datetime('now'))
-	`, lib.ID)
+		INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		VALUES ('art-2', 'Artist 2', 'Artist 2', '/music/art2', datetime('now'), datetime('now'))
+	`)
 	if err != nil {
 		t.Fatalf("inserting artist: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artist_libraries (artist_id, library_id, source) VALUES ('art-2', ?, 'filesystem')`,
+		lib.ID); err != nil {
+		t.Fatalf("inserting artist_libraries: %v", err)
 	}
 
 	count, err = svc.CountArtists(ctx, lib.ID)
@@ -898,21 +919,26 @@ func seedConnection(t *testing.T, db *sql.DB, id, connType string) {
 	}
 }
 
-// seedArtist inserts an artist row with the given library_id (may be empty).
+// seedArtist inserts an artist row and (when libraryID is non-empty) its
+// matching artist_libraries membership. Replaces the legacy library_id
+// column setup.
 func seedArtist(t *testing.T, db *sql.DB, id, name, libraryID string) {
 	t.Helper()
-	var libArg any
-	if libraryID == "" {
-		libArg = nil
-	} else {
-		libArg = libraryID
-	}
 	_, err := db.ExecContext(context.Background(), `
-		INSERT INTO artists (id, name, sort_name, path, library_id, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))
-	`, id, name, name, "/music/"+name, libArg)
+		INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+	`, id, name, name, "/music/"+name)
 	if err != nil {
 		t.Fatalf("seeding artist %s: %v", id, err)
+	}
+	if libraryID == "" {
+		return
+	}
+	if _, err := db.ExecContext(context.Background(),
+		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+		VALUES (?, ?, 'filesystem', datetime('now'))`,
+		id, libraryID); err != nil {
+		t.Fatalf("seeding artist_libraries for %s: %v", id, err)
 	}
 }
 
@@ -1173,14 +1199,14 @@ func TestDeleteWithArtists_PreservesArtistInOtherLibraries(t *testing.T) {
 		t.Fatalf("Create emby library: %v", err)
 	}
 
-	// Artist in BOTH libraries via membership rows.
+	// Artist in BOTH libraries via membership rows. seedArtist creates the
+	// fs membership; the second INSERT adds the emby one explicitly.
 	seedArtist(t, db, "art-multi", "Radiohead", fsLib.ID)
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
-		VALUES ('art-multi', ?, 'filesystem', datetime('now')),
-		       ('art-multi', ?, 'emby', datetime('now'))
-	`, fsLib.ID, embyLib.ID); err != nil {
-		t.Fatalf("seed memberships: %v", err)
+		VALUES ('art-multi', ?, 'emby', datetime('now'))
+	`, embyLib.ID); err != nil {
+		t.Fatalf("seed emby membership: %v", err)
 	}
 	seedPlatformID(t, db, "art-multi", "conn-emby", "emby-radiohead-1")
 

--- a/internal/library/service_test.go
+++ b/internal/library/service_test.go
@@ -1525,3 +1525,119 @@ func TestFindForArtistPath(t *testing.T) {
 		})
 	}
 }
+
+// TestListByConnectionID_AndCountArtists verifies the per-connection helpers
+// after the M:N storage cleanup. CountArtistsByConnectionID joins through
+// artist_libraries, so an artist that belongs to TWO libraries on the same
+// connection must only be counted once (DISTINCT).
+func TestListByConnectionID_AndCountArtists(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	// Two connections; one of them has two libraries.
+	for _, conn := range []struct{ id, name string }{
+		{"conn-emby", "Emby"},
+		{"conn-jelly", "Jellyfin"},
+	} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
+			VALUES (?, ?, 'emby', 'http://x:8096', 'enc', 1, 'ok', datetime('now'), datetime('now'))
+		`, conn.id, conn.name); err != nil {
+			t.Fatalf("inserting connection %s: %v", conn.id, err)
+		}
+	}
+
+	libs := []*Library{
+		{Name: "Emby Main", Type: TypeRegular, Source: SourceEmby, ConnectionID: "conn-emby", ExternalID: "ext-1"},
+		{Name: "Emby Side", Type: TypeRegular, Source: SourceEmby, ConnectionID: "conn-emby", ExternalID: "ext-2"},
+		{Name: "Jelly Main", Type: TypeRegular, Source: SourceJellyfin, ConnectionID: "conn-jelly", ExternalID: "ext-3"},
+	}
+	for _, lib := range libs {
+		if err := svc.Create(ctx, lib); err != nil {
+			t.Fatalf("Create %s: %v", lib.Name, err)
+		}
+	}
+
+	// ListByConnectionID returns libraries belonging to a connection, sorted by name.
+	embyLibs, err := svc.ListByConnectionID(ctx, "conn-emby")
+	if err != nil {
+		t.Fatalf("ListByConnectionID(conn-emby): %v", err)
+	}
+	if len(embyLibs) != 2 {
+		t.Fatalf("len(embyLibs) = %d, want 2", len(embyLibs))
+	}
+	if embyLibs[0].Name != "Emby Main" || embyLibs[1].Name != "Emby Side" {
+		t.Errorf("embyLibs names = [%q, %q], want [Emby Main, Emby Side]",
+			embyLibs[0].Name, embyLibs[1].Name)
+	}
+
+	jellyLibs, err := svc.ListByConnectionID(ctx, "conn-jelly")
+	if err != nil {
+		t.Fatalf("ListByConnectionID(conn-jelly): %v", err)
+	}
+	if len(jellyLibs) != 1 {
+		t.Fatalf("len(jellyLibs) = %d, want 1", len(jellyLibs))
+	}
+
+	// Empty result for an unknown connection.
+	none, err := svc.ListByConnectionID(ctx, "nope")
+	if err != nil {
+		t.Fatalf("ListByConnectionID(nope): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("len(none) = %d, want 0", len(none))
+	}
+
+	// Insert artists with memberships:
+	//   art-shared belongs to BOTH Emby libraries (must count as 1).
+	//   art-side belongs only to Emby Side.
+	//   art-jelly belongs only to Jelly Main.
+	for _, a := range []struct{ id string }{{"art-shared"}, {"art-side"}, {"art-jelly"}} {
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+			VALUES (?, ?, ?, '/music/'||?, datetime('now'), datetime('now'))
+		`, a.id, a.id, a.id, a.id); err != nil {
+			t.Fatalf("inserting artist %s: %v", a.id, err)
+		}
+	}
+	for _, link := range []struct{ artistID, libID string }{
+		{"art-shared", embyLibs[0].ID},
+		{"art-shared", embyLibs[1].ID},
+		{"art-side", embyLibs[1].ID},
+		{"art-jelly", jellyLibs[0].ID},
+	} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artist_libraries (artist_id, library_id, source) VALUES (?, ?, 'filesystem')`,
+			link.artistID, link.libID); err != nil {
+			t.Fatalf("inserting artist_libraries (%s, %s): %v", link.artistID, link.libID, err)
+		}
+	}
+
+	embyCount, err := svc.CountArtistsByConnectionID(ctx, "conn-emby")
+	if err != nil {
+		t.Fatalf("CountArtistsByConnectionID(conn-emby): %v", err)
+	}
+	// art-shared (1) + art-side (1) = 2 distinct, even though art-shared has
+	// two membership rows on conn-emby's libraries.
+	if embyCount != 2 {
+		t.Errorf("embyCount = %d, want 2 (DISTINCT artists across both Emby libraries)", embyCount)
+	}
+
+	jellyCount, err := svc.CountArtistsByConnectionID(ctx, "conn-jelly")
+	if err != nil {
+		t.Fatalf("CountArtistsByConnectionID(conn-jelly): %v", err)
+	}
+	if jellyCount != 1 {
+		t.Errorf("jellyCount = %d, want 1", jellyCount)
+	}
+
+	zeroCount, err := svc.CountArtistsByConnectionID(ctx, "nope")
+	if err != nil {
+		t.Fatalf("CountArtistsByConnectionID(nope): %v", err)
+	}
+	if zeroCount != 0 {
+		t.Errorf("zeroCount = %d, want 0", zeroCount)
+	}
+}

--- a/internal/rule/pipeline_results_test.go
+++ b/internal/rule/pipeline_results_test.go
@@ -131,6 +131,16 @@ func TestPipeline_FixFlipsFailToPassInSameRun(t *testing.T) {
 		t.Fatalf("setting automation_mode=auto: %v", err)
 	}
 
+	// Seed a libraries row so Service.Create can land a real
+	// artist_libraries membership; the post-create hydration of
+	// Artist.LibraryID then reflects the membership and the
+	// SharedFSCheck path observes a non-empty library id.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO libraries (id, name, type, source, created_at, updated_at)
+			VALUES ('lib-test', 'Test', 'regular', 'manual', datetime('now'), datetime('now'))`); err != nil {
+		t.Fatalf("seeding library: %v", err)
+	}
+
 	a := &artist.Artist{
 		Name:      "Fix Flips Pass",
 		SortName:  "Fix Flips Pass",

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -919,7 +919,7 @@ func (s *Service) UpsertViolation(ctx context.Context, v *RuleViolation) error {
 // ListViolations returns rule violations filtered by status.
 // If status is empty, returns all violations.
 func (s *Service) ListViolations(ctx context.Context, status string) ([]RuleViolation, error) {
-	query := `SELECT rv.id, rv.rule_id, rv.artist_id, rv.artist_name, COALESCE(l.name, '') AS library_name, rv.severity, rv.message, rv.fixable, rv.status, rv.candidates, rv.dismissed_at, rv.resolved_at, rv.created_at, rv.updated_at FROM rule_violations rv LEFT JOIN artists a ON a.id = rv.artist_id LEFT JOIN libraries l ON l.id = (SELECT al.library_id FROM artist_libraries al WHERE al.artist_id = a.id ORDER BY al.added_at, al.library_id LIMIT 1)`
+	query := `SELECT rv.id, rv.rule_id, rv.artist_id, rv.artist_name, COALESCE(l.name, '') AS library_name, rv.severity, rv.message, rv.fixable, rv.status, rv.candidates, rv.dismissed_at, rv.resolved_at, rv.created_at, rv.updated_at FROM rule_violations rv LEFT JOIN artists a ON a.id = rv.artist_id LEFT JOIN libraries l ON l.id = (SELECT al.library_id FROM artist_libraries al WHERE al.artist_id = a.id ORDER BY datetime(al.added_at), al.library_id LIMIT 1)`
 	args := []any{}
 	if status == "active" {
 		// active = open + pending_choice (violations that need attention)
@@ -1025,7 +1025,7 @@ func buildViolationFilter(p ViolationListParams) (whereClauses []string, args []
 
 // buildViolationFromClause returns the FROM/JOIN portion of a violation query.
 func buildViolationFromClause(needJoin bool) string {
-	q := ` FROM rule_violations rv LEFT JOIN artists a ON a.id = rv.artist_id LEFT JOIN libraries l ON l.id = (SELECT al.library_id FROM artist_libraries al WHERE al.artist_id = a.id ORDER BY al.added_at, al.library_id LIMIT 1)`
+	q := ` FROM rule_violations rv LEFT JOIN artists a ON a.id = rv.artist_id LEFT JOIN libraries l ON l.id = (SELECT al.library_id FROM artist_libraries al WHERE al.artist_id = a.id ORDER BY datetime(al.added_at), al.library_id LIMIT 1)`
 	if needJoin {
 		q += ` JOIN rules r ON r.id = rv.rule_id`
 	}
@@ -1216,7 +1216,7 @@ func GroupViolations(violations []RuleViolation, groupBy string) []ViolationGrou
 func (s *Service) GetViolationByID(ctx context.Context, id string) (*RuleViolation, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT rv.id, rv.rule_id, rv.artist_id, rv.artist_name, COALESCE(l.name, '') AS library_name, rv.severity, rv.message, rv.fixable, rv.status, rv.candidates, rv.dismissed_at, rv.resolved_at, rv.created_at, rv.updated_at
-		FROM rule_violations rv LEFT JOIN artists a ON a.id = rv.artist_id LEFT JOIN libraries l ON l.id = (SELECT al.library_id FROM artist_libraries al WHERE al.artist_id = a.id ORDER BY al.added_at, al.library_id LIMIT 1) WHERE rv.id = ?
+		FROM rule_violations rv LEFT JOIN artists a ON a.id = rv.artist_id LEFT JOIN libraries l ON l.id = (SELECT al.library_id FROM artist_libraries al WHERE al.artist_id = a.id ORDER BY datetime(al.added_at), al.library_id LIMIT 1) WHERE rv.id = ?
 	`, id)
 	v, err := scanViolation(row)
 	if err != nil {
@@ -1517,12 +1517,25 @@ func (s *Service) CountActiveViolationsByFixable(ctx context.Context, p Violatio
 // the number of violations dismissed.
 func (s *Service) DismissViolationsForLibrary(ctx context.Context, libraryID string) (int, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
+	// In the M:N model, only dismiss violations for artists whose ONLY library
+	// membership is the one being deleted. Artists that still belong to another
+	// library after this deletion should keep their active violations.
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE rule_violations
 		SET status = ?, dismissed_at = ?, updated_at = ?
 		WHERE status IN (?, ?)
-		AND artist_id IN (SELECT artist_id FROM artist_libraries WHERE library_id = ?)
-	`, ViolationStatusDismissed, now, now, ViolationStatusOpen, ViolationStatusPendingChoice, libraryID)
+		AND artist_id IN (
+			SELECT al.artist_id
+			FROM artist_libraries al
+			WHERE al.library_id = ?
+			  AND NOT EXISTS (
+				SELECT 1
+				FROM artist_libraries other
+				WHERE other.artist_id = al.artist_id
+				  AND other.library_id <> ?
+			  )
+		)
+	`, ViolationStatusDismissed, now, now, ViolationStatusOpen, ViolationStatusPendingChoice, libraryID, libraryID)
 	if err != nil {
 		return 0, fmt.Errorf("dismissing violations for library %s: %w", libraryID, err)
 	}

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -1335,6 +1335,14 @@ func (s *Service) CountActiveViolationsBySeverity(ctx context.Context, p Violati
 	if needJoin {
 		from += ` LEFT JOIN artists a ON a.id = rv.artist_id JOIN rules r ON r.id = rv.rule_id`
 	} else if strings.Contains(where, "FROM artist_libraries") {
+		// buildViolationFilter (in this same file) emits an EXISTS
+		// (SELECT 1 FROM artist_libraries ... WHERE al.artist_id = a.id ...)
+		// clause whenever ViolationListParams.LibraryID is set. That
+		// subquery references the `a` alias, so we must materialize the
+		// join even when the facet-count filter does not otherwise need
+		// it. The string check is coupled to that emitted SQL pattern;
+		// any change to buildViolationFilter's library-scoping clause
+		// must update this guard too.
 		from += ` LEFT JOIN artists a ON a.id = rv.artist_id`
 	}
 	query := `SELECT rv.severity, COUNT(*)` + from + where + ` GROUP BY rv.severity` //nolint:gosec // G202: from/where are built from whitelisted clauses with parameterized placeholders

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -919,7 +919,7 @@ func (s *Service) UpsertViolation(ctx context.Context, v *RuleViolation) error {
 // ListViolations returns rule violations filtered by status.
 // If status is empty, returns all violations.
 func (s *Service) ListViolations(ctx context.Context, status string) ([]RuleViolation, error) {
-	query := `SELECT rv.id, rv.rule_id, rv.artist_id, rv.artist_name, COALESCE(l.name, '') AS library_name, rv.severity, rv.message, rv.fixable, rv.status, rv.candidates, rv.dismissed_at, rv.resolved_at, rv.created_at, rv.updated_at FROM rule_violations rv LEFT JOIN artists a ON a.id = rv.artist_id LEFT JOIN libraries l ON l.id = a.library_id`
+	query := `SELECT rv.id, rv.rule_id, rv.artist_id, rv.artist_name, COALESCE(l.name, '') AS library_name, rv.severity, rv.message, rv.fixable, rv.status, rv.candidates, rv.dismissed_at, rv.resolved_at, rv.created_at, rv.updated_at FROM rule_violations rv LEFT JOIN artists a ON a.id = rv.artist_id LEFT JOIN libraries l ON l.id = (SELECT al.library_id FROM artist_libraries al WHERE al.artist_id = a.id ORDER BY al.added_at, al.library_id LIMIT 1)`
 	args := []any{}
 	if status == "active" {
 		// active = open + pending_choice (violations that need attention)
@@ -1005,9 +1005,10 @@ func buildViolationFilter(p ViolationListParams) (whereClauses []string, args []
 		args = append(args, like, like, like)
 	}
 
-	// Library filter via artist join (artists table is already joined)
+	// Library filter via artist_libraries membership (the artists table
+	// is already joined for the library_name display column).
 	if p.LibraryID != "" {
-		whereClauses = append(whereClauses, "a.library_id = ?")
+		whereClauses = append(whereClauses, "EXISTS (SELECT 1 FROM artist_libraries al WHERE al.artist_id = a.id AND al.library_id = ?)")
 		args = append(args, p.LibraryID)
 	}
 
@@ -1024,7 +1025,7 @@ func buildViolationFilter(p ViolationListParams) (whereClauses []string, args []
 
 // buildViolationFromClause returns the FROM/JOIN portion of a violation query.
 func buildViolationFromClause(needJoin bool) string {
-	q := ` FROM rule_violations rv LEFT JOIN artists a ON a.id = rv.artist_id LEFT JOIN libraries l ON l.id = a.library_id`
+	q := ` FROM rule_violations rv LEFT JOIN artists a ON a.id = rv.artist_id LEFT JOIN libraries l ON l.id = (SELECT al.library_id FROM artist_libraries al WHERE al.artist_id = a.id ORDER BY al.added_at, al.library_id LIMIT 1)`
 	if needJoin {
 		q += ` JOIN rules r ON r.id = rv.rule_id`
 	}
@@ -1215,7 +1216,7 @@ func GroupViolations(violations []RuleViolation, groupBy string) []ViolationGrou
 func (s *Service) GetViolationByID(ctx context.Context, id string) (*RuleViolation, error) {
 	row := s.db.QueryRowContext(ctx, `
 		SELECT rv.id, rv.rule_id, rv.artist_id, rv.artist_name, COALESCE(l.name, '') AS library_name, rv.severity, rv.message, rv.fixable, rv.status, rv.candidates, rv.dismissed_at, rv.resolved_at, rv.created_at, rv.updated_at
-		FROM rule_violations rv LEFT JOIN artists a ON a.id = rv.artist_id LEFT JOIN libraries l ON l.id = a.library_id WHERE rv.id = ?
+		FROM rule_violations rv LEFT JOIN artists a ON a.id = rv.artist_id LEFT JOIN libraries l ON l.id = (SELECT al.library_id FROM artist_libraries al WHERE al.artist_id = a.id ORDER BY al.added_at, al.library_id LIMIT 1) WHERE rv.id = ?
 	`, id)
 	v, err := scanViolation(row)
 	if err != nil {
@@ -1333,7 +1334,7 @@ func (s *Service) CountActiveViolationsBySeverity(ctx context.Context, p Violati
 	from := ` FROM rule_violations rv`
 	if needJoin {
 		from += ` LEFT JOIN artists a ON a.id = rv.artist_id JOIN rules r ON r.id = rv.rule_id`
-	} else if strings.Contains(where, "a.library_id") {
+	} else if strings.Contains(where, "FROM artist_libraries") {
 		from += ` LEFT JOIN artists a ON a.id = rv.artist_id`
 	}
 	query := `SELECT rv.severity, COUNT(*)` + from + where + ` GROUP BY rv.severity` //nolint:gosec // G202: from/where are built from whitelisted clauses with parameterized placeholders
@@ -1411,7 +1412,7 @@ func (s *Service) CountActiveViolationsByRule(ctx context.Context, p ViolationLi
 	// needJoin signals the category filter needs `r` (already joined above).
 	// The library filter independently requires the artists-table join because
 	// a.library_id is in the WHERE clause.
-	if needJoin || strings.Contains(where, "a.library_id") {
+	if needJoin || strings.Contains(where, "FROM artist_libraries") {
 		from += ` LEFT JOIN artists a ON a.id = rv.artist_id`
 	}
 	query := `SELECT rv.rule_id, r.name, COUNT(*) AS cnt` + from + where + ` GROUP BY rv.rule_id ORDER BY cnt DESC, rv.rule_id ASC` //nolint:gosec // G202: from/where are built from whitelisted clauses with parameterized placeholders
@@ -1438,18 +1439,16 @@ func (s *Service) CountActiveViolationsByRule(ctx context.Context, p ViolationLi
 // all filter dimensions in p EXCEPT library are applied.
 func (s *Service) CountActiveViolationsByLibrary(ctx context.Context, p ViolationListParams) (map[string]int, error) {
 	where, args, needJoin := countActiveWithFilter(p, "library")
-	// Library counts always need the artist join for a.library_id.
-	from := ` FROM rule_violations rv JOIN artists a ON a.id = rv.artist_id`
+	// Library counts join artist_libraries (the M:N membership table)
+	// directly so per-library facets reflect the authoritative
+	// membership record. An artist that is a member of multiple
+	// libraries contributes to each library's count.
+	from := ` FROM rule_violations rv JOIN artist_libraries al ON al.artist_id = rv.artist_id JOIN artists a ON a.id = rv.artist_id`
 	if needJoin {
 		// needJoin signals a rules-table join for category filter.
 		from += ` JOIN rules r ON r.id = rv.rule_id`
 	}
-	// Constrain non-NULL library even without other filters so the grouping key stays usable.
-	nonNull := " WHERE a.library_id IS NOT NULL"
-	if where != "" {
-		nonNull = where + " AND a.library_id IS NOT NULL"
-	}
-	query := `SELECT a.library_id, COUNT(*) AS cnt` + from + nonNull + ` GROUP BY a.library_id` //nolint:gosec // G202: from/nonNull are built from whitelisted clauses with parameterized placeholders
+	query := `SELECT al.library_id, COUNT(*) AS cnt` + from + where + ` GROUP BY al.library_id` //nolint:gosec // G202: from/where are built from whitelisted clauses with parameterized placeholders
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -1477,7 +1476,7 @@ func (s *Service) CountActiveViolationsByFixable(ctx context.Context, p Violatio
 	from := ` FROM rule_violations rv`
 	if needJoin {
 		from += ` LEFT JOIN artists a ON a.id = rv.artist_id JOIN rules r ON r.id = rv.rule_id`
-	} else if strings.Contains(where, "a.library_id") {
+	} else if strings.Contains(where, "FROM artist_libraries") {
 		// The library filter requires the artist join even when category is not set.
 		from += ` LEFT JOIN artists a ON a.id = rv.artist_id`
 	}
@@ -1503,17 +1502,18 @@ func (s *Service) CountActiveViolationsByFixable(ctx context.Context, p Violatio
 	return fixable, notFixable, rows.Err()
 }
 
-// DismissViolationsForLibrary dismisses all active violations for artists that
-// belong to the given library. This should be called before deleting a library
-// with deleteArtists=false, because the delete NULLs artists.library_id and the
-// association is lost. Returns the number of violations dismissed.
+// DismissViolationsForLibrary dismisses all active violations for artists
+// that belong to the given library. This should be called before deleting
+// a library with deleteArtists=false, because the cascade removes the
+// artist_libraries membership row and the association is lost. Returns
+// the number of violations dismissed.
 func (s *Service) DismissViolationsForLibrary(ctx context.Context, libraryID string) (int, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE rule_violations
 		SET status = ?, dismissed_at = ?, updated_at = ?
 		WHERE status IN (?, ?)
-		AND artist_id IN (SELECT id FROM artists WHERE library_id = ?)
+		AND artist_id IN (SELECT artist_id FROM artist_libraries WHERE library_id = ?)
 	`, ViolationStatusDismissed, now, now, ViolationStatusOpen, ViolationStatusPendingChoice, libraryID)
 	if err != nil {
 		return 0, fmt.Errorf("dismissing violations for library %s: %w", libraryID, err)
@@ -1530,7 +1530,7 @@ func (s *Service) CountActiveViolationsByCategory(ctx context.Context, p Violati
 	where, args, _ := countActiveWithFilter(p, "category")
 	// Category counts always need the rules join (GROUP BY r.category).
 	from := ` FROM rule_violations rv JOIN rules r ON r.id = rv.rule_id`
-	if strings.Contains(where, "a.library_id") {
+	if strings.Contains(where, "FROM artist_libraries") {
 		from += ` LEFT JOIN artists a ON a.id = rv.artist_id`
 	}
 	query := `SELECT r.category, COUNT(*)` + from + where + ` GROUP BY r.category` //nolint:gosec // G202: from/where are built from whitelisted clauses with parameterized placeholders
@@ -1559,9 +1559,9 @@ func (s *Service) CountActiveViolationsByCategory(ctx context.Context, p Violati
 }
 
 // DismissOrphanedViolations dismisses all active violations whose artist_id
-// no longer exists in the artists table OR whose artist has no library
-// (library_id IS NULL, meaning the library was removed but the artist was
-// kept). Returns the number dismissed.
+// no longer exists in the artists table OR whose artist holds no library
+// membership (the artist was retained but every library it belonged to was
+// removed). Returns the number dismissed.
 func (s *Service) DismissOrphanedViolations(ctx context.Context) (int, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	res, err := s.db.ExecContext(ctx, `
@@ -1570,7 +1570,7 @@ func (s *Service) DismissOrphanedViolations(ctx context.Context) (int, error) {
 		WHERE status IN (?, ?)
 		AND (
 			artist_id NOT IN (SELECT id FROM artists)
-			OR artist_id IN (SELECT id FROM artists WHERE library_id IS NULL)
+			OR artist_id NOT IN (SELECT artist_id FROM artist_libraries)
 		)
 	`, ViolationStatusDismissed, now, now, ViolationStatusOpen, ViolationStatusPendingChoice)
 	if err != nil {

--- a/internal/rule/service_test.go
+++ b/internal/rule/service_test.go
@@ -1240,19 +1240,24 @@ func TestDismissOrphanedViolations(t *testing.T) {
 	svc := NewService(db)
 	ctx := context.Background()
 
-	// Create a library so the real artist has a valid library_id.
+	// Create a library so the real artist has a membership.
 	_, err := db.ExecContext(ctx, `INSERT INTO libraries (id, name, path, type) VALUES (?, ?, ?, ?)`,
 		"lib-1", "Test Library", "/music", "regular")
 	if err != nil {
 		t.Fatalf("inserting library: %v", err)
 	}
 
-	// Create a real artist with a library, an orphaned violation (deleted
+	// Create a real artist with a membership, an orphaned violation (deleted
 	// artist), and a libraryless artist (library removed, artist kept).
-	_, err = db.ExecContext(ctx, `INSERT INTO artists (id, name, sort_name, type, path, library_id) VALUES (?, ?, ?, ?, ?, ?)`,
-		"real-artist", "Real Artist", "Real Artist", "person", "/music/Real Artist", "lib-1")
+	_, err = db.ExecContext(ctx, `INSERT INTO artists (id, name, sort_name, type, path) VALUES (?, ?, ?, ?, ?)`,
+		"real-artist", "Real Artist", "Real Artist", "person", "/music/Real Artist")
 	if err != nil {
 		t.Fatalf("inserting real artist: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artist_libraries (artist_id, library_id, source) VALUES (?, ?, 'filesystem')`,
+		"real-artist", "lib-1"); err != nil {
+		t.Fatalf("inserting artist_libraries: %v", err)
 	}
 
 	realV := &RuleViolation{
@@ -1338,16 +1343,21 @@ func TestDismissViolationsForLibrary(t *testing.T) {
 		}
 	}
 
-	// Insert artists belonging to each library.
+	// Insert artists and link them to libraries via artist_libraries.
 	for _, a := range []struct{ id, name, libID string }{
 		{"artist-a1", "Artist A1", "lib-a"},
 		{"artist-a2", "Artist A2", "lib-a"},
 		{"artist-b1", "Artist B1", "lib-b"},
 	} {
-		_, err := db.ExecContext(ctx, `INSERT INTO artists (id, name, sort_name, type, path, library_id)
-			VALUES (?, ?, ?, 'person', '/music/'||?, ?)`, a.id, a.name, a.name, a.id, a.libID)
+		_, err := db.ExecContext(ctx, `INSERT INTO artists (id, name, sort_name, type, path)
+			VALUES (?, ?, ?, 'person', '/music/'||?)`, a.id, a.name, a.name, a.id)
 		if err != nil {
 			t.Fatalf("inserting artist %s: %v", a.id, err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artist_libraries (artist_id, library_id, source) VALUES (?, ?, 'filesystem')`,
+			a.id, a.libID); err != nil {
+			t.Fatalf("inserting artist_libraries for %s: %v", a.id, err)
 		}
 	}
 
@@ -2262,7 +2272,6 @@ func TestCountActiveViolationsByLibrary(t *testing.T) {
 	}
 	// Artists: two in lib-a, one in lib-b, and one with no library (should
 	// not appear in counts because the handler expects library IDs only).
-	// Only libID is nullable here; ids are always set.
 	for _, a := range []struct {
 		id    string
 		libID sql.NullString
@@ -2272,9 +2281,16 @@ func TestCountActiveViolationsByLibrary(t *testing.T) {
 		{"art-b1", sql.NullString{String: "lib-b", Valid: true}},
 		{"art-none", sql.NullString{}},
 	} {
-		if _, err := db.ExecContext(ctx, `INSERT INTO artists (id, name, sort_name, type, path, library_id)
-			VALUES (?, ?, ?, 'person', '/music/'||?, ?)`, a.id, a.id, a.id, a.id, a.libID); err != nil {
+		if _, err := db.ExecContext(ctx, `INSERT INTO artists (id, name, sort_name, type, path)
+			VALUES (?, ?, ?, 'person', '/music/'||?)`, a.id, a.id, a.id, a.id); err != nil {
 			t.Fatalf("insert artist %s: %v", a.id, err)
+		}
+		if a.libID.Valid {
+			if _, err := db.ExecContext(ctx,
+				`INSERT INTO artist_libraries (artist_id, library_id, source) VALUES (?, ?, 'filesystem')`,
+				a.id, a.libID.String); err != nil {
+				t.Fatalf("insert artist_libraries for %s: %v", a.id, err)
+			}
 		}
 	}
 

--- a/internal/rule/service_test.go
+++ b/internal/rule/service_test.go
@@ -2947,3 +2947,112 @@ func TestResolveViolationIfActive(t *testing.T) {
 		}
 	}
 }
+
+// TestCountActiveViolations_LibraryFilterMaterializesArtistJoin exercises the
+// new `else if strings.Contains(where, "FROM artist_libraries")` guards added
+// to BySeverity, ByCategory, ByRule, and ByFixable. When the caller sets
+// LibraryID, buildViolationFilter emits an EXISTS subquery referencing the
+// `a` alias, so each facet count must materialize the LEFT JOIN to artists
+// even when its own filter dimension does not otherwise need it. Without
+// the guard the SQL would fail with "no such column: a.id".
+func TestCountActiveViolations_LibraryFilterMaterializesArtistJoin(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	// SeedDefaults populates the rules table so the ByCategory facet
+	// (which JOINs rules) and ByRule (which selects rule metadata) return
+	// non-empty rows for our seeded violations.
+	if err := svc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+
+	// Seed two libraries and link two artists, one per library.
+	for _, lib := range []struct{ id, name string }{
+		{"lib-x", "Library X"},
+		{"lib-y", "Library Y"},
+	} {
+		if _, err := db.ExecContext(ctx, `INSERT INTO libraries (id, name, type, created_at, updated_at)
+			VALUES (?, ?, 'regular', datetime('now'), datetime('now'))`, lib.id, lib.name); err != nil {
+			t.Fatalf("insert library %s: %v", lib.id, err)
+		}
+	}
+	for _, a := range []struct{ id, libID string }{
+		{"ax", "lib-x"},
+		{"ay", "lib-y"},
+	} {
+		if _, err := db.ExecContext(ctx, `INSERT INTO artists (id, name, sort_name, type, path)
+			VALUES (?, ?, ?, 'person', '/music/'||?)`, a.id, a.id, a.id, a.id); err != nil {
+			t.Fatalf("insert artist %s: %v", a.id, err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artist_libraries (artist_id, library_id, source) VALUES (?, ?, 'filesystem')`,
+			a.id, a.libID); err != nil {
+			t.Fatalf("insert artist_libraries: %v", err)
+		}
+	}
+
+	// One open violation per artist.
+	for _, v := range []*RuleViolation{
+		{RuleID: RuleNFOExists, ArtistID: "ax", ArtistName: "ax",
+			Severity: "error", Message: "m", Fixable: true, Status: ViolationStatusOpen},
+		{RuleID: RuleNFOExists, ArtistID: "ay", ArtistName: "ay",
+			Severity: "warning", Message: "m", Fixable: false, Status: ViolationStatusOpen},
+	} {
+		if err := svc.UpsertViolation(ctx, v); err != nil {
+			t.Fatalf("UpsertViolation: %v", err)
+		}
+	}
+
+	p := ViolationListParams{LibraryID: "lib-x"}
+
+	bySev, err := svc.CountActiveViolationsBySeverity(ctx, p)
+	if err != nil {
+		t.Fatalf("CountActiveViolationsBySeverity: %v", err)
+	}
+	if bySev["error"] != 1 || bySev["warning"] != 0 {
+		t.Errorf("bySev (lib-x) = %+v, want error=1 warning=0", bySev)
+	}
+
+	byCat, err := svc.CountActiveViolationsByCategory(ctx, p)
+	if err != nil {
+		t.Fatalf("CountActiveViolationsByCategory: %v", err)
+	}
+	totalCat := 0
+	for _, n := range byCat {
+		totalCat += n
+	}
+	if totalCat != 1 {
+		t.Errorf("byCat (lib-x) total = %d, want 1, full = %+v", totalCat, byCat)
+	}
+
+	byRule, err := svc.CountActiveViolationsByRule(ctx, p)
+	if err != nil {
+		t.Fatalf("CountActiveViolationsByRule: %v", err)
+	}
+	totalRule := 0
+	for _, c := range byRule {
+		totalRule += c.Count
+	}
+	if totalRule != 1 {
+		t.Errorf("byRule (lib-x) total = %d, want 1, full = %+v", totalRule, byRule)
+	}
+
+	fixable, notFixable, err := svc.CountActiveViolationsByFixable(ctx, p)
+	if err != nil {
+		t.Fatalf("CountActiveViolationsByFixable: %v", err)
+	}
+	if fixable != 1 || notFixable != 0 {
+		t.Errorf("byFixable (lib-x) = (%d, %d), want (1, 0)", fixable, notFixable)
+	}
+
+	// Sanity: lib-y sees the inverse counts (the warning, non-fixable row).
+	pY := ViolationListParams{LibraryID: "lib-y"}
+	bySevY, err := svc.CountActiveViolationsBySeverity(ctx, pY)
+	if err != nil {
+		t.Fatalf("CountActiveViolationsBySeverity(lib-y): %v", err)
+	}
+	if bySevY["warning"] != 1 || bySevY["error"] != 0 {
+		t.Errorf("bySev (lib-y) = %+v, want warning=1 error=0", bySevY)
+	}
+}

--- a/internal/rule/service_test.go
+++ b/internal/rule/service_test.go
@@ -1421,6 +1421,179 @@ func TestDismissViolationsForLibrary_NoViolations(t *testing.T) {
 	}
 }
 
+// TestListViolations_PrimaryLibraryMixedTimestamps verifies that the
+// primary-library subquery selects the chronologically oldest membership even
+// when artist_libraries.added_at contains a mix of legacy
+// "YYYY-MM-DD HH:MM:SS" and RFC3339 timestamps. Lexicographic sort would put
+// "2026-..." (RFC3339 with 'T') after legacy "2024-..." with space, so a raw
+// ORDER BY would silently pick the wrong oldest membership when years match.
+func TestListViolations_PrimaryLibraryMixedTimestamps(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	for _, lib := range []struct{ id, name string }{
+		{"lib-old", "Oldest Library"},
+		{"lib-new", "Newer Library"},
+	} {
+		if _, err := db.ExecContext(ctx, `INSERT INTO libraries (id, name, type, created_at, updated_at)
+			VALUES (?, ?, 'regular', datetime('now'), datetime('now'))`, lib.id, lib.name); err != nil {
+			t.Fatalf("inserting library %s: %v", lib.id, err)
+		}
+	}
+
+	if _, err := db.ExecContext(ctx, `INSERT INTO artists (id, name, sort_name, type, path)
+		VALUES ('artist-mixed', 'Mixed Artist', 'Mixed Artist', 'person', '/music/mixed')`); err != nil {
+		t.Fatalf("inserting artist: %v", err)
+	}
+
+	// lib-old joined first chronologically, but stored in legacy format.
+	// lib-new joined later, stored in RFC3339. Lexicographic compare of
+	// "2024-06-01 10:00:00" vs "2024-01-15T10:00:00Z" places the RFC3339 row
+	// FIRST (the 'T' character sorts after a space), which would incorrectly
+	// pick lib-new as primary if datetime() normalization is missing.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at) VALUES (?, ?, 'filesystem', ?)`,
+		"artist-mixed", "lib-old", "2024-06-01 10:00:00"); err != nil {
+		t.Fatalf("insert lib-old membership: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at) VALUES (?, ?, 'filesystem', ?)`,
+		"artist-mixed", "lib-new", "2024-01-15T10:00:00Z"); err != nil {
+		t.Fatalf("insert lib-new membership: %v", err)
+	}
+
+	v := &RuleViolation{
+		RuleID: RuleNFOExists, ArtistID: "artist-mixed", ArtistName: "Mixed Artist",
+		Severity: "error", Message: "missing nfo", Fixable: true, Status: ViolationStatusOpen,
+	}
+	if err := svc.UpsertViolation(ctx, v); err != nil {
+		t.Fatalf("UpsertViolation: %v", err)
+	}
+
+	got, err := svc.ListViolations(ctx, "active")
+	if err != nil {
+		t.Fatalf("ListViolations: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d violations, want 1", len(got))
+	}
+	// lib-new joined chronologically first (Jan vs Jun), so it is the oldest
+	// membership and must be the primary library_name.
+	if got[0].LibraryName != "Newer Library" {
+		t.Errorf("LibraryName = %q, want %q (datetime() normalization should pick the chronologically earliest membership)",
+			got[0].LibraryName, "Newer Library")
+	}
+
+	// GetViolationByID exercises the third copy of the subquery.
+	byID, err := svc.GetViolationByID(ctx, v.ID)
+	if err != nil {
+		t.Fatalf("GetViolationByID: %v", err)
+	}
+	if byID.LibraryName != "Newer Library" {
+		t.Errorf("GetViolationByID LibraryName = %q, want %q", byID.LibraryName, "Newer Library")
+	}
+
+	// ListViolationsFiltered exercises the second copy.
+	filtered, err := svc.ListViolationsFiltered(ctx, ViolationListParams{Status: "active"})
+	if err != nil {
+		t.Fatalf("ListViolationsFiltered: %v", err)
+	}
+	if len(filtered) != 1 {
+		t.Fatalf("ListViolationsFiltered got %d, want 1", len(filtered))
+	}
+	if filtered[0].LibraryName != "Newer Library" {
+		t.Errorf("ListViolationsFiltered LibraryName = %q, want %q",
+			filtered[0].LibraryName, "Newer Library")
+	}
+}
+
+// TestDismissViolationsForLibrary_PreservesSharedArtist verifies that an artist
+// who belongs to two libraries does NOT have their violations dismissed when
+// only one of those libraries is removed. The artist's surviving membership in
+// the other library means the violation is still actionable.
+func TestDismissViolationsForLibrary_PreservesSharedArtist(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	// Insert two libraries.
+	for _, lib := range []struct{ id, name string }{
+		{"lib-a", "Library A"},
+		{"lib-b", "Library B"},
+	} {
+		_, err := db.ExecContext(ctx, `INSERT INTO libraries (id, name, type, created_at, updated_at)
+			VALUES (?, ?, 'regular', datetime('now'), datetime('now'))`, lib.id, lib.name)
+		if err != nil {
+			t.Fatalf("inserting library %s: %v", lib.id, err)
+		}
+	}
+
+	// artist-shared belongs to BOTH lib-a and lib-b.
+	// artist-only-a belongs to lib-a alone.
+	if _, err := db.ExecContext(ctx, `INSERT INTO artists (id, name, sort_name, type, path)
+		VALUES ('artist-shared', 'Shared Artist', 'Shared Artist', 'person', '/music/shared')`); err != nil {
+		t.Fatalf("inserting artist-shared: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO artists (id, name, sort_name, type, path)
+		VALUES ('artist-only-a', 'Only A Artist', 'Only A Artist', 'person', '/music/only-a')`); err != nil {
+		t.Fatalf("inserting artist-only-a: %v", err)
+	}
+	for _, link := range []struct{ artistID, libID string }{
+		{"artist-shared", "lib-a"},
+		{"artist-shared", "lib-b"},
+		{"artist-only-a", "lib-a"},
+	} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artist_libraries (artist_id, library_id, source) VALUES (?, ?, 'filesystem')`,
+			link.artistID, link.libID); err != nil {
+			t.Fatalf("inserting artist_libraries (%s, %s): %v", link.artistID, link.libID, err)
+		}
+	}
+
+	violations := []*RuleViolation{
+		{RuleID: RuleNFOExists, ArtistID: "artist-shared", ArtistName: "Shared Artist",
+			Severity: "error", Message: "missing nfo", Fixable: true, Status: ViolationStatusOpen},
+		{RuleID: RuleNFOExists, ArtistID: "artist-only-a", ArtistName: "Only A Artist",
+			Severity: "error", Message: "missing nfo", Fixable: true, Status: ViolationStatusOpen},
+	}
+	for _, v := range violations {
+		if err := svc.UpsertViolation(ctx, v); err != nil {
+			t.Fatalf("upserting violation: %v", err)
+		}
+	}
+
+	// Dismiss for lib-a. Only artist-only-a's violation should be dismissed;
+	// artist-shared still belongs to lib-b, so its violation must remain open.
+	n, err := svc.DismissViolationsForLibrary(ctx, "lib-a")
+	if err != nil {
+		t.Fatalf("DismissViolationsForLibrary: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("dismissed = %d, want 1 (only artist-only-a)", n)
+	}
+
+	// artist-shared's violation must still be open.
+	gotShared, err := svc.GetViolationByID(ctx, violations[0].ID)
+	if err != nil {
+		t.Fatalf("GetViolationByID(shared): %v", err)
+	}
+	if gotShared.Status != ViolationStatusOpen {
+		t.Errorf("shared artist violation status = %q, want %q (still has lib-b membership)",
+			gotShared.Status, ViolationStatusOpen)
+	}
+
+	// artist-only-a's violation must be dismissed.
+	gotOnlyA, err := svc.GetViolationByID(ctx, violations[1].ID)
+	if err != nil {
+		t.Fatalf("GetViolationByID(only-a): %v", err)
+	}
+	if gotOnlyA.Status != ViolationStatusDismissed {
+		t.Errorf("only-a artist violation status = %q, want %q",
+			gotOnlyA.Status, ViolationStatusDismissed)
+	}
+}
+
 func TestGetComplianceForArtists(t *testing.T) {
 	db := setupTestDB(t)
 	svc := NewService(db)

--- a/internal/rule/service_test.go
+++ b/internal/rule/service_test.go
@@ -1435,6 +1435,11 @@ func TestListViolations_PrimaryLibraryMixedTimestamps(t *testing.T) {
 	for _, lib := range []struct{ id, name string }{
 		{"lib-old", "Oldest Library"},
 		{"lib-new", "Newer Library"},
+		// lib-aaa-tie: smaller library_id than lib-new, used to pin the
+		// secondary ORDER BY tie-breaker (lowest library_id wins when
+		// datetime(added_at) values are equal). Documented in the OpenAPI
+		// prose for Artist.library_id ("ties resolved by lowest library_id").
+		{"lib-aaa-tie", "Tie Library"},
 	} {
 		if _, err := db.ExecContext(ctx, `INSERT INTO libraries (id, name, type, created_at, updated_at)
 			VALUES (?, ?, 'regular', datetime('now'), datetime('now'))`, lib.id, lib.name); err != nil {
@@ -1447,24 +1452,29 @@ func TestListViolations_PrimaryLibraryMixedTimestamps(t *testing.T) {
 		t.Fatalf("inserting artist: %v", err)
 	}
 
-	// Both rows are timestamped on the same calendar date so that month/day
-	// differences do not mask the bug. lib-old uses legacy format with a space
-	// separator at 23:00 (chronologically LATER on that day); lib-new uses
-	// RFC3339 with a 'T' separator at 00:30 (chronologically EARLIER).
+	// Three memberships exercising both ORDER BY axes:
+	//   lib-old      "2024-01-15 23:00:00" (legacy SQLite, LATER on day)
+	//   lib-new      "2024-01-15T00:30:00Z" (RFC3339, EARLIER on day)
+	//   lib-aaa-tie  "2024-01-15 00:30:00"  (legacy SQLite, normalizes to the
+	//                                       SAME datetime as lib-new but with
+	//                                       a smaller library_id)
+	//
 	// Under raw TEXT comparison, " " (0x20) sorts before "T" (0x54), so
 	// lib-old's "2024-01-15 23:00:00" lexicographically PRECEDES lib-new's
 	// "2024-01-15T00:30:00Z" -- an unwrapped ORDER BY added_at would pick
-	// lib-old as primary, which is wrong. Only datetime() normalization
-	// recovers the true chronological order and picks lib-new.
-	if _, err := db.ExecContext(ctx,
-		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at) VALUES (?, ?, 'filesystem', ?)`,
-		"artist-mixed", "lib-old", "2024-01-15 23:00:00"); err != nil {
-		t.Fatalf("insert lib-old membership: %v", err)
-	}
-	if _, err := db.ExecContext(ctx,
-		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at) VALUES (?, ?, 'filesystem', ?)`,
-		"artist-mixed", "lib-new", "2024-01-15T00:30:00Z"); err != nil {
-		t.Fatalf("insert lib-new membership: %v", err)
+	// lib-old as primary, which is wrong. With datetime() normalization,
+	// lib-new and lib-aaa-tie tie at 2024-01-15T00:30:00, and the secondary
+	// `library_id` clause picks lib-aaa-tie (lexicographically smaller).
+	for _, m := range []struct{ libID, addedAt string }{
+		{"lib-old", "2024-01-15 23:00:00"},
+		{"lib-new", "2024-01-15T00:30:00Z"},
+		{"lib-aaa-tie", "2024-01-15 00:30:00"},
+	} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO artist_libraries (artist_id, library_id, source, added_at) VALUES (?, ?, 'filesystem', ?)`,
+			"artist-mixed", m.libID, m.addedAt); err != nil {
+			t.Fatalf("insert %s membership: %v", m.libID, err)
+		}
 	}
 
 	v := &RuleViolation{
@@ -1475,6 +1485,12 @@ func TestListViolations_PrimaryLibraryMixedTimestamps(t *testing.T) {
 		t.Fatalf("UpsertViolation: %v", err)
 	}
 
+	// All three subquery copies must agree on the primary library: the
+	// chronologically earliest membership, and on tie the row with the
+	// lowest library_id. lib-aaa-tie ties with lib-new at 2024-01-15T00:30:00
+	// and wins the secondary tie-breaker because "lib-aaa-tie" < "lib-new".
+	const wantPrimary = "Tie Library"
+
 	got, err := svc.ListViolations(ctx, "active")
 	if err != nil {
 		t.Fatalf("ListViolations: %v", err)
@@ -1482,11 +1498,9 @@ func TestListViolations_PrimaryLibraryMixedTimestamps(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("got %d violations, want 1", len(got))
 	}
-	// lib-new joined chronologically first (Jan vs Jun), so it is the oldest
-	// membership and must be the primary library_name.
-	if got[0].LibraryName != "Newer Library" {
-		t.Errorf("LibraryName = %q, want %q (datetime() normalization should pick the chronologically earliest membership)",
-			got[0].LibraryName, "Newer Library")
+	if got[0].LibraryName != wantPrimary {
+		t.Errorf("ListViolations LibraryName = %q, want %q (datetime() normalization + lowest library_id tie-breaker)",
+			got[0].LibraryName, wantPrimary)
 	}
 
 	// GetViolationByID exercises the third copy of the subquery.
@@ -1494,8 +1508,8 @@ func TestListViolations_PrimaryLibraryMixedTimestamps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetViolationByID: %v", err)
 	}
-	if byID.LibraryName != "Newer Library" {
-		t.Errorf("GetViolationByID LibraryName = %q, want %q", byID.LibraryName, "Newer Library")
+	if byID.LibraryName != wantPrimary {
+		t.Errorf("GetViolationByID LibraryName = %q, want %q", byID.LibraryName, wantPrimary)
 	}
 
 	// ListViolationsFiltered exercises the second copy.
@@ -1506,9 +1520,9 @@ func TestListViolations_PrimaryLibraryMixedTimestamps(t *testing.T) {
 	if len(filtered) != 1 {
 		t.Fatalf("ListViolationsFiltered got %d, want 1", len(filtered))
 	}
-	if filtered[0].LibraryName != "Newer Library" {
+	if filtered[0].LibraryName != wantPrimary {
 		t.Errorf("ListViolationsFiltered LibraryName = %q, want %q",
-			filtered[0].LibraryName, "Newer Library")
+			filtered[0].LibraryName, wantPrimary)
 	}
 }
 

--- a/internal/rule/service_test.go
+++ b/internal/rule/service_test.go
@@ -1447,19 +1447,23 @@ func TestListViolations_PrimaryLibraryMixedTimestamps(t *testing.T) {
 		t.Fatalf("inserting artist: %v", err)
 	}
 
-	// lib-old joined first chronologically, but stored in legacy format.
-	// lib-new joined later, stored in RFC3339. Lexicographic compare of
-	// "2024-06-01 10:00:00" vs "2024-01-15T10:00:00Z" places the RFC3339 row
-	// FIRST (the 'T' character sorts after a space), which would incorrectly
-	// pick lib-new as primary if datetime() normalization is missing.
+	// Both rows are timestamped on the same calendar date so that month/day
+	// differences do not mask the bug. lib-old uses legacy format with a space
+	// separator at 23:00 (chronologically LATER on that day); lib-new uses
+	// RFC3339 with a 'T' separator at 00:30 (chronologically EARLIER).
+	// Under raw TEXT comparison, " " (0x20) sorts before "T" (0x54), so
+	// lib-old's "2024-01-15 23:00:00" lexicographically PRECEDES lib-new's
+	// "2024-01-15T00:30:00Z" -- an unwrapped ORDER BY added_at would pick
+	// lib-old as primary, which is wrong. Only datetime() normalization
+	// recovers the true chronological order and picks lib-new.
 	if _, err := db.ExecContext(ctx,
 		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at) VALUES (?, ?, 'filesystem', ?)`,
-		"artist-mixed", "lib-old", "2024-06-01 10:00:00"); err != nil {
+		"artist-mixed", "lib-old", "2024-01-15 23:00:00"); err != nil {
 		t.Fatalf("insert lib-old membership: %v", err)
 	}
 	if _, err := db.ExecContext(ctx,
 		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at) VALUES (?, ?, 'filesystem', ?)`,
-		"artist-mixed", "lib-new", "2024-01-15T10:00:00Z"); err != nil {
+		"artist-mixed", "lib-new", "2024-01-15T00:30:00Z"); err != nil {
 		t.Fatalf("insert lib-new membership: %v", err)
 	}
 

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -97,7 +97,18 @@ func TestScan_PathlessLibrarySkipped(t *testing.T) {
 	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Visible Artist")
-	svc, artistSvc := setupScanner(t, libDir)
+	svc, artistSvc, db := setupScannerWithDB(t, libDir)
+
+	// Seed the libraries the lister will surface so artist_libraries
+	// memberships (and the LibraryID hydration that follows) actually
+	// land on created artists.
+	if _, err := db.ExecContext(context.Background(),
+		`INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)
+			VALUES ('lib-1', 'Main', ?, 'regular', 'manual', datetime('now'), datetime('now')),
+			       ('lib-2', 'API Only', '', 'regular', 'manual', datetime('now'), datetime('now'))`,
+		libDir); err != nil {
+		t.Fatalf("seeding libraries: %v", err)
+	}
 
 	// Set up a library lister that returns one healthy library and one pathless (empty path).
 	svc.SetLibraryLister(&stubLibraryLister{


### PR DESCRIPTION
## Summary

- Drops the legacy `artists.library_id` column (and `idx_artists_library_id`) in new migration 004; `artist_libraries` is the authoritative M:N membership record.
- Adds expression index `idx_artists_name_lower` so `LOWER(name) = LOWER(?)` lookups are index-driven (#1224).
- Normalises legacy `metadata_changes.created_at` rows from "YYYY-MM-DD HH:MM:SS" to RFC3339 in-migration; production code drops every `datetime()` wrapper and binds RFC3339 directly (#1018).
- Adds `Service.hydratePrimaryLibrary` / `hydratePrimaryLibrariesBatch` so live readers (rule engine shared-fs check, compliance CSV, artist detail library name) keep seeing `Artist.LibraryID` even though it is no longer a DB column.
- Removes the deprecated `GetByMBIDAndLibrary` / `GetByNameAndLibrary` / `FindByMBIDOrName` repository surface and the matching `Service` pass-throughs.
- Rewrites `ListPathsByLibrary`, `internal/artist/sqlite_completeness.go`, `sqlite_health_stats.go`, `sqlite_image.go` (`NewestWriteTimesByArtist`), `sqlite_platform.go` (`GetPresenceForArtists`) to use membership-only `EXISTS` / JOIN forms; legacy `OR a.library_id = ?` and UNION-fallback branches are gone.
- Rewrites every `LEFT JOIN libraries l ON l.id = a.library_id` in `internal/rule/service.go` to use a primary-library subquery against `artist_libraries`; per-library facet counts (`CountActiveViolationsByLibrary`) and dismiss helpers (`DismissViolationsForLibrary`, `DismissOrphanedViolations`) flip to membership semantics.
- `internal/library/service.go`: `Delete` drops the `UPDATE artists SET library_id = NULL` pre-step (CASCADE handles it); `DeleteWithArtists` drops the same plus the legacy `COALESCE(library_id, '') = ''` guard; `CountArtists` / `CountArtistsByConnectionID` read from `artist_libraries`.
- `internal/api/handlers_connection_library.go`: `resolveAndBackfillPlatformID` prefers an artist with membership in the connection library (new `findArtistInLibrary` helper) before falling back to unscoped MBID-then-name, so transitional duplicate-artist-row state still resolves to the connection-side row.
- `cmd/stillwater/main.go`: drops `assignOrphanedArtists`; `backfillDefaultLibrary` keeps the "ensure a Default library exists" half. New scans pick up memberships via `Service.Create -> AddDerivingSource`.
- Test fixtures (option A): tests that previously set `Artist.LibraryID` now also seed a `libraries` row so `Service.Create.recordInitialMembership` can land a real `artist_libraries` entry. Legacy `migrate_test.go` paths that exercise the runtime backfill helper lazily ALTER TABLE the column back via `ensureLegacyLibraryIDColumn`.
- `internal/database/query_plan_test.go` asserts `artist_by_lower_name` and `history_range_rfc3339` use indexes (no SCAN); per-library queries are rewritten through `artist_libraries`.

### EXPLAIN QUERY PLAN evidence

**Lower-name lookup** (`SELECT id FROM artists WHERE LOWER(name) = LOWER(?)`)
- Before: `SCAN artists`
- After:  `SEARCH artists USING INDEX idx_artists_name_lower (<expr>=?)`

**History range** (`SELECT id FROM metadata_changes WHERE artist_id = ? AND created_at >= ? AND created_at <= ? ORDER BY created_at DESC LIMIT 50`)
- Before: `datetime()`-wrapped, `USE TEMP B-TREE FOR ORDER BY`
- After:  `SEARCH metadata_changes USING INDEX idx_metadata_changes_artist (artist_id=? AND created_at>? AND created_at<?)`

**Artists in library** (`SELECT a.id, a.path FROM artists a JOIN artist_libraries al ON al.artist_id = a.id WHERE al.library_id = ?`)
- Before: `SEARCH artists USING INDEX idx_artists_library_id`
- After:  `SEARCH al USING INDEX idx_artist_libraries_library`

## Test plan

- [x] `go test -race ./...` (all packages green)
- [x] `make lint` (0 issues)
- [x] `bash scripts/pre-push-gate.sh` (typos / gofmt / templ / build / lint / govulncheck / OpenAPI consistency / generated files / raw error leak / OpenAPI breaking changes / patch coverage 71.09%)
- [x] `internal/database/query_plan_test.go` asserts the new lower-name and history-range queries use indexes (no SCAN)
- [ ] UAT: populate via Emby on a 500+-artist library; observe latency vs baseline
- [ ] UAT: Reports > History view; verify queries return correct rows post-normalization
- [x] `grep -rn 'library_id' internal/artist/ internal/library/ internal/api/` returns only references inside `artist_libraries` SQL, JSON tags, query parameter names, log keys, and updated comments — no `artists.library_id` reads or writes.

Closes #1214, Closes #1224, Closes #1018

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Artists can belong to multiple libraries; a single primary library is now derived.

* **Bug Fixes**
  * Library-scoped lookups and platform-ID propagation tightened to prevent cross-library leaks.
  * Scan, history ordering, counts, and violation scoping updated to reflect membership model.

* **Database Migrations**
  * Legacy single-library column removed, memberships backfilled; case-insensitive name index and timestamp normalization added.

* **Documentation**
  * API schema clarifies primary-library semantics.

* **Tests**
  * Expanded coverage for hydration, membership, migrations, scanning, and library-scoped behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->