### PR TITLE
chore(lint): enable musttag and register writeJSON marshaller

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - gosec
     - govet
     - misspell
+    - musttag
     - nilerr
     - noctx
     - revive
@@ -46,6 +47,15 @@ linters:
           severity: warning
     misspell:
       locale: US
+    musttag:
+      functions:
+        # API response wrapper. Without this, musttag only checks direct
+        # encoding/json call sites and misses every handler response struct
+        # that flows through writeJSON -- defeating the linter's purpose for
+        # the request/response body drift class M49 was created to deflect.
+        - name: github.com/sydlexius/stillwater/internal/api.writeJSON
+          tag: json
+          arg-pos: 2
     usestdlibvars:
       http-method: true
       http-status-code: true


### PR DESCRIPTION
## Summary

Final M49 W1 lint-baseline PR (F4). Enables `musttag` to gate request/response struct fields that lack a `json:"..."` tag — the request-body-drift class explicitly named in the M49 milestone charter.

- **Enables `musttag`** in `.golangci.yml` `linters.enable` (alphabetical: between `misspell` and `nilerr`).
- **Registers `writeJSON`** as a marshaller via `linters-settings.musttag.functions` with `arg-pos: 2`. Critical wiring detail: `musttag` does not follow call graphs — it checks struct argument types only at call sites of registered marshallers. Stillwater serves nearly every API response via `writeJSON(w, status, v)` (defined at `internal/api/handlers.go:1303`), so the default config (`encoding/json` only) would miss the entire handler surface and defeat the linter's purpose.
- **0 cleanup-sweep findings.** The codebase is comprehensively tagged already; this PR ratchets the existing-quality state into a future-regression gate rather than uncovering present-day gaps. `writeError` (the only sibling wrapper) takes a `string` not a struct, so no further registration needed.

## Test plan

- [x] `golangci-lint run ./...` against the new config returns `0 issues` (~33s wall time, full enabled-linter set).
- [x] `golangci-lint linters | grep musttag` confirms it appears under "Enabled by your configuration".
- [x] **Negative test**: temporarily stripped `json:"path"` from `filesystemBrowseResponse.Path`, re-ran with `--enable-only musttag` against `./internal/api/`, observed 3 musttag findings (decode site + writeJSON sites). Restored the tag, lint returned to 0. Confirms the `arg-pos: 2` registration actually fires.
- [x] Pre-push hook ran the full gate (including F5's new diff-only `--new-from-rev` lint step) — all checks passed.

## Closes M49 W1

This is the last of the five W1 lint-baseline PRs. After merge, M49 W2 (greenfield additions) becomes dispatchable. Predecessors: F1 #1428 (exhaustive), F2 #1429 (errorlint), F3 #1430 (usestdlibvars), F5 #1431 (gate diff-lint).

Closes #1387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality tooling configuration to enable additional linting validation. This enhancement strengthens static code analysis to maintain consistent coding patterns across the codebase, improve code reliability standards, and reduce potential issues through enhanced automated validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->