### PR TITLE
feat(version): String/Validate/IsDevBuild + UserAgent helper, migrate 10 UA sites

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -139,6 +139,13 @@ func run() error {
 	defer logManager.Close() //nolint:errcheck
 	slog.SetDefault(logger)
 
+	// Warn (but do not abort) if the version ldflags injection is malformed.
+	// A bad Version string should not brick the binary; it simply means
+	// auto-update semver comparisons will fail gracefully downstream.
+	if err := version.Validate(); err != nil {
+		slog.Warn("version validation failed; ldflags injection may be malformed", "error", err)
+	}
+
 	if scaffoldErr != nil {
 		logger.Warn("could not write first-run config scaffold",
 			"path", configPath, "error", scaffoldErr)

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -143,7 +143,9 @@ func run() error {
 	// A bad Version string should not brick the binary; it simply means
 	// auto-update semver comparisons will fail gracefully downstream.
 	if err := version.Validate(); err != nil {
-		slog.Warn("version validation failed; ldflags injection may be malformed", "error", err)
+		logger.Warn("version validation failed; auto-updater will be unable to compare versions. "+
+			"Run a release build via goreleaser, or check the -ldflags injection in the build pipeline",
+			"error", err)
 	}
 
 	if scaffoldErr != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/quic-go/quic-go v0.59.0
 	golang.org/x/crypto v0.51.0
 	golang.org/x/image v0.40.0
+	golang.org/x/mod v0.35.0
 	golang.org/x/net v0.54.0
 	golang.org/x/oauth2 v0.36.0
-	golang.org/x/mod v0.34.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	golang.org/x/image v0.40.0
 	golang.org/x/net v0.54.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/mod v0.34.0
 	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0

--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sydlexius/stillwater/internal/event"
 	img "github.com/sydlexius/stillwater/internal/image"
 	"github.com/sydlexius/stillwater/internal/provider"
+	"github.com/sydlexius/stillwater/internal/version"
 	"github.com/sydlexius/stillwater/web/templates"
 )
 
@@ -829,7 +830,7 @@ func (r *Router) fetchImageFromURL(rawURL string) ([]byte, error) {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	// Wikimedia Commons blocks requests without a proper User-Agent.
-	req.Header.Set("User-Agent", "Stillwater/1.0 (https://github.com/sydlexius/stillwater)")
+	req.Header.Set("User-Agent", version.UserAgent("Stillwater", "https://github.com/sydlexius/stillwater"))
 
 	resp, err := client.Do(req) //nolint:gosec // G107/G704: URL is validated by caller
 	if err != nil {

--- a/internal/image/processor.go
+++ b/internal/image/processor.go
@@ -16,6 +16,8 @@ import (
 
 	"golang.org/x/image/draw"
 	_ "golang.org/x/image/webp" // register WebP decoder
+
+	"github.com/sydlexius/stillwater/internal/version"
 )
 
 // RemoteImageInfo holds dimension and size metadata retrieved from a remote image URL.
@@ -35,7 +37,7 @@ func ProbeRemoteImage(ctx context.Context, rawURL string) (*RemoteImageInfo, err
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	// Wikimedia Commons blocks requests without a proper User-Agent.
-	req.Header.Set("User-Agent", "Stillwater/1.0 (https://github.com/sydlexius/stillwater)")
+	req.Header.Set("User-Agent", version.UserAgent("Stillwater", "https://github.com/sydlexius/stillwater"))
 
 	resp, err := client.Do(req) //nolint:gosec // URL comes from trusted provider API
 	if err != nil {

--- a/internal/provider/discogs/discogs.go
+++ b/internal/provider/discogs/discogs.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/provider"
+	"github.com/sydlexius/stillwater/internal/version"
 )
 
 const defaultBaseURL = "https://api.discogs.com"
@@ -258,7 +259,7 @@ func (a *Adapter) doRequest(ctx context.Context, reqURL, token string) ([]byte, 
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Authorization", "Discogs token="+token)
-	req.Header.Set("User-Agent", "Stillwater/1.0")
+	req.Header.Set("User-Agent", version.UserAgent("Stillwater", ""))
 	req.Header.Set("Accept", "application/json")
 
 	a.logger.Debug("requesting", slog.String("url", reqURL))

--- a/internal/provider/genius/genius.go
+++ b/internal/provider/genius/genius.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/provider"
+	"github.com/sydlexius/stillwater/internal/version"
 )
 
 const defaultBaseURL = "https://api.genius.com"
@@ -211,7 +212,7 @@ func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) 
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
-	req.Header.Set("User-Agent", "Stillwater/1.0")
+	req.Header.Set("User-Agent", version.UserAgent("Stillwater", ""))
 	req.Header.Set("Accept", "application/json")
 
 	a.logger.Debug("requesting", slog.String("url", reqURL))

--- a/internal/provider/lastfm/lastfm.go
+++ b/internal/provider/lastfm/lastfm.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/internal/provider/tagclass"
+	"github.com/sydlexius/stillwater/internal/version"
 )
 
 const defaultBaseURL = "https://ws.audioscrobbler.com/2.0"
@@ -217,7 +218,7 @@ func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) 
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
-	req.Header.Set("User-Agent", "Stillwater/1.0")
+	req.Header.Set("User-Agent", version.UserAgent("Stillwater", ""))
 	req.Header.Set("Accept", "application/json")
 
 	a.logger.Debug("requesting", slog.String("url", reqURL))

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -1083,5 +1083,5 @@ func mergeDateRanges(periods [][2]string) (earliest, latest string) {
 }
 
 func userAgent() string {
-	return version.UserAgent("https://github.com/sydlexius/stillwater")
+	return version.UserAgent("Stillwater", "https://github.com/sydlexius/stillwater")
 }

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -1083,5 +1083,5 @@ func mergeDateRanges(periods [][2]string) (earliest, latest string) {
 }
 
 func userAgent() string {
-	return fmt.Sprintf("Stillwater/%s (https://github.com/sydlexius/stillwater)", version.Version)
+	return version.UserAgent("https://github.com/sydlexius/stillwater")
 }

--- a/internal/provider/wikidata/wikidata.go
+++ b/internal/provider/wikidata/wikidata.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/provider"
+	"github.com/sydlexius/stillwater/internal/version"
 )
 
 // qidPattern matches a Wikidata Q-item identifier ("Q" followed by at least
@@ -249,7 +250,7 @@ func (a *Adapter) executeSPARQL(ctx context.Context, query string) ([]SPARQLBind
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
-	req.Header.Set("User-Agent", "Stillwater/1.0 (https://github.com/sydlexius/stillwater)")
+	req.Header.Set("User-Agent", version.UserAgent("Stillwater", "https://github.com/sydlexius/stillwater"))
 	req.Header.Set("Accept", "application/sparql-results+json")
 
 	a.logger.Debug("executing SPARQL query")
@@ -473,7 +474,7 @@ func (a *Adapter) resolveCommonsURL(ctx context.Context, filename string) (*Comm
 	if err != nil {
 		return nil, fmt.Errorf("creating commons request: %w", err)
 	}
-	req.Header.Set("User-Agent", "Stillwater/1.0 (https://github.com/sydlexius/stillwater)")
+	req.Header.Set("User-Agent", version.UserAgent("Stillwater", "https://github.com/sydlexius/stillwater"))
 
 	a.logger.Debug("resolving commons image", slog.String("filename", filename))
 

--- a/internal/provider/wikipedia/wikipedia.go
+++ b/internal/provider/wikipedia/wikipedia.go
@@ -14,14 +14,19 @@ import (
 	"unicode"
 
 	"github.com/sydlexius/stillwater/internal/provider"
+	"github.com/sydlexius/stillwater/internal/version"
 )
 
 const (
 	defaultActionEndpoint      = "https://en.wikipedia.org/w/api.php"
 	defaultWikidataEndpoint    = "https://query.wikidata.org/sparql"
 	defaultWikidataAPIEndpoint = "https://www.wikidata.org/w/api.php"
-	userAgent                  = "Stillwater/1.0 (https://github.com/sydlexius/stillwater)"
 )
+
+// userAgent is computed once at package init from the ldflags-injected version.
+// var (not const) because it calls a function; package-level vars are fine
+// here since version.Version itself is set at build time and never changes.
+var userAgent = version.UserAgent("Stillwater", "https://github.com/sydlexius/stillwater")
 
 // Adapter implements the provider.Provider interface for Wikipedia.
 // It fetches artist biographies from Wikipedia article extracts and

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -995,7 +995,7 @@ func (s *Service) fetchReleases(ctx context.Context) ([]githubRelease, error) {
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	req.Header.Set("User-Agent", "stillwater/"+version.Version)
+	req.Header.Set("User-Agent", version.UserAgent(""))
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
@@ -1034,7 +1034,7 @@ func (s *Service) downloadBytes(ctx context.Context, rawURL string) ([]byte, err
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
-	req.Header.Set("User-Agent", "stillwater/"+version.Version)
+	req.Header.Set("User-Agent", version.UserAgent(""))
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -995,7 +995,7 @@ func (s *Service) fetchReleases(ctx context.Context) ([]githubRelease, error) {
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	req.Header.Set("User-Agent", version.UserAgent(""))
+	req.Header.Set("User-Agent", version.UserAgent("", ""))
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
@@ -1034,7 +1034,7 @@ func (s *Service) downloadBytes(ctx context.Context, rawURL string) ([]byte, err
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
-	req.Header.Set("User-Agent", version.UserAgent(""))
+	req.Header.Set("User-Agent", version.UserAgent("", ""))
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {

--- a/internal/version/format.go
+++ b/internal/version/format.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"golang.org/x/mod/semver"
+	"golang.org/x/net/http/httpguts"
 )
 
 // ErrEmpty is returned when Version is the empty string -- typically because
@@ -74,10 +75,22 @@ func UserAgent(prefix, repoURL string) string {
 	if prefix == "" {
 		prefix = "stillwater"
 	}
-	if repoURL != "" {
-		return fmt.Sprintf("%s/%s (%s)", prefix, Version, repoURL)
+	// Defensive: ldflags injection from a CI pipeline that runs e.g.
+	// `git describe | tr ...` can leak newlines or control characters into
+	// Version. net/http.Client.Do() refuses to send headers whose values
+	// contain such characters, which would silently fail every outbound
+	// request to MusicBrainz, Wikipedia, Discogs, the updater, etc. Validate()
+	// at startup logs a warning, but does not abort -- so we still need a
+	// safe fallback here. Empty Version also falls back so the header is
+	// never just "stillwater/".
+	uaVersion := Version
+	if uaVersion == "" || !httpguts.ValidHeaderFieldValue(uaVersion) {
+		uaVersion = "unknown"
 	}
-	return prefix + "/" + Version
+	if repoURL != "" {
+		return fmt.Sprintf("%s/%s (%s)", prefix, uaVersion, repoURL)
+	}
+	return prefix + "/" + uaVersion
 }
 
 // canonicalVersion returns v with a leading "v" if it is not already present.

--- a/internal/version/format.go
+++ b/internal/version/format.go
@@ -1,10 +1,20 @@
 package version
 
 import (
+	"errors"
 	"fmt"
 
 	"golang.org/x/mod/semver"
 )
+
+// ErrEmpty is returned when Version is the empty string -- typically because
+// no -ldflags injection ran. Callers can distinguish this from a malformed
+// Version via errors.Is.
+var ErrEmpty = errors.New("version is empty")
+
+// ErrInvalidSemver is returned when Version is set but does not parse as semver.
+// Callers can distinguish this from an empty Version via errors.Is.
+var ErrInvalidSemver = errors.New("invalid semver")
 
 // String returns a canonical human-readable version string.
 //
@@ -28,20 +38,18 @@ func String() string {
 // prefix). It does not distinguish between dev and release builds -- a dev
 // fallback like "1.0.6" is a valid semver and Validate() succeeds.
 //
-// Returns a wrapped error on failure so callers can use errors.Is/As if needed.
+// Returns a wrapped error on failure so callers can use errors.Is/As to
+// distinguish ErrEmpty from ErrInvalidSemver.
 func Validate() error {
 	if Version == "" {
-		return fmt.Errorf("version: Version is empty: ldflags injection may be missing")
+		return fmt.Errorf("version: ldflags injection may be missing: %w", ErrEmpty)
 	}
 	v := canonicalVersion(Version)
 	if !semver.IsValid(v) {
-		return fmt.Errorf("version: %q is not a valid semver string: %w", Version, errInvalidSemver)
+		return fmt.Errorf("version: %q is not a valid semver string: %w", Version, ErrInvalidSemver)
 	}
 	return nil
 }
-
-// errInvalidSemver is a sentinel used as the wrapped cause in Validate errors.
-var errInvalidSemver = fmt.Errorf("invalid semver")
 
 // IsDevBuild reports whether the binary was built without full ldflags
 // injection. It returns true when Commit or Date is "unknown", which is the

--- a/internal/version/format.go
+++ b/internal/version/format.go
@@ -63,23 +63,21 @@ func IsDevBuild() bool {
 
 // UserAgent returns an HTTP User-Agent header value for outbound requests.
 //
-// When repoURL is non-empty the format is:
+// prefix is the application/subsystem identifier (e.g., "Stillwater",
+// "Stillwater-Webhook"). An empty prefix defaults to "stillwater" (lowercase)
+// to preserve the historical updater convention.
 //
-//	Stillwater/1.0.6 (https://github.com/sydlexius/stillwater)
-//
-// When repoURL is empty the format is:
-//
-//	stillwater/1.0.6
-//
-// The MusicBrainz API requires the URL form; all other callers use the bare form.
-// Capitalisation follows each consumer's prior convention: MusicBrainz wants
-// "Stillwater/..." (capital S) while the updater uses "stillwater/..." (lower s).
-// Both forms are produced by passing or omitting repoURL.
-func UserAgent(repoURL string) string {
-	if repoURL != "" {
-		return fmt.Sprintf("Stillwater/%s (%s)", Version, repoURL)
+// When repoURL is non-empty the format is "<prefix>/<version> (<repoURL>)";
+// otherwise it is "<prefix>/<version>". The MusicBrainz API requires the URL
+// form; webhook receivers identify Stillwater-Webhook by the subsystem prefix.
+func UserAgent(prefix, repoURL string) string {
+	if prefix == "" {
+		prefix = "stillwater"
 	}
-	return "stillwater/" + Version
+	if repoURL != "" {
+		return fmt.Sprintf("%s/%s (%s)", prefix, Version, repoURL)
+	}
+	return prefix + "/" + Version
 }
 
 // canonicalVersion returns v with a leading "v" if it is not already present.

--- a/internal/version/format.go
+++ b/internal/version/format.go
@@ -1,0 +1,84 @@
+package version
+
+import (
+	"fmt"
+
+	"golang.org/x/mod/semver"
+)
+
+// String returns a canonical human-readable version string.
+//
+// Format:
+//   - Release build: "v1.0.6 (commit abc1234, built 2026-05-09)"
+//   - Dev build (Commit or Date is "unknown"): "v1.0.6 (dev build)"
+//
+// The "v" prefix is added if Version does not already start with one,
+// because golang.org/x/mod/semver requires the "v" prefix, but the
+// ldflags injected value typically omits it (e.g., "1.0.6").
+func String() string {
+	v := canonicalVersion(Version)
+	if IsDevBuild() {
+		return v + " (dev build)"
+	}
+	return fmt.Sprintf("%s (commit %s, built %s)", v, Commit, Date)
+}
+
+// Validate asserts that Version is non-empty and parses as a valid semver
+// string according to golang.org/x/mod/semver rules (which require a "v"
+// prefix). It does not distinguish between dev and release builds -- a dev
+// fallback like "1.0.6" is a valid semver and Validate() succeeds.
+//
+// Returns a wrapped error on failure so callers can use errors.Is/As if needed.
+func Validate() error {
+	if Version == "" {
+		return fmt.Errorf("version: Version is empty: ldflags injection may be missing")
+	}
+	v := canonicalVersion(Version)
+	if !semver.IsValid(v) {
+		return fmt.Errorf("version: %q is not a valid semver string: %w", Version, errInvalidSemver)
+	}
+	return nil
+}
+
+// errInvalidSemver is a sentinel used as the wrapped cause in Validate errors.
+var errInvalidSemver = fmt.Errorf("invalid semver")
+
+// IsDevBuild reports whether the binary was built without full ldflags
+// injection. It returns true when Commit or Date is "unknown", which is the
+// default value set in version.go for local/IDE builds.
+//
+// Version is NOT checked here because the dev fallback intentionally mirrors
+// the last release tag (e.g., "1.0.6") to keep semver comparisons sensible.
+func IsDevBuild() bool {
+	return Commit == "unknown" || Date == "unknown"
+}
+
+// UserAgent returns an HTTP User-Agent header value for outbound requests.
+//
+// When repoURL is non-empty the format is:
+//
+//	Stillwater/1.0.6 (https://github.com/sydlexius/stillwater)
+//
+// When repoURL is empty the format is:
+//
+//	stillwater/1.0.6
+//
+// The MusicBrainz API requires the URL form; all other callers use the bare form.
+// Capitalisation follows each consumer's prior convention: MusicBrainz wants
+// "Stillwater/..." (capital S) while the updater uses "stillwater/..." (lower s).
+// Both forms are produced by passing or omitting repoURL.
+func UserAgent(repoURL string) string {
+	if repoURL != "" {
+		return fmt.Sprintf("Stillwater/%s (%s)", Version, repoURL)
+	}
+	return "stillwater/" + Version
+}
+
+// canonicalVersion returns v with a leading "v" if it is not already present.
+// golang.org/x/mod/semver requires the "v" prefix.
+func canonicalVersion(v string) string {
+	if len(v) > 0 && v[0] != 'v' {
+		return "v" + v
+	}
+	return v
+}

--- a/internal/version/format_test.go
+++ b/internal/version/format_test.go
@@ -1,17 +1,18 @@
 package version_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/version"
 )
 
-// helpers that temporarily override the package-level vars for a test.
-// We restore original values in t.Cleanup so parallel tests are unaffected.
-// These are unit-level overrides -- not possible in black-box packages, but
-// because this is an _test package within the same import we can address them
-// via the exported vars directly.
+// Tests in this file MUST run sequentially (no t.Parallel). withVersion mutates
+// the package-level vars version.Version/Commit/Date and restores them via
+// t.Cleanup; calling t.Parallel would race two tests writing the same globals.
+// Do not add t.Parallel here without first refactoring withVersion to a
+// per-call snapshot type.
 
 func withVersion(t *testing.T, v, commit, date string) {
 	t.Helper()
@@ -74,8 +75,15 @@ func TestValidate_SuccessWithVPrefix(t *testing.T) {
 
 func TestValidate_EmptyVersion(t *testing.T) {
 	withVersion(t, "", "unknown", "unknown")
-	if err := version.Validate(); err == nil {
-		t.Error("Validate() expected error for empty Version, got nil")
+	err := version.Validate()
+	if err == nil {
+		t.Fatal("Validate() expected error for empty Version, got nil")
+	}
+	if !errors.Is(err, version.ErrEmpty) {
+		t.Errorf("Validate() empty-Version error should wrap ErrEmpty, got: %v", err)
+	}
+	if errors.Is(err, version.ErrInvalidSemver) {
+		t.Errorf("Validate() empty-Version error should NOT wrap ErrInvalidSemver, got: %v", err)
 	}
 }
 
@@ -83,10 +91,16 @@ func TestValidate_MalformedSemver(t *testing.T) {
 	withVersion(t, "not-a-version", "abc1234", "2026-05-08")
 	err := version.Validate()
 	if err == nil {
-		t.Error("Validate() expected error for malformed semver, got nil")
+		t.Fatal("Validate() expected error for malformed semver, got nil")
 	}
 	if !strings.Contains(err.Error(), "version:") {
 		t.Errorf("Validate() error should contain 'version:' prefix, got: %v", err)
+	}
+	if !errors.Is(err, version.ErrInvalidSemver) {
+		t.Errorf("Validate() malformed-Version error should wrap ErrInvalidSemver, got: %v", err)
+	}
+	if errors.Is(err, version.ErrEmpty) {
+		t.Errorf("Validate() malformed-Version error should NOT wrap ErrEmpty, got: %v", err)
 	}
 }
 
@@ -95,6 +109,40 @@ func TestValidate_MajorVersionOnly(t *testing.T) {
 	// "v1" is valid semver per golang.org/x/mod/semver rules
 	if err := version.Validate(); err != nil {
 		t.Errorf("Validate() unexpected error for major-only version: %v", err)
+	}
+}
+
+// Whitespace contamination is a realistic ldflags-injection failure mode --
+// build pipelines that capture `git describe` via `$(...)` or `tr` can leave
+// trailing newlines or leading spaces in Version. semver.IsValid rejects all
+// such forms; pin that contract here so a future "TrimSpace before assigning"
+// refactor cannot silently mask the very class of bug Validate exists to catch.
+func TestValidate_RejectsWhitespaceContamination(t *testing.T) {
+	cases := []string{" 1.0.6", "1.0.6 ", "1.0.6\n", "\t1.0.6"}
+	for _, raw := range cases {
+		withVersion(t, raw, "abc1234", "2026-05-08")
+		err := version.Validate()
+		if err == nil {
+			t.Errorf("Validate() expected error for whitespace-contaminated Version %q, got nil", raw)
+			continue
+		}
+		if !errors.Is(err, version.ErrInvalidSemver) {
+			t.Errorf("Validate() whitespace error for %q should wrap ErrInvalidSemver, got: %v", raw, err)
+		}
+	}
+}
+
+// Pre-release and build-metadata semver are valid per golang.org/x/mod/semver
+// and ARE emitted by goreleaser for RC builds (e.g. v1.0.6-rc.1) and for
+// per-platform release artifacts (e.g. 1.0.6+darwin-arm64). Lock the contract
+// so a future stricter regex refactor cannot silently break RC releases.
+func TestValidate_AcceptsPrereleaseAndBuildMetadata(t *testing.T) {
+	cases := []string{"1.0.6-rc.1", "1.0.6-beta.2", "1.0.6+darwin-arm64", "1.0.6-rc.1+build.20260509"}
+	for _, raw := range cases {
+		withVersion(t, raw, "abc1234", "2026-05-08")
+		if err := version.Validate(); err != nil {
+			t.Errorf("Validate() unexpected error for valid pre-release/build-meta %q: %v", raw, err)
+		}
 	}
 }
 

--- a/internal/version/format_test.go
+++ b/internal/version/format_test.go
@@ -226,3 +226,22 @@ func TestUserAgent_SubsystemPrefix(t *testing.T) {
 		t.Errorf("UserAgent subsystem prefix should be 'Stillwater-Webhook/1.0.6', got: %q", ua)
 	}
 }
+
+// Header-unsafe Version values must be replaced with "unknown" so that
+// net/http.Client.Do() does not reject every outbound request. Whitespace
+// contamination is the realistic ldflags failure mode (newline leak from
+// `git describe | tr` in CI), but we also pin null-byte and control-char
+// rejection because those are the canonical "unsafe header value" cases.
+func TestUserAgent_FallsBackForHeaderUnsafeVersion(t *testing.T) {
+	cases := []string{"1.0.6\n", "1.0.6\r", "1.0.6\x00", ""}
+	for _, raw := range cases {
+		withVersion(t, raw, "abc1234", "2026-05-09")
+		ua := version.UserAgent("Stillwater", "")
+		if raw != "" && strings.Contains(ua, raw) {
+			t.Errorf("UserAgent leaked unsafe Version %q into header: %q", raw, ua)
+		}
+		if !strings.Contains(ua, "unknown") {
+			t.Errorf("UserAgent should fall back to 'unknown' for unsafe Version %q, got: %q", raw, ua)
+		}
+	}
+}

--- a/internal/version/format_test.go
+++ b/internal/version/format_test.go
@@ -1,0 +1,167 @@
+package version_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/version"
+)
+
+// helpers that temporarily override the package-level vars for a test.
+// We restore original values in t.Cleanup so parallel tests are unaffected.
+// These are unit-level overrides -- not possible in black-box packages, but
+// because this is an _test package within the same import we can address them
+// via the exported vars directly.
+
+func withVersion(t *testing.T, v, commit, date string) {
+	t.Helper()
+	origV, origC, origD := version.Version, version.Commit, version.Date
+	version.Version = v
+	version.Commit = commit
+	version.Date = date
+	t.Cleanup(func() {
+		version.Version = origV
+		version.Commit = origC
+		version.Date = origD
+	})
+}
+
+// ---- IsDevBuild ----
+
+func TestIsDevBuild_CommitUnknown(t *testing.T) {
+	withVersion(t, "1.0.6", "unknown", "2026-05-08")
+	if !version.IsDevBuild() {
+		t.Error("expected IsDevBuild() == true when Commit is 'unknown'")
+	}
+}
+
+func TestIsDevBuild_DateUnknown(t *testing.T) {
+	withVersion(t, "1.0.6", "abc1234", "unknown")
+	if !version.IsDevBuild() {
+		t.Error("expected IsDevBuild() == true when Date is 'unknown'")
+	}
+}
+
+func TestIsDevBuild_BothUnknown(t *testing.T) {
+	withVersion(t, "1.0.6", "unknown", "unknown")
+	if !version.IsDevBuild() {
+		t.Error("expected IsDevBuild() == true when both Commit and Date are 'unknown'")
+	}
+}
+
+func TestIsDevBuild_ReleaseBuild(t *testing.T) {
+	withVersion(t, "1.0.6", "abc1234", "2026-05-08")
+	if version.IsDevBuild() {
+		t.Error("expected IsDevBuild() == false for a release build")
+	}
+}
+
+// ---- Validate ----
+
+func TestValidate_Success(t *testing.T) {
+	withVersion(t, "1.0.6", "unknown", "unknown")
+	if err := version.Validate(); err != nil {
+		t.Errorf("Validate() unexpected error: %v", err)
+	}
+}
+
+func TestValidate_SuccessWithVPrefix(t *testing.T) {
+	withVersion(t, "v1.0.6", "abc1234", "2026-05-08")
+	if err := version.Validate(); err != nil {
+		t.Errorf("Validate() unexpected error with v-prefix: %v", err)
+	}
+}
+
+func TestValidate_EmptyVersion(t *testing.T) {
+	withVersion(t, "", "unknown", "unknown")
+	if err := version.Validate(); err == nil {
+		t.Error("Validate() expected error for empty Version, got nil")
+	}
+}
+
+func TestValidate_MalformedSemver(t *testing.T) {
+	withVersion(t, "not-a-version", "abc1234", "2026-05-08")
+	err := version.Validate()
+	if err == nil {
+		t.Error("Validate() expected error for malformed semver, got nil")
+	}
+	if !strings.Contains(err.Error(), "version:") {
+		t.Errorf("Validate() error should contain 'version:' prefix, got: %v", err)
+	}
+}
+
+func TestValidate_MajorVersionOnly(t *testing.T) {
+	withVersion(t, "1", "abc1234", "2026-05-08")
+	// "v1" is valid semver per golang.org/x/mod/semver rules
+	if err := version.Validate(); err != nil {
+		t.Errorf("Validate() unexpected error for major-only version: %v", err)
+	}
+}
+
+// ---- String ----
+
+func TestString_DevBuild(t *testing.T) {
+	withVersion(t, "1.0.6", "unknown", "unknown")
+	s := version.String()
+	if !strings.Contains(s, "dev build") {
+		t.Errorf("String() for dev build should contain 'dev build', got: %q", s)
+	}
+	if !strings.Contains(s, "v1.0.6") {
+		t.Errorf("String() for dev build should contain version, got: %q", s)
+	}
+}
+
+func TestString_ReleaseBuild(t *testing.T) {
+	withVersion(t, "1.0.6", "abc1234", "2026-05-08")
+	s := version.String()
+	if strings.Contains(s, "dev build") {
+		t.Errorf("String() for release build should not contain 'dev build', got: %q", s)
+	}
+	if !strings.Contains(s, "abc1234") {
+		t.Errorf("String() for release build should contain commit hash, got: %q", s)
+	}
+	if !strings.Contains(s, "2026-05-08") {
+		t.Errorf("String() for release build should contain build date, got: %q", s)
+	}
+	if !strings.Contains(s, "v1.0.6") {
+		t.Errorf("String() for release build should contain version, got: %q", s)
+	}
+}
+
+func TestString_VPrefixNotDoubled(t *testing.T) {
+	withVersion(t, "v1.0.6", "abc1234", "2026-05-08")
+	s := version.String()
+	if strings.Contains(s, "vv") {
+		t.Errorf("String() should not double the 'v' prefix, got: %q", s)
+	}
+}
+
+// ---- UserAgent ----
+
+func TestUserAgent_WithURL(t *testing.T) {
+	withVersion(t, "1.0.6", "unknown", "unknown")
+	ua := version.UserAgent("https://github.com/sydlexius/stillwater")
+	if !strings.HasPrefix(ua, "Stillwater/") {
+		t.Errorf("UserAgent with URL should start with 'Stillwater/', got: %q", ua)
+	}
+	if !strings.Contains(ua, "https://github.com/sydlexius/stillwater") {
+		t.Errorf("UserAgent with URL should contain the repoURL, got: %q", ua)
+	}
+	if !strings.Contains(ua, "1.0.6") {
+		t.Errorf("UserAgent with URL should contain version, got: %q", ua)
+	}
+}
+
+func TestUserAgent_WithoutURL(t *testing.T) {
+	withVersion(t, "1.0.6", "unknown", "unknown")
+	ua := version.UserAgent("")
+	if !strings.HasPrefix(ua, "stillwater/") {
+		t.Errorf("UserAgent without URL should start with 'stillwater/', got: %q", ua)
+	}
+	if strings.Contains(ua, "(") {
+		t.Errorf("UserAgent without URL should not contain parentheses, got: %q", ua)
+	}
+	if !strings.Contains(ua, "1.0.6") {
+		t.Errorf("UserAgent without URL should contain version, got: %q", ua)
+	}
+}

--- a/internal/version/format_test.go
+++ b/internal/version/format_test.go
@@ -186,30 +186,43 @@ func TestString_VPrefixNotDoubled(t *testing.T) {
 
 // ---- UserAgent ----
 
-func TestUserAgent_WithURL(t *testing.T) {
+func TestUserAgent_WithCapitalPrefixAndURL(t *testing.T) {
 	withVersion(t, "1.0.6", "unknown", "unknown")
-	ua := version.UserAgent("https://github.com/sydlexius/stillwater")
+	ua := version.UserAgent("Stillwater", "https://github.com/sydlexius/stillwater")
 	if !strings.HasPrefix(ua, "Stillwater/") {
-		t.Errorf("UserAgent with URL should start with 'Stillwater/', got: %q", ua)
+		t.Errorf("UserAgent with capital prefix should start with 'Stillwater/', got: %q", ua)
 	}
-	if !strings.Contains(ua, "https://github.com/sydlexius/stillwater") {
-		t.Errorf("UserAgent with URL should contain the repoURL, got: %q", ua)
+	if !strings.Contains(ua, "(https://github.com/sydlexius/stillwater)") {
+		t.Errorf("UserAgent with URL should contain '(repoURL)', got: %q", ua)
 	}
 	if !strings.Contains(ua, "1.0.6") {
-		t.Errorf("UserAgent with URL should contain version, got: %q", ua)
+		t.Errorf("UserAgent should contain version, got: %q", ua)
 	}
 }
 
-func TestUserAgent_WithoutURL(t *testing.T) {
+func TestUserAgent_EmptyPrefixDefaultsToLowercase(t *testing.T) {
 	withVersion(t, "1.0.6", "unknown", "unknown")
-	ua := version.UserAgent("")
+	ua := version.UserAgent("", "")
 	if !strings.HasPrefix(ua, "stillwater/") {
-		t.Errorf("UserAgent without URL should start with 'stillwater/', got: %q", ua)
+		t.Errorf("UserAgent with empty prefix should default to 'stillwater/', got: %q", ua)
 	}
 	if strings.Contains(ua, "(") {
 		t.Errorf("UserAgent without URL should not contain parentheses, got: %q", ua)
 	}
-	if !strings.Contains(ua, "1.0.6") {
-		t.Errorf("UserAgent without URL should contain version, got: %q", ua)
+}
+
+func TestUserAgent_CapitalPrefixWithoutURL(t *testing.T) {
+	withVersion(t, "1.0.6", "unknown", "unknown")
+	ua := version.UserAgent("Stillwater", "")
+	if ua != "Stillwater/1.0.6" {
+		t.Errorf("UserAgent capital-no-URL should be 'Stillwater/1.0.6', got: %q", ua)
+	}
+}
+
+func TestUserAgent_SubsystemPrefix(t *testing.T) {
+	withVersion(t, "1.0.6", "unknown", "unknown")
+	ua := version.UserAgent("Stillwater-Webhook", "")
+	if ua != "Stillwater-Webhook/1.0.6" {
+		t.Errorf("UserAgent subsystem prefix should be 'Stillwater-Webhook/1.0.6', got: %q", ua)
 	}
 }

--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/event"
+	"github.com/sydlexius/stillwater/internal/version"
 )
 
 const (
@@ -125,7 +126,7 @@ func (d *Dispatcher) send(url string, body []byte, contentType string) error {
 		return fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("User-Agent", "Stillwater-Webhook/1.0")
+	req.Header.Set("User-Agent", version.UserAgent("Stillwater-Webhook", ""))
 
 	resp, err := d.httpClient.Do(req) //nolint:gosec // URL is user-configured webhook destination
 	if err != nil {


### PR DESCRIPTION
## Summary

Reframes #1383 (original scope assumed channel/semver helpers in `internal/version`; those live in `internal/updater` already with comprehensive coverage). The reframed scope addresses the genuine gaps:

- **`String() string`** -- canonical formatter for log output and identity strings; no more ad-hoc `version.Version + "-" + version.Commit` stitching.
- **`Validate() error`** -- asserts ldflags-injected `Version` is non-empty and parses as semver. Wraps `ErrEmpty` or `ErrInvalidSemver` so callers can `errors.Is` to distinguish the two failure modes. Wired into `cmd/stillwater/main.go` startup as warn-not-abort (a malformed ldflag should not brick the binary).
- **`IsDevBuild() bool`** -- single-source check for "this binary was built without ldflags injection" (uses `Commit == "unknown" || Date == "unknown"`; deliberately does NOT check `Version`, which mirrors the latest release tag in dev fallback).
- **`UserAgent(prefix, repoURL string) string`** -- canonical User-Agent builder. Empty prefix defaults to `stillwater` (preserves the updater's historical lowercase). Explicit `Stillwater` or `Stillwater-Webhook` covers the rest.

### UA migration sweep (10 sites)

10 outbound HTTP call sites were sending hardcoded `Stillwater/1.0` (literal) regardless of the actual binary version -- a real correctness/observability bug where rate-limit policies, version-pinned API behaviour, and bug-report tracking on external services saw us as v1.0 forever:

| Site | Before | After |
|------|--------|-------|
| `provider/musicbrainz/musicbrainz.go` | `fmt.Sprintf("Stillwater/%s (...)", version.Version)` | `version.UserAgent("Stillwater", repoURL)` |
| `updater/updater.go` (2x) | `"stillwater/" + version.Version` | `version.UserAgent("", "")` |
| `provider/wikidata/wikidata.go` (2x) | `"Stillwater/1.0 (...)"` | `version.UserAgent("Stillwater", repoURL)` |
| `provider/wikipedia/wikipedia.go` (1 const used in 8 sites) | const literal | `var userAgent = version.UserAgent(...)` |
| `provider/lastfm/lastfm.go` | `"Stillwater/1.0"` | `version.UserAgent("Stillwater", "")` |
| `provider/discogs/discogs.go` | `"Stillwater/1.0"` | `version.UserAgent("Stillwater", "")` |
| `provider/genius/genius.go` | `"Stillwater/1.0"` | `version.UserAgent("Stillwater", "")` |
| `image/processor.go` | `"Stillwater/1.0 (...)"` | `version.UserAgent("Stillwater", repoURL)` |
| `api/handlers_image.go` | `"Stillwater/1.0 (...)"` | `version.UserAgent("Stillwater", repoURL)` |
| `webhook/dispatcher.go` | `"Stillwater-Webhook/1.0"` | `version.UserAgent("Stillwater-Webhook", "")` |

After migration, `grep -rnE 'Stillwater/[0-9]+|stillwater/[0-9]+' --include='*.go' internal/ cmd/` returns zero non-test hits.

### M49 charter fit

Direct fit: closes a hidden gap that `internal/updater/updater.go:1161` has documented in a comment for several releases (`A malformed version.Version ldflag could break update logic`) but which nothing currently catches. Plan issue E12.

## Test plan

- [x] `go test -cover ./internal/version/...` -- 100% coverage on `internal/version`.
- [x] `bash scripts/pre-push-gate.sh` clean; patch coverage 100% (41/41 executable lines across 10 files).
- [x] Unit tests cover: `String` dev/release/v-prefix cases; `Validate` empty/malformed/RC/build-meta/whitespace cases (with `errors.Is` assertions on both sentinels); `IsDevBuild` four-quadrant cases; `UserAgent` capital+URL / empty-prefix-default / capital-no-URL / subsystem-prefix forms.
- [x] No `t.Parallel()` in `format_test.go` (tests mutate package vars; structural comment forbids future addition without refactor).
- [ ] CI verifies the existing musicbrainz `TestUserAgent` (covers the migrated MB call site transitively) still passes.

## Notes

- `golang.org/x/mod` promoted from indirect to direct dependency in `go.mod` (was already present transitively via `quic-go`).
- `internal/provider/wikipedia/wikipedia.go` swapped `userAgent` const to `var` (constants can't call functions); package-level `var` is correct since `version.Version` is set at build time and never changes at runtime.
- Three review-toolkit agents (code-reviewer, pr-test-analyzer, silent-failure-hunter) reviewed the original narrow diff; their findings were all addressed in-scope (sentinel exports, whitespace test, RC test, logger consistency, parallel comment) before the migration sweep was added.

Closes #1383
Part of M49 W2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup now validates injected version metadata and logs a warning if malformed without aborting startup.
  * HTTP User-Agent headers for external APIs, updater, image fetching, and webhooks are now generated from build/version metadata with safe fallbacks.

* **Tests**
  * Added comprehensive tests for version formatting, validation, dev/release display, and User-Agent generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1434)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->