### PR TITLE
chore(gate): catch unresolved conflict markers + invalid mkdocs.yml locally

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -42,6 +42,30 @@ warn() {
 }
 
 # --------------------------------------------------------------------------
+# 0. conflict markers -- catch unresolved merge markers in staged files
+# --------------------------------------------------------------------------
+# Cheap, fast-failing, runs before any other check. Staged files only --
+# unrelated unstaged conflicts in the working tree do not block this commit.
+# Marker forms checked: <<<<<<< (start), ======= (separator), >>>>>>> (end).
+# The trailing space/EOL guard avoids matching legitimate content like a string
+# of seven equals in a markdown ASCII rule.
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM -- || true)
+if [ -n "$STAGED_FILES" ]; then
+    MARKERS=$(echo "$STAGED_FILES" | xargs -I {} git diff --cached -U0 -- {} 2>/dev/null \
+        | grep -nE '^\+(<{7}|={7}|>{7})( |$)' || true)
+    if [ -n "$MARKERS" ]; then
+        echo -e "${RED}${BOLD}FAIL${RESET} conflict-markers: unresolved merge conflict markers in staged content:"
+        echo "$MARKERS" | head -20 | sed 's/^/  /'
+        echo ""
+        echo "Resolve the conflicts (search for '<<<<<<<') and re-stage."
+        exit 1
+    fi
+    pass "conflict-markers"
+else
+    warn "conflict-markers (no staged files)"
+fi
+
+# --------------------------------------------------------------------------
 # 1. typos -- spell check staged files
 # --------------------------------------------------------------------------
 if git diff --cached --name-only --diff-filter=ACM -- | grep -q .; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -49,7 +49,7 @@ warn() {
 # Marker forms checked: <<<<<<< (start), ======= (separator), >>>>>>> (end).
 # The trailing space/EOL guard avoids matching legitimate content like a string
 # of seven equals in a markdown ASCII rule.
-MARKERS=$(git diff --cached -U0 --diff-filter=ACM -- 2>/dev/null \
+MARKERS=$(git diff --cached -U0 --diff-filter=ACMR -- 2>/dev/null \
     | grep -nE '^\+(<{7}|={7}|>{7})( |$)' || true)
 if [ -n "$MARKERS" ]; then
     echo -e "${RED}${BOLD}FAIL${RESET} conflict-markers: unresolved merge conflict markers in staged content:"
@@ -58,7 +58,7 @@ if [ -n "$MARKERS" ]; then
     echo "Resolve the conflicts (search for '<<<<<<<') and re-stage."
     exit 1
 fi
-if git diff --cached --name-only --diff-filter=ACM -- | grep -q .; then
+if git diff --cached --name-only --diff-filter=ACMR -- | grep -q .; then
     pass "conflict-markers"
 else
     warn "conflict-markers (no staged files)"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -49,17 +49,16 @@ warn() {
 # Marker forms checked: <<<<<<< (start), ======= (separator), >>>>>>> (end).
 # The trailing space/EOL guard avoids matching legitimate content like a string
 # of seven equals in a markdown ASCII rule.
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM -- || true)
-if [ -n "$STAGED_FILES" ]; then
-    MARKERS=$(echo "$STAGED_FILES" | xargs -I {} git diff --cached -U0 -- {} 2>/dev/null \
-        | grep -nE '^\+(<{7}|={7}|>{7})( |$)' || true)
-    if [ -n "$MARKERS" ]; then
-        echo -e "${RED}${BOLD}FAIL${RESET} conflict-markers: unresolved merge conflict markers in staged content:"
-        echo "$MARKERS" | head -20 | sed 's/^/  /'
-        echo ""
-        echo "Resolve the conflicts (search for '<<<<<<<') and re-stage."
-        exit 1
-    fi
+MARKERS=$(git diff --cached -U0 --diff-filter=ACM -- 2>/dev/null \
+    | grep -nE '^\+(<{7}|={7}|>{7})( |$)' || true)
+if [ -n "$MARKERS" ]; then
+    echo -e "${RED}${BOLD}FAIL${RESET} conflict-markers: unresolved merge conflict markers in staged content:"
+    echo "$MARKERS" | head -20 | sed 's/^/  /'
+    echo ""
+    echo "Resolve the conflicts (search for '<<<<<<<') and re-stage."
+    exit 1
+fi
+if git diff --cached --name-only --diff-filter=ACM -- | grep -q .; then
     pass "conflict-markers"
 else
     warn "conflict-markers (no staged files)"

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -19,6 +19,27 @@ cleanup() {
 }
 trap cleanup EXIT
 
+echo "=== Conflict markers (tracked files) ==="
+# Catch unresolved merge markers across every tracked file regardless of
+# extension. Mkdocs.yml conflict in PR #1357 round 1 slipped through because
+# the local sweep filter only included *.go/*.json/*.templ/*.md. This check
+# runs in milliseconds and fail-fasts before the test suite eats 2-3 minutes.
+# Markers checked: <<<<<<< (start), ======= (separator), >>>>>>> (end), each
+# requiring a trailing space or EOL to avoid matching legitimate content like
+# a markdown ASCII rule of exactly seven equals.
+markers=$(git ls-files -z \
+    | xargs -0 grep -nE '^(<{7}|={7}|>{7})( |$)' 2>/dev/null \
+    | head -50 || true)
+if [ -n "$markers" ]; then
+    echo "FAIL: unresolved merge conflict markers in tracked files:"
+    echo "$markers" | sed 's/^/  /'
+    echo ""
+    echo "Resolve the conflicts (search for '<<<<<<<') and re-run the gate."
+    exit 1
+fi
+echo "OK"
+
+echo ""
 echo "=== Tests ==="
 go test -race -count=1 -covermode=atomic -coverprofile="$COVER_OUT" ./...
 
@@ -29,6 +50,31 @@ go test -count=1 -run TestOpenAPIConsistency -v ./internal/api/
 echo ""
 echo "=== Generated files ==="
 bash "$SCRIPT_DIR/check-generated.sh"
+
+echo ""
+echo "=== Mkdocs config YAML ==="
+# Catch syntax errors (incl. residual conflict markers, indentation slips,
+# duplicate keys) in the mkdocs config before CI's "Build site" job does.
+# Stdlib PyYAML only -- no need for mkdocs itself locally. If python3 is
+# missing or PyYAML is unavailable, skip with a one-line warning rather than
+# fail the gate (a dev without a Python toolchain shouldn't be blocked).
+if [ -f docs/site/mkdocs.yml ]; then
+    if command -v python3 >/dev/null 2>&1; then
+        if python3 -c 'import yaml' 2>/dev/null; then
+            if ! python3 -c 'import sys, yaml; yaml.safe_load(open("docs/site/mkdocs.yml"))' 2>&1; then
+                echo "FAIL: docs/site/mkdocs.yml is not valid YAML (see error above)."
+                exit 1
+            fi
+            echo "OK"
+        else
+            echo "SKIP: PyYAML not installed (pip install pyyaml -- runs only on demand)"
+        fi
+    else
+        echo "SKIP: python3 not in PATH"
+    fi
+else
+    echo "SKIP: docs/site/mkdocs.yml not present"
+fi
 
 echo ""
 echo "=== Raw error leak check ==="


### PR DESCRIPTION
## Summary

PR #1357 round 1 push left an unresolved conflict marker in \`docs/site/mkdocs.yml\` because my local marker-sweep filter only included \`*.go/*.json/*.templ/*.md\` and missed \`*.yml\`. CI's "Build site" job caught it via mkdocs build failing on invalid YAML, costing one extra CR/CI round to fix what should have been a local-gate failure.

Two cheap, fail-fast additions:

- **Pre-commit hook** (\`.githooks/pre-commit\`): new section 0 sweeps STAGED file content for conflict markers (\`<<<<<<<\`, \`=======\`, \`>>>>>>>\`) regardless of file extension. Trailing space/EOL guard avoids matching legitimate content like a markdown ASCII rule of exactly seven equals.
- **Pre-push gate** (\`scripts/pre-push-gate.sh\`): same conflict-marker sweep across every tracked file via \`git ls-files -z\`, runs at the top of the gate before the 2-3 min test suite so contributors fail fast. Plus a YAML-only \`mkdocs.yml\` validation via PyYAML (stdlib parse, no need for mkdocs itself locally) that gracefully skips when python3 or PyYAML are unavailable -- a dev without a Python toolchain shouldn't be blocked.

## Verification

- Self-validation: this commit's own pre-commit hook ran and didn't false-positive on its own diff (which contains literal \`<<<<<<<\` patterns inside grep regexes and comments -- the \`^\\+\` prefix + \`( |\$)\` suffix guards filter those out correctly).
- Tested both checks against synthetic broken inputs:
  - Tracked file with a marker: gate fails with \`README.md:202:<<<<<<< HEAD\`.
  - mkdocs.yml with conflict markers spliced in: gate fails with PyYAML's parse error.
  - Real \`docs/site/mkdocs.yml\`: gate passes cleanly.
- Full \`bash scripts/pre-push-gate.sh\` end-to-end: every existing check still runs in order.

## Out of scope

- Full \`mkdocs build --strict\` (would catch broken nav refs, missing pages, plugin issues that YAML parse alone misses) -- requires mkdocs in PATH. Could be a follow-up gated behind \`command -v mkdocs\`.
- Other config files that could grow conflict-marker risk (\`docker-compose*.yml\`, \`.golangci.yml\`, etc.) -- the tracked-file marker check already covers them; their semantic validity is each tool's concern.

## Test plan

- [x] Synthetic broken-marker test passes (gate fails as expected)
- [x] Synthetic broken-mkdocs test passes (PyYAML parse error)
- [x] Real tree passes both checks
- [x] Full pre-push gate end-to-end clean
- [x] Pre-commit hook self-validation (this commit's own hook run)

Closes #1358

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an early pre-commit check that scans staged changes for unresolved merge conflict markers, shows matching lines with guidance, and blocks commits until resolved.
  * Added a pre-push gate that scans all tracked files for merge conflict markers and fails pushes if any are found.
  * Added conditional YAML syntax validation during pre-push: runs when the site config and Python+YAML support are present, otherwise skips with a notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->