### PR TITLE
chore(ci): pin Bruno CLI install by SHA-256

### DIFF
--- a/.github/workflows/bruno-ci.yml
+++ b/.github/workflows/bruno-ci.yml
@@ -110,7 +110,18 @@ jobs:
             -o stillwater ./cmd/stillwater
 
       - name: Install Bruno CLI
-        run: npm install -g @usebruno/cli@1.22.0
+        # Pinned by SHA-256 against the published npm tarball so Scorecard
+        # treats this as a hash-pinned dependency. Bump VERSION + SHA256
+        # together; the registry attests SHA-512 integrity at publish time.
+        env:
+          BRUNO_VERSION: "1.22.0"
+          BRUNO_SHA256: "10e62e8d2385c1cb38820dbd374e829c1061d4e5a4aa7851b7cecc0ef02eb86f"
+        run: |
+          url="https://registry.npmjs.org/@usebruno/cli/-/cli-${BRUNO_VERSION}.tgz"
+          curl -fsSL --retry 3 --retry-delay 2 "$url" -o bruno-cli.tgz
+          echo "${BRUNO_SHA256}  bruno-cli.tgz" | sha256sum -c -
+          npm install -g ./bruno-cli.tgz
+          rm -f bruno-cli.tgz
 
       - name: Pick a free port
         id: port


### PR DESCRIPTION
## Summary

Resolves code-scanning alert #81 (Scorecard `PinnedDependenciesID`, medium severity): the previous `npm install -g @usebruno/cli@1.22.0` step in `bruno-ci.yml` was not hash-pinned, because the version tag alone is mutable from npm's perspective.

The workflow now downloads the published tarball, verifies it against a checked-in SHA-256, and installs from the local file:

```yaml
- name: Install Bruno CLI
  env:
    BRUNO_VERSION: "1.22.0"
    BRUNO_SHA256: "10e62e8d2385c1cb38820dbd374e829c1061d4e5a4aa7851b7cecc0ef02eb86f"
  run: |
    url="https://registry.npmjs.org/@usebruno/cli/-/cli-${BRUNO_VERSION}.tgz"
    curl -fsSL --retry 3 --retry-delay 2 "$url" -o bruno-cli.tgz
    echo "${BRUNO_SHA256}  bruno-cli.tgz" | sha256sum -c -
    npm install -g ./bruno-cli.tgz
    rm -f bruno-cli.tgz
```

## Trust chain for the SHA-256

The embedded SHA-256 (`10e62e8d2385c1cb38820dbd374e829c1061d4e5a4aa7851b7cecc0ef02eb86f`) was derived as follows:
1. Downloaded `https://registry.npmjs.org/@usebruno/cli/-/cli-1.22.0.tgz` (24,887 bytes).
2. Computed SHA-512 of the downloaded bytes and confirmed it matched the registry's published `dist.integrity` field (`sha512-6hbVKBfCcA4Ur9r23v3Ssbiz3SqqtFVv1Cz7olhQrqH2GAScvHdAHqJtDLKEmv9VZJbM9MuJp0onDlOvuQo6VQ==`).
3. Computed SHA-256 of the same verified bytes.

This anchors the hash to npm's publish-time attestation rather than to whatever the registry served at compute time.

## Operational notes

- `curl --retry 3 --retry-delay 2` makes the step robust to transient npm-registry blips, so a network flake does not masquerade as an integrity violation.
- Bumping Bruno going forward requires updating `BRUNO_VERSION` and `BRUNO_SHA256` together. The inline comment documents this.
- Scorecard re-analyzes on push to `main`; the alert should auto-resolve on the next run.

## Test plan
- [x] actionlint passes on the modified workflow
- [x] SHA-256 cross-checked against npm registry SHA-512 integrity
- [ ] CI: Bruno API Tests run green
- [ ] After merge: Scorecard alert #81 auto-resolves on next analysis

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with improved installation verification and security measures for build dependencies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1460)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->