### PR TITLE
chore(deps): bump gitpython 3.1.49 -> 3.1.50 (GHSA-mv93-w799-cj2w)

### DIFF
--- a/docs/site/requirements.txt
+++ b/docs/site/requirements.txt
@@ -173,9 +173,9 @@ gitdb==4.0.12 \
     --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
     --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
     # via gitpython
-gitpython==3.1.49 \
-    --hash=sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c \
-    --hash=sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1
+gitpython==3.1.50 \
+    --hash=sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc \
+    --hash=sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9
     # via mkdocs-git-revision-date-localized-plugin
 idna==3.13 \
     --hash=sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242 \


### PR DESCRIPTION
## Summary

- Bumps transitive `gitpython` from 3.1.49 to 3.1.50 in `docs/site/requirements.txt` to clear Scorecard alert #80 (Dependabot alert #2).
- Advisory: GHSA-mv93-w799-cj2w (HIGH, CVSS 7.0) — newline injection via `config_writer().set_value()` `section` parameter bypasses the incomplete CVE-2026-42215 fix and enables RCE through a forged `[core] hooksPath` entry.
- Pulled in transitively by `mkdocs-git-revision-date-localized-plugin`; only used by the docs site build (`.github/workflows/pages.yml`), never linked into the runtime binary.
- Regenerated via `pip-compile --generate-hashes --upgrade-package gitpython`; hashes verified against PyPI.

## Risk

Low. The exploit needs attacker-controlled `section` strings into `set_value()`. The mkdocs plugin uses GitPython read-only against this repo's own git history, with no untrusted strings crossing the boundary. Bumping anyway because it is free and clears the alert.

## Test plan

- [x] `pip-compile --generate-hashes --upgrade-package gitpython` regenerates lockfile cleanly with no transitive cascade
- [x] Diff is exactly the gitpython version + two sha256 hashes
- [x] Hashes match `https://pypi.org/pypi/gitpython/3.1.50/json` (wheel + sdist)
- [ ] Pages workflow runs `pip install --require-hashes -r docs/site/requirements.txt` successfully on next push to a docs branch (CI gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to the latest compatible versions for improved stability and security.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1437)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->