### PR TITLE
docs(core-concepts): add platform-profiles, auto-provisioning, and conflict-gate pages

### DIFF
--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -88,11 +88,14 @@ nav:
   - Core concepts:
       - core-concepts/index.md
       - Artists and libraries: core-concepts/artists-and-libraries.md
-      - NFO files: core-concepts/nfo-files.md
+      - Auto-provisioning: core-concepts/auto-provisioning.md
+      - Conflict gate: core-concepts/conflict-gate.md
+      - Field locks: core-concepts/field-locks.md
       - Images: core-concepts/images.md
+      - NFO files: core-concepts/nfo-files.md
+      - Platform profiles: core-concepts/platform-profiles.md
       - Providers: core-concepts/providers.md
       - Rules: core-concepts/rules.md
-      - Field locks: core-concepts/field-locks.md
   - How-to:
       - how-to/index.md
       - Run scans: how-to/run-scans.md

--- a/docs/site/src/core-concepts/auto-provisioning.md
+++ b/docs/site/src/core-concepts/auto-provisioning.md
@@ -1,0 +1,70 @@
+---
+description: How Stillwater creates a local account for a federated user on first sign-in, the guard rails that restrict who qualifies, and how the default role is assigned.
+---
+
+<!-- code: internal/auth/provider.go (Authenticator.CanAutoProvision, Authenticator.MapRole), internal/auth/provider_emby.go (EmbyProvider.CanAutoProvision, guardRail "admin"/"any_user"), internal/auth/provider_jellyfin.go (JellyfinProvider.CanAutoProvision), internal/auth/provider_oidc.go (OIDCProvider.CanAutoProvision, userGroups, adminGroups), internal/auth/user.go (CreateFederatedUser), internal/api/handlers.go (completeLogin: lookup -> guard rail -> provision -> session), web/templates/settings_auth_providers.templ -->
+
+# Auto-provisioning
+
+**Auto-provisioning** is the mechanism that creates a Stillwater account the first time a federated user signs in. Without it, every new user would need an administrator to pre-create their account manually. With it, a user whose identity passes the configured guard rail gets a Stillwater account automatically on first login.
+
+## The sign-in flow
+
+When a user signs in via Emby, Jellyfin, or OIDC, Stillwater runs through three steps in order:
+
+1. **Credential check** -- Stillwater forwards the credentials to the upstream provider. If the provider rejects them, login fails immediately.
+2. **Account lookup** -- Stillwater searches for an existing local account linked to that provider identity. If it finds one, the user logs in.
+3. **Provision or reject** -- if no existing account is found, Stillwater consults the guard rail. Pass the guard rail and a new account is created on the spot and a session is issued. Fail it and the login is rejected with "This account is not authorized for this Stillwater instance."
+
+The provisioned account is a permanent Stillwater account. It persists across sessions and is visible in Settings > Users. Stillwater does not re-create or re-provision on subsequent sign-ins; the existing account is found at step 2 and reused.
+
+## Guard rails
+
+A guard rail is the condition an incoming identity must satisfy before auto-provisioning fires. Guard rails exist to prevent anyone with a valid upstream account from walking into your Stillwater instance.
+
+### Emby and Jellyfin guard rails
+
+Two options:
+
+- **Admins only** -- only users who are administrators on the upstream server qualify. This is the default. If the upstream server marks the user as an admin, Stillwater provisions them as an administrator (ignoring the configured default role for that connection). If the upstream server marks them as a regular user, login is rejected.
+- **Any user** -- any user who can authenticate against the upstream server qualifies. Combined with a permissive Emby or Jellyfin installation, this means anyone on the upstream server can sign in.
+
+The guard rail setting lives under Settings > Auth providers > Emby (or Jellyfin) > Guard rail (see [`settings-auth-providers-auth-emby-guard-rail`](../reference/settings-by-tab.md#settings-auth-providers-auth-emby-guard-rail) and [`settings-auth-providers-auth-jellyfin-guard-rail`](../reference/settings-by-tab.md#settings-auth-providers-auth-jellyfin-guard-rail)).
+
+### OIDC guard rails
+
+OIDC works differently because the IdP does not expose a simple admin flag. Two guard rail knobs:
+
+- **User groups** -- a list of IdP group names. A user must belong to at least one of them to qualify. If the list is empty, any authenticated user qualifies.
+- **Admin groups** -- a list of IdP group names. Membership in any of these groups maps the user to the `administrator` role, overriding the default role.
+
+Both lists use case-insensitive matching. An empty user groups list is the broadest guard rail: any IdP user can be provisioned.
+
+For group claims to work, the IdP must include a `groups` claim in its ID tokens. Some providers (Authentik, Keycloak) support this; others (Okta, Azure AD in some configurations) may not include it by default. If admin group mapping has no effect, check whether your IdP is emitting group claims.
+
+## Default role
+
+When provisioning fires and the guard rail passes, Stillwater assigns the new account a role. The role comes from two sources in priority order:
+
+1. **Role mapping** -- if the provider signals admin status (Emby/Jellyfin: `IsAdministrator`; OIDC: `adminGroups` membership), the account is created as `administrator`.
+2. **Default role setting** -- otherwise, the configured default role for the connection is used. Both Emby and Jellyfin connections have a default role setting (see [`settings-auth-providers-auth-default-role-emby`](../reference/settings-by-tab.md#settings-auth-providers-auth-default-role-emby)); the OIDC provider has its own (see [`settings-auth-providers-auth-default-role-oidc`](../reference/settings-by-tab.md#settings-auth-providers-auth-default-role-oidc)).
+
+The default roles are `administrator` and `operator`. Operators have full access to library management but cannot change system settings.
+
+## Display name sync
+
+After a federated user signs in to their existing account, Stillwater checks whether their display name changed on the upstream provider. If it did, the local account's display name is updated to match. This is a best-effort operation and non-fatal if it fails; the session is issued regardless.
+
+## What happens when an upstream user is removed
+
+Stillwater does not delete or deactivate local accounts when the upstream account disappears. The user's next sign-in attempt will fail at step 1 (credential check) because the upstream provider rejects the credentials. The local account stays in the database and must be deactivated manually from Settings > Users if you want to revoke access. Sessions that were issued before the upstream removal remain valid until they expire naturally (24 hours from issue).
+
+## Enabling auto-provisioning
+
+Auto-provisioning is disabled by default for every provider. To enable it:
+
+- For Emby: Settings > Auth providers > Emby > Enable auto-provisioning (see [`settings-auth-providers-auth-auto-provision-emby`](../reference/settings-by-tab.md#settings-auth-providers-auth-auto-provision-emby))
+- For Jellyfin: Settings > Auth providers > Jellyfin > Enable auto-provisioning (see [`settings-auth-providers-auth-auto-provision-jellyfin`](../reference/settings-by-tab.md#settings-auth-providers-auth-auto-provision-jellyfin))
+- For OIDC: Settings > Auth providers > OIDC > Enable auto-provisioning (see [`settings-auth-providers-auth-auto-provision-oidc`](../reference/settings-by-tab.md#settings-auth-providers-auth-auto-provision-oidc))
+
+Each provider's auto-provision toggle is independent. You can enable it for Emby without enabling it for Jellyfin or OIDC.

--- a/docs/site/src/core-concepts/auto-provisioning.md
+++ b/docs/site/src/core-concepts/auto-provisioning.md
@@ -47,7 +47,7 @@ For group claims to work, the IdP must include a `groups` claim in its ID tokens
 When provisioning fires and the guard rail passes, Stillwater assigns the new account a role. The role comes from two sources in priority order:
 
 1. **Role mapping** -- if the provider signals admin status (Emby/Jellyfin: `IsAdministrator`; OIDC: `adminGroups` membership), the account is created as `administrator`.
-2. **Default role setting** -- otherwise, the configured default role for the connection is used. Both Emby and Jellyfin connections have a default role setting (see [`settings-auth-providers-auth-default-role-emby`](../reference/settings-by-tab.md#settings-auth-providers-auth-default-role-emby)); the OIDC provider has its own (see [`settings-auth-providers-auth-default-role-oidc`](../reference/settings-by-tab.md#settings-auth-providers-auth-default-role-oidc)).
+2. **Default role setting** -- otherwise, the configured default role for the connection is used. Both Emby and Jellyfin connections have a default role setting (see [`settings-auth-providers-auth-default-role-emby`](../reference/settings-by-tab.md#settings-auth-providers-auth-default-role-emby) and [`settings-auth-providers-auth-default-role-jellyfin`](../reference/settings-by-tab.md#settings-auth-providers-auth-default-role-jellyfin)); the OIDC provider has its own (see [`settings-auth-providers-auth-default-role-oidc`](../reference/settings-by-tab.md#settings-auth-providers-auth-default-role-oidc)).
 
 The default roles are `administrator` and `operator`. Operators have full access to library management but cannot change system settings.
 

--- a/docs/site/src/core-concepts/conflict-gate.md
+++ b/docs/site/src/core-concepts/conflict-gate.md
@@ -1,0 +1,87 @@
+---
+description: How the conflict gate detects when a connected media server is writing files that would collide with Stillwater's writes, and how it pauses Stillwater's output to prevent a tug-of-war.
+---
+
+<!-- code: internal/conflict/ledger.go (Ledger, ConnectionState, RoundTrip, BannerState, Axis, AnyImageConflict, AnyNFOConflict), internal/conflict/detector.go (Detector, Refresh, Current, detectRoundTrips, checkOne, DisableFileWriteBack auto-re-disable), internal/conflict/gate.go (Gate, AllowImageWrite, AllowNFOWrite, BlockedError), internal/publish/publisher.go (gate checks before writes), internal/connection/ (connection model and feature toggles) -->
+
+# Conflict gate
+
+The **conflict gate** is Stillwater's protection against a write-collision loop with a connected media server. When the gate fires, Stillwater pauses its own image and NFO writes until the collision source is resolved.
+
+## The round-trip problem
+
+When Stillwater shares a library directory with a connected platform (Emby, Jellyfin, Lidarr), writes from either side are visible to the other through the shared filesystem. The loop works like this:
+
+1. Stillwater writes `backdrop.jpg` and `artist.nfo` into the artist directory.
+2. Emby's metadata refresh job detects the changed files and re-reads them.
+3. Emby then writes its own copy of the same metadata back to disk under its preferred filenames -- possibly overwriting Stillwater's files or creating duplicates alongside them.
+4. On the next scan, Stillwater sees the files it did not write and either ignores them (if it wrote the same content) or detects a conflict.
+
+The specific risk depends on how the peer is configured. An Emby server with "Save local metadata" on will rewrite `artist.nfo`. One with "Save artwork locally" on will write image files. If both savers are on, both axes collide.
+
+## What the gate detects
+
+The gate does not watch filesystem events. Instead, it queries each enabled connected platform's API to check whether that platform is configured to write files to disk:
+
+- **NFO writeback** -- the peer's metadata saver is on. Any NFO file Stillwater writes may be overwritten on the next refresh cycle.
+- **Image writeback** -- the peer's image/artwork saver is on. Any image Stillwater writes may be duplicated or overwritten.
+- **Round-trip overlap** -- two or more enabled connections point to library directories that overlap on disk. Even if only one peer has a saver enabled, the other peer sees every write from either side through the shared path.
+
+The detection result is stored as a **ledger** -- a snapshot of every enabled connection's write-back state plus any round-trip pairs found among their library paths. The ledger is cached for five minutes; callers that need an immediate re-check (for example, after toggling a setting) can force a refresh.
+
+## Banner states
+
+The ledger drives the banner that appears at the top of the Stillwater UI:
+
+- **Clean (emerald)** -- no conflicts detected.
+- **Image writes paused (amber)** -- one or more connections have image writeback on, or Stillwater could not determine their state (fail-closed).
+- **NFO writes paused (amber)** -- one or more connections have NFO writeback on, or state unknown.
+- **Both paused (amber)** -- image and NFO writeback both detected.
+- **Round-trip (red)** -- two enabled connections share a filesystem path. This is the most severe state: any Stillwater write reaches both peers, regardless of which saver is enabled. The banner names the overlapping path.
+- **Foreign files (slate/blue)** -- no configuration conflict, but files in the library were written by a media server without a Stillwater provenance stamp. This is a warning, not a gate: writes are not paused, but the files are surfaced for review.
+
+Severity order is highest-first: round-trip overrides image/NFO overrides foreign files overrides clean. Two banners are never shown at the same time; the worse state wins.
+
+## How writes are gated
+
+Before Stillwater writes an image or an NFO file, it consults the gate:
+
+- For image writes: `AllowImageWrite` returns an error if any enabled, unmanaged connection has image writeback on, or if any round-trip pair exists, or if any connection's state could not be determined.
+- For NFO writes: `AllowNFOWrite` does the same for NFO writeback.
+
+When either check returns a blocked error, the write is rejected and the banner reflects the current ledger state. Rule fixers, manual saves, and bulk operations all go through this check. The gate is not bypassable from the UI.
+
+The fail-closed behavior is intentional: if Stillwater cannot confirm a connection's state (network error, API timeout), it treats that connection as conflicted rather than silently proceeding. A false positive -- a brief network hiccup blocking writes -- is preferable to a false negative that triggers a collision loop.
+
+## Coalesce and the detection cache
+
+Multiple concurrent callers could all observe a stale cache at the same moment and each trigger a separate network sweep of every peer. The detector prevents that with a **coalesce** pattern: when the cache is stale and multiple goroutines request a refresh at the same instant, exactly one performs the network fan-out. The others wait, then find the cache populated by the first and return immediately without additional requests.
+
+The cache TTL is five minutes. This balances "you see your remediation reflected quickly" against "we don't hammer every peer on every write."
+
+## "Let Stillwater manage" and auto-re-disable
+
+Each connection has a "Let Stillwater manage" toggle. When on, Stillwater calls the platform's API to turn off its local savers and then marks that connection as managed. A managed connection is excluded from the gate: its savers are assumed off.
+
+The toggle also makes a standing promise: if someone re-enables a saver on the platform's own admin UI while the toggle is on, Stillwater detects the drift on the next conflict refresh and calls the disable API again automatically. If that automatic re-disable fails (peer unreachable), the in-memory managed flag is cleared and the gate re-closes for that connection until the next successful refresh.
+
+## Feature toggles on connections
+
+Each connection has three feature toggles that interact with the conflict gate:
+
+- **image_write** -- whether Stillwater writes image files for artists sourced from this connection. See [`settings-connections-connections-feature-image-write`](../reference/settings-by-tab.md#settings-connections-connections-feature-image-write).
+- **nfo_write** -- whether Stillwater writes NFO files for artists sourced from this connection. See [`settings-connections-connections-feature-nfo-write`](../reference/settings-by-tab.md#settings-connections-connections-feature-nfo-write).
+- **library_import** -- whether Stillwater imports the library listing from this connection during scans. See [`settings-connections-connections-feature-library-import`](../reference/settings-by-tab.md#settings-connections-connections-feature-library-import).
+
+Disabling `image_write` or `nfo_write` on a connection stops Stillwater from writing those files for that connection's artists, but it does not change what the peer itself writes. The conflict gate operates independently: it watches what the *peer* is configured to write, not what Stillwater is configured to write.
+
+## Relationship to field locks and rules
+
+The conflict gate and [field locks](field-locks.md) protect against different things:
+
+- **Locks** say "this field should never change automatically." They are set ahead of time and express intent.
+- **The conflict gate** says "right now, external activity is detected -- pause disk writes until it stops." It is reactive and transient.
+
+Both apply regardless of the other. A locked artist still benefits from the gate pausing writes when a platform is meddling. An unlocked artist still gets the gate's protection even though locks aren't set.
+
+For [rules](rules.md), the conflict gate is consulted before any fix that produces an image or NFO write. If the gate is active when a rule fixer runs, the write is deferred and the violation stays open rather than silently failing.

--- a/docs/site/src/core-concepts/conflict-gate.md
+++ b/docs/site/src/core-concepts/conflict-gate.md
@@ -67,7 +67,7 @@ The toggle also makes a standing promise: if someone re-enables a saver on the p
 
 ## Feature toggles on connections
 
-Each connection has three feature toggles that interact with the conflict gate:
+Each connection has several feature toggles; three of them interact with how Stillwater writes to the shared library:
 
 - **image_write** -- whether Stillwater writes image files for artists sourced from this connection. See [`settings-connections-connections-feature-image-write`](../reference/settings-by-tab.md#settings-connections-connections-feature-image-write).
 - **nfo_write** -- whether Stillwater writes NFO files for artists sourced from this connection. See [`settings-connections-connections-feature-nfo-write`](../reference/settings-by-tab.md#settings-connections-connections-feature-nfo-write).

--- a/docs/site/src/core-concepts/index.md
+++ b/docs/site/src/core-concepts/index.md
@@ -1,10 +1,10 @@
 ---
-description: The mental model behind Stillwater -- artists, libraries, NFO files, images, providers, rules, and locks.
+description: The mental model behind Stillwater -- artists, libraries, NFO files, images, providers, rules, locks, platform profiles, auto-provisioning, and the conflict gate.
 ---
 
 # Core concepts
 
-A short tour of the seven entities Stillwater is built around. If you've followed [Getting started](../getting-started/index.md), you've already used most of these in passing. This section explains the shape of each one and how they connect.
+A short tour of the entities Stillwater is built around. If you've followed [Getting started](../getting-started/index.md), you've already used most of these in passing. This section explains the shape of each one and how they connect.
 
 <div class="grid cards" markdown>
 
@@ -16,13 +16,29 @@ A short tour of the seven entities Stillwater is built around. If you've followe
 
     [Read more](artists-and-libraries.md)
 
-- __NFO files__
+- __Auto-provisioning__
 
     ---
 
-    The XML metadata format every supported platform reads. Stillwater parses, edits, and writes Kodi-compatible artist.nfo files.
+    How Stillwater creates a local account for a federated user on first sign-in, the guard rails that restrict who qualifies, and how roles are assigned.
 
-    [Read more](nfo-files.md)
+    [Read more](auto-provisioning.md)
+
+- __Conflict gate__
+
+    ---
+
+    How Stillwater detects when a connected media server is configured to write files that would collide with its own writes, and pauses output until the collision source is resolved.
+
+    [Read more](conflict-gate.md)
+
+- __Field locks__
+
+    ---
+
+    The mechanism that keeps your manual edits from being overwritten by refreshes, fixers, or connected platforms.
+
+    [Read more](field-locks.md)
 
 - __Images__
 
@@ -31,6 +47,22 @@ A short tour of the seven entities Stillwater is built around. If you've followe
     Four image slots per artist -- thumb, fanart, logo, banner -- with platform-specific naming, multi-fanart, and resolution thresholds.
 
     [Read more](images.md)
+
+- __NFO files__
+
+    ---
+
+    The XML metadata format every supported platform reads. Stillwater parses, edits, and writes Kodi-compatible artist.nfo files.
+
+    [Read more](nfo-files.md)
+
+- __Platform profiles__
+
+    ---
+
+    Named bundles of image filename conventions and NFO field-map settings that tell Stillwater how to write files for a specific media server.
+
+    [Read more](platform-profiles.md)
 
 - __Providers__
 
@@ -47,14 +79,6 @@ A short tour of the seven entities Stillwater is built around. If you've followe
     Checks that run against artists. Each rule has three meaningful states (disabled, manual, auto) and a fixer that resolves violations.
 
     [Read more](rules.md)
-
-- __Field locks__
-
-    ---
-
-    The mechanism that keeps your manual edits from being overwritten by refreshes, fixers, or connected platforms.
-
-    [Read more](field-locks.md)
 
 </div>
 
@@ -73,6 +97,10 @@ Library  ---owns--->  Artists
    |
    +--- decides scan + watch behavior
    +--- holds the connection to Emby / Jellyfin / Lidarr (or "manual")
+   +--- NFO + image writes shaped by the active Platform profile
+   +--- NFO + image writes gated by the Conflict gate
 ```
 
-Most workflows touch three or four of these at once. A "refresh this artist's biography" run walks: artist → providers (in priority order) → field locks (which fields to skip) → NFO file (atomic write) → conflict gate (paused if a platform is meddling). Knowing the pieces makes the workflow legible.
+Users sign in via a local account or a federated provider (Emby, Jellyfin, OIDC). Auto-provisioning creates a local account from the federated identity on first sign-in, subject to the provider's guard rail.
+
+Most workflows touch three or four of these at once. A "refresh this artist's biography" run walks: artist → providers (in priority order) → field locks (which fields to skip) → platform profile (which NFO field map to use) → NFO file (atomic write) → conflict gate (paused if a platform is meddling). Knowing the pieces makes the workflow legible.

--- a/docs/site/src/core-concepts/platform-profiles.md
+++ b/docs/site/src/core-concepts/platform-profiles.md
@@ -1,0 +1,62 @@
+---
+description: How platform profiles bundle image filename conventions and NFO field-map settings so Stillwater writes files in the shape each media server expects.
+---
+
+<!-- code: internal/platform/model.go (Profile, ImageNaming, NFOFormat), internal/platform/service.go (GetActive, SetActive), internal/nfo/fieldmap.go (NFOFieldMap, ApplyFieldMap, DefaultFieldMap), internal/nfo/writeback.go (WriteBackArtistNFOWithFieldMap), internal/publish/publisher.go (getActiveNamingConfig, getActiveFanartPrimary), web/templates/settings.templ (General tab platform profile picker) -->
+
+# Platform profiles
+
+A **platform profile** is a named configuration bundle that tells Stillwater how to write files for a specific media server. It packs two things together: the filenames to use for each image type, and the field-map rules that control how genres, styles, and moods are written into NFO elements. Changing the active profile changes the shape of every file Stillwater writes from that point forward.
+
+## What a profile controls
+
+### Image filenames
+
+Each platform has expectations about what image files are named. Kodi looks for `fanart.jpg` in the artist directory; Emby and Jellyfin look for `backdrop.jpg`. Both look for `folder.jpg` as the thumb. If Stillwater writes the wrong filename, the platform either ignores the file or falls back to a lower-quality asset.
+
+A profile's image naming table covers four slots -- thumb, fanart, logo, banner -- and each slot can list more than one filename. When Stillwater writes images it uses the first name in the list as the primary file; the rest are written as additional copies. That multi-name support lets a single profile satisfy two platforms that share a library directory.
+
+The built-in profiles ship with the conventions each platform actually uses:
+
+| Profile | Thumb | Fanart | Logo | Banner |
+|---|---|---|---|---|
+| Kodi | folder.jpg | fanart.jpg | logo.png | banner.jpg |
+| Emby | folder.jpg | backdrop.jpg | logo.png | banner.jpg |
+| Jellyfin | folder.jpg | backdrop.jpg | logo.png | banner.jpg |
+| Plex | artist.jpg | fanart.jpg | logo.png | banner.jpg |
+
+Emby and Jellyfin use identical conventions in the built-in profiles. Kodi differs on the fanart filename; Plex differs on the thumb filename. The Custom profile is a copy of the Kodi defaults that you can edit freely.
+
+### NFO field map
+
+Different platforms interpret the `<genre>`, `<style>`, and `<mood>` XML elements differently. Kodi surfaces each in its own category; Emby and Jellyfin surface styles as Tags but largely ignore mood elements. The field map controls how Stillwater fills those elements when it writes an NFO.
+
+Three tiers, evaluated in order:
+
+1. **Default behavior** -- each category writes to its native element. Genres go into `<genre>`, styles into `<style>`, moods into `<mood>`. This is the Kodi-compatible default and what all built-in profiles use.
+2. **Moods-as-styles** -- moods are additionally written as `<style>` elements. Emby and Jellyfin surface styles as Tags, so this makes moods visible without losing the original `<mood>` elements that Kodi reads.
+3. **Advanced remap** -- a full matrix mapping any source category (genres, styles, moods) to any NFO element. Use when your platform ignores certain elements entirely and you want to consolidate.
+
+The field map is configured via Settings, not by switching profiles directly. The active profile's image naming and NFO enabled flag are per-profile, but the field map settings are global. See [NFO files](nfo-files.md) for the full description of how the field map affects what gets written.
+
+<!-- SCREENSHOT: Settings > General > Platform profile picker | state: active profile set to Emby | annotation: where to switch the active profile -->
+
+## One active profile at a time
+
+Exactly one profile is active at any moment. Switching to a different profile is instantaneous -- it changes a single database flag -- but it only affects writes that happen after the switch. Files already on disk keep whatever names they were written with; Stillwater does not rename existing files when you change profiles.
+
+That means switching from Kodi to Emby mid-library leaves some artists with `fanart.jpg` and others with `backdrop.jpg`, until a re-write cycle touches each artist. If that matters for your setup, run a library rescan and a rules pass after switching so every artist gets the new filenames.
+
+## Built-in vs custom profiles
+
+The five built-in profiles (Emby, Jellyfin, Kodi, Plex, Custom) ship pre-seeded. The four platform-named ones are read-only -- you cannot change their image naming or other settings. The Custom profile is built-in but editable: it starts with Kodi-style defaults and you can reshape it freely.
+
+You can also create your own profiles. A user-created profile is fully editable and can be deleted. The only constraint: filenames must use `.jpg`, `.jpeg`, or `.png` extensions; logos must use `.png`; no path separators in filename values.
+
+## The Plex profile and NFO writes
+
+The Plex profile ships with NFO writes disabled (`nfo_enabled = false`). Plex does not read Kodi-style `artist.nfo` files; writing them serves no purpose and creates clutter. When Plex is active, Stillwater writes images but skips NFO output. Switch to a different profile to re-enable NFO writes.
+
+## How to switch profiles
+
+Settings > General > Platform profile. The picker shows all profiles with the active one highlighted. Selecting a different profile and saving activates it immediately. See [images](images.md) for how image filenames interact with the active profile, and [NFO files](nfo-files.md) for how the field map affects NFO output.


### PR DESCRIPTION
## Summary

Closes #1351.

Adds three new core-concepts pages teaching the three concepts the issue identified as missing from the docs:

- **`core-concepts/platform-profiles.md`** (62 lines) -- what a profile bundles (per-profile image filenames + global NFO field-map), built-in vs custom profiles, the Plex-no-NFO case, switching mechanics
- **`core-concepts/auto-provisioning.md`** (70 lines) -- federated sign-in flow, Emby/Jellyfin guard rails (Admins-only / Any user) vs OIDC (User groups / Admin groups), default role assignment, what happens when an upstream user is removed
- **`core-concepts/conflict-gate.md`** (87 lines) -- round-trip problem, gate detection, six banner states with severity ordering, fail-closed semantics, coalesce + 5-minute cache TTL, "Let Stillwater manage" auto-re-disable

## Scope correction

The issue body proposed a single new `concepts.md` (or `glossary.md`). Audit of `docs/site/src/core-concepts/` found:

- The directory already has dedicated files per topic (artists-and-libraries, field-locks, images, nfo-files, providers, rules) ranging 59-116 lines each.
- Three of the six concepts the issue lists are already covered: NFO file (`nfo-files.md`), Rule modes + Violation (`rules.md` lines 10, 12-27 with the three-modes table).
- Three are not covered: Platform profile, Auto-provisioning + guard rail, Conflict gate / write-back / round-trip.

A flat glossary alongside the existing teaching pages would create the skeletal-docs anti-pattern. New dedicated pages match the existing structure.

## Authoring discipline

Every claim in the prose was code-grounded during authoring:

- 24-hour session lifetime (`internal/auth/auth.go:17`)
- "administrator" + "operator" two-role validation (`internal/auth/user.go:127-133`)
- 5-minute conflict-detector cache TTL (`internal/conflict/detector.go:24`)
- Exact verbatim error message from `internal/api/handlers.go:239`
- Coalesce single-flight pattern (`internal/conflict/detector.go:185-208`)
- 6 banner states with colors and severity ordering (`internal/conflict/ledger.go:178-220`)
- 5 built-in profiles + image-filename table (`migrations/001_initial_schema.sql:521-526`)
- Plex profile NFO-disabled by default (`migrations:525`)
- Filename validation rules (`internal/platform/model.go:100-110`)

Local prose review (comment-analyzer agent) verified 17 factual claims against code. All match. One framing tweak applied as a follow-up commit (conflict-gate.md feature-toggle list scoped to "three of them interact with how Stillwater writes" rather than implying exhaustive enumeration).

## Files

- NEW `docs/site/src/core-concepts/platform-profiles.md`
- NEW `docs/site/src/core-concepts/auto-provisioning.md`
- NEW `docs/site/src/core-concepts/conflict-gate.md`
- EDIT `docs/site/mkdocs.yml` -- 3 new nav entries, alphabetical order
- EDIT `docs/site/src/core-concepts/index.md` -- 3 new grid cards, alphabetical reorder, frontmatter sync, ASCII diagram updated to mention platform profiles + conflict gate

## What stays unchanged

- All existing concept pages (`nfo-files.md`, `rules.md`, etc.) untouched
- All `settings.*.description` keys in `internal/i18n/locales/en.json` untouched (issue body explicitly defers description-rewrite to a separate PR)
- `_settings-anchors.txt` registries unchanged (no anchor minting)
- No code changes anywhere in `internal/` or `cmd/` or `web/templates/`

## Test plan

- [x] `bash scripts/pre-push-gate.sh` PASS end-to-end (race detector, OpenAPI consistency, generated files clean, mkdocs config valid, no breaking changes)
- [x] `git diff origin/main...HEAD -- '*_settings-anchors.txt'` empty
- [x] All 8 cross-link anchors used in the new pages verified present in `docs/site/src/reference/_settings-anchors.txt`
- [x] Page lengths within 60-120 line target (62 / 70 / 87)
- [x] Prose review (comment-analyzer): 2 APPROVE + 1 TWEAK applied; 17/17 spot-checked claims match code
- [ ] mkdocs render verified by GitHub Pages CI
- [ ] HelpHint deep-link target test (manual, post-merge): from running Settings page, follow a setting that the conflict-gate page references via existing anchor and confirm the live docs render anchors correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Auto-provisioning docs covering federated sign-in, account provisioning, role assignment, and provider toggles
  * Added Conflict Gate docs describing write-collision detection, gating behavior, banner states, and management toggle behavior
  * Added Platform Profiles docs describing filename conventions, NFO field-map remapping, profile switching, and constraints
  * Reorganized and expanded Core Concepts landing page for improved navigation and clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->