### PR TITLE
test(fuzz): add FuzzProviderResponses (MB/discogs/wikidata/wikipedia) + FuzzMusicBrainzDiffSnapshot

### DIFF
--- a/internal/provider/discogs/discogs_fuzz_test.go
+++ b/internal/provider/discogs/discogs_fuzz_test.go
@@ -1,0 +1,78 @@
+package discogs
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// FuzzDiscogsResponses feeds arbitrary JSON to the four Discogs
+// response-decoder paths that json.Unmarshal bytes from the wire:
+//
+//   - SearchResponse        (artist search, discogs.go:78)
+//   - ArtistDetail          (artist detail by ID, discogs.go:148)
+//   - ArtistDetail          (artist images, discogs.go:211)
+//   - ArtistReleasesResponse (release list, discogs.go:309)
+//   - MasterRelease          (master release genres/styles, discogs.go:329)
+//
+// The decoders must not panic regardless of input; returning an error is
+// acceptable and expected for malformed JSON.
+func FuzzDiscogsResponses(f *testing.F) {
+	// Seed from testdata JSON corpus.
+	jsonFiles, err := filepath.Glob("testdata/*.json")
+	if err != nil {
+		f.Fatalf("globbing testdata: %v", err)
+	}
+	for _, path := range jsonFiles {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			f.Fatalf("reading seed file %s: %v", path, err)
+		}
+		f.Add(data)
+	}
+
+	// Crafted edge cases from the issue body.
+	f.Add([]byte(`{}`))
+	// Search response shapes.
+	f.Add([]byte(`{"results":[],"pagination":{"page":1,"pages":0,"per_page":50,"items":0}}`))
+	f.Add([]byte(`{"results":[{"id":3840,"title":"Radiohead","type":"artist"}]}`))
+	// ArtistDetail with deeply nested aliases.
+	f.Add([]byte(`{"id":1,"name":"Test","aliases":[{"id":2,"name":"Alt","active":true},{"id":3,"name":"Old","active":false}]}`))
+	// ArtistDetail with members array.
+	f.Add([]byte(`{"members":[{"id":10,"name":"Member A","active":true},{"id":11,"name":"Member B","active":false}]}`))
+	// Fields with wrong types (string where object/array expected).
+	f.Add([]byte(`{"images":"not-an-array"}`))
+	f.Add([]byte(`{"aliases":{"id":1}}`))
+	f.Add([]byte(`{"pagination":"not-an-object"}`))
+	f.Add([]byte(`{"id":"should-be-int"}`))
+	// ArtistReleasesResponse.
+	f.Add([]byte(`{"pagination":{"page":1,"pages":1},"releases":[{"id":1,"title":"Album","type":"master","role":"Main","year":2001}]}`))
+	// MasterRelease.
+	f.Add([]byte(`{"id":5001,"title":"OK Computer","genres":["Alternative Rock"],"styles":["Art Rock","Post-Britpop"]}`))
+	f.Add([]byte(`{"genres":[],"styles":[]}`))
+	// Responses with circular id refs (Discogs doesn't emit them, but fuzz must not panic).
+	f.Add([]byte(`{"id":1,"aliases":[{"id":1}]}`))
+	// Empty and null.
+	f.Add([]byte(``))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`[]`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// SearchResponse -- covers discogs.go:78.
+		var sr SearchResponse
+		_ = json.Unmarshal(data, &sr)
+
+		// ArtistDetail (artist detail + images) -- covers discogs.go:148 and discogs.go:211.
+		var detail ArtistDetail
+		_ = json.Unmarshal(data, &detail)
+
+		// ArtistReleasesResponse -- covers discogs.go:309.
+		var releases ArtistReleasesResponse
+		_ = json.Unmarshal(data, &releases)
+
+		// MasterRelease -- covers discogs.go:329.
+		var master MasterRelease
+		_ = json.Unmarshal(data, &master)
+	})
+}

--- a/internal/provider/musicbrainz/musicbrainz_fuzz_test.go
+++ b/internal/provider/musicbrainz/musicbrainz_fuzz_test.go
@@ -1,0 +1,114 @@
+package musicbrainz
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// FuzzMusicBrainzResponses feeds arbitrary JSON to the four MusicBrainz
+// response-decoder paths that json.Unmarshal bytes from the wire:
+//
+//   - SearchResponse      (artist search, musicbrainz.go:74)
+//   - MBArtist            (artist detail, musicbrainz.go:130)
+//   - MBArtist            (member alias lookup, musicbrainz.go:373)
+//   - MBReleaseGroupSearchResponse (release-group browse, musicbrainz.go:446)
+//
+// The decoders must not panic regardless of input; returning an error is
+// acceptable and expected for malformed JSON.
+func FuzzMusicBrainzResponses(f *testing.F) {
+	// Seed from testdata JSON corpus.
+	jsonFiles, err := filepath.Glob("testdata/*.json")
+	if err != nil {
+		f.Fatalf("globbing testdata: %v", err)
+	}
+	for _, path := range jsonFiles {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			f.Fatalf("reading seed file %s: %v", path, err)
+		}
+		f.Add(data)
+	}
+
+	// Crafted edge cases from the issue body.
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"artists":[]}`))
+	f.Add([]byte(`{"artists":[{"id":"00000000-0000-0000-0000-000000000000","name":"Test","score":100}]}`))
+	// Deeply nested aliases array.
+	f.Add([]byte(`{"aliases":[{"name":"A","sort-name":"A","type":"Artist name","locale":"en","primary":true},{"name":"B","sort-name":"B","type":"Search hint","locale":"ja","primary":false}]}`))
+	// Deeply nested relations array.
+	f.Add([]byte(`{"relations":[{"type":"member of band","target-type":"artist","direction":"backward","attributes":[],"artist":{"id":"00000000-0000-0000-0000-000000000001","name":"Member"}}]}`))
+	// Fields with wrong types (string where object expected).
+	f.Add([]byte(`{"life-span":"not-an-object"}`))
+	f.Add([]byte(`{"tags":"not-an-array"}`))
+	f.Add([]byte(`{"genres":{"id":"x"}}`))
+	f.Add([]byte(`{"relations":[{"artist":"should-be-object"}]}`))
+	// Circular-style id references.
+	f.Add([]byte(`{"id":"aa","relations":[{"artist":{"id":"aa","relations":[]}}]}`))
+	// Release-group response shapes.
+	f.Add([]byte(`{"release-group-count":0,"release-group-offset":0,"release-groups":[]}`))
+	f.Add([]byte(`{"release-groups":[{"id":"rg1","title":"Album","primary-type":"Album","first-release-date":"2001-01-01"}]}`))
+	// Empty and whitespace.
+	f.Add([]byte(``))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`[]`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// SearchResponse -- covers musicbrainz.go:74.
+		var sr SearchResponse
+		_ = json.Unmarshal(data, &sr)
+
+		// MBArtist (artist detail and member alias lookup) -- covers
+		// musicbrainz.go:130 and musicbrainz.go:373.
+		var artist MBArtist
+		_ = json.Unmarshal(data, &artist)
+
+		// MBReleaseGroupSearchResponse -- covers musicbrainz.go:446.
+		var rgr MBReleaseGroupSearchResponse
+		_ = json.Unmarshal(data, &rgr)
+	})
+}
+
+// FuzzMusicBrainzDiffSnapshot feeds arbitrary strings to normalizeSliceJSON,
+// the JSON-array decoder inside diff.go:175. The function must never panic;
+// it falls back to direct string comparison for non-JSON inputs.
+func FuzzMusicBrainzDiffSnapshot(f *testing.F) {
+	// Valid snapshot JSON arrays.
+	f.Add(`["rock","alternative","indie"]`)
+	f.Add(`["Pop","Rock","Electronic"]`)
+	f.Add(`[]`)
+
+	// Mixed / tricky element types expressed as strings.
+	f.Add(`["a","b","a"]`)
+	f.Add(`["","  ","null"]`)
+
+	// Snapshots with NaN / +Inf (not valid JSON, exercises the fallback path).
+	f.Add(`[NaN, Infinity, -Infinity]`)
+
+	// Snapshots with extremely large element counts (10,000 items).
+	largeArray := make([]byte, 0, 10000*4+2)
+	largeArray = append(largeArray, '[')
+	for i := 0; i < 10000; i++ {
+		if i > 0 {
+			largeArray = append(largeArray, ',')
+		}
+		largeArray = append(largeArray, '"', 'a', '"')
+	}
+	largeArray = append(largeArray, ']')
+	f.Add(string(largeArray))
+
+	// Non-JSON inputs that trigger the fallback.
+	f.Add(``)
+	f.Add(`not json`)
+	f.Add(`{}`)
+
+	// Wrong-type inputs.
+	f.Add(`"scalar"`)
+	f.Add(`42`)
+
+	f.Fuzz(func(t *testing.T, s string) {
+		// normalizeSliceJSON must never panic. It returns a string in all cases.
+		_ = normalizeSliceJSON(s)
+	})
+}

--- a/internal/provider/wikidata/wikidata_fuzz_test.go
+++ b/internal/provider/wikidata/wikidata_fuzz_test.go
@@ -1,0 +1,64 @@
+package wikidata
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// FuzzWikidataResponses feeds arbitrary JSON to the two Wikidata
+// response-decoder paths that json.Unmarshal bytes from the wire:
+//
+//   - SPARQLResponse  (SPARQL artist query, wikidata.go:280)
+//   - CommonsResponse (Wikimedia Commons image lookup, wikidata.go:497)
+//
+// The decoders must not panic regardless of input; returning an error is
+// acceptable and expected for malformed JSON.
+func FuzzWikidataResponses(f *testing.F) {
+	// Seed from testdata JSON corpus.
+	jsonFiles, err := filepath.Glob("testdata/*.json")
+	if err != nil {
+		f.Fatalf("globbing testdata: %v", err)
+	}
+	for _, path := range jsonFiles {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			f.Fatalf("reading seed file %s: %v", path, err)
+		}
+		f.Add(data)
+	}
+
+	// Crafted edge cases from the issue body.
+	f.Add([]byte(`{}`))
+	// Minimal valid SPARQL response.
+	f.Add([]byte(`{"results":{"bindings":[]}}`))
+	// Full SPARQL binding row.
+	f.Add([]byte(`{"results":{"bindings":[{"item":{"type":"uri","value":"http://www.wikidata.org/entity/Q44190"},"itemLabel":{"type":"literal","value":"Radiohead"},"inception":{"type":"literal","value":"1985-01-01T00:00:00Z"},"dissolved":{"type":"literal","value":""},"countryLabel":{"type":"literal","value":"United Kingdom"},"genreLabel":{"type":"literal","value":"alternative rock"}}]}}`))
+	// Deeply nested / repeated bindings.
+	f.Add([]byte(`{"results":{"bindings":[{"item":{"type":"uri","value":"http://www.wikidata.org/entity/Q1"}},{"item":{"type":"uri","value":"http://www.wikidata.org/entity/Q2"}}]}}`))
+	// Fields with wrong types (string where object expected).
+	f.Add([]byte(`{"results":"not-an-object"}`))
+	f.Add([]byte(`{"results":{"bindings":"not-an-array"}}`))
+	f.Add([]byte(`{"results":{"bindings":[{"item":"should-be-object"}]}}`))
+	// CommonsResponse shapes.
+	f.Add([]byte(`{"query":{"pages":{}}}`))
+	f.Add([]byte(`{"query":{"pages":{"-1":{"pageid":-1,"title":"File:Missing.jpg","imageinfo":[]}}}}`))
+	f.Add([]byte(`{"query":{"pages":{"12345":{"pageid":12345,"title":"File:Radiohead.jpg","imageinfo":[{"url":"https://commons.example/Radiohead.jpg","width":1200,"height":800}]}}}}`))
+	// Responses with circular-style repeated ids.
+	f.Add([]byte(`{"query":{"pages":{"1":{"pageid":1},"2":{"pageid":1}}}}`))
+	// Empty and null.
+	f.Add([]byte(``))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`[]`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// SPARQLResponse -- covers wikidata.go:280.
+		var sparql SPARQLResponse
+		_ = json.Unmarshal(data, &sparql)
+
+		// CommonsResponse -- covers wikidata.go:497.
+		var commons CommonsResponse
+		_ = json.Unmarshal(data, &commons)
+	})
+}

--- a/internal/provider/wikipedia/wikipedia_fuzz_test.go
+++ b/internal/provider/wikipedia/wikipedia_fuzz_test.go
@@ -1,0 +1,85 @@
+package wikipedia
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// FuzzWikipediaResponses feeds arbitrary JSON to the five Wikipedia/Wikidata
+// response-decoder paths that json.Unmarshal bytes from the wire:
+//
+//   - sparqlResponse   (MBID-to-title SPARQL, wikipedia.go:539)
+//   - wbEntityResponse (localized sitelink lookup, wikipedia.go:630)
+//   - wbEntityResponse (Q-ID to title via sitelinks, wikipedia.go:699)
+//   - extractResponse  (Wikipedia article extract, wikipedia.go:786)
+//   - parseResponse    (MediaWiki wikitext parse, wikipedia.go:854)
+//
+// The response types are unexported, so this file uses package wikipedia
+// (not package wikipedia_test) to access them directly. The decoders must
+// not panic regardless of input; returning an error is acceptable and
+// expected for malformed JSON.
+func FuzzWikipediaResponses(f *testing.F) {
+	// Seed from testdata corpus (text files; read as raw bytes for the fuzzer).
+	textFiles, err := filepath.Glob("testdata/*.txt")
+	if err != nil {
+		f.Fatalf("globbing testdata: %v", err)
+	}
+	for _, path := range textFiles {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			f.Fatalf("reading seed file %s: %v", path, err)
+		}
+		f.Add(data)
+	}
+
+	// Crafted edge cases from the issue body.
+	f.Add([]byte(`{}`))
+	// Minimal valid SPARQL response (sparqlResponse).
+	f.Add([]byte(`{"results":{"bindings":[]}}`))
+	// SPARQL binding with item and article.
+	f.Add([]byte(`{"results":{"bindings":[{"item":{"value":"http://www.wikidata.org/entity/Q44190"},"article":{"value":"https://en.wikipedia.org/wiki/Radiohead"}}]}}`))
+	// Multiple bindings.
+	f.Add([]byte(`{"results":{"bindings":[{"item":{"value":"http://www.wikidata.org/entity/Q1"},"article":{"value":"https://en.wikipedia.org/wiki/A"}},{"item":{"value":"http://www.wikidata.org/entity/Q2"},"article":{"value":"https://en.wikipedia.org/wiki/B"}}]}}`))
+	// wbEntityResponse (sitelinks).
+	f.Add([]byte(`{"entities":{}}`))
+	f.Add([]byte(`{"entities":{"Q44190":{"sitelinks":{"enwiki":{"title":"Radiohead"},"jawiki":{"title":"レディオヘッド"}}}}}`))
+	f.Add([]byte(`{"entities":{"Q44190":{"sitelinks":{}}}}`))
+	// extractResponse.
+	f.Add([]byte(`{"query":{"pages":{}}}`))
+	f.Add([]byte(`{"query":{"pages":{"-1":{"pageid":-1,"title":"Missing","extract":""}}}}`))
+	f.Add([]byte(`{"query":{"pages":{"44190":{"pageid":44190,"title":"Radiohead","extract":"Radiohead are an English rock band..."}}}}`))
+	// parseResponse (wikitext).
+	f.Add([]byte(`{"parse":{"title":"Radiohead","pageid":44190,"wikitext":{"*":"{{Infobox musical artist|name=Radiohead}}"}}}`))
+	f.Add([]byte(`{"parse":{"title":"","pageid":0,"wikitext":{"*":""}}}`))
+	// Fields with wrong types.
+	f.Add([]byte(`{"results":"not-an-object"}`))
+	f.Add([]byte(`{"entities":"not-an-object"}`))
+	f.Add([]byte(`{"query":{"pages":"not-an-object"}}`))
+	f.Add([]byte(`{"parse":"not-an-object"}`))
+	// Responses with deeply nested / alias-style circular id refs.
+	f.Add([]byte(`{"entities":{"Q1":{"sitelinks":{"enwiki":{"title":"A"}}},"Q2":{"sitelinks":{"enwiki":{"title":"A"}}}}}`))
+	// Empty and null.
+	f.Add([]byte(``))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`[]`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// sparqlResponse -- covers wikipedia.go:539.
+		var sparql sparqlResponse
+		_ = json.Unmarshal(data, &sparql)
+
+		// wbEntityResponse -- covers wikipedia.go:630 and wikipedia.go:699.
+		var wbResp wbEntityResponse
+		_ = json.Unmarshal(data, &wbResp)
+
+		// extractResponse -- covers wikipedia.go:786.
+		var extResp extractResponse
+		_ = json.Unmarshal(data, &extResp)
+
+		// parseResponse -- covers wikipedia.go:854.
+		var parseResp parseResponse
+		_ = json.Unmarshal(data, &parseResp)
+	})
+}


### PR DESCRIPTION
## Summary
- M49 W3 sub-task 3G. Five fuzz funcs across four provider packages, exercising every `json.Unmarshal` site that decodes upstream provider responses:
  - `FuzzMusicBrainzResponses` -> SearchResponse, MBArtist (2x), MBReleaseGroupSearchResponse -- 10 testdata + 15 inline seeds, 671,135 execs/10s
  - `FuzzMusicBrainzDiffSnapshot` -> `normalizeSliceJSON` at diff.go:175 -- 9 inline seeds, 371,756 execs/10s
  - `FuzzDiscogsResponses` -> SearchResponse, ArtistDetail (2x), ArtistReleasesResponse, MasterRelease -- 5 testdata + 14 inline seeds, 500,148 execs/10s
  - `FuzzWikidataResponses` -> SPARQLResponse, CommonsResponse -- 7 testdata + 13 inline seeds, 1,422,421 execs/10s
  - `FuzzWikipediaResponses` -> sparqlResponse, wbEntityResponse (2x), extractResponse, parseResponse -- 8 testdata + 16 inline seeds, 1,227,713 execs/10s

Per-provider `testdata/*` JSON corpora bootstrap the seeds; crafted edge cases (empty `{}`, deeply nested arrays, wrong-type fields, NaN / +Inf numerics, circular id refs, mixed-item-type snapshots) supplement.

## Package access
Each fuzz file is in `package <provider>` (no `_test` suffix on the package decl) for internal access -- `normalizeSliceJSON` in musicbrainz and all five wikipedia response types are unexported.

## Line-number note
Issue body line citations were 1-5 lines off the current source (e.g. wikidata SPARQLResponse decode is at line 281, not 280). All decoder functions and call sites are present and structurally unchanged.

## Test plan
- [x] `go test ./internal/provider/{musicbrainz,discogs,wikidata,wikipedia}/...`
- [x] Five fuzz runs at 10s each, no panics
- [x] `golangci-lint run` clean across all four provider packages

Closes #1368.
Closes #1369.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive fuzzing tests for Discogs, MusicBrainz (including snapshot normalization), Wikidata, and Wikipedia integrations.
  * Seeds include real testdata plus crafted edge cases (empty/null/wrong-types/malformed/circular-like inputs) to exercise decoding paths and guard against panics, improving resilience and stability when handling external provider responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1476)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->