### PR TITLE
chore(security): refresh expired .grype.yaml ignores

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -5,33 +5,22 @@
 # The grype-ignore-expiry job in security.yml fails when entries expire.
 
 ignore:
-  # OpenSSL 3.5.5 -- no fix available in Alpine 3.23 as of 2026-04-09.
-  # Upstream: https://www.openssl.org/news/vulnerabilities.html
-  - vulnerability: CVE-2026-2673
-    package:
-      name: libcrypto3
-      type: apk
-    review-by: "2026-05-09"
-    reason: "No patched OpenSSL in Alpine 3.23; upstream fix is 3.5.6"
-  - vulnerability: CVE-2026-2673
-    package:
-      name: libssl3
-      type: apk
-    review-by: "2026-05-09"
-    reason: "No patched OpenSSL in Alpine 3.23; upstream fix is 3.5.6"
-
-  # curl 8.17.0 -- no fix available in Alpine 3.23 as of 2026-04-09.
+  # curl 8.17.0 -- no fix in Alpine 3.23-main as of 2026-05-11.
+  # v3.23 still carries 8.17.0-r1; fix is 8.19.0-r0 in edge-main only.
+  # Upstream: https://security.alpinelinux.org/vuln/CVE-2026-3805
   - vulnerability: CVE-2026-3805
     package:
       name: curl
       type: apk
-    review-by: "2026-05-09"
-    reason: "No patched curl in Alpine 3.23; awaiting upstream backport"
+    review-by: "2026-06-09"
+    reason: "Alpine 3.23 still on 8.17.0-r1; fix 8.19.0-r0 not yet backported"
 
-  # nghttp2 1.68.0 -- no fix available in Alpine 3.23 as of 2026-04-09.
+  # nghttp2 1.68.0 -- no fix in Alpine 3.23-main as of 2026-05-11.
+  # v3.23 still carries 1.68.0-r0; fix 1.68.1 not yet released in this branch.
+  # Upstream: https://security.alpinelinux.org/vuln/CVE-2026-27135
   - vulnerability: CVE-2026-27135
     package:
       name: nghttp2-libs
       type: apk
-    review-by: "2026-05-09"
-    reason: "No patched nghttp2 in Alpine 3.23; awaiting upstream backport"
+    review-by: "2026-06-09"
+    reason: "Alpine 3.23 still on 1.68.0-r0; fix 1.68.1 not yet backported"


### PR DESCRIPTION
## Summary

The scheduled Security workflow on main started failing 2026-05-10 because four `.grype.yaml` ignore entries reached their `review-by: 2026-05-09` date. This refreshes the entries against fresh upstream evidence from the Alpine 3.23 security tracker (verified 2026-05-11).

- **CVE-2026-2673** (`libcrypto3`, `libssl3`): **removed**. Alpine 3.23-main shipped `openssl 3.5.6-r0`, which carries the upstream fix. The next base-image rebuild picks it up automatically; the suppression is obsolete.
- **CVE-2026-3805** (`curl`): **extended to 2026-06-09**. Alpine 3.23 still carries `8.17.0-r1`; fix `8.19.0-r0` is in `edge-main` only.
- **CVE-2026-27135** (`nghttp2-libs`): **extended to 2026-06-09**. Alpine 3.23 still carries `1.68.0-r0`; fix `1.68.1` is not yet backported to the stable branch.

This unblocks the Grype Ignore Expiry Check on main and on any open PR (Dependabot #1455 currently fails the same check for the same reason).

## Test plan
- [x] Verified Alpine 3.23 package status for each CVE via https://security.alpinelinux.org/vuln/ pages
- [x] Confirmed both remaining `review-by` dates are in the future (2026-06-09 > 2026-05-11)
- [x] Pre-commit hook passed locally
- [ ] CI: Grype Ignore Expiry Check goes green

## Follow-ups
- After this merges: comment `@dependabot rebase` on #1455 to refresh its checks.
- Separate small PR forthcoming for code-scanning alert #81 (Scorecard Pinned-Dependencies on `bruno-ci.yml` npm install).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated security vulnerability scanning configuration with refreshed CVE ignore entries and metadata for enhanced vulnerability management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1459)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->