### PR TITLE
chore(lint): enable exhaustive linter for enum switches + cleanup sweep

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   default: none
   enable:
     - errcheck
+    - exhaustive
     - govet
     - staticcheck
     - unused
@@ -22,6 +23,8 @@ linters:
     - revive
     - nilerr
   settings:
+    exhaustive:
+      default-signifies-exhaustive: true
     gosec:
       excludes:
         - G104  # Unhandled errors (too noisy for http.Error calls)

--- a/internal/provider/orchestrator_test.go
+++ b/internal/provider/orchestrator_test.go
@@ -1779,6 +1779,8 @@ func TestFetchImagesCollectsFromAllProviders(t *testing.T) {
 			thumbCount++
 		case ImageFanart:
 			fanartCount++
+		default:
+			// Other image types are not relevant to this assertion.
 		}
 	}
 	if thumbCount != 2 {


### PR DESCRIPTION
## Summary

- Enables `exhaustive` in `.golangci.yml` with `default-signifies-exhaustive: true` so existing defensive `default:` branches satisfy the linter without forced case enumeration.
- Sweeps the 9 findings: 8 were already covered by pre-existing `default:` branches, 1 required adding a `default:` to a counting-loop test in `internal/provider/orchestrator_test.go` (no runtime behavior change). Zero `//exhaustive:ignore` directives.
- First of 5 sequential M49 W1 PRs (F1 exhaustive -> F2 errorlint -> F3 usestdlibvars -> F4 musttag -> F5 gate-runs-lint). W2-W5 of M49 are blocked until W1 fully merged (rebase-storm prevention).

## Test plan

- [x] `golangci-lint run ./...` clean (exhaustive enabled, 0 findings)
- [x] `make build` clean
- [x] `go test ./...` all packages pass
- [x] `bash scripts/pre-push-gate.sh` clean (race detector + OpenAPI + patch coverage all green; "no Go source changes in scope" for patch coverage since the only Go edit is a test-file default branch)

Closes #1384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality assurance with stricter validation for switch statement completeness.

* **Tests**
  * Improved test robustness for image type handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->