### PR TITLE
chore(lint): enable contextcheck to enforce request-context propagation

### DIFF
--- a/.github/instructions/go-api.instructions.md
+++ b/.github/instructions/go-api.instructions.md
@@ -33,8 +33,18 @@ HTTP handlers run concurrently (net/http). Check for:
 - Package-level variables read or written without synchronization
 - Shared caches, maps, or singletons accessed from handlers
 - Goroutines using `context.Background()` where `context.WithoutCancel(reqCtx)`
-  should be used. This is review-only today; planned for machine enforcement once
-  `contextcheck` is enabled in `.golangci.yml`.
+  should be used. Machine-enforced by gosec G118 and `contextcheck`. The
+  suppression form depends on which rules actually fire:
+  - Direct `go fn(context.Background(), ...)` triggers both rules; suppress with
+    `//nolint:gosec,contextcheck // reason`.
+  - Boot-time constructors, helpers without a ctx parameter, and detached
+    bodies that first build `context.WithTimeout(context.Background(), ...)`
+    typically only fire `contextcheck`; suppress with `//nolint:contextcheck // reason`.
+  - Note that `contextcheck` cannot flag `context.Background()` inside an
+    http.Handler method whose signature is `(w, *http.Request)` -- the rule
+    needs a ctx parameter to compare against. Reviewer eyes still catch this
+    class; use `context.WithoutCancel(req.Context())` over bare `Background()`
+    when the handler spawns a goroutine that should inherit request values.
 
 ## Status code changes
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
   default: none
   enable:
     - bodyclose
+    - contextcheck
     - errcheck
     - errorlint
     - exhaustive
@@ -88,9 +89,26 @@ linters:
           - gosec
           - errcheck
           - noctx
+          - contextcheck
       - text: "catalogue.*is a misspelling"
         linters:
           - misspell
+      # contextcheck descends through the templ.Component interface boundary
+      # and reports synthetic cascade findings at every handler that calls a
+      # templ component. templ's runtime propagates ctx correctly via
+      # Render(ctx, w) but the static analyzer cannot see that across the
+      # interface, so the "should pass the context parameter" class fires on
+      # the hand-written call site. Suppressing only that error text leaves
+      # the "Non-inherited new context" class active in the same files --
+      # though note that class requires the enclosing function to have a
+      # `ctx context.Context` parameter to compare against, which most
+      # http.Handler methods (`(w, *http.Request)`) lack. Reviewer eyes still
+      # catch handler-method goroutines that should use
+      # `context.WithoutCancel(req.Context())` instead of bare Background.
+      - text: "should pass the context parameter"
+        path: 'internal/api/handlers.*\.go'
+        linters:
+          - contextcheck
 
 formatters:
   enable:

--- a/internal/api/handlers_inbound_webhook.go
+++ b/internal/api/handlers_inbound_webhook.go
@@ -15,6 +15,8 @@ import (
 
 // handleLidarrWebhook receives inbound webhook events from Lidarr.
 // POST /api/v1/webhooks/inbound/lidarr
+//
+//nolint:contextcheck // async webhook processing detaches via a fresh bounded context (see WithTimeout below); request returns before processing starts
 func (r *Router) handleLidarrWebhook(w http.ResponseWriter, req *http.Request) {
 	// Limit request body to 1 MB
 	req.Body = http.MaxBytesReader(w, req.Body, 1<<20)
@@ -189,6 +191,8 @@ func artistNameFromPayload(p webhook.LidarrPayload) string {
 
 // handleEmbyWebhook receives inbound webhook events from Emby.
 // POST /api/v1/webhooks/inbound/emby
+//
+//nolint:contextcheck // async webhook processing detaches via a fresh bounded context (see WithTimeout below); request returns before processing starts
 func (r *Router) handleEmbyWebhook(w http.ResponseWriter, req *http.Request) {
 	req.Body = http.MaxBytesReader(w, req.Body, 1<<20)
 
@@ -320,6 +324,8 @@ func (r *Router) handleEmbyLibraryScan(ctx context.Context) {
 
 // handleJellyfinWebhook receives inbound webhook events from the Jellyfin webhook plugin.
 // POST /api/v1/webhooks/inbound/jellyfin
+//
+//nolint:contextcheck // async webhook processing detaches via a fresh bounded context (see WithTimeout below); request returns before processing starts
 func (r *Router) handleJellyfinWebhook(w http.ResponseWriter, req *http.Request) {
 	req.Body = http.MaxBytesReader(w, req.Body, 1<<20)
 

--- a/internal/api/middleware/ratelimit.go
+++ b/internal/api/middleware/ratelimit.go
@@ -24,6 +24,8 @@ type LoginRateLimiter struct {
 
 // NewLoginRateLimiter creates a rate limiter that cleans up stale entries periodically.
 // The cleanup goroutine stops when the provided context is canceled.
+//
+//nolint:contextcheck // boot-time constructor; ctx is the long-lived app context that governs the cleanup goroutine, not a request ctx
 func NewLoginRateLimiter(ctx context.Context) *LoginRateLimiter {
 	if ctx == nil {
 		ctx = context.Background()

--- a/internal/rule/checkers.go
+++ b/internal/rule/checkers.go
@@ -81,12 +81,12 @@ func checkThumbExists(_ context.Context, a *artist.Artist, _ RuleConfig) *Violat
 // makeThumbSquareChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the thumbnail.
 func (e *Engine) makeThumbSquareChecker() Checker {
-	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.ThumbExists {
 			return nil // thumb_exists rule handles this case
 		}
 
-		w, h, err := e.getImageDimensionsResolved(a.ID, a.Path, "thumb", thumbPatterns)
+		w, h, err := e.getImageDimensionsResolved(ctx, a.ID, a.Path, "thumb", thumbPatterns)
 		if err != nil {
 			return nil // cannot read image; skip check
 		}
@@ -119,12 +119,12 @@ func (e *Engine) makeThumbSquareChecker() Checker {
 // makeThumbMinResChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the thumbnail.
 func (e *Engine) makeThumbMinResChecker() Checker {
-	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.ThumbExists {
 			return nil // thumb_exists rule handles this case
 		}
 
-		w, h, err := e.getImageDimensionsResolved(a.ID, a.Path, "thumb", thumbPatterns)
+		w, h, err := e.getImageDimensionsResolved(ctx, a.ID, a.Path, "thumb", thumbPatterns)
 		if err != nil {
 			return nil // cannot read image; skip check
 		}
@@ -209,11 +209,11 @@ func checkBioExists(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violat
 // makeFanartMinResChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the fanart.
 func (e *Engine) makeFanartMinResChecker() Checker {
-	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.FanartExists {
 			return nil // fanart_exists handles missing fanart
 		}
-		w, h, err := e.getImageDimensionsResolved(a.ID, a.Path, "fanart", fanartPatterns)
+		w, h, err := e.getImageDimensionsResolved(ctx, a.ID, a.Path, "fanart", fanartPatterns)
 		if err != nil {
 			return nil
 		}
@@ -241,11 +241,11 @@ func (e *Engine) makeFanartMinResChecker() Checker {
 // makeFanartAspectChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the fanart.
 func (e *Engine) makeFanartAspectChecker() Checker {
-	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.FanartExists {
 			return nil
 		}
-		w, h, err := e.getImageDimensionsResolved(a.ID, a.Path, "fanart", fanartPatterns)
+		w, h, err := e.getImageDimensionsResolved(ctx, a.ID, a.Path, "fanart", fanartPatterns)
 		if err != nil {
 			return nil
 		}
@@ -275,11 +275,11 @@ func (e *Engine) makeFanartAspectChecker() Checker {
 // makeLogoMinResChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the logo.
 func (e *Engine) makeLogoMinResChecker() Checker {
-	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.LogoExists {
 			return nil
 		}
-		w, _, err := e.getImageDimensionsResolved(a.ID, a.Path, "logo", logoPatterns)
+		w, _, err := e.getImageDimensionsResolved(ctx, a.ID, a.Path, "logo", logoPatterns)
 		if err != nil {
 			return nil
 		}
@@ -318,11 +318,11 @@ func checkBannerExists(_ context.Context, a *artist.Artist, _ RuleConfig) *Viola
 // makeBannerMinResChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the banner.
 func (e *Engine) makeBannerMinResChecker() Checker {
-	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.BannerExists {
 			return nil
 		}
-		w, h, err := e.getImageDimensionsResolved(a.ID, a.Path, "banner", bannerPatterns)
+		w, h, err := e.getImageDimensionsResolved(ctx, a.ID, a.Path, "banner", bannerPatterns)
 		if err != nil {
 			return nil
 		}
@@ -482,7 +482,7 @@ func (e *Engine) getLogoBoundsFromBytes(data []byte) (content, original goimage.
 // the logo through the platform image fetcher and caches the raw bytes only
 // when a violation is found, so the fixer can consume them.
 func (e *Engine) makeLogoPaddingChecker() Checker {
-	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.LogoExists {
 			return nil
 		}
@@ -525,7 +525,7 @@ func (e *Engine) makeLogoPaddingChecker() Checker {
 			if !cached {
 				var fetchErr error
 				data, _, fetchErr = e.imageFetcher.FetchArtistImage(
-					context.Background(), a.ID, "logo")
+					ctx, a.ID, "logo")
 				if fetchErr != nil {
 					e.logger.Debug("logo padding check skipped: API fetch failed",
 						slog.String("artist", a.Name),
@@ -743,21 +743,21 @@ func expectedImageFiles(profile *platform.Profile, artistPath string) map[string
 // backdrop3.jpg with no backdrop2.jpg). Gap detection is handled by the
 // backdrop_sequencing rule (#519).
 func (e *Engine) makeExtraneousImagesChecker() Checker {
-	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if a.Path == "" {
-			return e.checkExtraneousImagesFromDB(a, cfg)
+			return e.checkExtraneousImagesFromDB(ctx, a, cfg)
 		}
 
 		// When shared filesystem is detected, union expected files from all
 		// profiles to avoid flagging platform-written images.
-		if e.IsSharedFilesystem(context.Background(), a) && e.platformService != nil {
-			expected := expectedImageFilesAllProfiles(context.Background(), e.platformService, e.logger, a.Path)
+		if e.IsSharedFilesystem(ctx, a) && e.platformService != nil {
+			expected := expectedImageFilesAllProfiles(ctx, e.platformService, e.logger, a.Path)
 			return e.checkExtraneousAgainst(a, expected, cfg)
 		}
 
 		var profile *platform.Profile
 		if e.platformService != nil {
-			profile, _ = e.platformService.GetActive(context.Background())
+			profile, _ = e.platformService.GetActive(ctx)
 		}
 		expected := expectedImageFiles(profile, a.Path)
 
@@ -839,7 +839,7 @@ func (e *Engine) checkExtraneousAgainst(a *artist.Artist, expected map[string]bo
 // files, it queries the artist_images table for rows with unrecognized
 // image_type values or invalid slot_index values (e.g., slot_index > 0 for
 // non-fanart types, which only support a single slot).
-func (e *Engine) checkExtraneousImagesFromDB(a *artist.Artist, cfg RuleConfig) *Violation {
+func (e *Engine) checkExtraneousImagesFromDB(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 	if e.db == nil {
 		return nil
 	}
@@ -852,7 +852,7 @@ func (e *Engine) checkExtraneousImagesFromDB(a *artist.Artist, cfg RuleConfig) *
 		"banner": true,
 	}
 
-	rows, err := e.db.QueryContext(context.Background(),
+	rows, err := e.db.QueryContext(ctx,
 		`SELECT image_type, slot_index FROM artist_images WHERE artist_id = ?`,
 		a.ID)
 	if err != nil {
@@ -894,7 +894,7 @@ func (e *Engine) checkExtraneousImagesFromDB(a *artist.Artist, cfg RuleConfig) *
 	// artist_images row. These are images the platform knows about but
 	// Stillwater does not track, indicating unmanaged/orphaned images.
 	if e.imageFetcher != nil {
-		platformSlots, slotErr := e.imageFetcher.ListArtistImageSlots(context.Background(), a.ID)
+		platformSlots, slotErr := e.imageFetcher.ListArtistImageSlots(ctx, a.ID)
 		if slotErr == nil {
 			for imgType, count := range platformSlots {
 				for slot := 0; slot < count; slot++ {
@@ -1049,7 +1049,7 @@ func checkDirectoryNameMismatch(_ context.Context, a *artist.Artist, cfg RuleCon
 // pre-computed dHash values from the artist_images table and compares all
 // pairs using Hamming distance.
 func (e *Engine) makeImageDuplicateChecker() Checker {
-	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if a.Path == "" || e.db == nil {
 			return nil
 		}
@@ -1067,7 +1067,7 @@ func (e *Engine) makeImageDuplicateChecker() Checker {
 		// Select one hash per image_type (slot_index = 0) to compare across
 		// different types only. Within-type comparison (e.g. fanart slot 0 vs 1)
 		// is not the goal of this rule.
-		rows, err := e.db.QueryContext(context.Background(),
+		rows, err := e.db.QueryContext(ctx,
 			`SELECT image_type, phash FROM artist_images WHERE artist_id = ? AND slot_index = 0 AND exists_flag = 1 AND phash IS NOT NULL AND phash != '' AND phash != '0000000000000000'`,
 			a.ID)
 		if err != nil {
@@ -1148,14 +1148,14 @@ func checkMetadataQuality(_ context.Context, a *artist.Artist, cfg RuleConfig) *
 // backdrop3.jpg exist (gap at 1,2), or backdrop1.jpg exists without
 // backdrop.jpg (wrong starting point), a violation is returned.
 func (e *Engine) makeBackdropSequencingChecker() Checker {
-	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if a.Path == "" {
-			return e.checkBackdropSequencingFromDB(a, cfg)
+			return e.checkBackdropSequencingFromDB(ctx, a, cfg)
 		}
 
 		var profile *platform.Profile
 		if e.platformService != nil {
-			profile, _ = e.platformService.GetActive(context.Background())
+			profile, _ = e.platformService.GetActive(ctx)
 		}
 
 		var fanartNames []string
@@ -1211,12 +1211,12 @@ func (e *Engine) makeBackdropSequencingChecker() Checker {
 // backdrop sequencing checker. Instead of discovering fanart files on disk, it
 // queries the artist_images table for fanart slot indices and checks that they
 // form a contiguous 0..N-1 sequence with no gaps.
-func (e *Engine) checkBackdropSequencingFromDB(a *artist.Artist, cfg RuleConfig) *Violation {
+func (e *Engine) checkBackdropSequencingFromDB(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 	if e.db == nil {
 		return nil
 	}
 
-	rows, err := e.db.QueryContext(context.Background(),
+	rows, err := e.db.QueryContext(ctx,
 		`SELECT slot_index FROM artist_images WHERE artist_id = ? AND image_type = 'fanart' ORDER BY slot_index`,
 		a.ID)
 	if err != nil {
@@ -1276,10 +1276,10 @@ func (e *Engine) checkBackdropSequencingFromDB(a *artist.Artist, cfg RuleConfig)
 // the active platform profile (falling back to defaults) and sums the discovered
 // files for each pattern. Duplicate files across patterns are not double-counted
 // A `seen` map deduplicates files that appear under multiple naming patterns.
-func (e *Engine) countBackdrops(dir string) int {
+func (e *Engine) countBackdrops(ctx context.Context, dir string) int {
 	var profile *platform.Profile
 	if e.platformService != nil {
-		profile, _ = e.platformService.GetActive(context.Background())
+		profile, _ = e.platformService.GetActive(ctx)
 	}
 
 	var fanartNames []string
@@ -1312,12 +1312,12 @@ func (e *Engine) countBackdrops(dir string) int {
 // countBackdropsFromDB counts the number of fanart image slots recorded in the
 // artist_images table for the given artist. Used for API-imported artists that
 // have no local filesystem path.
-func (e *Engine) countBackdropsFromDB(artistID string) int {
+func (e *Engine) countBackdropsFromDB(ctx context.Context, artistID string) int {
 	if e.db == nil {
 		return 0
 	}
 	var count int
-	err := e.db.QueryRowContext(context.Background(),
+	err := e.db.QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM artist_images WHERE artist_id = ? AND image_type = 'fanart' AND exists_flag = 1`,
 		artistID).Scan(&count)
 	if err != nil {
@@ -1333,7 +1333,7 @@ func (e *Engine) countBackdropsFromDB(artistID string) int {
 // scanning the directory. For API-imported artists (no path), the artist_images
 // table is queried instead.
 func (e *Engine) makeBackdropMinCountChecker() Checker {
-	return func(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		minCount := cfg.MinCount
 		if minCount <= 0 {
 			minCount = 1 // safety default
@@ -1341,9 +1341,9 @@ func (e *Engine) makeBackdropMinCountChecker() Checker {
 
 		var count int
 		if a.Path != "" {
-			count = e.countBackdrops(a.Path)
+			count = e.countBackdrops(ctx, a.Path)
 		} else {
-			count = e.countBackdropsFromDB(a.ID)
+			count = e.countBackdropsFromDB(ctx, a.ID)
 		}
 
 		if count >= minCount {

--- a/internal/rule/checkers_test.go
+++ b/internal/rule/checkers_test.go
@@ -913,7 +913,7 @@ func TestCheckBackdropSequencing_SingleFile(t *testing.T) {
 func TestCountBackdrops_Empty(t *testing.T) {
 	dir := t.TempDir()
 	e := &Engine{platformService: nil}
-	count := e.countBackdrops(dir)
+	count := e.countBackdrops(context.Background(), dir)
 	if count != 0 {
 		t.Errorf("countBackdrops empty dir = %d, want 0", count)
 	}
@@ -924,7 +924,7 @@ func TestCountBackdrops_SingleFanart(t *testing.T) {
 	createTestJPEG(t, filepath.Join(dir, "fanart.jpg"), 1920, 1080)
 
 	e := &Engine{platformService: nil}
-	count := e.countBackdrops(dir)
+	count := e.countBackdrops(context.Background(), dir)
 	if count != 1 {
 		t.Errorf("countBackdrops single = %d, want 1", count)
 	}
@@ -937,7 +937,7 @@ func TestCountBackdrops_MultipleFanart(t *testing.T) {
 	createTestJPEG(t, filepath.Join(dir, "fanart3.jpg"), 1920, 1080)
 
 	e := &Engine{platformService: nil}
-	count := e.countBackdrops(dir)
+	count := e.countBackdrops(context.Background(), dir)
 	if count < 3 {
 		t.Errorf("countBackdrops multiple = %d, want >= 3", count)
 	}
@@ -950,7 +950,7 @@ func TestCountBackdrops_IgnoresNonFanart(t *testing.T) {
 	createTestJPEG(t, filepath.Join(dir, "logo.png"), 400, 200)
 
 	e := &Engine{platformService: nil}
-	count := e.countBackdrops(dir)
+	count := e.countBackdrops(context.Background(), dir)
 	if count != 1 {
 		t.Errorf("countBackdrops with non-fanart = %d, want 1", count)
 	}
@@ -1455,7 +1455,7 @@ func TestGetImageDimensionsFromDB(t *testing.T) {
 	e := &Engine{db: db, logger: slog.Default()}
 
 	// No row: returns (0, 0, nil).
-	w, h, err := e.getImageDimensionsFromDB("nonexistent", "thumb")
+	w, h, err := e.getImageDimensionsFromDB(context.Background(), "nonexistent", "thumb")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1466,7 +1466,7 @@ func TestGetImageDimensionsFromDB(t *testing.T) {
 	// Insert a row with real dimensions.
 	seedImageDimensions(t, db, "artist-1", "thumb", 600, 600)
 
-	w, h, err = e.getImageDimensionsFromDB("artist-1", "thumb")
+	w, h, err = e.getImageDimensionsFromDB(context.Background(), "artist-1", "thumb")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1475,7 +1475,7 @@ func TestGetImageDimensionsFromDB(t *testing.T) {
 	}
 
 	// Different image type returns (0, 0) when not seeded.
-	w, h, err = e.getImageDimensionsFromDB("artist-1", "fanart")
+	w, h, err = e.getImageDimensionsFromDB(context.Background(), "artist-1", "fanart")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1487,7 +1487,7 @@ func TestGetImageDimensionsFromDB(t *testing.T) {
 func TestGetImageDimensionsFromDB_NilDB(t *testing.T) {
 	e := &Engine{db: nil, logger: slog.Default()}
 
-	w, h, err := e.getImageDimensionsFromDB("artist-1", "thumb")
+	w, h, err := e.getImageDimensionsFromDB(context.Background(), "artist-1", "thumb")
 	if err != nil {
 		t.Fatalf("unexpected error with nil db: %v", err)
 	}
@@ -1503,7 +1503,7 @@ func TestGetImageDimensionsResolved_DBFirst(t *testing.T) {
 	seedImageDimensions(t, db, "artist-2", "fanart", 1920, 1080)
 
 	// DB has dimensions: should return them even with empty Path.
-	w, h, err := e.getImageDimensionsResolved("artist-2", "", "fanart", fanartPatterns)
+	w, h, err := e.getImageDimensionsResolved(context.Background(), "artist-2", "", "fanart", fanartPatterns)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1520,7 +1520,7 @@ func TestGetImageDimensionsResolved_FallbackToFS(t *testing.T) {
 	dir := t.TempDir()
 	createTestJPEG(t, filepath.Join(dir, "fanart.jpg"), 1920, 1080)
 
-	w, h, err := e.getImageDimensionsResolved("artist-3", dir, "fanart", fanartPatterns)
+	w, h, err := e.getImageDimensionsResolved(context.Background(), "artist-3", dir, "fanart", fanartPatterns)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1534,7 +1534,7 @@ func TestGetImageDimensionsResolved_NoDBNoFS(t *testing.T) {
 	e := &Engine{db: db, logger: slog.Default()}
 
 	// No DB dimensions and empty path: should return an error.
-	_, _, err := e.getImageDimensionsResolved("artist-4", "", "thumb", thumbPatterns)
+	_, _, err := e.getImageDimensionsResolved(context.Background(), "artist-4", "", "thumb", thumbPatterns)
 	if err == nil {
 		t.Error("expected error when neither DB nor filesystem can provide dimensions")
 	}
@@ -1921,7 +1921,7 @@ func TestCheckExtraneousImagesFromDB_ValidImages(t *testing.T) {
 
 	e := &Engine{db: db, logger: slog.Default()}
 	a := &artist.Artist{ID: "art-1", Name: "Test Artist", Path: ""}
-	v := e.checkExtraneousImagesFromDB(a, RuleConfig{})
+	v := e.checkExtraneousImagesFromDB(context.Background(), a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil for artist with only valid images, got: %s", v.Message)
 	}
@@ -1935,7 +1935,7 @@ func TestCheckExtraneousImagesFromDB_UnknownImageType(t *testing.T) {
 
 	e := &Engine{db: db, logger: slog.Default()}
 	a := &artist.Artist{ID: "art-2", Name: "Test Artist 2", Path: ""}
-	v := e.checkExtraneousImagesFromDB(a, RuleConfig{})
+	v := e.checkExtraneousImagesFromDB(context.Background(), a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation for unknown image_type 'poster'")
 	}
@@ -1958,7 +1958,7 @@ func TestCheckExtraneousImagesFromDB_InvalidSlotIndex(t *testing.T) {
 
 	e := &Engine{db: db, logger: slog.Default()}
 	a := &artist.Artist{ID: "art-3", Name: "Test Artist 3", Path: ""}
-	v := e.checkExtraneousImagesFromDB(a, RuleConfig{})
+	v := e.checkExtraneousImagesFromDB(context.Background(), a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation for thumb with slot_index > 0")
 	}
@@ -1976,7 +1976,7 @@ func TestCheckExtraneousImagesFromDB_FanartMultiSlotValid(t *testing.T) {
 
 	e := &Engine{db: db, logger: slog.Default()}
 	a := &artist.Artist{ID: "art-4", Name: "Test Artist 4", Path: ""}
-	v := e.checkExtraneousImagesFromDB(a, RuleConfig{})
+	v := e.checkExtraneousImagesFromDB(context.Background(), a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil for fanart with multiple valid slots, got: %s", v.Message)
 	}
@@ -1988,7 +1988,7 @@ func TestCheckExtraneousImagesFromDB_NoImages(t *testing.T) {
 
 	e := &Engine{db: db, logger: slog.Default()}
 	a := &artist.Artist{ID: "art-5", Name: "Test Artist 5", Path: ""}
-	v := e.checkExtraneousImagesFromDB(a, RuleConfig{})
+	v := e.checkExtraneousImagesFromDB(context.Background(), a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil for artist with no images, got: %s", v.Message)
 	}
@@ -1997,7 +1997,7 @@ func TestCheckExtraneousImagesFromDB_NoImages(t *testing.T) {
 func TestCheckExtraneousImagesFromDB_NilDB(t *testing.T) {
 	e := &Engine{db: nil, logger: slog.Default()}
 	a := &artist.Artist{ID: "art-6", Name: "Test Artist 6", Path: ""}
-	v := e.checkExtraneousImagesFromDB(a, RuleConfig{})
+	v := e.checkExtraneousImagesFromDB(context.Background(), a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil when db is nil, got: %s", v.Message)
 	}
@@ -2015,7 +2015,7 @@ func TestCheckExtraneousImagesFromDB_PlatformUntracked(t *testing.T) {
 	}
 	e := &Engine{db: db, logger: slog.Default(), imageFetcher: mock}
 	a := &artist.Artist{ID: "art-plat-1", Name: "Platform Artist", Path: ""}
-	v := e.checkExtraneousImagesFromDB(a, RuleConfig{})
+	v := e.checkExtraneousImagesFromDB(context.Background(), a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation for platform-reported fanart with no DB row")
 	}
@@ -2049,7 +2049,7 @@ func TestCheckExtraneousImagesFromDB_PlatformAllTracked(t *testing.T) {
 	}
 	e := &Engine{db: db, logger: slog.Default(), imageFetcher: mock}
 	a := &artist.Artist{ID: "art-plat-2", Name: "Tracked Artist", Path: ""}
-	v := e.checkExtraneousImagesFromDB(a, RuleConfig{})
+	v := e.checkExtraneousImagesFromDB(context.Background(), a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil when all platform slots are tracked in DB, got: %s", v.Message)
 	}
@@ -2067,7 +2067,7 @@ func TestCheckExtraneousImagesFromDB_PlatformFetchError(t *testing.T) {
 	}
 	e := &Engine{db: db, logger: slog.Default(), imageFetcher: mock}
 	a := &artist.Artist{ID: "art-plat-3", Name: "Error Artist", Path: ""}
-	v := e.checkExtraneousImagesFromDB(a, RuleConfig{})
+	v := e.checkExtraneousImagesFromDB(context.Background(), a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil when platform fetch fails, got: %s", v.Message)
 	}
@@ -2081,7 +2081,7 @@ func TestCheckExtraneousImagesFromDB_NoFetcher(t *testing.T) {
 
 	e := &Engine{db: db, logger: slog.Default()} // no imageFetcher
 	a := &artist.Artist{ID: "art-plat-4", Name: "No Fetcher Artist", Path: ""}
-	v := e.checkExtraneousImagesFromDB(a, RuleConfig{})
+	v := e.checkExtraneousImagesFromDB(context.Background(), a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil for valid DB rows with no fetcher, got: %s", v.Message)
 	}
@@ -2098,7 +2098,7 @@ func TestCheckBackdropSequencingFromDB_Contiguous(t *testing.T) {
 
 	e := &Engine{db: db, logger: slog.Default()}
 	a := &artist.Artist{ID: "art-10", Name: "Test Artist 10", Path: ""}
-	v := e.checkBackdropSequencingFromDB(a, RuleConfig{})
+	v := e.checkBackdropSequencingFromDB(context.Background(), a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil for contiguous fanart slots, got: %s", v.Message)
 	}
@@ -2112,7 +2112,7 @@ func TestCheckBackdropSequencingFromDB_WithGap(t *testing.T) {
 
 	e := &Engine{db: db, logger: slog.Default()}
 	a := &artist.Artist{ID: "art-11", Name: "Test Artist 11", Path: ""}
-	v := e.checkBackdropSequencingFromDB(a, RuleConfig{})
+	v := e.checkBackdropSequencingFromDB(context.Background(), a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation for gap in fanart slot sequence")
 	}
@@ -2134,7 +2134,7 @@ func TestCheckBackdropSequencingFromDB_NoFanart(t *testing.T) {
 
 	e := &Engine{db: db, logger: slog.Default()}
 	a := &artist.Artist{ID: "art-12", Name: "Test Artist 12", Path: ""}
-	v := e.checkBackdropSequencingFromDB(a, RuleConfig{})
+	v := e.checkBackdropSequencingFromDB(context.Background(), a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil when no fanart images exist, got: %s", v.Message)
 	}
@@ -2147,7 +2147,7 @@ func TestCheckBackdropSequencingFromDB_SingleFanart(t *testing.T) {
 
 	e := &Engine{db: db, logger: slog.Default()}
 	a := &artist.Artist{ID: "art-13", Name: "Test Artist 13", Path: ""}
-	v := e.checkBackdropSequencingFromDB(a, RuleConfig{})
+	v := e.checkBackdropSequencingFromDB(context.Background(), a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil for single fanart image, got: %s", v.Message)
 	}
@@ -2156,7 +2156,7 @@ func TestCheckBackdropSequencingFromDB_SingleFanart(t *testing.T) {
 func TestCheckBackdropSequencingFromDB_NilDB(t *testing.T) {
 	e := &Engine{db: nil, logger: slog.Default()}
 	a := &artist.Artist{ID: "art-14", Name: "Test Artist 14", Path: ""}
-	v := e.checkBackdropSequencingFromDB(a, RuleConfig{})
+	v := e.checkBackdropSequencingFromDB(context.Background(), a, RuleConfig{})
 	if v != nil {
 		t.Errorf("expected nil when db is nil, got: %s", v.Message)
 	}
@@ -2170,7 +2170,7 @@ func TestCheckBackdropSequencingFromDB_StartsAtNonZero(t *testing.T) {
 
 	e := &Engine{db: db, logger: slog.Default()}
 	a := &artist.Artist{ID: "art-15", Name: "Test Artist 15", Path: ""}
-	v := e.checkBackdropSequencingFromDB(a, RuleConfig{})
+	v := e.checkBackdropSequencingFromDB(context.Background(), a, RuleConfig{})
 	if v == nil {
 		t.Fatal("expected violation when fanart starts at slot 1 instead of 0")
 	}

--- a/internal/rule/fscache.go
+++ b/internal/rule/fscache.go
@@ -381,11 +381,11 @@ func (e *Engine) getImageDimensionsCached(dirPath string, patterns []string) (in
 // of a specific image type (slot 0, exists_flag = 1). Returns (0, 0, nil) when
 // the row exists but dimensions are not populated, or when no matching row
 // exists. An error is only returned on actual database failures.
-func (e *Engine) getImageDimensionsFromDB(artistID, imageType string) (int, int, error) {
+func (e *Engine) getImageDimensionsFromDB(ctx context.Context, artistID, imageType string) (int, int, error) {
 	if e.db == nil {
 		return 0, 0, nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	var w, h int
@@ -410,9 +410,9 @@ func (e *Engine) getImageDimensionsFromDB(artistID, imageType string) (int, int,
 // checks to work for API-imported artists (no filesystem path) as long as some
 // pipeline (e.g., scanner or provider image downloads) has populated the
 // artist_images width/height columns.
-func (e *Engine) getImageDimensionsResolved(artistID, dirPath, imageType string, patterns []string) (int, int, error) {
+func (e *Engine) getImageDimensionsResolved(ctx context.Context, artistID, dirPath, imageType string, patterns []string) (int, int, error) {
 	// Try DB first -- works for both filesystem and API-imported artists.
-	w, h, err := e.getImageDimensionsFromDB(artistID, imageType)
+	w, h, err := e.getImageDimensionsFromDB(ctx, artistID, imageType)
 	if err != nil {
 		return 0, 0, fmt.Errorf("querying dimensions from DB: %w", err)
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -121,7 +121,7 @@ func (s *Service) Run(ctx context.Context) (*ScanResult, error) {
 	// Use the shutdown context so the scan outlives the HTTP request but
 	// is still canceled on application shutdown.
 	s.scanWg.Add(1)
-	go s.runScan(s.shutdownCtx, result)
+	go s.runScan(s.shutdownCtx, result) //nolint:contextcheck // intentional -- scan goroutine must outlive request; scoped to shutdownCtx for app-level cancellation
 
 	return &snapshot, nil
 }

--- a/internal/server/listeners.go
+++ b/internal/server/listeners.go
@@ -52,6 +52,8 @@ type listenerEntry struct {
 // shuts down all listeners in parallel with a shared 10s deadline. The
 // first non-http.ErrServerClosed start error wins; otherwise every
 // non-nil shutdown error is wrapped together via errors.Join.
+//
+//nolint:contextcheck // boot-time entry point; ctx originates from main's signal handler and is the long-lived app context, not inherited from a caller's request ctx
 func RunListeners(ctx context.Context, cfg *config.Config, handler http.Handler, logger *slog.Logger) error {
 	if cfg == nil {
 		return errors.New("server: nil config")

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -813,7 +813,7 @@ func (s *Service) Apply(ctx context.Context) error {
 	// HTTP request. The handler already detaches via context.WithoutCancel, but
 	// using context.Background() here makes the intent explicit at the service
 	// layer and avoids any inherited deadline or cancellation from the caller.
-	go s.runApply(context.Background(), "") //nolint:gosec // G118: intentional -- goroutine must outlive request context
+	go s.runApply(context.Background(), "") //nolint:gosec,contextcheck // gosec G118 + contextcheck both fire on this line; apply goroutine intentionally outlives request context (handler already detaches via WithoutCancel)
 	return nil
 }
 
@@ -1434,7 +1434,7 @@ func (s *Service) maybeAutoApply(_ context.Context, cfg Config, result CheckResu
 	// Apply is async; writing the marker here at kickoff time would
 	// record an "applied" event for downloads that ultimately failed
 	// checksum or extraction.
-	if err := s.applyAuto(result.Latest); err != nil {
+	if err := s.applyAuto(result.Latest); err != nil { //nolint:contextcheck // applyAuto detaches by design; goroutine must outlive scheduler tick
 		// ErrAlreadyRunning / ErrRestartRequired are expected when the
 		// admin already triggered a manual Apply. Anything else is a
 		// real failure but still non-fatal for the scheduler.
@@ -1453,8 +1453,9 @@ func (s *Service) maybeAutoApply(_ context.Context, cfg Config, result CheckResu
 // Takes no ctx because runApply uses context.Background() (the goroutine
 // must outlive the originating tick); the marker write also uses a
 // fresh background context for the same reason. Keeping the signature
-// ctx-free makes that intent explicit and avoids the gosec G118
-// false-positive on a deliberately detached goroutine.
+// ctx-free makes that intent explicit; the contextcheck suppression at
+// the call site documents that applyAuto has no ctx parameter by design
+// because its internal goroutine (below) must outlive the scheduler tick.
 func (s *Service) applyAuto(candidateVersion string) error {
 	if s.isDocker {
 		return fmt.Errorf("binary update is not supported in Docker environments")


### PR DESCRIPTION
## Summary

Continues the M49 lint expansion thread (#1428-#1432, #1452). Probing contextcheck against the existing tree surfaced 141 findings; triage showed 120 are false positives from contextcheck's static analysis descending through the `templ.Component` interface boundary -- templ's runtime propagates ctx correctly via `Render(ctx, w)` but the analyzer cannot see that across the interface. The remaining 21 split into real ctx-propagation gaps in `internal/rule/` and intentional long-lived goroutines elsewhere.

**Real refactors:**
- `internal/rule/fscache.go`: `getImageDimensionsFromDB` and `getImageDimensionsResolved` accept ctx; the timeout derives from it.
- `internal/rule/checkers.go`: ctx threaded through every dimension-checker closure plus the leaf helpers (`checkExtraneousImagesFromDB`, `checkBackdropSequencingFromDB`, `countBackdrops`, `countBackdropsFromDB`, image-fetcher / platform-service / DB-query call sites). 27 test callers updated.

**Justified suppressions (long-lived goroutines, ctx-by-design):**
- `internal/updater/updater.go:816` -- apply goroutine outlives request. Note: gosec G118 IS the goroutine-context rule (not decompression-bomb as PR #1461's audit claimed); both gosec and contextcheck fire here, so the directive is now `//nolint:gosec,contextcheck`.
- `internal/scanner/scanner.go:124` -- scan goroutine scoped to `shutdownCtx`.
- `internal/api/middleware/ratelimit.go:27` -- boot-time constructor.
- `internal/server/listeners.go:55` -- boot-time entry point.
- `internal/api/handlers_inbound_webhook.go` (3 sites) -- async webhook processing detaches via fresh bounded context.

**Config (`.golangci.yml`):** enable `contextcheck`, add it to the `_test.go` exclusion list, and add a templ-cascade exclusion (`text: "should pass the context parameter"` + `path: 'internal/api/handlers.*\.go'`) that suppresses only the synthetic interface-descent class while leaving the "Non-inherited new context" class active.

**Also corrects PR #1461's `go-api.instructions.md` edit:** gosec G118 is the real machine-enforcement of the goroutine-context rule, not decompression-bomb. Rule guidance now distinguishes when `gosec,contextcheck` is required vs. `contextcheck`-only.

## Follow-ups (filed during review)

- #1463 -- webhook goroutines bypass app-shutdown sequencing (architectural; pattern improvement)
- #1464 -- `Service.Apply(ctx)` accepts ctx but discards it (misleading signature)
- #1465 -- `handlers_image.go` ClearImageFlag goroutine uses bare Background and has no panic recovery

These are pre-existing patterns the contextcheck rollout surfaced but did not fix in this PR -- contextcheck cannot statically flag handler-method goroutines (its rule needs a `ctx context.Context` parameter to compare against). The `.golangci.yml` comment block now documents this coverage limit honestly.

Closes #1462

## Test plan

- [x] `go test -race -count=1 ./...` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Patch coverage 86.96% (40/46 lines), threshold 70%
- [x] OpenAPI consistency test passes
- [x] Local review-toolkit run (code-reviewer + silent-failure-hunter + comment-analyzer) -- findings addressed in-PR or filed as #1463/#1464/#1465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal code quality checks and context handling patterns to improve application reliability and maintainability.

---

**Note:** This release contains internal improvements with no user-facing changes or new features.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1466)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->