### PR TITLE
test(fuzz): add FuzzEncryptionDecrypt for encryption.Encryptor.Decrypt

### DIFF
--- a/internal/encryption/encryption_fuzz_test.go
+++ b/internal/encryption/encryption_fuzz_test.go
@@ -1,0 +1,91 @@
+package encryption
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+// FuzzEncryptionDecrypt feeds arbitrary strings to Encryptor.Decrypt to verify
+// it never panics. Every stored secret in Stillwater (provider API keys, OIDC
+// client secret, federated-auth tokens) flows through this function, so
+// panic-safety is a hard requirement.
+//
+// The target function does: base64 decode -> length check against nonce size ->
+// AES-GCM Open. Seeds exercise truncated nonces, bad padding, empty input,
+// Unicode, CRLF-embedded base64, and ciphertexts with swapped AAD or truncated
+// tags.
+func FuzzEncryptionDecrypt(f *testing.F) {
+	// Build a working Encryptor to generate valid seed ciphertexts.
+	// NewEncryptor("") generates a random 32-byte key and returns it
+	// base64-encoded alongside the Encryptor. The returned key is not used
+	// here because we only need the Encryptor for seed generation.
+	enc, _, err := NewEncryptor("")
+	if err != nil {
+		f.Fatalf("constructing test Encryptor: %v", err)
+	}
+
+	// Seed 1: a valid Encrypt() output -- the happy-path round-trip case.
+	validCiphertext, err := enc.Encrypt("stillwater-test-secret")
+	if err != nil {
+		f.Fatalf("generating valid ciphertext seed: %v", err)
+	}
+	f.Add(validCiphertext)
+
+	// Seed 2: empty string -- base64 decode succeeds (empty), then the
+	// length check fires immediately.
+	f.Add("")
+
+	// Seed 3: base64 with invalid padding -- decode should return an error,
+	// not a panic.
+	f.Add("bm90dmFsaWRwYWRkaW5nIQ")
+
+	// Seed 4: base64 of a byte slice shorter than the nonce size (12 bytes
+	// for GCM). Here we encode 5 bytes -- well under the 12-byte nonce.
+	f.Add(base64.StdEncoding.EncodeToString([]byte{0x01, 0x02, 0x03, 0x04, 0x05}))
+
+	// Seed 5: base64 of exactly nonce-size bytes (12). After slicing out the
+	// nonce, the remaining ciphertext is empty, exercising the boundary
+	// between the length check and gcm.Open.
+	f.Add(base64.StdEncoding.EncodeToString(make([]byte, 12)))
+
+	// Seed 6: Unicode string -- not valid base64, exercises the decode error
+	// path with multi-byte runes.
+	f.Add("こんにちは世界")
+
+	// Seed 7: CRLF-embedded base64 -- standard base64 decoders reject \r\n;
+	// verifies the error path rather than a panic.
+	legitB64 := base64.StdEncoding.EncodeToString([]byte("someplaintext"))
+	f.Add(legitB64[:4] + "\r\n" + legitB64[4:])
+
+	// Seed 8: ciphertext encrypted by a different Encryptor (swapped key /
+	// different AAD context). gcm.Open must return an authentication error,
+	// not a panic.
+	enc2, _, err := NewEncryptor("")
+	if err != nil {
+		f.Fatalf("constructing second test Encryptor: %v", err)
+	}
+	altCiphertext, err := enc2.Encrypt("different-key-secret")
+	if err != nil {
+		f.Fatalf("generating alt-key ciphertext seed: %v", err)
+	}
+	f.Add(altCiphertext)
+
+	// Seed 9: valid ciphertext with the GCM tag truncated by 1 byte. After
+	// base64 re-encoding the result is a syntactically valid base64 string
+	// whose ciphertext section is one byte too short for the 16-byte GCM tag,
+	// so gcm.Open must return an authentication failure.
+	rawValid, err := base64.StdEncoding.DecodeString(validCiphertext)
+	if err != nil {
+		f.Fatalf("decoding valid ciphertext for truncation seed: %v", err)
+	}
+	if len(rawValid) > 0 {
+		truncated := rawValid[:len(rawValid)-1]
+		f.Add(base64.StdEncoding.EncodeToString(truncated))
+	}
+
+	f.Fuzz(func(t *testing.T, encoded string) {
+		// Decrypt must never panic regardless of input. Returning an error
+		// for invalid, malformed, or unauthenticated ciphertext is correct.
+		_, _ = enc.Decrypt(encoded)
+	})
+}


### PR DESCRIPTION
## Summary
- M49 W3 sub-task 3D. Adds `FuzzEncryptionDecrypt` exercising the AES-GCM `Decrypt` path that every stored secret in Stillwater (provider API keys, OIDC client secret, federated-auth tokens) flows through.
- 9 seeds covering valid round-trip ciphertexts, base64 with invalid padding, base64 below/at nonce-size boundary, Unicode strings, CRLF-embedded base64, ciphertext encrypted by a different Encryptor (wrong-key path), and tag-truncated ciphertext.
- 1,755,950 execs/10s on local smoke run.

## Implementation note
The test Encryptor is constructed via `NewEncryptor("")` which auto-generates a random 32-byte key internally -- no hard-coded key material. A second `NewEncryptor("")` call produces the distinct Encryptor used to generate the wrong-key seed.

## Test plan
- [x] `go test ./internal/encryption/...`
- [x] `go test -run=^FuzzEncryptionDecrypt$ -fuzz=^FuzzEncryptionDecrypt$ -fuzztime=10s ./internal/encryption` -> 1.75M execs, no panics
- [x] `golangci-lint run ./internal/encryption/...` clean

Closes #1365.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced encryption security validation with comprehensive fuzz testing that systematically validates the decryption function against numerous edge cases including malformed inputs, invalid padding, corrupted ciphertexts, and various invalid data formats to ensure robust handling of unexpected inputs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1473)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->