### PR TITLE
fix(docs): entity-encode XML/HTML in generated settings reference

### DIFF
--- a/cmd/gen-settings-reference/main.go
+++ b/cmd/gen-settings-reference/main.go
@@ -817,6 +817,19 @@ func humanize(id string) string {
 // Rendering
 // ---------------------------------------------------------------------------
 
+// markdownEscape entity-encodes the angle brackets in user-facing prose so
+// XML/HTML-like tokens (e.g. <lockdata>true</lockdata>) render as literal
+// text in MkDocs Material output rather than being silently dropped as
+// unknown inline HTML elements. Ampersands are intentionally NOT escaped:
+// prose contains them legitimately ("save & restart"), and the runtime UI
+// reads the same i18n strings unescaped (tooltips, screen readers) so
+// escaping the source would leak literal entities into the live UI.
+func markdownEscape(s string) string {
+	return mdEscapeReplacer.Replace(s)
+}
+
+var mdEscapeReplacer = strings.NewReplacer("<", "&lt;", ">", "&gt;")
+
 // renderDocument walks the document tree and emits the Markdown body that
 // goes between the BEGIN/END markers. Tabs render as `##` headings, sections
 // as `###` headings with optional prose description, and controls as bullet
@@ -832,7 +845,7 @@ func renderDocument(doc document) string {
 	// last section, which already emits a trailing blank in renderSection.
 	b.WriteString("\n")
 	for _, tab := range doc.Tabs {
-		fmt.Fprintf(&b, "## %s  {#%s}\n\n", tab.Label, tabAnchor(tab.ID))
+		fmt.Fprintf(&b, "## %s  {#%s}\n\n", markdownEscape(tab.Label), tabAnchor(tab.ID))
 		for _, sec := range tab.Sections {
 			renderSection(&b, tab.ID, sec)
 		}
@@ -841,9 +854,9 @@ func renderDocument(doc document) string {
 }
 
 func renderSection(b *strings.Builder, tabID string, sec docSection) {
-	fmt.Fprintf(b, "### %s  {#%s}\n\n", sec.Title, sectionAnchor(tabID, sec.ID))
+	fmt.Fprintf(b, "### %s  {#%s}\n\n", markdownEscape(sec.Title), sectionAnchor(tabID, sec.ID))
 	if sec.Description != "" {
-		b.WriteString(sec.Description)
+		b.WriteString(markdownEscape(sec.Description))
 		b.WriteString("\n\n")
 	}
 	if len(sec.Controls) == 0 {
@@ -861,7 +874,7 @@ func renderSection(b *strings.Builder, tabID string, sec docSection) {
 // fold into the bullet's prose with simple inline markers; if the control has
 // none of those, only the label and anchor render.
 func renderControl(b *strings.Builder, tabID, secID string, ctrl docControl) {
-	fmt.Fprintf(b, "- **%s** {#%s}", ctrl.Label, controlAnchor(tabID, secID, ctrl.ID))
+	fmt.Fprintf(b, "- **%s** {#%s}", markdownEscape(ctrl.Label), controlAnchor(tabID, secID, ctrl.ID))
 
 	prose := composeControlProse(ctrl)
 	if prose != "" {
@@ -878,13 +891,13 @@ func renderControl(b *strings.Builder, tabID, secID string, ctrl docControl) {
 func composeControlProse(ctrl docControl) string {
 	parts := []string{}
 	if ctrl.Description != "" {
-		parts = append(parts, ctrl.Description)
+		parts = append(parts, markdownEscape(ctrl.Description))
 	}
 	if ctrl.Visibility != "" {
-		parts = append(parts, "*Visibility:* "+ctrl.Visibility)
+		parts = append(parts, "*Visibility:* "+markdownEscape(ctrl.Visibility))
 	}
 	if ctrl.Help != "" {
-		parts = append(parts, "**Help:** "+ctrl.Help)
+		parts = append(parts, "**Help:** "+markdownEscape(ctrl.Help))
 	}
 	return strings.Join(parts, " ")
 }

--- a/cmd/gen-settings-reference/main_test.go
+++ b/cmd/gen-settings-reference/main_test.go
@@ -221,6 +221,72 @@ func TestRenderControl_VisibilityAndHelp(t *testing.T) {
 	}
 }
 
+// TestMarkdownEscape verifies that user-facing prose containing XML-like
+// tokens (e.g. <lockdata>true</lockdata>) is entity-encoded so MkDocs
+// Material renders the brackets as literal text rather than dropping them
+// as unknown inline HTML elements. Ampersands stay unescaped because prose
+// contains them legitimately and the runtime UI reads the source strings
+// unescaped.
+func TestMarkdownEscape(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "lock_nfo case",
+			in:   "stamps <lockdata>true</lockdata> into every NFO",
+			want: "stamps &lt;lockdata&gt;true&lt;/lockdata&gt; into every NFO",
+		},
+		{
+			name: "ampersand preserved",
+			in:   "save & restart",
+			want: "save & restart",
+		},
+		{
+			name: "no angle brackets",
+			in:   "plain prose with no special chars",
+			want: "plain prose with no special chars",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "mixed angles and ampersand",
+			in:   "<a href=\"x?y=1&z=2\">link</a>",
+			want: "&lt;a href=\"x?y=1&z=2\"&gt;link&lt;/a&gt;",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := markdownEscape(tc.in); got != tc.want {
+				t.Errorf("markdownEscape(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderControl_EscapesAngleBrackets is a regression guard for #1305:
+// the bullet's prose must entity-encode XML tokens emitted from i18n values
+// so the rendered docs page shows them as literal text.
+func TestRenderControl_EscapesAngleBrackets(t *testing.T) {
+	var b strings.Builder
+	renderControl(&b, "libraries", "libraries", docControl{
+		ID:          "lock_nfo_label",
+		Label:       "Lock NFOs",
+		Description: "stamps <lockdata>true</lockdata> into every NFO",
+	})
+	out := b.String()
+	if !strings.Contains(out, "&lt;lockdata&gt;true&lt;/lockdata&gt;") {
+		t.Errorf("expected entity-encoded <lockdata> in output, got: %q", out)
+	}
+	if strings.Contains(out, "<lockdata>") {
+		t.Errorf("output still contains raw <lockdata>: %q", out)
+	}
+}
+
 // TestCollectAnchors_DeterministicAndUnique verifies the companion file is
 // sorted, deduplicated, and contains every kind of anchor the document
 // emits (tab, section, control).

--- a/docs/site/src/reference/settings-by-tab.md
+++ b/docs/site/src/reference/settings-by-tab.md
@@ -124,7 +124,7 @@ Manage your music library paths. Each library maps to a directory containing art
 
 - **Connection** {#settings-libraries-libraries-connection-badge}
 - **Lock NFOs** {#settings-libraries-libraries-lock-nfo-label}
-- **When on, Stillwater stamps <lockdata>true</lockdata> into every NFO it writes for this library. This tells Emby and Jellyfin to refuse metadata refreshes for those artists, preserving Stillwater's curated values from being overwritten by the platform's own scrapers. Off by default. Tip: artists whose NFO already contains <lockdata>true</lockdata> (set by Stillwater or another tool) are automatically marked as locked at the artist level.** {#settings-libraries-libraries-lock-nfo-title}
+- **When on, Stillwater stamps &lt;lockdata&gt;true&lt;/lockdata&gt; into every NFO it writes for this library. This tells Emby and Jellyfin to refuse metadata refreshes for those artists, preserving Stillwater's curated values from being overwritten by the platform's own scrapers. Off by default. Tip: artists whose NFO already contains &lt;lockdata&gt;true&lt;/lockdata&gt; (set by Stillwater or another tool) are automatically marked as locked at the artist level.** {#settings-libraries-libraries-lock-nfo-title}
 - **Add Library** {#settings-libraries-libraries-add}
 - **Regular** {#settings-libraries-libraries-type-regular}
 - **Classical** {#settings-libraries-libraries-type-classical}


### PR DESCRIPTION
## Summary

- Add `markdownEscape()` helper to `cmd/gen-settings-reference/main.go` that entity-encodes `<` and `>` (not `&`) and apply it to every emit path that writes user-facing prose: `renderDocument` tab heading, `renderSection` title and description, `renderControl` label, `composeControlProse` description/visibility/help.
- MkDocs Material treats unknown HTML elements as inline pass-through, so XML-like tokens in i18n values were being silently stripped from the rendered docs page. Today this affected one bullet (Libraries section's `lock_nfo_title`, which mentions `<lockdata>true</lockdata>`); the regression guard catches future cases at the generator level rather than at render time.
- Ampersands stay unescaped: prose contains them legitimately ("save & restart") and the runtime UI consumes the same i18n values unescaped (tooltips, screen readers), so escaping at the source would leak literal entities into the live UI.

## Verification

- `cd cmd/gen-settings-reference && go test ./... -run "TestMarkdownEscape|TestRenderControl_EscapesAngleBrackets" -v` (5 helper subtests + 1 render regression) — passes.
- `make generate-docs` regenerates `docs/site/src/reference/settings-by-tab.md`. Diff is exactly one line (the lock_nfo bullet); `_settings-anchors.txt` is unchanged because anchors derive from IDs, not prose.
- `bash scripts/pre-push-gate.sh` — 100.00% patch coverage (9/9), full Go suite green, OpenAPI/generated-files/raw-error-leak/breaking-changes checks all OK.

## Test plan

- [x] `markdownEscape("<lockdata>true</lockdata>")` returns `&lt;lockdata&gt;true&lt;/lockdata&gt;`.
- [x] `markdownEscape("save & restart")` returns `save & restart` unchanged.
- [x] Empty-string and no-special-chars inputs round-trip correctly.
- [x] `renderControl` regression: a control whose description contains `<lockdata>` emits the entity-encoded form into the bullet prose, never the raw form.
- [x] Pre-push gate green (full Go suite, OpenAPI, generated files, patch coverage).
- [ ] Render-time spot check: serve the docs site and confirm the Libraries section's `lock_nfo_title` bullet now shows the literal `<lockdata>true</lockdata>` text instead of the empty string between "stamps" and "into" — left unchecked here because MkDocs' rendering of `&lt;` as `<` literal text is a CommonMark property; the generator's job ends at the Markdown source.

Closes #1305

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of angle brackets in settings descriptions and labels to prevent incorrect HTML interpretation in documentation.

* **Documentation**
  * Updated settings reference documentation with properly escaped content examples.

* **Tests**
  * Added comprehensive test cases validating angle bracket escaping functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->