### PR TITLE
chore(release): migrate goreleaser to dockers_v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,60 +34,35 @@ builds:
 
 archives:
   - id: default
-    format: tar.gz
+    formats:
+      - tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
-dockers:
-  - id: amd64
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-amd64"
+dockers_v2:
+  - id: stillwater
+    images:
+      - "ghcr.io/sydlexius/stillwater"
+    # dockers_v2 ignores empty tag templates, so prerelease gating is encoded
+    # by emitting "" for the disallowed branch:
+    #   :VERSION       always
+    #   :MAJOR.MINOR   non-prerelease only
+    #   :latest        non-prerelease only
+    #   :beta          prerelease only
+    tags:
+      - "{{ .Version }}"
+      - "{{ if not .Prerelease }}{{ .Major }}.{{ .Minor }}{{ end }}"
+      - "{{ if not .Prerelease }}latest{{ end }}"
+      - "{{ if .Prerelease }}beta{{ end }}"
     dockerfile: build/docker/Dockerfile.goreleaser
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
+    platforms:
+      - linux/amd64
+      - linux/arm64
     extra_files:
       - build/docker/entrypoint.sh
-
-  - id: arm64
-    goos: linux
-    goarch: arm64
-    image_templates:
-      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
-    dockerfile: build/docker/Dockerfile.goreleaser
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-    extra_files:
-      - build/docker/entrypoint.sh
-
-docker_manifests:
-  - name_template: "ghcr.io/sydlexius/stillwater:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-amd64"
-      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/sydlexius/stillwater:{{ .Major }}.{{ .Minor }}"
-    skip_push: "{{ .Prerelease }}"
-    image_templates:
-      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-amd64"
-      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/sydlexius/stillwater:latest"
-    skip_push: "{{ .Prerelease }}"
-    image_templates:
-      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-amd64"
-      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/sydlexius/stillwater:beta"
-    skip_push: '{{ not .Prerelease }}'
-    image_templates:
-      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-amd64"
-      - "ghcr.io/sydlexius/stillwater:{{ .Version }}-arm64"
 
 signs:
   - cmd: cosign
@@ -106,8 +81,12 @@ docker_signs:
     args:
       - sign
       - --yes
-      - ${artifact}
-    artifacts: all
+      # Sign by immutable digest, not the mutable tag reference. dockers_v2
+      # produces multiple logical tags (:VERSION, :MAJOR.MINOR, :latest,
+      # :beta) all pointing at the same image; signing ${artifact} alone
+      # races against concurrent tag updates, while ${artifact}@${digest}
+      # pins the signature to the specific image content.
+      - ${artifact}@${digest}
 
 changelog:
   sort: asc

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -12,7 +12,11 @@ RUN mkdir -p /config /music && chown stillwater:stillwater /config /music
 
 WORKDIR /app
 
-COPY stillwater /usr/local/bin/stillwater
+# dockers_v2 runs a single buildx that fans out across platforms and stages
+# each platform's binary under $TARGETPLATFORM/ in the build context.
+# extra_files (entrypoint.sh) keep their original relative path.
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/stillwater /usr/local/bin/stillwater
 COPY build/docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 


### PR DESCRIPTION
## Summary

- Replace `dockers:` (2 entries) + `docker_manifests:` (4 entries) with a single `dockers_v2:` block, eliminating the 2x4 cartesian product. Same 4 logical tags (`:VERSION`, `:MAJOR.MINOR`, `:latest`, `:beta`) with the same prerelease-gating semantics, encoded via empty-tag elision instead of `skip_push`.
- Update `Dockerfile.goreleaser` to `ARG TARGETPLATFORM` + `COPY $TARGETPLATFORM/stillwater ...` since v2 runs one buildx that fans out across platforms.
- `docker_signs` now signs by `${artifact}@${digest}` instead of `${artifact}` -- pre-empts the same CR finding fixed in sister repo sydlexius/mxlrcgo-svc#91 (mutable-tag race when v2 emits multiple tags pointing at one image).
- Bundled cleanup: `archives.format` -> `archives.formats` (plural list) so `goreleaser check` is fully deprecation-free.

Closes #1291.

## Why bundle the archives.format fix

The issue scoped to docker deprecations, but `archives.format` was the only other deprecation surfaced by `goreleaser check`. Both are 1-line/4-line config migrations on the same file; bundling lets the success criterion ("no deprecation warnings") be the literal `goreleaser check` exit code instead of an awkward grep.

## Caveats

- **`dockers_v2` is flagged experimental by goreleaser.** Sister repo sydlexius/mxlrcgo-svc has been running on it in production since #91 (2026-05-03) without incident, but goreleaser may evolve the schema. If they ship a breaking change, we'll follow.
- **Docker build itself is not exercised on this PR.** The CI `Docker Build` job uses `build/docker/Dockerfile` (the dev image), not `Dockerfile.goreleaser`. The goreleaser path is exercised only by the actual release workflow on tag push. Recommended: verify on the next prerelease tag (`vX.Y.Z-rcN`) that `:beta` gating still works before promoting to a non-prerelease.

## Test plan

- [x] `goreleaser check` -- clean (no deprecation warnings)
- [x] `goreleaser release --snapshot --clean --skip=before,publish,sign,docker` -- all 5 platforms built, all archives produced (tar.gz unix, zip windows)
- [x] Pre-push hook -- clean (no Go/templ/openapi changes; non-Go gate is no-op)
- [x] Docs check -- no user-facing or dev-setup prose claims invalidated
- [ ] **Manual on first release tag**: confirm release workflow emits zero docker deprecation warnings, all 4 logical tags exist on ghcr.io after a non-prerelease tag, `:beta` exists after a prerelease tag, cosign signatures verify against the manifest digests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Docker image build infrastructure to support multi-platform deployments targeting `linux/amd64` and `linux/arm64` architectures.
  * Enhanced container image tagging with prerelease-aware version identification for improved release tracking.
  * Improved Docker image signing by using immutable digests, ensuring reliable signature verification and preventing inconsistencies during concurrent image updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->