### PR TITLE
chore(docs): audit .github/instructions/ for post-M49 lint surface

### DIFF
--- a/.github/instructions/ci-actions.instructions.md
+++ b/.github/instructions/ci-actions.instructions.md
@@ -7,7 +7,5 @@ applyTo: ".github/workflows/*.{yml,yaml}"
 - `actions/setup-go` steps should use `go-version-file: go.mod` rather than a
   hardcoded `go-version` string. Hardcoded versions drift from `go.mod` and cause
   CI breakage.
-- When an endpoint's HTTP status code changes, verify that `scripts/smoke.sh` and
-  any integration tests are updated to expect the new code.
 - All GitHub Actions must be pinned to commit SHAs (not version tags) for supply
   chain security. The original version tag should be kept as an inline comment.

--- a/.github/instructions/go-api.instructions.md
+++ b/.github/instructions/go-api.instructions.md
@@ -33,7 +33,8 @@ HTTP handlers run concurrently (net/http). Check for:
 - Package-level variables read or written without synchronization
 - Shared caches, maps, or singletons accessed from handlers
 - Goroutines using `context.Background()` where `context.WithoutCancel(reqCtx)`
-  should be used (gosec G118)
+  should be used. This is review-only today; planned for machine enforcement once
+  `contextcheck` is enabled in `.golangci.yml`.
 
 ## Status code changes
 

--- a/.github/instructions/lint-config.instructions.md
+++ b/.github/instructions/lint-config.instructions.md
@@ -1,0 +1,70 @@
+---
+applyTo: ".golangci.yml"
+---
+
+# Lint Configuration Review
+
+The lint surface is intentionally curated, not maximal. Rules below describe the
+cadence and conventions established during Milestone 49 (PRs #1428-#1432, #1452).
+
+## Cadence: one linter per PR
+
+When enabling a new linter, the PR must contain both the enable and the full
+cleanup sweep in a single change. Splitting them produces a window where CI is
+red on `main` for unrelated work.
+
+- Run `golangci-lint cache clean && golangci-lint run --max-issues-per-linter 0
+  --max-same-issues 0 ./...` before sizing the sweep. The default cap of 50
+  issues per linter hides batches and produces under-scoped PRs.
+- For each violation, decide: real fix, justified `//nolint:foo // reason`
+  suppression, or config-level exclusion in `linters.exclusions.rules`. Avoid
+  config exclusions for paths that are not categorically exempt; per-site
+  `//nolint` with a reason is preferred because it survives refactors.
+
+## `//nolint` directive convention
+
+`nolintlint` is enabled with `require-explanation: true`. Every `//nolint:foo`
+directive must carry a `// reason` comment after the directive:
+
+```go
+defer f.Close() //nolint:errcheck // Close error not actionable on cleanup
+```
+
+The reason text is the friction that turns "I'll just nolint this" into either
+a real fix or a reviewable justification. Do not paper over the requirement
+with placeholder text like `// silence linter`.
+
+## Test-file exclusions are load-bearing
+
+`linters.exclusions.rules` excludes `gosec`, `errcheck`, and `noctx` from
+`_test.go` files. This is intentional, not aspirational; rewriting tests to pass
+these linters generates ceremony without value. The corresponding review-time
+rules live in `go-tests.instructions.md` and are the only enforcement for those
+classes in test code.
+
+## Custom function registration
+
+Linters that walk call sites by function name require explicit registration
+when handlers wrap a stdlib helper. The current example is `musttag`:
+
+```yaml
+musttag:
+  functions:
+    - name: github.com/sydlexius/stillwater/internal/api.writeJSON
+      tag: json
+      arg-pos: 2
+```
+
+When introducing a new response-wrapper helper (anything that hides
+`encoding/json` from the call site), register it here. Without registration,
+`musttag` only validates direct `json.Marshal` callers and silently misses every
+handler response that flows through the wrapper.
+
+## CI version pin
+
+`.github/workflows/ci.yml` pins the `golangci-lint` action to a specific
+version. Bumping the pin requires a probe PR: enable the new version against a
+clean cache and verify no transient or analyzer-regression findings appear
+before merging. The `gosec` taint analyzer in particular has produced phantom
+findings in past releases that did not reproduce locally; PR #1452 bumped the
+pin in that scenario.


### PR DESCRIPTION
## Summary

The three Copilot instruction files (`ci-actions`, `go-api`, `go-tests`) predated the M49 linter expansion (PRs #1428-#1432, #1452). This PR audits them against the now-enforced linter set and adds a new file codifying the cadence.

- **`ci-actions.instructions.md`**: Removed the misplaced "status code change should update smoke.sh / integration tests" rule. The file's `applyTo: .github/workflows/*.{yml,yaml}` means it never fires on handler code anyway, and the same rule lives correctly in `go-api.instructions.md`.
- **`go-api.instructions.md`**: Fixed the `gosec G118` mis-citation on the "use `context.WithoutCancel(reqCtx)` not `context.Background()`" rule. G118 is decompression-bomb detection; the actual machine-enforcement path is `contextcheck`, queued as a separate sweep.
- **`lint-config.instructions.md`** (new, `applyTo: .golangci.yml`): Codifies the M49 cadence so future contributors know to enable one linter per PR with the cleanup sweep bundled. Documents the `//nolint // reason` convention, why the `_test.go` exclusions for `gosec` / `errcheck` / `noctx` are load-bearing, and the `musttag` custom-function registration pattern.

The other rules in the audited files are review-only (semantic accuracy, error-path warnings, data-race patterns) and remain load-bearing — no linter replaces them. Net delta is small because the files were durable, not stale.

## Test plan

- [x] Pre-push gate (all hard checks pass; no Go source changes in scope)
- [x] `markdownlint` passes via pre-commit hook
- [ ] Visual review of the three files in the GitHub diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal GitHub Actions workflow configuration requirements for version management and consistency.
  * Established comprehensive linting configuration review guidelines defining update cadence and comment conventions.
  
* **Chores**
  * Refined concurrency review standards for Go development practices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1461)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->