### PR TITLE
chore(ci): add pip ecosystem for docs site to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,19 @@ updates:
       - dependencies
       - docker
     open-pull-requests-limit: 5
+
+  # Docs site uses pip-compile with --generate-hashes; Dependabot detects the
+  # autogen header on requirements.txt and updates both .in and .txt together
+  # for direct deps. Transitive security alerts in the lockfile (see #1437)
+  # still need manual pip-compile --upgrade-package runs.
+  - package-ecosystem: pip
+    directory: /docs/site
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "docs"
+    labels:
+      - dependencies
+      - documentation
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

- Adds a `pip` entry to `.github/dependabot.yml` covering `docs/site/requirements.{in,txt}` on the same weekly Monday cadence as the other three ecosystems.
- Dependabot detects the `# autogenerated by pip-compile` header on the lockfile and will update `.in` and `.txt` together for direct deps (`mkdocs-material`, three mkdocs plugins).
- Limit set to 3 open PRs given the small dep surface (4 direct).

## Why now

Follow-up to PR #1437 (gitpython 3.1.49 -> 3.1.50). RCA on that transitive vuln found Dependabot has been silently skipping the docs-site lockfile because no `pip` ecosystem was configured. This brings direct deps under the same auto-update rhythm as gomod / github-actions / docker.

## Known limitation

This does NOT close the transitive blind spot. `gitpython` (the dep that triggered #1437) is pulled in by `mkdocs-git-revision-date-localized-plugin` and is not in `requirements.in`. Dependabot cannot run `pip-compile --upgrade-package` against a transitive, so transitive lockfile security alerts will still need manual action via the workflow documented in `docs/site/requirements.in`. The Scorecard workflow will continue to surface them via code-scanning alerts as a backstop.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses cleanly with all four ecosystems
- [ ] After merge, observe whether Dependabot opens a docs/site PR on the next weekly Monday run (or sooner if a new docs dep version is already available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled weekly automated dependency updates for documentation to keep packages current and address security vulnerabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1438)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->