### PR TITLE
feat(ci): wire diff-only golangci-lint into pre-push gate

### DIFF
--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -6,6 +6,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BASE=$(git merge-base main HEAD 2>/dev/null || echo "HEAD~1")
 
+# Validate BASE resolves to a real commit so downstream steps that pass it to
+# git diff / golangci-lint --new-from-rev fail loudly instead of silently
+# degrading to "no diff -> nothing to check -> pass" (the silent-degradation
+# class documented in reference_pre_push_gate_hardening.md).
+if ! git rev-parse --verify -q "$BASE^{commit}" >/dev/null; then
+  echo "FAIL: cannot resolve BASE ('$BASE') to a commit; aborting gate" >&2
+  exit 2
+fi
+
 # Source the per-worktree run-path helper. Provides $SW_RUN_DIR keyed by the
 # worktree basename so concurrent gate runs in different worktrees write to
 # disjoint paths and can never clobber each other's coverage profiles. See
@@ -42,6 +51,23 @@ echo "OK"
 echo ""
 echo "=== Tests ==="
 go test -race -count=1 -covermode=atomic -coverprofile="$COVER_OUT" ./...
+
+echo ""
+echo "=== Lint (diff-only) ==="
+# Lint only the lines changed since BASE. With a warm cache this runs in
+# ~5s; cold it can take ~30s. Closes the `git commit --no-verify` bypass:
+# the pre-commit hook lints staged files, but a `--no-verify` commit + plain
+# `git push` historically reached this gate without any lint pass, letting
+# regressions slip to CI. SKIP-with-hint when golangci-lint is missing,
+# matching the script's existing convention for optional dev tools (oasdiff,
+# python3); BASE is validated at intake, so an unreadable rev is caught
+# above this point rather than silently producing an empty diff.
+if ! command -v golangci-lint >/dev/null 2>&1; then
+  echo "SKIP: golangci-lint not in PATH (install: brew install golangci-lint)"
+else
+  golangci-lint run --new-from-rev="$BASE" ./...
+  echo "OK"
+fi
 
 echo ""
 echo "=== OpenAPI consistency ==="

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # pre-push-gate.sh -- deterministic pre-push checks; run before code review
-# Exit status: 0 = all hard checks passed; 1 = a hard check failed
+# Exit status:
+#   0 = all hard checks passed
+#   1 = a hard check failed (test, lint, openapi, etc.)
+#   2 = invalid input / setup state (e.g. BASE rev cannot be resolved by
+#       `git rev-parse --verify -q "$BASE^{commit}"` -- see the BASE guard
+#       directly below)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -58,16 +63,19 @@ echo "=== Lint (diff-only) ==="
 # ~5s; cold it can take ~30s. Closes the `git commit --no-verify` bypass:
 # the pre-commit hook lints staged files, but a `--no-verify` commit + plain
 # `git push` historically reached this gate without any lint pass, letting
-# regressions slip to CI. SKIP-with-hint when golangci-lint is missing,
-# matching the script's existing convention for optional dev tools (oasdiff,
-# python3); BASE is validated at intake, so an unreadable rev is caught
-# above this point rather than silently producing an empty diff.
+# regressions slip to CI. BASE is validated at intake, so an unreadable rev
+# is caught above this point rather than silently producing an empty diff.
+#
+# Hard-fail (not SKIP) when golangci-lint is missing: the lint step is the
+# entire purpose of closing the no-verify bypass. SKIP would re-open the
+# bypass on machines without the tool. Distinct from the oasdiff / python3
+# SKIPs above which gate optional warnings, not the project's lint policy.
 if ! command -v golangci-lint >/dev/null 2>&1; then
-  echo "SKIP: golangci-lint not in PATH (install: brew install golangci-lint)"
-else
-  golangci-lint run --new-from-rev="$BASE" ./...
-  echo "OK"
+  echo "FAIL: golangci-lint not in PATH (install: brew install golangci-lint)" >&2
+  exit 1
 fi
+golangci-lint run --new-from-rev="$BASE" ./...
+echo "OK"
 
 echo ""
 echo "=== OpenAPI consistency ==="


### PR DESCRIPTION
## Summary

Closes the `git commit --no-verify` bypass: the pre-commit hook lints staged files, but a `--no-verify` commit followed by `git push` historically reached the gate without any lint pass, letting regressions slip to CI.

- Adds `golangci-lint run --new-from-rev="$BASE" ./...` to `scripts/pre-push-gate.sh` after the test step. Diff-only keeps wall time low (~5s warm cache, ~30s cold per F5 acceptance criterion).
- Hardens `BASE` resolution at intake: validate it points to a real commit and exit 2 if not, so downstream steps (existing raw-error-leak diff, OpenAPI diff, and the new lint step) fail loudly instead of silently degrading to "no diff -> nothing to check -> pass" (the silent-failure class documented in `reference_pre_push_gate_hardening.md`).
- SKIP-with-hint when `golangci-lint` is missing, matching the script's existing convention for optional dev tools (oasdiff, python3).

## Test plan

- [x] Smoke test: `golangci-lint run --new-from-rev="$BASE" ./...` runs in ~9s on this branch and reports `0 issues`.
- [x] Pre-push hook on push ran the new gate (including the new lint step), all checks PASS.
- [x] Stays well under the 3-min total wall-time budget called out in #1388.
- [x] BASE validation exits 2 cleanly when given a bogus rev (manually verified).

Closes #1388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a differential "lint (diff-only)" phase that lints only changes since the base commit.

* **Bug Fixes**
  * Hardened base-commit validation to fail fast with a clear error and exit code when the base is invalid.
  * Linting now hard-fails if the linter is not installed, providing an explicit install hint instead of skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->