### PR TITLE
test(fuzz): add FuzzExifMetaParse, FuzzDetectFormat, FuzzImageHashHexParse

### DIFF
--- a/internal/image/fuzz_test.go
+++ b/internal/image/fuzz_test.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"image/jpeg"
 	"image/png"
+	"io"
 	"testing"
 )
 
@@ -103,4 +104,146 @@ func encodeJPEG(f interface {
 		f.Fatalf("encoding JPEG seed: %v", err)
 	}
 	return buf.Bytes()
+}
+
+// FuzzExifMetaParse feeds arbitrary strings to ParseExifMeta. It must never
+// panic -- returning an error for malformed input is expected and correct.
+func FuzzExifMetaParse(f *testing.F) {
+	// Known-good Stillwater provenance strings.
+	f.Add("stillwater:v1|source=fanarttv|fetched=2024-01-15T12:00:00Z|url=https://example.com/img.jpg|dhash=abcdef0123456789|rule=artist-thumb|mode=auto")
+	f.Add("stillwater:v1|source=musicbrainz|fetched=2025-06-01T00:00:00Z|url=https://mb.org/a/b?x=1&y=2|dhash=0000000000000000|rule=artist-fanart|mode=manual")
+	f.Add("stillwater:v1|source=user|fetched=2024-03-20T08:30:00Z|url=https://site.example/path%7Cwith%25pipe|dhash=ffffffffffffffff|rule=|mode=user")
+	// Prefix only (no fields).
+	f.Add("stillwater:v1")
+	// Empty string (valid; returns zero struct).
+	f.Add("")
+	// Non-Stillwater strings (should be ignored, no error).
+	f.Add("not a stillwater string")
+	f.Add("ImageDescription=some other app")
+	// Truncated EXIF strings.
+	f.Add("stillwater:v1|source=")
+	f.Add("stillwater:v1|")
+	f.Add("stillwater:v1|fetched=2024-01-15T12:00:00Z|source")
+	// Fields with no '=' separator.
+	f.Add("stillwater:v1|noequalssign|source=x")
+	// Mismatched delimiters.
+	f.Add("stillwater:v1||source=x||")
+	f.Add("stillwater:v1|source=a|b|c=d")
+	// Binary-ish bytes in values (high-bit chars, NULs, etc.).
+	f.Add("stillwater:v1|source=\x00\xff\xfe\x01|mode=auto")
+	f.Add("stillwater:v1|url=https://host/\xff\xfe\x80path")
+	// UTF-16 BOMs in input.
+	f.Add("\xff\xfestillwater:v1|source=x")
+	f.Add("\xfe\xffstillwater:v1|source=x")
+	// Very long strings.
+	f.Add("stillwater:v1|source=" + string(make([]byte, 1<<20)))
+	// Malformed fetched timestamp.
+	f.Add("stillwater:v1|fetched=not-a-time")
+	f.Add("stillwater:v1|fetched=2024-99-99T99:99:99Z")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		// Must not panic. Errors on invalid input are expected.
+		_, _ = ParseExifMeta(s)
+	})
+}
+
+// FuzzDetectFormat feeds arbitrary byte slices to DetectFormat. It must never
+// panic. For inputs that succeed (nil error), it verifies that the returned
+// replay reader reproduces the original bytes exactly.
+func FuzzDetectFormat(f *testing.F) {
+	// Valid JPEG magic bytes.
+	f.Add(encodeJPEG(f, solidImage(10, 10, color.White)))
+	f.Add(encodeJPEG(f, solidImage(100, 100, color.RGBA{R: 200, G: 100, B: 50, A: 255})))
+	// Valid PNG magic bytes.
+	f.Add(encodePNG(f, solidImage(10, 10, color.Black)))
+	f.Add(encodePNG(f, solidImage(50, 50, color.RGBA{R: 0, G: 128, B: 255, A: 255})))
+	// Valid WebP magic bytes: RIFF....WEBP header with minimal content.
+	f.Add([]byte{'R', 'I', 'F', 'F', 0x1C, 0x00, 0x00, 0x00, 'W', 'E', 'B', 'P', 'V', 'P', '8', 'L'})
+	// Valid GIF magic bytes (DetectFormat doesn't return "gif" but the unrecognized-format branch must not panic).
+	f.Add([]byte{'G', 'I', 'F', '8', '7', 'a'})
+	f.Add([]byte{'G', 'I', 'F', '8', '9', 'a'})
+	// Truncated headers: 0, 1, 3, 8 bytes.
+	f.Add([]byte{})
+	f.Add([]byte{0xFF})
+	f.Add([]byte{0xFF, 0xD8, 0xFF})
+	f.Add([]byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A})
+	// Polyglot: valid PNG signature followed by JPEG content.
+	f.Add(append([]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}, []byte{0xFF, 0xD8, 0xFF, 0xE0}...))
+	// Valid magic but truncated body (just the first 3 bytes of a JPEG).
+	f.Add([]byte{0xFF, 0xD8, 0xFF})
+	// Single-byte stream.
+	f.Add([]byte{0x00})
+	// Random garbage data.
+	f.Add([]byte("not an image"))
+	f.Add([]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		r := bytes.NewReader(data)
+		_, replay, err := DetectFormat(r)
+		if err != nil {
+			// Unrecognized format is expected -- no panic is the goal.
+			return
+		}
+
+		// For successful detections, the replay reader must reproduce all
+		// original bytes so that subsequent decoders see the full image data.
+		replayed, readErr := io.ReadAll(replay)
+		if readErr != nil {
+			t.Fatalf("reading replay reader failed: %v", readErr)
+		}
+		if !bytes.Equal(replayed, data) {
+			t.Errorf("replay reader mismatch: got %d bytes, want %d bytes", len(replayed), len(data))
+		}
+	})
+}
+
+// FuzzImageHashHexParse feeds arbitrary strings to ParseHashHex. It must never
+// panic. For successful parses, it round-trips through HashHex and verifies
+// that re-parsing yields the same value.
+func FuzzImageHashHexParse(f *testing.F) {
+	// Valid 16-char lowercase hex strings.
+	f.Add("0000000000000000")
+	f.Add("ffffffffffffffff")
+	f.Add("abcdef0123456789")
+	f.Add("deadbeefcafebabe")
+	// Valid mixed-case hex.
+	f.Add("ABCDEF0123456789")
+	f.Add("AbCdEf0123456789")
+	f.Add("DeAdBeEfCaFe1234")
+	// Zero-length input.
+	f.Add("")
+	// Oversize inputs.
+	f.Add("0000000000000000f")
+	f.Add("00000000000000000000000000000000")
+	// Hex with leading "0x" prefix (not valid for ParseUint base-16).
+	f.Add("0xabcdef01234567")
+	f.Add("0XABCDEF01234567")
+	// Hex with internal whitespace.
+	f.Add("abcdef01 23456789")
+	f.Add("abcdef01\t23456789")
+	f.Add("abcdef01\n23456789")
+	// Unicode lookalike characters (e.g. fullwidth hex digits, Cyrillic).
+	f.Add("０１２３４５６７８９０１２３４５") // fullwidth 0-9 * 16
+	f.Add("аbcdef0123456789") // Cyrillic 'а' instead of Latin 'a'
+	// Exactly 15 chars (too short) and 17 chars (too long).
+	f.Add("000000000000000")
+	f.Add("00000000000000000")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		val, err := ParseHashHex(s)
+		if err != nil {
+			// Invalid input is expected -- no panic is the goal.
+			return
+		}
+
+		// Round-trip: HashHex then ParseHashHex must recover the same value.
+		hexStr := HashHex(val)
+		val2, err2 := ParseHashHex(hexStr)
+		if err2 != nil {
+			t.Fatalf("ParseHashHex(%q) succeeded but round-trip ParseHashHex(%q) failed: %v", s, hexStr, err2)
+		}
+		if val != val2 {
+			t.Errorf("round-trip mismatch: original=%016x, after HashHex+ParseHashHex=%016x", val, val2)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- M49 W3 sub-task 3C. Bundles three fuzz targets for `internal/image/`:
  - `FuzzExifMetaParse` -> `ParseExifMeta` (exif.go:77) -- 20 seeds, 408,751 execs/10s
  - `FuzzDetectFormat` -> `DetectFormat` (processor.go:83) -- 13 seeds, 72,081 execs/10s
  - `FuzzImageHashHexParse` -> `ParseHashHex` (hash.go:67) -- 19 seeds, 291,158 execs/10s

All three are co-located in `internal/image/fuzz_test.go` next to the existing `FuzzPerceptualHash` and `FuzzPerceptualHashDeterminism`.

## Acceptance-criteria asserts
- `FuzzDetectFormat`: when `DetectFormat` returns `nil` error, the body calls `io.ReadAll(replay)` and asserts byte-for-byte equality with the input slice. Catches any replay-reader implementation that loses bytes for valid headers.
- `FuzzImageHashHexParse`: on successful parse, the body round-trips through `HashHex` and re-parses, asserting the value matches. (Issue body referenced `FormatHashHex`; actual function name is `HashHex`.)

## Note
The pre-commit `typos` hook flagged a hex seed containing `BaBe`; replaced with `DeAdBeEfCaFe1234` (semantically equivalent coverage). `FuzzDetectFormat`'s execution rate plateaus after ~70k execs because `DetectFormat` has a very shallow branching structure (12-byte header read + small set of magic comparisons) -- the corpus exhausts coverage quickly, which is expected.

## Test plan
- [x] `go test ./internal/image/...`
- [x] All three fuzz runs at 10s, no panics
- [x] `golangci-lint run ./internal/image/...` clean

Closes #1363.
Closes #1364.
Closes #1370.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added fuzz testing for image handling: metadata parsing, format detection, and image-hash parsing/round-trip. Ensures no panics on malformed inputs, verifies successful detections replay original bytes exactly, and confirms stable round-trip behavior for parsed hashes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1472)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->