### PR TITLE
chore(version): bump dev fallback to 1.0.5

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // These variables are set at build time via -ldflags.
 var (
-	Version = "1.0.1"
+	Version = "1.0.5"
 	Commit  = "unknown"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

- Bumps `internal/version/version.go` from `1.0.1` to `1.0.5` so `go run ./cmd/stillwater` shows the right version when ldflags are not injected.
- Built artifacts are unaffected — `.goreleaser.yml` injects the version via `-ldflags -X .../version.Version={{ .Version }}` at build time, so v1.0.5 binaries already have the correct value.
- The release commit was tagged directly at v1.0.5 push time. Branch protection on `main` correctly rejected the direct-to-main push, routing this single-line bump through a PR.

## Test plan

- [x] Local build shows the bump
- [x] Pre-commit hook passes (typos, gofmt, build, golangci-lint, govulncheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application version updated to 1.0.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->