### PR TITLE
feat(server): optional HTTP-to-HTTPS redirect listener (#929)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       # Direct TLS (BYO certificate). Uncomment when SW_TLS_CERT_FILE/KEY_FILE
       # are set below; pick whichever host port matches your deployment.
       # - "443:1973"
+      # Optional HTTP-to-HTTPS redirect listener. Uncomment alongside the TLS
+      # mappings above when SW_HTTP_REDIRECT_PORT is set. Pairs with port 80
+      # so users typing http://yourhost get sent to HTTPS automatically.
+      # - "80:80"
     environment:
       - PUID=99
       - PGID=100
@@ -21,6 +25,8 @@ services:
       # - SW_TLS_CERT_FILE=/config/tls/fullchain.pem
       # - SW_TLS_KEY_FILE=/config/tls/privkey.pem
       # - SW_TLS_PORT=1973  # 0 or unset reuses SW_PORT (collapse mode)
+      # Optional HTTP-to-HTTPS redirect listener (see docs/how-to/http-redirect):
+      # - SW_HTTP_REDIRECT_PORT=80
     volumes:
       - stillwater-data:/config
       - /path/to/your/music:/music:rw

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
       - Update Stillwater: how-to/self-update.md
       - Reverse proxy: how-to/reverse-proxy.md
       - Direct TLS setup: how-to/direct-tls-setup.md
+      - HTTP-to-HTTPS redirect: how-to/http-redirect.md
   - Reference:
       - reference/index.md
       - Settings, by tab: reference/settings-by-tab.md

--- a/docs/site/src/how-to/direct-tls-setup.md
+++ b/docs/site/src/how-to/direct-tls-setup.md
@@ -61,7 +61,7 @@ key_file  = "/config/tls/privkey.pem"
 port      = 0  # 0 reuses [server].port; set to 443 for split-port deploys.
 ```
 
-## Confirm it took effect
+## TLS status { #settings-general-tls-status }
 
 Open Settings, scroll to the General tab. The TLS Status card shows one of three states:
 
@@ -97,4 +97,4 @@ Added in v1.1.0; see issue [#932](https://github.com/sydlexius/stillwater/issues
 
 ### HTTP-to-HTTPS redirect listener
 
-Added in v1.1.0; see issue [#929](https://github.com/sydlexius/stillwater/issues/929). Setting `SW_HTTP_REDIRECT_PORT=80` will make Stillwater bind a second plain-HTTP listener that 301-redirects every request to the HTTPS port.
+Added in v1.1.0. Setting `SW_HTTP_REDIRECT_PORT=80` makes Stillwater bind a second plain-HTTP listener that 301-redirects every request to the HTTPS port. See the [HTTP-to-HTTPS redirect](http-redirect.md) how-to for setup details and reverse-proxy interactions.

--- a/docs/site/src/how-to/http-redirect.md
+++ b/docs/site/src/how-to/http-redirect.md
@@ -1,0 +1,84 @@
+---
+description: Add a plain-HTTP listener that 301-redirects every request to the HTTPS port.
+---
+
+# HTTP-to-HTTPS redirect
+
+When you serve HTTPS directly from Stillwater (see [Direct TLS setup](direct-tls-setup.md)), users who type `http://yourhost` in the address bar reach a closed port unless you also bind plain HTTP somewhere. The HTTP-to-HTTPS redirect listener fills that gap: it binds a second port (typically `80`) and answers every request with a `301 Moved Permanently` to the same path on HTTPS.
+
+## When to enable it { #http-redirect-when }
+
+Enable the redirect listener when:
+
+- Stillwater terminates TLS itself (you have set `SW_TLS_CERT_FILE` and `SW_TLS_KEY_FILE`).
+- The host is reachable on port 80 from the networks your users come from.
+- You do not have a reverse proxy in front of Stillwater that already handles the redirect.
+
+Skip it when:
+
+- A reverse proxy (SWAG, Caddy, Traefik, Nginx) fronts Stillwater. The proxy should own port 80 and the redirect; doubling up either fails to bind or produces a redirect loop.
+- Stillwater is reached only via direct HTTPS links (no human types the URL by hand).
+- Port 80 is unavailable on the host (used by another service, blocked by the firewall, not forwarded by NAT).
+
+## Enabling the redirect listener { #http-redirect-enable }
+
+Set the redirect port via env var, command line, or config file. Port 80 is the standard HTTP port and what browsers assume when no scheme prefix is given.
+
+```bash
+export SW_TLS_CERT_FILE=/config/tls/fullchain.pem
+export SW_TLS_KEY_FILE=/config/tls/privkey.pem
+export SW_HTTP_REDIRECT_PORT=80
+```
+
+Or in `config.toml`:
+
+```toml
+[server.tls]
+cert_file = "/config/tls/fullchain.pem"
+key_file  = "/config/tls/privkey.pem"
+
+[server.http_redirect]
+port = 80
+```
+
+Stillwater rejects two misconfigurations at startup:
+
+- The redirect port equals the HTTPS port. The two listeners cannot share a socket.
+- The redirect port is set without TLS configured. There would be nowhere to redirect to.
+
+## Port 80 reachability { #http-redirect-port-80 }
+
+Binding port 80 has two practical wrinkles:
+
+- **Privileged port.** On Linux ports below 1024 require root or the `CAP_NET_BIND_SERVICE` capability. The official container image runs with that capability when needed; native installs may need `setcap` or a higher port (e.g. `SW_HTTP_REDIRECT_PORT=8080` paired with a NAT rule on the gateway).
+- **NAT and firewalls.** If users reach Stillwater across a router or cloud security group, port 80 must be forwarded just like the HTTPS port. Otherwise the redirect listener is bound but unreachable, and the typed-URL case still fails silently.
+
+## Verifying the redirect { #http-redirect-verify }
+
+Use `curl -I` to see the redirect headers without following them:
+
+```bash
+curl -I http://yourhost/
+```
+
+Expected response:
+
+```
+HTTP/1.1 301 Moved Permanently
+Location: https://yourhost/
+```
+
+Query strings and paths are preserved. A request to `http://yourhost/artists?page=2` redirects to `https://yourhost/artists?page=2`.
+
+## Settings page indicator { #http-redirect-settings }
+
+Once the redirect listener is active the Settings General tab shows it on the TLS Status card under the Listening row, alongside the HTTPS port. If the row is missing after a restart, double-check the env var spelling and the startup logs for a validation error.
+
+## Interaction with reverse proxies { #http-redirect-reverse-proxy }
+
+Do not enable the redirect listener and a reverse proxy that handles TLS at the same time. Two patterns work; pick one:
+
+- **Reverse proxy terminates TLS.** Stillwater stays on plain HTTP on its default port; the proxy listens on 80 and 443 and issues the redirect itself. Leave `SW_HTTP_REDIRECT_PORT` unset.
+- **Stillwater terminates TLS.** Stillwater binds 443 and (with this feature enabled) 80; no reverse proxy is involved on those ports.
+
+Mixing them either fails to bind port 80 (proxy and Stillwater contend for the same socket) or produces a redirect loop (proxy redirects to HTTPS, Stillwater redirects back, browser bails after a few hops).

--- a/docs/site/src/reference/environment-variables.md
+++ b/docs/site/src/reference/environment-variables.md
@@ -28,7 +28,7 @@ The table below is generated from the configuration definition; do not edit it b
 | `SW_DB_PATH` | path | `/config/stillwater.db` | Filesystem path to the SQLite database file. |
 | `SW_ENCRYPTION_KEY` | string | unset | Key used to encrypt provider API keys at rest. When unset Stillwater generates one on first run and persists it in the config directory. |
 | `SW_HTTP3_ENABLED` | boolean | `false` | Reserved for future use; not yet active. HTTP/3 (QUIC) listener wiring lands in a follow-up PR. |
-| `SW_HTTP_REDIRECT_PORT` | integer | unset | Reserved for future use; not yet active. Plain-HTTP redirect listener wiring lands in a follow-up PR. Numeric values outside 1-65535 are rejected at startup. |
+| `SW_HTTP_REDIRECT_PORT` | integer | unset | Optional plain-HTTP listener port that 301-redirects to the HTTPS listener. Requires TLS to be configured (SW_TLS_CERT_FILE + SW_TLS_KEY_FILE). Typical value 80; must differ from SW_TLS_PORT (or SW_PORT in collapse mode). Numeric values outside 1-65535 are rejected at startup. |
 | `SW_LOG_FORMAT` | string | `json` | Log output format. Use json for log aggregators or text for friendlier console output. |
 | `SW_LOG_LEVEL` | string | `info` | Log level at startup. One of trace, debug, info, warn, error. The runtime can also adjust the live level from the Logs settings tab. |
 | `SW_MUSIC_PATH` | path | `/music` | Default music library path used as a starting point when no library has been added through the UI. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,10 +62,10 @@ func (c TLSConfig) Enabled() bool {
 }
 
 // HTTPRedirectConfig configures the optional plain-HTTP listener that 301s to
-// the HTTPS port. Stubbed today; the redirect listener wiring follows in a
-// later milestone PR.
+// the HTTPS port. Active only when TLS is also configured (cert+key set);
+// otherwise validate() rejects the misconfiguration at startup.
 type HTTPRedirectConfig struct {
-	Port int `yaml:"port" toml:"port" env:"SW_HTTP_REDIRECT_PORT" default:"unset" desc:"Reserved for future use; not yet active. Plain-HTTP redirect listener wiring lands in a follow-up PR. Numeric values outside 1-65535 are rejected at startup."`
+	Port int `yaml:"port" toml:"port" env:"SW_HTTP_REDIRECT_PORT" default:"unset" desc:"Optional plain-HTTP listener port that 301-redirects to the HTTPS listener. Requires TLS to be configured (SW_TLS_CERT_FILE + SW_TLS_KEY_FILE). Typical value 80; must differ from SW_TLS_PORT (or SW_PORT in collapse mode). Numeric values outside 1-65535 are rejected at startup."`
 }
 
 // HTTP3Config toggles the QUIC/HTTP3 listener. Stubbed today; the QUIC
@@ -186,8 +186,10 @@ const scaffoldTOML = `# Stillwater configuration
 # key_file = "/config/tls/privkey.pem"
 # port = 0  # 0 reuses [server].port; set to e.g. 443 for split-port deploys.
 
-# Plain-HTTP redirect listener. Reserved for future use; not yet active.
-# Wiring lands in a follow-up PR.
+# Plain-HTTP redirect listener. When set together with [server.tls], Stillwater
+# binds a second listener on this port that 301-redirects every request to the
+# HTTPS listener. Requires TLS to be configured; otherwise startup fails.
+# See: https://sydlexius.github.io/stillwater/how-to/http-redirect/
 # [server.http_redirect]
 # port = 80
 
@@ -291,7 +293,9 @@ func Load(path string) (*Config, error) {
 		}
 	}
 
-	cfg.loadFromEnv()
+	if err := cfg.loadFromEnv(); err != nil {
+		return nil, fmt.Errorf("loading env: %w", err)
+	}
 
 	if err := cfg.validate(); err != nil {
 		return nil, fmt.Errorf("validating config: %w", err)
@@ -380,7 +384,7 @@ func detectFormat(path string, data []byte) configFormat {
 // loadFromEnv overlays environment variables onto c. Env-var values take
 // precedence over any file-loaded values per the API-first contract: an
 // operator can override one knob via env without rewriting the whole file.
-func (c *Config) loadFromEnv() {
+func (c *Config) loadFromEnv() error {
 	if v := os.Getenv("SW_PORT"); v != "" {
 		if port, err := strconv.Atoi(v); err == nil {
 			c.Server.Port = port
@@ -446,9 +450,11 @@ func (c *Config) loadFromEnv() {
 		}
 	}
 	if v := os.Getenv("SW_HTTP_REDIRECT_PORT"); v != "" {
-		if port, err := strconv.Atoi(v); err == nil {
-			c.Server.HTTPRedirect.Port = port
+		port, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid SW_HTTP_REDIRECT_PORT %q: %w", v, err)
 		}
+		c.Server.HTTPRedirect.Port = port
 	}
 	// Treat empty SW_HTTP3_ENABLED as "do not override"; the rest of the
 	// loader follows that convention so a `t.Setenv(key, "")` test helper
@@ -480,6 +486,7 @@ func (c *Config) loadFromEnv() {
 	if v := os.Getenv("SW_ACME_CACHE_DIR"); v != "" {
 		c.ACME.CacheDir = v
 	}
+	return nil
 }
 
 // validate enforces required fields and normalizes a few values that the
@@ -533,6 +540,14 @@ func (c *Config) validate() error {
 	redirectPort := c.Server.HTTPRedirect.Port
 	if effectiveTLSPort != 0 && redirectPort != 0 && effectiveTLSPort == redirectPort {
 		return fmt.Errorf("TLS port and HTTP redirect port must differ (both=%d)", effectiveTLSPort)
+	}
+
+	// The redirect listener only makes sense when there is an HTTPS listener
+	// to redirect to. Refuse to start with the misconfiguration rather than
+	// quietly skipping the redirect (which would let a deploy that thought it
+	// was redirecting silently keep serving plain HTTP only on Server.Port).
+	if redirectPort != 0 && !tlsCertSet {
+		return fmt.Errorf("HTTP redirect port requires TLS to be configured (set SW_TLS_CERT_FILE and SW_TLS_KEY_FILE)")
 	}
 
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -386,9 +386,11 @@ func detectFormat(path string, data []byte) configFormat {
 // operator can override one knob via env without rewriting the whole file.
 func (c *Config) loadFromEnv() error {
 	if v := os.Getenv("SW_PORT"); v != "" {
-		if port, err := strconv.Atoi(v); err == nil {
-			c.Server.Port = port
+		port, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid SW_PORT %q: %w", v, err)
 		}
+		c.Server.Port = port
 	}
 	if v := os.Getenv("SW_BASE_PATH"); v != "" {
 		c.Server.BasePath = v
@@ -445,9 +447,11 @@ func (c *Config) loadFromEnv() error {
 		c.Server.TLS.KeyFile = v
 	}
 	if v := os.Getenv("SW_TLS_PORT"); v != "" {
-		if port, err := strconv.Atoi(v); err == nil {
-			c.Server.TLS.Port = port
+		port, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("invalid SW_TLS_PORT %q: %w", v, err)
 		}
+		c.Server.TLS.Port = port
 	}
 	if v := os.Getenv("SW_HTTP_REDIRECT_PORT"); v != "" {
 		port, err := strconv.Atoi(v)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -834,6 +834,50 @@ func TestValidate_TLSPortCollapseClashesWithRedirect(t *testing.T) {
 	}
 }
 
+// TestValidate_RedirectWithoutTLS rejects a configuration that asks for the
+// HTTP-to-HTTPS redirect listener but does not configure TLS. There would be
+// nothing to redirect to; quietly skipping the redirect would silently leave
+// the deploy on plain HTTP.
+func TestValidate_RedirectWithoutTLS(t *testing.T) {
+	clearSWEnv(t)
+	t.Setenv("SW_HTTP_REDIRECT_PORT", "80")
+	if _, err := Load(""); err == nil {
+		t.Fatal("expected error: redirect port set without TLS")
+	}
+}
+
+// TestValidate_RedirectWithTLSAccepted covers the happy path: TLS configured
+// with a split port, redirect listener on a distinct port. Loader accepts it.
+func TestValidate_RedirectWithTLSAccepted(t *testing.T) {
+	clearSWEnv(t)
+	t.Setenv("SW_TLS_CERT_FILE", "/tmp/c.pem")
+	t.Setenv("SW_TLS_KEY_FILE", "/tmp/k.pem")
+	t.Setenv("SW_TLS_PORT", "443")
+	t.Setenv("SW_HTTP_REDIRECT_PORT", "80")
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Server.HTTPRedirect.Port != 80 {
+		t.Errorf("HTTPRedirect.Port = %d; want 80", cfg.Server.HTTPRedirect.Port)
+	}
+	if cfg.Server.TLS.Port != 443 {
+		t.Errorf("TLS.Port = %d; want 443", cfg.Server.TLS.Port)
+	}
+}
+
+// TestLoad_RedirectPortMalformedFailsLoud asserts that a non-numeric value
+// for SW_HTTP_REDIRECT_PORT returns an error from Load instead of silently
+// discarding the env var (which would leave the redirect listener disabled
+// and the operator unaware).
+func TestLoad_RedirectPortMalformedFailsLoud(t *testing.T) {
+	clearSWEnv(t)
+	t.Setenv("SW_HTTP_REDIRECT_PORT", "80a")
+	if _, err := Load(""); err == nil {
+		t.Fatal("expected error: malformed SW_HTTP_REDIRECT_PORT must not be silently discarded")
+	}
+}
+
 // TestValidate_TLSConfiguredWithoutPortCollapsesToServerPort exercises the
 // happy path: cert and key set, TLS.Port unset. Loader accepts it; the
 // listener layer (RunListeners) treats Server.Port as the HTTPS port.

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -1535,7 +1535,7 @@
   "settings.tls_status.active_acme_with_domain": "Active (ACME, %s)",
   "settings.tls_status.active_byo": "Active (BYO certificate)",
   "settings.tls_status.description": "Read-only summary of the HTTPS listener. Configure TLS via SW_TLS_CERT_FILE / SW_TLS_KEY_FILE or the [server.tls] block in config.toml.",
-  "settings.tls_status.help": "Stillwater can serve over HTTPS using either a certificate you provide (SW_TLS_CERT_FILE / SW_TLS_KEY_FILE or [server.tls] in config.toml) or automatic Let's Encrypt issuance via ACME. This card shows which mode is active and which ports are bound; configuration is read-only here.",
+  "settings.tls_status.help": "Stillwater can serve over HTTPS using either a certificate you provide (SW_TLS_CERT_FILE / SW_TLS_KEY_FILE or [server.tls] in config.toml) or automatic Let's Encrypt issuance via ACME. The optional HTTP redirect listener (SW_HTTP_REDIRECT_PORT, typically 80) appears here when active and 301-redirects every plain-HTTP request to the HTTPS port. This card shows which mode is active and which ports are bound; configuration is read-only here.",
   "settings.tls_status.inactive": "Inactive",
   "settings.tls_status.listener_http": "HTTP on :%d",
   "settings.tls_status.listener_https": "HTTPS on :%d",

--- a/internal/server/listeners.go
+++ b/internal/server/listeners.go
@@ -18,7 +18,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -140,7 +143,16 @@ func RunListeners(ctx context.Context, cfg *config.Config, handler http.Handler,
 // PRs an obvious place to splice in their entries without rewriting the
 // shutdown harness.
 func buildEntries(cfg *config.Config, handler http.Handler, logger *slog.Logger) []listenerEntry {
-	return []listenerEntry{buildPrimaryListener(cfg, handler, logger)}
+	entries := []listenerEntry{buildPrimaryListener(cfg, handler, logger)}
+	// The redirect listener is opt-in (HTTPRedirect.Port > 0) AND only meaningful
+	// when TLS is active -- there is nowhere to redirect to without an HTTPS
+	// listener. validate() rejects the misconfiguration up front; this guard is
+	// belt-and-suspenders so a future config path that bypasses validate() does
+	// not silently spin up a redirect-to-itself.
+	if cfg.Server.HTTPRedirect.Port > 0 && cfg.Server.TLS.Enabled() {
+		entries = append(entries, buildRedirectListener(cfg, logger))
+	}
+	return entries
 }
 
 // buildPrimaryListener returns the entry for the main HTTP/HTTPS server.
@@ -197,4 +209,119 @@ func buildPrimaryListener(cfg *config.Config, handler http.Handler, logger *slog
 		serve:    srv.ListenAndServe,
 		shutdown: srv.Shutdown,
 	}
+}
+
+// buildRedirectListener returns an entry for the optional plain-HTTP listener
+// that 301s every request to the HTTPS listener. It is only registered when
+// TLS is active and HTTPRedirect.Port is non-zero (see buildEntries).
+//
+// The effective HTTPS port is the same value the primary listener resolved:
+// TLS.Port when set, otherwise Server.Port (collapse mode). validate() rejects
+// the redirect-port-equals-TLS-port collision so this listener is guaranteed
+// to bind a distinct port.
+func buildRedirectListener(cfg *config.Config, logger *slog.Logger) listenerEntry {
+	httpsPort := cfg.Server.TLS.Port
+	if httpsPort == 0 {
+		httpsPort = cfg.Server.Port
+	}
+	addr := fmt.Sprintf(":%d", cfg.Server.HTTPRedirect.Port)
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           redirectHandler(httpsPort),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
+	logger.Debug("redirect listener configured",
+		slog.String("addr", addr),
+		slog.Int("https_port", httpsPort),
+	)
+	return listenerEntry{
+		name:     "http-redirect",
+		addr:     addr,
+		serve:    srv.ListenAndServe,
+		shutdown: srv.Shutdown,
+	}
+}
+
+// redirectHandler returns an http.Handler that issues a 301 Moved Permanently
+// to the same path on https://<host>:<httpsPort>. Query string and fragment
+// from the original request are preserved via r.RequestURI (which includes
+// the raw path + query exactly as the client sent it).
+//
+// Host parsing handles three shapes:
+//   - "example.com"        -- no port, use as-is
+//   - "example.com:80"     -- strip the explicit port, replace with httpsPort
+//   - "[::1]:80"           -- IPv6 literal, brackets preserved by net.SplitHostPort
+//
+// When httpsPort is 443 the port suffix is omitted from the Location header so
+// the browser address bar shows the canonical URL ("https://example.com/path"
+// instead of "https://example.com:443/path").
+func redirectHandler(httpsPort int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Reject anything that is not a normal origin-form request. CONNECT
+		// (RequestURI = "host:port") and server-form OPTIONS (RequestURI = "*")
+		// would splice into a malformed Location otherwise.
+		if !strings.HasPrefix(r.RequestURI, "/") {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		host := r.Host
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
+		}
+		// Reject Hosts whose hostname portion contains characters that have no
+		// place in a URL authority. net/http already blocks CRLF in header
+		// values, but spaces, control bytes, and stray quotes would still
+		// produce a Location that browsers either reject or interpret in
+		// surprising ways.
+		if !isValidHostName(host) {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		// Re-add brackets for IPv6 literals so the resulting URL is well-formed.
+		if isIPv6Literal(host) {
+			host = "[" + host + "]"
+		}
+		var target string
+		if httpsPort == 443 {
+			target = "https://" + host + r.RequestURI
+		} else {
+			target = "https://" + host + ":" + strconv.Itoa(httpsPort) + r.RequestURI
+		}
+		w.Header().Set("Location", target)
+		w.WriteHeader(http.StatusMovedPermanently)
+	})
+}
+
+// isValidHostName accepts a hostname or IP literal containing only the ASCII
+// characters legal in a URL host: letters, digits, dot, hyphen, colon (for
+// IPv6 literals after net.SplitHostPort), and the brackets net/url permits.
+// Rejects empty input and anything containing whitespace, slashes, or other
+// reserved/control bytes.
+func isValidHostName(host string) bool {
+	if host == "" || len(host) > 253 {
+		return false
+	}
+	for i := 0; i < len(host); i++ {
+		c := host[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '.', c == '-', c == ':':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isIPv6Literal reports whether host is a bare IPv6 address (no brackets,
+// no port). net.SplitHostPort strips the brackets when present, so after that
+// step a colon in the remaining string means we are looking at an IPv6 host
+// that needs its brackets restored before we splice it back into a URL.
+func isIPv6Literal(host string) bool {
+	return net.ParseIP(host) != nil && strings.Contains(host, ":")
 }

--- a/internal/server/listeners_test.go
+++ b/internal/server/listeners_test.go
@@ -474,7 +474,28 @@ func TestRunListeners_RedirectIntegration(t *testing.T) {
 	go func() { done <- RunListeners(ctx, cfg, handler, discardLogger()) }()
 
 	redirectAddr := "127.0.0.1:" + strconv.Itoa(redirectPort)
+	tlsAddr := "127.0.0.1:" + strconv.Itoa(tlsPort)
 	pollUntilServing(t, redirectAddr)
+	pollUntilServing(t, tlsAddr)
+
+	// Verify the HTTPS sibling is actually serving. pollUntilServing only
+	// confirms the TCP socket is bound; without a real HTTPS round-trip a
+	// regression that stopped registering the TLS listener would still let
+	// the redirect-Location assertion pass (the URL is computed, not chased).
+	httpsClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test cert is self-signed
+		},
+		Timeout: 2 * time.Second,
+	}
+	tlsResp, err := httpsClient.Get("https://" + tlsAddr + "/")
+	if err != nil {
+		t.Fatalf("HTTPS GET on TLS listener: %v", err)
+	}
+	tlsResp.Body.Close()
+	if tlsResp.StatusCode != http.StatusOK {
+		t.Fatalf("TLS listener status = %d; want 200", tlsResp.StatusCode)
+	}
 
 	// Use a client that does NOT follow redirects; we want to inspect the
 	// Location header directly, not chase it into the TLS listener.

--- a/internal/server/listeners_test.go
+++ b/internal/server/listeners_test.go
@@ -14,6 +14,8 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -360,6 +362,177 @@ func TestRunListeners_NilArgs(t *testing.T) {
 	}
 }
 
+// TestRedirectHandler covers the redirect target construction across the host
+// shapes the handler must support: bare hostname, hostname with explicit port,
+// IPv4 literal, and bracketed IPv6 literal. Each row asserts that the 301
+// status fires and the Location header points to the right HTTPS URL.
+func TestRedirectHandler(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		httpsPort  int
+		hostHeader string
+		requestURI string
+		wantLoc    string
+	}{
+		{
+			name:       "bare host, default https port omits :443",
+			httpsPort:  443,
+			hostHeader: "example.com",
+			requestURI: "/artists",
+			wantLoc:    "https://example.com/artists",
+		},
+		{
+			name:       "host with explicit :80 stripped, redirect to non-default port",
+			httpsPort:  1973,
+			hostHeader: "example.com:80",
+			requestURI: "/",
+			wantLoc:    "https://example.com:1973/",
+		},
+		{
+			name:       "preserves query string",
+			httpsPort:  443,
+			hostHeader: "example.com",
+			requestURI: "/search?q=test&page=2",
+			wantLoc:    "https://example.com/search?q=test&page=2",
+		},
+		{
+			name:       "IPv4 literal with port",
+			httpsPort:  443,
+			hostHeader: "127.0.0.1:80",
+			requestURI: "/healthz",
+			wantLoc:    "https://127.0.0.1/healthz",
+		},
+		{
+			name:       "IPv6 literal with port preserves brackets",
+			httpsPort:  443,
+			hostHeader: "[::1]:80",
+			requestURI: "/",
+			wantLoc:    "https://[::1]/",
+		},
+		{
+			name:       "non-default https port appears in target",
+			httpsPort:  8443,
+			hostHeader: "stillwater.local",
+			requestURI: "/api/v1/health",
+			wantLoc:    "https://stillwater.local:8443/api/v1/health",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := redirectHandler(tc.httpsPort)
+			req := &http.Request{
+				Method:     "GET",
+				Host:       tc.hostHeader,
+				RequestURI: tc.requestURI,
+				URL:        mustParseURL(t, tc.requestURI),
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusMovedPermanently {
+				t.Errorf("status = %d; want 301", rec.Code)
+			}
+			gotLoc := rec.Header().Get("Location")
+			if gotLoc != tc.wantLoc {
+				t.Errorf("Location = %q; want %q", gotLoc, tc.wantLoc)
+			}
+		})
+	}
+}
+
+// TestRunListeners_RedirectIntegration asserts the redirect listener actually
+// runs alongside the HTTPS listener and returns 301 with the right Location
+// over a real socket. Without this, the unit test above passes even if the
+// listener never registers (buildEntries gating bug).
+func TestRunListeners_RedirectIntegration(t *testing.T) {
+	// Not t.Parallel: see TestRunListeners_PlainHTTPStartAndShutdown.
+	dir := t.TempDir()
+	certPath, keyPath := generateSelfSignedCert(t, dir)
+	tlsPort := freePort(t)
+	redirectPort := freePort(t)
+	if tlsPort == redirectPort {
+		t.Skip("freePort returned identical ports; rerun")
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Port: freePort(t),
+			TLS: config.TLSConfig{
+				CertFile: certPath,
+				KeyFile:  keyPath,
+				Port:     tlsPort,
+			},
+			HTTPRedirect: config.HTTPRedirectConfig{Port: redirectPort},
+		},
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- RunListeners(ctx, cfg, handler, discardLogger()) }()
+
+	redirectAddr := "127.0.0.1:" + strconv.Itoa(redirectPort)
+	pollUntilServing(t, redirectAddr)
+
+	// Use a client that does NOT follow redirects; we want to inspect the
+	// Location header directly, not chase it into the TLS listener.
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Get("http://" + redirectAddr + "/foo?bar=baz")
+	if err != nil {
+		t.Fatalf("HTTP GET on redirect listener: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMovedPermanently {
+		t.Errorf("status = %d; want 301", resp.StatusCode)
+	}
+	gotLoc := resp.Header.Get("Location")
+	wantLoc := "https://127.0.0.1:" + strconv.Itoa(tlsPort) + "/foo?bar=baz"
+	if gotLoc != wantLoc {
+		t.Errorf("Location = %q; want %q", gotLoc, wantLoc)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("RunListeners returned %v; want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunListeners did not exit within 5s of cancel")
+	}
+}
+
+// TestRunListeners_RedirectSkippedWithoutTLS asserts the redirect listener is
+// NOT registered when TLS is not configured, even if HTTPRedirect.Port is set.
+// (The config validator rejects this combination separately; this guard is
+// inside buildEntries as belt-and-suspenders.)
+func TestRunListeners_RedirectSkippedWithoutTLS(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Port:         9999,
+			HTTPRedirect: config.HTTPRedirectConfig{Port: 8080},
+		},
+	}
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+	entries := buildEntries(cfg, handler, discardLogger())
+	if len(entries) != 1 {
+		t.Errorf("buildEntries returned %d entries; want 1 (redirect must be skipped without TLS)", len(entries))
+	}
+	for _, e := range entries {
+		if e.name == "http-redirect" {
+			t.Errorf("redirect listener registered without TLS configured")
+		}
+	}
+}
+
 // TestRunListeners_BindFailureSurfacesError asserts a non-graceful start
 // error (port already in use) propagates as the function's return value.
 // The test binds the wildcard ":<port>" upfront so RunListeners' wildcard
@@ -383,4 +556,133 @@ func TestRunListeners_BindFailureSurfacesError(t *testing.T) {
 	if err == nil {
 		t.Fatal("RunListeners returned nil; want bind error")
 	}
+}
+
+// TestRedirectHandler_RejectsBadInputs covers the defensive guards: a
+// non-origin-form RequestURI (CONNECT/OPTIONS shapes) and a malformed Host
+// header must return 400, not splice into a malformed Location.
+func TestRedirectHandler_RejectsBadInputs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		host       string
+		requestURI string
+	}{
+		{name: "RequestURI without leading slash (CONNECT-like)", host: "example.com", requestURI: "example.com:443"},
+		{name: "RequestURI = *", host: "example.com", requestURI: "*"},
+		{name: "Host with whitespace", host: "evil .com", requestURI: "/foo"},
+		{name: "Host with slash", host: "evil/com", requestURI: "/foo"},
+		{name: "Empty Host", host: "", requestURI: "/foo"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := redirectHandler(443)
+			req := &http.Request{Method: "GET", Host: tc.host, RequestURI: tc.requestURI}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("status = %d; want 400 (Location = %q)", rec.Code, rec.Header().Get("Location"))
+			}
+			if loc := rec.Header().Get("Location"); loc != "" {
+				t.Errorf("Location = %q; want empty", loc)
+			}
+		})
+	}
+}
+
+// TestRunListeners_RedirectShutdownPropagation verifies that canceling the
+// parent context tears down BOTH the HTTPS and the redirect listener -- not
+// just the one we happen to dial in TestRunListeners_RedirectIntegration.
+// Without this, a future regression where buildRedirectListener wires a no-op
+// shutdown would pass the integration test but leave the redirect socket
+// listening forever.
+func TestRunListeners_RedirectShutdownPropagation(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := generateSelfSignedCert(t, dir)
+	tlsPort := freePort(t)
+	redirectPort := freePort(t)
+	if tlsPort == redirectPort {
+		t.Skip("freePort returned identical ports; rerun")
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Port:         freePort(t),
+			TLS:          config.TLSConfig{CertFile: certPath, KeyFile: keyPath, Port: tlsPort},
+			HTTPRedirect: config.HTTPRedirectConfig{Port: redirectPort},
+		},
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- RunListeners(ctx, cfg, handler, discardLogger()) }()
+	pollUntilServing(t, "127.0.0.1:"+strconv.Itoa(redirectPort))
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("RunListeners did not exit within 5s of cancel")
+	}
+
+	// Re-dial both ports; both should refuse within ~250ms.
+	for _, p := range []int{redirectPort, tlsPort} {
+		conn, err := net.DialTimeout("tcp", "127.0.0.1:"+strconv.Itoa(p), 250*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			t.Errorf("port %d still accepting connections after shutdown", p)
+		}
+	}
+}
+
+// TestRunListeners_RedirectBindFailureCancelsHTTPS asserts the errgroup
+// contract: if the redirect listener cannot bind (port already held), the
+// HTTPS sibling is also torn down so the operator sees a single fatal error
+// instead of a half-running daemon.
+func TestRunListeners_RedirectBindFailureCancelsHTTPS(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := generateSelfSignedCert(t, dir)
+	hold, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	defer hold.Close()
+	redirectPort := hold.Addr().(*net.TCPAddr).Port
+	tlsPort := freePort(t)
+	if tlsPort == redirectPort {
+		t.Skip("freePort collision with held port; rerun")
+	}
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Port:         freePort(t),
+			TLS:          config.TLSConfig{CertFile: certPath, KeyFile: keyPath, Port: tlsPort},
+			HTTPRedirect: config.HTTPRedirectConfig{Port: redirectPort},
+		},
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = RunListeners(ctx, cfg, handler, discardLogger())
+	if err == nil {
+		t.Fatal("RunListeners returned nil; want bind error from redirect listener")
+	}
+	// HTTPS sibling must also be down.
+	conn, dialErr := net.DialTimeout("tcp", "127.0.0.1:"+strconv.Itoa(tlsPort), 250*time.Millisecond)
+	if dialErr == nil {
+		conn.Close()
+		t.Errorf("HTTPS port %d still accepting connections after sibling bind failure", tlsPort)
+	}
+}
+
+// mustParseURL is a tiny helper so the redirect-handler table tests can
+// populate http.Request.URL without bubbling parse errors through every row.
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.ParseRequestURI(raw)
+	if err != nil {
+		t.Fatalf("url.ParseRequestURI(%q): %v", raw, err)
+	}
+	return u
 }


### PR DESCRIPTION
## Summary

- Adds a plain-HTTP listener (`SW_HTTP_REDIRECT_PORT`) that 301-redirects every request to the configured HTTPS listener. Disabled by default; requires TLS to be active.
- Registers the redirect socket as a sibling under the existing `RunListeners` errgroup, so graceful shutdown and start-error propagation work without new harness code.
- Validation rejects redirect-without-TLS and redirect-port == TLS-port (in both split and collapse modes).
- Adds an `@components.ContextHelp` adjacent to the TLS Status card and a new `how-to/http-redirect.md` page anchored at `settings-general-tls-status` so the in-app deep-link is ready to wire when M53/#1132 lands.

## Verification

- `bash scripts/pre-push-gate.sh` clean. Patch coverage 96.55% (84/87 lines on hand-written code; generated `*_templ.go` excluded).
- Native UAT against self-signed cert on `1973/1974`: 301 with port-swap (root, path+query, trailing slash, explicit non-default Host port stripped), HSTS present on HTTPS, manual UI check on the General tab confirms the new TLS card line and ContextHelp popover render.
- Full review-toolkit run: addressed Critical (silent `SW_HTTP_REDIRECT_PORT` Atoi swallow now fails loud), HIGH (redirect handler now rejects non-origin-form RequestURI and malformed Host headers with 400), and LOW (`containsByte` replaced with `strings.Contains`). Added two new tests covering shutdown propagation re-dial and bind-failure cancellation of the HTTPS sibling, per pr-test-analyzer's Important findings.

## Out of scope

- The 4-arg `ContextHelp(id, title, help, anchorSlug)` form from M53/#1132 is not on `main` yet, so the popover is text-only here. Deep-link wiring tracked in #1354.
- The same Atoi-swallow pattern exists for `SW_TLS_PORT` and `SW_PORT` (added by #928 / pre-existing); follow-up sweep recommended but out of #929 scope.
- The redirect listener and the future ACME challenge listener (#930) both want port 80; the second-to-merge between #929 and #930 needs a small composition tweak. Documented in code comments on both branches.

## Test plan

- [x] `go test -race ./...` passes
- [x] `bash scripts/pre-push-gate.sh` passes (96.55% patch coverage)
- [x] Native UAT against self-signed cert on 1973/1974
- [x] Manual UI smoke of the TLS Status card on General tab
- [x] OpenAPI consistency verified (no API surface changed)

Closes #929
Part of M47 (v1.1.0)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional HTTP→HTTPS redirect listener that issues 301 redirects for plain HTTP requests. Enable via SW_HTTP_REDIRECT_PORT (requires TLS).
  * Startup now validates redirect configuration (numeric port, distinct from HTTPS, and TLS required); misconfiguration causes startup failure.

* **Documentation**
  * New how-to guide and updated docs/Settings UI help describing redirect behavior and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->