### PR TITLE
feat(ci): scheduled fuzz workflow (weekly cron + workflow_dispatch, 60s/target)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -54,6 +54,10 @@ jobs:
   fuzz:
     name: Fuzz (${{ matrix.fuzz_func }})
     runs-on: ubuntu-latest
+    # Belt-and-braces against a fuzz target hanging outside the per-test
+    # -fuzztime budget; 15 minutes is well above the expected duration of
+    # 60s per matrix entry plus checkout/setup overhead.
+    timeout-minutes: 15
     strategy:
       # Let every target run even when one crashes so we collect all
       # failing corpora in a single pass.
@@ -84,14 +88,18 @@ jobs:
       - name: Restore fuzz corpus and build cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
+          # Per-fuzz-function paths and keys: two matrix entries per package
+          # run concurrently and each writes new corpus into testdata/fuzz/<name>/.
+          # Sharing a path or key would let one job's save-cache stomp the
+          # other's new entries.
           path: |
             ~/.cache/go-build
-            ${{ matrix.package }}/testdata/fuzz
+            ${{ matrix.package }}/testdata/fuzz/${{ matrix.fuzz_func }}
           # Bust corpus when go.sum changes: new/upgraded deps may open or
           # close code paths, making old inputs misleading.
-          key: fuzz-corpus-${{ matrix.package }}-${{ hashFiles('go.sum') }}
+          key: fuzz-corpus-${{ matrix.package }}-${{ matrix.fuzz_func }}-${{ hashFiles('go.sum') }}
           restore-keys: |
-            fuzz-corpus-${{ matrix.package }}-
+            fuzz-corpus-${{ matrix.package }}-${{ matrix.fuzz_func }}-
 
       - name: Run fuzz target (${{ matrix.fuzz_func }})
         run: |

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -18,15 +18,20 @@
 #   The trade-off is acceptable at the current target count (<10).
 #
 # Cache strategy:
-#   - Key: "fuzz-corpus-<package>-<hash of go.sum>"
+#   - Key: "fuzz-corpus-<package>-<fuzz_func>-<hash of go.sum>"
 #     go.sum changing (new/upgraded deps) busts the corpus to avoid
 #     replaying inputs that exercised old code paths against new code.
+#     Per-target keys keep concurrent matrix entries from stomping each
+#     other's save-cache.
 #   - restore-keys fall back to the previous corpus snapshot for the
-#     same package so the corpus still accumulates between go.sum bumps.
+#     same (package, fuzz_func) pair so each target accumulates safely
+#     between go.sum bumps.
 #   - Cache paths per matrix entry:
-#       ~/.cache/go-build       -- the Go build cache (speeds up -fuzz compile)
-#       <package>/testdata/fuzz -- accumulated corpus entries (written by go test
-#                                  -fuzz when new interesting inputs are found)
+#       ~/.cache/go-build               -- the Go build cache (speeds up -fuzz compile)
+#       <package>/testdata/fuzz/<FuzzName>
+#                                       -- accumulated corpus entries for one
+#                                          target (written by go test -fuzz when
+#                                          new interesting inputs are found)
 #
 # Crash handling:
 #   - go test -fuzz exits non-zero on a crash, which fails the matrix entry.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,115 @@
+# Scheduled fuzz workflow
+#
+# Triggers: weekly cron on Monday 06:00 UTC + manual workflow_dispatch.
+#
+# Schedule choice (Monday 06:00 UTC):
+#   - Offset from the existing security.yml cron (Monday 03:30 UTC) by 2.5 h
+#     so the two weekly jobs do not compete for ubuntu-latest capacity.
+#   - Morning UTC means failures appear early in the European/US workday.
+#
+# Discovery approach -- static matrix:
+#   The four fuzz targets are enumerated explicitly rather than via a
+#   runtime `grep | jq` dynamic approach. Reasons:
+#     1. Dynamic enumeration requires a separate "discover" job, adding
+#        latency and complexity for four targets.
+#     2. A static matrix is self-documenting and easy to review in CI.
+#     3. When M49 W3 lands new targets, adding a line is a one-line PR
+#        that goes through normal review -- intentional, not accidental.
+#   The trade-off is acceptable at the current target count (<10).
+#
+# Cache strategy:
+#   - Key: "fuzz-corpus-<package>-<hash of go.sum>"
+#     go.sum changing (new/upgraded deps) busts the corpus to avoid
+#     replaying inputs that exercised old code paths against new code.
+#   - restore-keys fall back to the previous corpus snapshot for the
+#     same package so the corpus still accumulates between go.sum bumps.
+#   - Cache paths per matrix entry:
+#       ~/.cache/go-build       -- the Go build cache (speeds up -fuzz compile)
+#       <package>/testdata/fuzz -- accumulated corpus entries (written by go test
+#                                  -fuzz when new interesting inputs are found)
+#
+# Crash handling:
+#   - go test -fuzz exits non-zero on a crash, which fails the matrix entry.
+#   - The testdata/fuzz/<FuzzName>/ directory for the failing package is
+#     uploaded as a named artifact so developers can reproduce locally:
+#       go test -run=FuzzXxx/corpus-file ./internal/<pkg>/...
+#   - Automatic issue creation is deliberately omitted; CI failure + artifact
+#     is sufficient signal without the complexity of dedup / rate-limiting.
+
+name: Fuzz
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: Fuzz (${{ matrix.fuzz_func }})
+    runs-on: ubuntu-latest
+    strategy:
+      # Let every target run even when one crashes so we collect all
+      # failing corpora in a single pass.
+      fail-fast: false
+      matrix:
+        include:
+          - package: internal/nfo
+            fuzz_func: FuzzParse
+          - package: internal/nfo
+            fuzz_func: FuzzParseWriteRoundTrip
+          - package: internal/image
+            fuzz_func: FuzzPerceptualHash
+          - package: internal/image
+            fuzz_func: FuzzPerceptualHashDeterminism
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          # Disable the built-in module/build cache so actions/cache below
+          # owns the cache lifecycle (keyed per package + go.sum hash).
+          cache: false
+
+      - name: Restore fuzz corpus and build cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.cache/go-build
+            ${{ matrix.package }}/testdata/fuzz
+          # Bust corpus when go.sum changes: new/upgraded deps may open or
+          # close code paths, making old inputs misleading.
+          key: fuzz-corpus-${{ matrix.package }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.package }}-
+
+      - name: Run fuzz target (${{ matrix.fuzz_func }})
+        run: |
+          go test \
+            -fuzz=^${{ matrix.fuzz_func }}$ \
+            -fuzztime=60s \
+            -run=^$ \
+            ./${{ matrix.package }}/...
+
+      - name: Upload crash corpus on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-crash-${{ matrix.fuzz_func }}
+          # Upload the entire fuzz testdata directory for the failing package.
+          # This includes both the seed corpus and any new inputs that triggered
+          # the crash so a developer can reproduce with:
+          #   go test -run=FuzzXxx/corpus-entry ./internal/<pkg>/...
+          path: ${{ matrix.package }}/testdata/fuzz/${{ matrix.fuzz_func }}
+          if-no-files-found: warn
+          retention-days: 90


### PR DESCRIPTION
## Summary
- New `.github/workflows/fuzz.yml` runs every Go fuzz target on a weekly Monday 06:00 UTC cron and on `workflow_dispatch`, with a 60s budget per target.
- Static matrix enumerates the four existing targets (`internal/nfo`: `FuzzParse`, `FuzzParseWriteRoundTrip`; `internal/image`: `FuzzPerceptualHash`, `FuzzPerceptualHashDeterminism`). Picked over dynamic `grep` discovery because static is self-documenting and one-line additions stay reviewable -- documented in workflow comments.
- Fuzz corpus persists across runs via `actions/cache` keyed on `<package>-<hash(go.sum)>` so corpus accumulates between weekly runs but busts when deps change. Restore-key fallback retains corpus across `go.sum` bumps.
- Crash handling: the matrix entry fails (it's `fail-fast: false` so all four still run); the offending `testdata/fuzz/<FuzzName>/` is uploaded as a job artifact (`fuzz-crash-<func>`, 90-day retention) so developers can reproduce locally with `go test -run=FuzzXxx/corpus-entry ./internal/<pkg>/...`. Auto-issue creation deliberately omitted -- CI failure + artifact is sufficient signal without dedup/rate-limiting complexity.
- Cron offset 2.5h after `security.yml`'s Monday 03:30 UTC slot to avoid competing for `ubuntu-latest` capacity.
- Workflow does NOT block on M49 W3 fuzz target additions (A1-A10) -- the existing four are enough seed; new targets land via one-line matrix additions.

## Test plan
- [x] `actionlint .github/workflows/fuzz.yml` clean.
- [x] Manual invocation of the embedded `go test -fuzz` command against both packages with a 10s budget passes locally:
  - `go test -fuzz=^FuzzParse$ -fuzztime=10s -run=^$ ./internal/nfo/...` → PASS (~81k execs)
  - `go test -fuzz=^FuzzPerceptualHash$ -fuzztime=10s -run=^$ ./internal/image/...` → PASS (~652k execs)
- [ ] First scheduled run lands on Monday 06:00 UTC; verify all four targets exit clean against current corpus.
- [ ] Manually trigger via `gh workflow run fuzz.yml` once after merge to validate the matrix and cache key end-to-end.

Closes #1390
Part of M49 W2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a scheduled fuzz-testing workflow that runs weekly and can be triggered manually.
  * Executes multiple fuzz targets in parallel and ensures all targets complete even if some fail.
  * Uses caching to speed up repeated runs.
  * When a fuzz run detects a failure, uploads the failing corpus as a downloadable artifact retained for 90 days.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1433)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->