### PR TITLE
chore(deps): bump Go toolchain to 1.26.3 (govulncheck stdlib fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sydlexius/stillwater
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/a-h/templ v0.3.1001


### PR DESCRIPTION
## Summary

- Bump `go.mod` from `go 1.26.2` to `go 1.26.3` to clear two new Go stdlib advisories.
- Pure toolchain bump -- single-line change, no other code or dependency edits.

Closes #1344.

## Why

`govulncheck ./...` started failing on every PR after these two stdlib advisories landed; both are fixed in Go 1.26.3:

- **GO-2026-4971** -- Panic in `net.Dial` / `net.LookupPort` when handling NUL byte on Windows (fixed in `net@go1.26.3`).
- **GO-2026-4918** -- Infinite loop in `net/http` HTTP/2 transport on bad `SETTINGS_MAX_FRAME_SIZE` (fixed in `net/http@go1.26.3`).

Both this branch's parent (`main`) and existing open PRs (#1329, #1333) were on `go 1.26.2` and would all fail this check until the bump lands.

## Local verification

```
$ govulncheck ./...
Go: go1.26.3
Scanner: govulncheck@v1.1.4
DB: https://vuln.go.dev
DB updated: 2026-05-07 19:21:40 +0000 UTC
No vulnerabilities found.
```

Pre-push gate passed (full Go test suite + OpenAPI + breaking-changes + generated-files + patch coverage).

## Test plan

- [x] `govulncheck ./...` clean locally with go1.26.3.
- [x] `go build ./...` clean.
- [x] `go test -race ./...` clean (full suite via pre-push gate).
- [ ] CI `Go Vulnerability Check` passes.
- [ ] After merge: rebase #1329 and #1333 to inherit the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go runtime to version 1.26.3, incorporating the latest patches and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->