### PR TITLE
chore: v1.0.6 release prep (Dockerfile go 1.26.3 digest + version bump)

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage
-FROM golang:1.26-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
+FROM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 
 RUN apk add --no-cache curl libstdc++ libgcc
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // These variables are set at build time via -ldflags.
 var (
-	Version = "1.0.5"
+	Version = "1.0.6"
 	Commit  = "unknown"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

Two paired changes for the v1.0.6 security release:

1. **Dockerfile pin**: bump `golang:1.26-alpine` digest from `f85330846cde` (go1.26.2) to `91eda9776261` (go1.26.3). Fixes the post-merge Docker Build failure on `main` after #1345 raised `go.mod` to `go 1.26.3`.
2. **Dev-fallback version**: bump `internal/version/version.go` `Version` from `"1.0.5"` to `"1.0.6"`. goreleaser injects the real value via `-ldflags` at tag time; this fallback is only visible in `make dev` / `go run` builds.

## Why

#1345's Go bump cleared the govulncheck stdlib advisories at the source level but left the build still using a Go 1.26.2 image. The first push to `main` after merge tried to download modules with `GOTOOLCHAIN=local` and crashed with:

```
go: go.mod requires go >= 1.26.3 (running go 1.26.2; GOTOOLCHAIN=local)
```

PR-time CI skipped Docker Build for `go.mod`-only diffs (paths-filter), so the gap only surfaced post-merge. Failing run: https://github.com/sydlexius/stillwater/actions/runs/25521959479/job/74908906732

The v1.0.6 release exists specifically to ship Go 1.26.3 (and thus the `GO-2026-4971` + `GO-2026-4918` stdlib fixes) to end users running the Docker image and binary releases.

## Local verification

```
$ docker run --rm -v "$PWD":/src -w /src \
    golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d \
    sh -c 'go version && go mod download && echo SUCCESS'
go version go1.26.3 linux/arm64
SUCCESS
```

Pre-push gate: full Go suite + OpenAPI + breaking changes + generated files + govulncheck + hadolint all clean.

## Test plan

- [x] `golang:1.26-alpine@sha256:91eda9776261...` resolves to go1.26.3.
- [x] `go mod download` succeeds inside the new image with `GOTOOLCHAIN=local`.
- [x] Pre-push gate clean.
- [ ] CI `Docker Build` passes (it now triggers because Dockerfile changed).
- [ ] CI `Go Vulnerability Check` continues to pass.
- [ ] After merge: tag `v1.0.6` (signed annotated) so goreleaser publishes the patched binaries + image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.0.6
  * Updated container base image

<!-- end of auto-generated comment: release notes by coderabbit.ai -->