### PR TITLE
fix(api): switch CSRF token map cleanup to ticker-based + add deterministic test

### DIFF
--- a/internal/api/middleware/csrf.go
+++ b/internal/api/middleware/csrf.go
@@ -13,16 +13,95 @@ const csrfTokenHeader = "X-CSRF-Token" //nolint:gosec // G101: not a credential,
 const csrfCookieName = "csrf_token"
 const csrfTokenTTL = 24 * time.Hour
 
+// csrfCleanupInterval is how often expired tokens are swept from the in-memory
+// map. One hour is well below csrfTokenTTL (24h), which means expired tokens
+// never linger long enough to bloat memory under sustained load, but the sweep
+// is infrequent enough that the lock-contention cost is negligible.
+const csrfCleanupInterval = time.Hour
+
 // CSRF provides token-based CSRF protection for HTMX form submissions.
 // It validates that state-changing requests include a matching CSRF token.
+//
+// A background goroutine started in NewCSRF periodically sweeps expired
+// tokens from the in-memory map. Callers must invoke Close exactly once
+// (typically tied to server shutdown) to stop the goroutine.
 type CSRF struct {
 	mu     sync.RWMutex
 	tokens map[string]time.Time
+
+	// stop is closed by Close to signal the cleanup goroutine to exit.
+	// closeOnce guards against multiple Close calls so the channel is
+	// closed at most once (closing a closed channel panics).
+	stop      chan struct{}
+	closeOnce sync.Once
+
+	// trigger is an optional test hook: sending on it forces a cleanup
+	// sweep without waiting for the ticker. Nil in production; tests
+	// populate it via newCSRFForTest.
+	trigger chan struct{}
+	// done is closed by the cleanup goroutine right before it returns.
+	// Tests use it to assert the goroutine has fully exited after Close.
+	done chan struct{}
 }
 
-// NewCSRF creates a CSRF middleware instance.
+// NewCSRF creates a CSRF middleware instance and starts its background
+// cleanup goroutine. Callers must invoke Close when the instance is no
+// longer needed (typically wired to the server's shutdown context) to
+// avoid leaking the goroutine.
 func NewCSRF() *CSRF {
-	return &CSRF{tokens: make(map[string]time.Time)}
+	c := &CSRF{
+		tokens: make(map[string]time.Time),
+		stop:   make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+	go c.cleanupLoop(csrfCleanupInterval)
+	return c
+}
+
+// newCSRFForTest is identical to NewCSRF except it accepts an explicit
+// cleanup interval and exposes a trigger channel so tests can fire a
+// sweep synchronously rather than waiting on wall-clock time.
+func newCSRFForTest(interval time.Duration) *CSRF {
+	c := &CSRF{
+		tokens:  make(map[string]time.Time),
+		stop:    make(chan struct{}),
+		done:    make(chan struct{}),
+		trigger: make(chan struct{}, 1),
+	}
+	go c.cleanupLoop(interval)
+	return c
+}
+
+// Close stops the background cleanup goroutine. It is safe to call multiple
+// times; subsequent calls are no-ops. Close blocks until the goroutine has
+// returned, which guarantees no further map mutations after Close returns.
+func (c *CSRF) Close() {
+	c.closeOnce.Do(func() {
+		close(c.stop)
+	})
+	<-c.done
+}
+
+// cleanupLoop runs until stop is closed, sweeping expired tokens on every
+// tick. The trigger channel (test-only) forces an immediate sweep.
+func (c *CSRF) cleanupLoop(interval time.Duration) {
+	defer close(c.done)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stop:
+			return
+		case <-ticker.C:
+			c.mu.Lock()
+			c.cleanExpiredLocked()
+			c.mu.Unlock()
+		case <-c.trigger:
+			c.mu.Lock()
+			c.cleanExpiredLocked()
+			c.mu.Unlock()
+		}
+	}
 }
 
 // Middleware returns the CSRF handler that validates tokens on unsafe methods.
@@ -88,10 +167,6 @@ func (c *CSRF) generate() string {
 
 	c.mu.Lock()
 	c.tokens[token] = time.Now()
-	// Periodically clean up expired tokens to prevent memory growth
-	if len(c.tokens) > 0 && len(c.tokens)%100 == 0 {
-		c.cleanExpiredLocked()
-	}
 	c.mu.Unlock()
 
 	return token

--- a/internal/api/middleware/csrf_test.go
+++ b/internal/api/middleware/csrf_test.go
@@ -3,7 +3,9 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
+	"time"
 )
 
 func TestCSRF_SafeMethodSetsToken(t *testing.T) {
@@ -115,6 +117,118 @@ func TestCSRF_ExistingValidCookieNotReplaced(t *testing.T) {
 			t.Error("should not re-set cookie when valid token exists")
 		}
 	}
+}
+
+// TestCSRF_CleanupRemovesExpiredTokens seeds 1000 already-expired tokens,
+// fires the cleanup loop via the test-only trigger channel, and asserts
+// the entire map is purged. This replaces the old len%100==0 heuristic
+// that only ran opportunistically inside generate().
+//
+// Determinism: the test uses newCSRFForTest (which exposes a trigger
+// channel) so the sweep runs synchronously instead of waiting on the
+// real ticker. No time.Sleep is used; we Gosched-yield and re-check the
+// map size in a bounded loop.
+func TestCSRF_CleanupRemovesExpiredTokens(t *testing.T) {
+	t.Parallel()
+	c := newCSRFForTest(time.Hour) // ticker effectively never fires during the test
+	t.Cleanup(c.Close)
+
+	// Seed 1000 tokens with creation times well past csrfTokenTTL so the
+	// sweep marks every one of them as expired.
+	expired := time.Now().Add(-2 * csrfTokenTTL)
+	c.mu.Lock()
+	for i := 0; i < 1000; i++ {
+		c.tokens[generateRandomTokenForTest(t)] = expired
+	}
+	if got := len(c.tokens); got != 1000 {
+		c.mu.Unlock()
+		t.Fatalf("seed: len(tokens) = %d, want 1000", got)
+	}
+	c.mu.Unlock()
+
+	// Fire the cleanup loop synchronously via the test hook.
+	c.trigger <- struct{}{}
+
+	// The cleanup goroutine grabs c.mu under Lock; spin-yield until we
+	// observe the post-sweep state. Bounded by a large iteration count
+	// so a regression cannot hang the suite.
+	const maxIters = 10_000
+	for i := 0; i < maxIters; i++ {
+		c.mu.RLock()
+		n := len(c.tokens)
+		c.mu.RUnlock()
+		if n == 0 {
+			return
+		}
+		runtime.Gosched()
+	}
+	c.mu.RLock()
+	n := len(c.tokens)
+	c.mu.RUnlock()
+	t.Fatalf("after cleanup trigger: len(tokens) = %d, want 0", n)
+}
+
+// TestCSRF_CleanupKeepsLiveTokens verifies that the sweep only removes
+// expired tokens; tokens issued within csrfTokenTTL must remain.
+func TestCSRF_CleanupKeepsLiveTokens(t *testing.T) {
+	t.Parallel()
+	c := newCSRFForTest(time.Hour)
+	t.Cleanup(c.Close)
+
+	live := c.generate() // freshly issued, well inside TTL
+
+	// Add 500 expired tokens alongside the live one.
+	expired := time.Now().Add(-2 * csrfTokenTTL)
+	c.mu.Lock()
+	for i := 0; i < 500; i++ {
+		c.tokens[generateRandomTokenForTest(t)] = expired
+	}
+	c.mu.Unlock()
+
+	c.trigger <- struct{}{}
+
+	const maxIters = 10_000
+	for i := 0; i < maxIters; i++ {
+		c.mu.RLock()
+		_, stillLive := c.tokens[live]
+		n := len(c.tokens)
+		c.mu.RUnlock()
+		if n == 1 && stillLive {
+			return
+		}
+		runtime.Gosched()
+	}
+	t.Fatal("live token was evicted or expired tokens were not swept")
+}
+
+// TestCSRF_CloseStopsGoroutine asserts Close is idempotent and that it
+// blocks until the cleanup goroutine has fully exited. The second call
+// must not panic on the already-closed stop channel.
+func TestCSRF_CloseStopsGoroutine(t *testing.T) {
+	t.Parallel()
+	c := newCSRFForTest(time.Millisecond) // fast ticker so any leak is obvious under -race
+	c.Close()
+	// Second Close must be a no-op. The done channel is closed before
+	// the first Close returns, so the second Close returns immediately.
+	c.Close()
+	select {
+	case <-c.done:
+		// expected: goroutine has returned
+	default:
+		t.Fatal("Close returned but cleanup goroutine is still running")
+	}
+}
+
+// generateRandomTokenForTest returns a unique opaque string. We use
+// crypto/rand via the production generator so test keys live in the
+// same key space as real tokens; collisions across the seed loop are
+// statistically impossible at 32 random bytes.
+func generateRandomTokenForTest(t *testing.T) string {
+	t.Helper()
+	// A throwaway CSRF with no cleanup goroutine is enough: generate()
+	// only touches the local map under its own mutex.
+	c := &CSRF{tokens: map[string]time.Time{}}
+	return c.generate()
 }
 
 func TestCSRF_HeadAndOptionsAreSafe(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -281,6 +281,13 @@ func (r *Router) Handler(ctx context.Context) http.Handler {
 	authMw := middleware.Auth(r.authService)
 	optAuthMw := middleware.OptionalAuth(r.authService)
 	csrf := middleware.NewCSRF()
+	// Stop the CSRF cleanup goroutine when the server context is canceled.
+	// CSRF mirrors LoginRateLimiter's lifecycle but exposes an explicit
+	// Close() so tests can stop the goroutine without a context.
+	go func() {
+		<-ctx.Done()
+		csrf.Close()
+	}()
 	loginRL := middleware.NewLoginRateLimiter(ctx)
 	requireMultiUser := middleware.RequireMultiUser(r.getStringSetting)
 


### PR DESCRIPTION
## Summary

- Replace the opportunistic `len%100==0` heuristic in `csrf.cleanExpiredLocked` with a 1h `time.Ticker`-driven sweep that runs regardless of traffic shape.
- Add `Close()` (idempotent, blocks until the goroutine exits) and wire it to the server shutdown context via a small goroutine in `router.go`, mirroring how `LoginRateLimiter` is shut down.
- Add three deterministic tests: 1000 expired tokens sweep clean within bounded retries, live tokens are preserved across a sweep, and `Close()` is idempotent + actually stops the goroutine. No `time.Sleep`.

## Test plan

- [x] `go test -race -count=1 ./internal/api/middleware/...`
- [x] `go test -race -count=1 ./internal/api/...`
- [x] `bash scripts/pre-push-gate.sh` (patch coverage 90.91%, 40/44 lines)
- [x] UAT: dev-restart from worktree, login page renders, `/api/v1/artists` Bearer auth returns artists, SIGTERM shutdown exits in 2s with no goroutine hang in log
- [x] Test naming: `TestCSRF_CleanupRemovesExpiredTokens`, `TestCSRF_CleanupKeepsLiveTokens`, `TestCSRF_CloseStopsGoroutine`

Closes #1371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized CSRF token cleanup to run in the background, reducing per-request overhead.
  * Enhanced CSRF middleware shutdown to ensure graceful cleanup of resources when the server stops.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1477)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->