### PR TITLE
feat(api): sort-column allowlist for list/search endpoints + 400 on unknown sort + tests

### DIFF
--- a/internal/api/handlers_artist.go
+++ b/internal/api/handlers_artist.go
@@ -18,11 +18,19 @@ import (
 // GET /api/v1/artists
 func (r *Router) handleListArtists(w http.ResponseWriter, req *http.Request) {
 	userID := middleware.UserIDFromContext(req.Context())
+	sortKey, ok := validateSortParam(w, req, allowedArtistSort)
+	if !ok {
+		return
+	}
+	order, ok := validateOrderParam(w, req)
+	if !ok {
+		return
+	}
 	params := artist.ListParams{
 		Page:      intQuery(req, "page", 1),
 		PageSize:  r.getUserPageSize(req.Context(), userID, intQuery(req, "page_size", 0)),
-		Sort:      req.URL.Query().Get("sort"),
-		Order:     req.URL.Query().Get("order"),
+		Sort:      sortKey,
+		Order:     order,
 		Search:    req.URL.Query().Get("search"),
 		Filter:    req.URL.Query().Get("filter"),
 		LibraryID: req.URL.Query().Get("library_id"),
@@ -149,11 +157,19 @@ func (r *Router) handleArtistsPage(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	sortKey, ok := validateSortParam(w, req, allowedArtistSort)
+	if !ok {
+		return
+	}
+	order, ok := validateOrderParam(w, req)
+	if !ok {
+		return
+	}
 	params := artist.ListParams{
 		Page:      intQuery(req, "page", 1),
 		PageSize:  r.getUserPageSize(req.Context(), userID, intQuery(req, "page_size", 0)),
-		Sort:      req.URL.Query().Get("sort"),
-		Order:     req.URL.Query().Get("order"),
+		Sort:      sortKey,
+		Order:     order,
 		Search:    req.URL.Query().Get("search"),
 		Filter:    req.URL.Query().Get("filter"),
 		LibraryID: req.URL.Query().Get("library_id"),

--- a/internal/api/handlers_artist_lock.go
+++ b/internal/api/handlers_artist_lock.go
@@ -215,11 +215,19 @@ func (r *Router) setImageLock(w http.ResponseWriter, req *http.Request, locked b
 // handleListLockedArtists returns a paginated list of locked artists.
 // GET /api/v1/artists/locked
 func (r *Router) handleListLockedArtists(w http.ResponseWriter, req *http.Request) {
+	sortKey, ok := validateSortParam(w, req, allowedArtistSort)
+	if !ok {
+		return
+	}
+	order, ok := validateOrderParam(w, req)
+	if !ok {
+		return
+	}
 	params := artist.ListParams{
 		Page:     intQuery(req, "page", 1),
 		PageSize: intQuery(req, "page_size", 50),
-		Sort:     req.URL.Query().Get("sort"),
-		Order:    req.URL.Query().Get("order"),
+		Sort:     sortKey,
+		Order:    order,
 		Filter:   "locked",
 	}
 	params.Validate()

--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -443,6 +443,13 @@ func (r *Router) handleImageSearch(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Validate sort before any provider fetch/probe work so bad requests
+	// fail fast with 400 rather than after expensive upstream calls.
+	sortBy, ok := validateSortParam(w, req, allowedImageSearchSort)
+	if !ok {
+		return
+	}
+
 	a, err := r.artistService.GetByID(req.Context(), artistID)
 	if err != nil {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "artist not found"})
@@ -476,12 +483,6 @@ func (r *Router) handleImageSearch(w http.ResponseWriter, req *http.Request) {
 	// Probe dimensions for images that have none (e.g., Fanart.tv)
 	images = r.probeImageDimensions(req.Context(), images)
 
-	// Sort images by the requested criterion (default: likes descending).
-	// Normalize unknown sort values so only valid values propagate to templates.
-	sortBy := req.URL.Query().Get("sort")
-	if sortBy != "" && sortBy != "likes" && sortBy != "resolution" {
-		sortBy = ""
-	}
 	sortImageResults(images, sortBy)
 
 	// Return HTML for HTMX requests, JSON for API requests
@@ -509,6 +510,11 @@ var validWebSearchImageTypes = map[string]bool{
 // GET /api/v1/artists/{id}/images/websearch?type=thumb
 func (r *Router) handleWebImageSearch(w http.ResponseWriter, req *http.Request) {
 	artistID, ok := RequirePathParam(w, req, "id")
+	if !ok {
+		return
+	}
+
+	sortBy, ok := validateSortParam(w, req, allowedImageSearchSort)
 	if !ok {
 		return
 	}
@@ -544,11 +550,6 @@ func (r *Router) handleWebImageSearch(w http.ResponseWriter, req *http.Request) 
 		allImages = append(allImages, images...)
 	}
 
-	// Sort web search results the same way as the main image search.
-	sortBy := req.URL.Query().Get("sort")
-	if sortBy != "" && sortBy != "likes" && sortBy != "resolution" {
-		sortBy = ""
-	}
 	sortImageResults(allImages, sortBy)
 
 	if isHTMXRequest(req) {

--- a/internal/api/handlers_notifications.go
+++ b/internal/api/handlers_notifications.go
@@ -19,7 +19,10 @@ import (
 // handleListNotifications returns rule violations with optional filtering and sorting.
 // GET /api/v1/notifications?status=open&severity=error&category=image&sort=artist_name&order=asc
 func (r *Router) handleListNotifications(w http.ResponseWriter, req *http.Request) {
-	p := parseNotificationParams(req)
+	p, ok := parseNotificationParams(w, req)
+	if !ok {
+		return
+	}
 
 	violations, err := r.ruleService.ListViolationsFiltered(req.Context(), p)
 	if err != nil {
@@ -41,7 +44,10 @@ func (r *Router) handleListNotifications(w http.ResponseWriter, req *http.Reques
 // Respects the same filter/sort params as handleListNotifications.
 // GET /api/v1/notifications/export
 func (r *Router) handleNotificationsExport(w http.ResponseWriter, req *http.Request) {
-	p := parseNotificationParams(req)
+	p, ok := parseNotificationParams(w, req)
+	if !ok {
+		return
+	}
 
 	violations, err := r.ruleService.ListViolationsFiltered(req.Context(), p)
 	if err != nil {
@@ -235,7 +241,10 @@ var validGroupByValues = map[string]bool{
 }
 
 // parseNotificationParams extracts filter/sort/group params from the request.
-func parseNotificationParams(req *http.Request) rule.ViolationListParams {
+// Validates the sort and order parameters against the violation allowlist;
+// on unknown values it writes a 400 response and returns ok=false so the
+// caller can stop processing.
+func parseNotificationParams(w http.ResponseWriter, req *http.Request) (rule.ViolationListParams, bool) {
 	q := req.URL.Query()
 
 	status := q.Get("status")
@@ -243,11 +252,17 @@ func parseNotificationParams(req *http.Request) rule.ViolationListParams {
 		status = "active"
 	}
 
-	sort := q.Get("sort")
-	order := q.Get("order")
+	sortKey, ok := validateSortParam(w, req, allowedViolationSort)
+	if !ok {
+		return rule.ViolationListParams{}, false
+	}
+	order, ok := validateOrderParam(w, req)
+	if !ok {
+		return rule.ViolationListParams{}, false
+	}
 	// Normalize defaults so UI sort icons match actual query behavior.
-	if sort == "" {
-		sort = "severity"
+	if sortKey == "" {
+		sortKey = "severity"
 	}
 	if order == "" {
 		order = "desc"
@@ -260,13 +275,13 @@ func parseNotificationParams(req *http.Request) rule.ViolationListParams {
 
 	return rule.ViolationListParams{
 		Status:   status,
-		Sort:     sort,
+		Sort:     sortKey,
 		Order:    order,
 		Severity: q.Get("severity"),
 		Category: q.Get("category"),
 		RuleID:   q.Get("rule_id"),
 		GroupBy:  groupBy,
-	}
+	}, true
 }
 
 // handleApplyViolationCandidate downloads and applies a chosen image candidate.

--- a/internal/api/handlers_notifications_test.go
+++ b/internal/api/handlers_notifications_test.go
@@ -78,7 +78,11 @@ func TestParseNotificationParams(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
-			p := parseNotificationParams(req)
+			w := httptest.NewRecorder()
+			p, ok := parseNotificationParams(w, req)
+			if !ok {
+				t.Fatalf("parseNotificationParams returned ok=false; status=%d body=%q", w.Code, w.Body.String())
+			}
 			if p.Sort != tc.wantSort {
 				t.Errorf("Sort = %q, want %q", p.Sort, tc.wantSort)
 			}
@@ -101,7 +105,11 @@ func TestParseNotificationParams(t *testing.T) {
 func TestParseNotificationParams_DefaultStatus(t *testing.T) {
 	t.Parallel()
 	req := httptest.NewRequest(http.MethodGet, "/notifications/table", nil)
-	p := parseNotificationParams(req)
+	w := httptest.NewRecorder()
+	p, ok := parseNotificationParams(w, req)
+	if !ok {
+		t.Fatalf("parseNotificationParams returned ok=false; status=%d body=%q", w.Code, w.Body.String())
+	}
 	if p.Status != "active" {
 		t.Errorf("default status = %q, want active", p.Status)
 	}

--- a/internal/api/handlers_report.go
+++ b/internal/api/handlers_report.go
@@ -257,7 +257,10 @@ func (r *Router) handleViolationTrend(w http.ResponseWriter, req *http.Request) 
 // GET /api/v1/reports/compliance
 func (r *Router) handleReportCompliance(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	params := complianceListParams(req)
+	params, ok := complianceListParams(w, req)
+	if !ok {
+		return
+	}
 
 	artists, total, err := r.artistService.List(ctx, params)
 	if err != nil {
@@ -319,7 +322,10 @@ func (r *Router) handleReportCompliance(w http.ResponseWriter, req *http.Request
 func (r *Router) handleReportComplianceExport(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	params := complianceListParams(req)
+	params, ok := complianceListParams(w, req)
+	if !ok {
+		return
+	}
 	params.Page = 1
 	params.PageSize = 200
 
@@ -428,11 +434,20 @@ func sanitizeCSV(s string) string {
 }
 
 // complianceListParams extracts ListParams from a compliance report request.
-func complianceListParams(req *http.Request) artist.ListParams {
-	sort := req.URL.Query().Get("sort")
-	order := req.URL.Query().Get("order")
-	if sort == "" {
-		sort = "name"
+// Validates the sort and order parameters against the artist allowlist; on
+// unknown values it writes a 400 response and returns ok=false so the caller
+// can stop processing.
+func complianceListParams(w http.ResponseWriter, req *http.Request) (artist.ListParams, bool) {
+	sortKey, ok := validateSortParam(w, req, allowedArtistSort)
+	if !ok {
+		return artist.ListParams{}, false
+	}
+	order, ok := validateOrderParam(w, req)
+	if !ok {
+		return artist.ListParams{}, false
+	}
+	if sortKey == "" {
+		sortKey = "name"
 	}
 	if order == "" {
 		order = "asc"
@@ -441,7 +456,7 @@ func complianceListParams(req *http.Request) artist.ListParams {
 	params := artist.ListParams{
 		Page:           intQuery(req, "page", 1),
 		PageSize:       intQuery(req, "page_size", 50),
-		Sort:           sort,
+		Sort:           sortKey,
 		Order:          order,
 		Search:         req.URL.Query().Get("search"),
 		Filter:         req.URL.Query().Get("filter"),
@@ -459,7 +474,7 @@ func complianceListParams(req *http.Request) artist.ListParams {
 	}
 
 	params.Validate()
-	return params
+	return params, true
 }
 
 // handleCompliancePage renders the compliance report HTML page.
@@ -472,7 +487,10 @@ func (r *Router) handleCompliancePage(w http.ResponseWriter, req *http.Request) 
 	}
 
 	ctx := req.Context()
-	params := complianceListParams(req)
+	params, ok := complianceListParams(w, req)
+	if !ok {
+		return
+	}
 	status := req.URL.Query().Get("status")
 
 	artists, total, err := r.artistService.List(ctx, params)

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -2036,8 +2036,13 @@ paths:
             default: 50
         - name: sort
           in: query
+          description: |
+            Sort column. Unknown values are rejected with 400 Bad Request.
+            Empty defaults to "name".
           schema:
             type: string
+            enum: [name, sort_name, health_score, updated_at, created_at]
+            default: name
         - name: order
           in: query
           schema:
@@ -2146,6 +2151,12 @@ paths:
                   page_size:
                     type: integer
                     description: Number of records per page.
+        "400":
+          description: Invalid sort or order parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /artists/badge:
     get:
@@ -2214,8 +2225,13 @@ paths:
             default: 50
         - name: sort
           in: query
+          description: |
+            Sort column. Unknown values are rejected with 400 Bad Request.
+            Empty defaults to "name".
           schema:
             type: string
+            enum: [name, sort_name, health_score, updated_at, created_at]
+            default: name
         - name: order
           in: query
           schema:
@@ -2243,6 +2259,12 @@ paths:
                   page_size:
                     type: integer
                     description: Number of records per page.
+        "400":
+          description: Invalid sort or order parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /artists/{id}/lock:
     post:
@@ -2929,6 +2951,12 @@ paths:
             text/html:
               schema:
                 type: string
+        "400":
+          description: Invalid sort parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /artists/{id}/images/crop:
     post:
@@ -5192,6 +5220,21 @@ paths:
           schema:
             type: string
             enum: [compliant, non_compliant]
+        - name: sort
+          in: query
+          description: |
+            Sort column. Unknown values are rejected with 400 Bad Request.
+            Empty defaults to "name".
+          schema:
+            type: string
+            enum: [name, sort_name, health_score, updated_at, created_at]
+            default: name
+        - name: order
+          in: query
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: asc
       responses:
         "200":
           description: Paginated compliance report
@@ -5249,6 +5292,12 @@ paths:
                   page_size:
                     type: integer
                     description: Number of records per page.
+        "400":
+          description: Invalid sort or order parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /webhooks:
     get:
@@ -7128,6 +7177,12 @@ paths:
                   count:
                     type: integer
                     description: Total number of violations in this response.
+        "400":
+          description: Invalid sort or order parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /notifications/{id}/dismiss:
     post:
@@ -7568,6 +7623,12 @@ paths:
                   count:
                     type: integer
                     description: Total number of violations in this response.
+        "400":
+          description: Invalid sort or order parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /notifications/resolved:
     delete:
@@ -7689,14 +7750,19 @@ paths:
       parameters:
         - name: sort
           in: query
+          description: |
+            Sort column. Unknown values are rejected with 400 Bad Request.
+            Empty defaults to "name".
           schema:
             type: string
+            enum: [name, sort_name, health_score, updated_at, created_at]
             default: name
         - name: order
           in: query
           schema:
             type: string
             enum: [asc, desc]
+            default: asc
         - name: search
           in: query
           schema:
@@ -7729,6 +7795,12 @@ paths:
             text/csv:
               schema:
                 type: string
+        "400":
+          description: Invalid sort or order parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /reports/metadata-completeness:
     get:
@@ -9750,6 +9822,12 @@ paths:
             text/html:
               schema:
                 type: string
+        "400":
+          description: Invalid sort parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /artists/{id}/images/logo/trim:
     post:

--- a/internal/api/sort.go
+++ b/internal/api/sort.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/sydlexius/stillwater/internal/dbutil"
+)
+
+// allowedArtistSort is the allowlist of public sort keys for artist list
+// and search endpoints (handleListArtists, handleArtistsPage,
+// handleListLockedArtists, compliance report). The map value is the
+// canonical SQL column name passed downstream to artist.ListParams.Sort.
+// The empty key is allowed and resolves to the per-handler default ("name").
+var allowedArtistSort = map[string]string{
+	"name":         "name",
+	"sort_name":    "sort_name",
+	"health_score": "health_score",
+	"updated_at":   "updated_at",
+	"created_at":   "created_at",
+}
+
+// allowedViolationSort is the allowlist for rule violation list/export
+// endpoints. The empty key is allowed and resolves to the parser default
+// ("severity"). Keys mirror the documented ViolationListParams.Sort values.
+var allowedViolationSort = map[string]string{
+	"artist_name": "artist_name",
+	"severity":    "severity",
+	"rule_id":     "rule_id",
+	"created_at":  "created_at",
+}
+
+// allowedImageSearchSort is the allowlist for the in-memory sorter used by
+// the artist image search endpoints. Empty key means "no sort"; the
+// sortImageResults helper applies its built-in default in that case.
+var allowedImageSearchSort = map[string]string{
+	"likes":      "likes",
+	"resolution": "resolution",
+}
+
+// validateSortParam reads the "sort" query parameter, validates it against
+// the supplied allowlist, and on rejection writes a 400 response and
+// returns ok=false. The canonical column is returned; on the empty-key
+// path (column == "") the caller substitutes its own default before
+// forwarding to the data layer.
+func validateSortParam(w http.ResponseWriter, req *http.Request, allowed map[string]string) (column string, ok bool) {
+	raw := req.URL.Query().Get("sort")
+	col, valid := dbutil.ValidateSortKey(raw, allowed)
+	if !valid {
+		writeError(w, req, http.StatusBadRequest, "invalid sort key: "+raw)
+		return "", false
+	}
+	return col, true
+}
+
+// validateOrderParam reads the "order" query parameter, accepts only
+// "", "asc", "desc", and writes a 400 response on anything else.
+func validateOrderParam(w http.ResponseWriter, req *http.Request) (order string, ok bool) {
+	raw := req.URL.Query().Get("order")
+	normalized, valid := dbutil.ValidateSortOrder(raw)
+	if !valid {
+		writeError(w, req, http.StatusBadRequest, "invalid order: "+raw)
+		return "", false
+	}
+	return normalized, true
+}

--- a/internal/api/sort_test.go
+++ b/internal/api/sort_test.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSortAllowlist_RejectsUnknown asserts every list/search endpoint that
+// reads ?sort returns 400 (Bad Request) for an unknown key instead of
+// silently falling back to a default. This is the boundary protection
+// added by #1372; downstream allowlist checks remain as defense-in-depth.
+func TestSortAllowlist_RejectsUnknown(t *testing.T) {
+	t.Parallel()
+
+	// Each entry exercises one handler that reads the ?sort query
+	// parameter. The chosen unknown keys deliberately include shapes a
+	// naive caller might use to probe injection (SQL fragments, mixed
+	// case, unrelated terms) so the test doubles as a small fuzz table.
+	cases := []struct {
+		name    string
+		method  string
+		url     string
+		handler func(r *Router, w http.ResponseWriter, req *http.Request)
+	}{
+		{
+			name:    "list artists JSON",
+			method:  http.MethodGet,
+			url:     "/api/v1/artists?sort=DROP+TABLE",
+			handler: (*Router).handleListArtists,
+		},
+		{
+			name:    "list artists JSON unknown key",
+			method:  http.MethodGet,
+			url:     "/api/v1/artists?sort=evil_key",
+			handler: (*Router).handleListArtists,
+		},
+		{
+			name:    "list locked artists",
+			method:  http.MethodGet,
+			url:     "/api/v1/artists/locked?sort=evil_key",
+			handler: (*Router).handleListLockedArtists,
+		},
+		{
+			name:    "compliance report",
+			method:  http.MethodGet,
+			url:     "/api/v1/reports/compliance?sort=evil_key",
+			handler: (*Router).handleReportCompliance,
+		},
+		{
+			name:    "compliance export",
+			method:  http.MethodGet,
+			url:     "/api/v1/reports/compliance/export?sort=evil_key",
+			handler: (*Router).handleReportComplianceExport,
+		},
+		{
+			name:    "list notifications",
+			method:  http.MethodGet,
+			url:     "/api/v1/notifications?sort=evil_key",
+			handler: (*Router).handleListNotifications,
+		},
+		{
+			name:    "notifications export",
+			method:  http.MethodGet,
+			url:     "/api/v1/notifications/export?sort=evil_key",
+			handler: (*Router).handleNotificationsExport,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r, _ := testRouter(t)
+			req := httptest.NewRequest(tc.method, tc.url, nil)
+			w := httptest.NewRecorder()
+			tc.handler(r, w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 (body=%q)", w.Code, w.Body.String())
+			}
+			// API responses use the structured {"error": "..."} JSON envelope.
+			var body map[string]string
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decoding response body %q: %v", w.Body.String(), err)
+			}
+			if !strings.Contains(body["error"], "invalid sort key") {
+				t.Errorf("error message %q does not mention invalid sort key", body["error"])
+			}
+		})
+	}
+}
+
+// TestSortAllowlist_AcceptsKnown asserts a known sort key still produces 200,
+// guarding against accidental over-restriction during the allowlist sweep.
+func TestSortAllowlist_AcceptsKnown(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		url     string
+		handler func(r *Router, w http.ResponseWriter, req *http.Request)
+	}{
+		{
+			name:    "list artists with sort_name",
+			url:     "/api/v1/artists?sort=sort_name&order=asc",
+			handler: (*Router).handleListArtists,
+		},
+		{
+			name:    "list artists empty sort uses default",
+			url:     "/api/v1/artists",
+			handler: (*Router).handleListArtists,
+		},
+		{
+			name:    "list notifications with severity",
+			url:     "/api/v1/notifications?sort=severity&order=desc",
+			handler: (*Router).handleListNotifications,
+		},
+		{
+			name:    "list notifications empty sort uses default",
+			url:     "/api/v1/notifications",
+			handler: (*Router).handleListNotifications,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r, _ := testRouter(t)
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			w := httptest.NewRecorder()
+			tc.handler(r, w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (body=%q)", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestSortAllowlist_RejectsUnknownOrder asserts the order parameter is also
+// allowlisted; only "", "asc", "desc" are accepted. Mirrors the sort test by
+// asserting both the 400 status and the structured error envelope content.
+func TestSortAllowlist_RejectsUnknownOrder(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists?order=sideways", nil)
+	w := httptest.NewRecorder()
+	r.handleListArtists(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body=%q)", w.Code, w.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding response body %q: %v", w.Body.String(), err)
+	}
+	if !strings.Contains(body["error"], "invalid order") {
+		t.Errorf("error message %q does not mention invalid order", body["error"])
+	}
+}
+
+// Note: the image search endpoints (handleImageSearch, handleWebImageSearch)
+// also gate sort through validateSortParam against allowedImageSearchSort,
+// but exercising them end-to-end requires a fully wired artist and live
+// provider responses. The shared helper is covered by the table-driven
+// cases above plus the dbutil package tests; the image handlers route
+// through the same boundary helper with the same semantics.

--- a/internal/artist/scan.go
+++ b/internal/artist/scan.go
@@ -164,10 +164,12 @@ func scanArtistWithExtra(row interface{ Scan(...any) error }, n int) (*artistWit
 }
 
 // validatedOrderClause returns a safe ORDER BY column expression from
-// ListParams. It assumes params.Validate() was called upstream to normalize
-// and allowlist the Sort and Order fields. The switch on params.Sort and the
-// fixed dir values below use only string literals, so static-analysis tools
-// can verify no user input flows into the SQL string.
+// ListParams. The HTTP boundary (dbutil.ValidateSortKey via the api package
+// helpers) rejects unknown sort keys with 400, and params.Validate() is a
+// second-line defense that normalizes any remaining unexpected value to the
+// "name" default. The switch on params.Sort and the fixed dir values below
+// use only string literals, so static-analysis tools can verify no user
+// input flows into the SQL string.
 func validatedOrderClause(params ListParams) string {
 	var col string
 	switch params.Sort {

--- a/internal/dbutil/sortguard.go
+++ b/internal/dbutil/sortguard.go
@@ -1,0 +1,54 @@
+package dbutil
+
+// ValidateSortKey checks a user-supplied sort key against a per-endpoint
+// allowlist of canonical column names. It returns the canonical SQL column
+// (the map value) when the key is allowed, false otherwise.
+//
+// An empty key returns the empty string and ok=true so handlers can preserve
+// their existing default-when-empty behavior (the caller substitutes its own
+// default before passing the result into a query). The allowlist values are
+// always literal column expressions controlled by the caller, never user
+// input, so the returned string is safe to interpolate into ORDER BY.
+//
+// Typical use at an HTTP boundary:
+//
+//	var allowedArtistSort = map[string]string{
+//	    "name":         "name",
+//	    "sort_name":    "sort_name",
+//	    "health_score": "health_score",
+//	    "updated_at":   "updated_at",
+//	    "created_at":   "created_at",
+//	}
+//
+//	col, ok := dbutil.ValidateSortKey(req.URL.Query().Get("sort"), allowedArtistSort)
+//	if !ok {
+//	    // 400 Bad Request with structured error JSON
+//	}
+//
+// Empty-string allowlist values are permitted (e.g. for in-memory sorters
+// that distinguish "no sort" from a named sort).
+func ValidateSortKey(key string, allowed map[string]string) (column string, ok bool) {
+	if key == "" {
+		return "", true
+	}
+	col, found := allowed[key]
+	if !found {
+		return "", false
+	}
+	return col, true
+}
+
+// ValidateSortOrder checks a user-supplied order string against the fixed
+// {"", "asc", "desc"} set. Empty input returns ok=true with the empty string
+// so the caller can substitute its own default. Any other value returns ok
+// false so the handler can emit a 400.
+func ValidateSortOrder(order string) (normalized string, ok bool) {
+	switch order {
+	case "":
+		return "", true
+	case "asc", "desc":
+		return order, true
+	default:
+		return "", false
+	}
+}

--- a/internal/dbutil/sortguard_test.go
+++ b/internal/dbutil/sortguard_test.go
@@ -1,0 +1,109 @@
+package dbutil
+
+import "testing"
+
+func TestValidateSortKey(t *testing.T) {
+	allowed := map[string]string{
+		"name":         "name",
+		"sort_name":    "sort_name",
+		"health_score": "health_score",
+	}
+
+	tests := []struct {
+		name       string
+		key        string
+		wantColumn string
+		wantOK     bool
+	}{
+		{
+			name:       "empty key returns ok with empty column for caller default",
+			key:        "",
+			wantColumn: "",
+			wantOK:     true,
+		},
+		{
+			name:       "known key returns canonical column",
+			key:        "name",
+			wantColumn: "name",
+			wantOK:     true,
+		},
+		{
+			name:       "known key with different value returns mapped column",
+			key:        "sort_name",
+			wantColumn: "sort_name",
+			wantOK:     true,
+		},
+		{
+			name:       "unknown key rejected",
+			key:        "evil",
+			wantColumn: "",
+			wantOK:     false,
+		},
+		{
+			name:       "SQL injection attempt rejected",
+			key:        "name; DROP TABLE artists",
+			wantColumn: "",
+			wantOK:     false,
+		},
+		{
+			name:       "case-sensitive match",
+			key:        "Name",
+			wantColumn: "",
+			wantOK:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			col, ok := ValidateSortKey(tc.key, allowed)
+			if ok != tc.wantOK {
+				t.Errorf("ValidateSortKey(%q) ok = %v, want %v", tc.key, ok, tc.wantOK)
+			}
+			if col != tc.wantColumn {
+				t.Errorf("ValidateSortKey(%q) column = %q, want %q", tc.key, col, tc.wantColumn)
+			}
+		})
+	}
+}
+
+func TestValidateSortKey_AllowlistWithRemappedColumn(t *testing.T) {
+	// The allowlist maps the public key to a different SQL expression --
+	// useful when the API key name differs from the column name (e.g. the
+	// "severity" public key maps to a CASE expression).
+	allowed := map[string]string{
+		"severity": "CASE rv.severity WHEN 'error' THEN 3 ELSE 0 END",
+	}
+	col, ok := ValidateSortKey("severity", allowed)
+	if !ok {
+		t.Fatalf("expected ok=true for known key")
+	}
+	if col != "CASE rv.severity WHEN 'error' THEN 3 ELSE 0 END" {
+		t.Errorf("expected mapped CASE expression, got %q", col)
+	}
+}
+
+func TestValidateSortOrder(t *testing.T) {
+	tests := []struct {
+		input  string
+		want   string
+		wantOK bool
+	}{
+		{"", "", true},
+		{"asc", "asc", true},
+		{"desc", "desc", true},
+		{"ASC", "", false},
+		{"ascending", "", false},
+		{"random", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got, ok := ValidateSortOrder(tc.input)
+			if ok != tc.wantOK {
+				t.Errorf("ValidateSortOrder(%q) ok = %v, want %v", tc.input, ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Errorf("ValidateSortOrder(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -1032,7 +1032,12 @@ func buildViolationFromClause(needJoin bool) string {
 	return q
 }
 
-// buildViolationOrderClause returns the ORDER BY portion for a violation query.
+// buildViolationOrderClause returns the ORDER BY portion for a violation
+// query. The HTTP boundary (dbutil.ValidateSortKey via the api package
+// helpers) rejects unknown sort keys with 400, so by the time control
+// reaches this helper p.Sort is either empty or a member of the allowlist.
+// The default branch ("severity DESC, created_at DESC") remains as a second
+// line of defense for non-HTTP callers (tests, internal call sites).
 func buildViolationOrderClause(p ViolationListParams) string {
 	severityRank := `CASE rv.severity WHEN 'error' THEN 3 WHEN 'warning' THEN 2 WHEN 'info' THEN 1 ELSE 0 END`
 


### PR DESCRIPTION
## Summary

- Add `internal/dbutil/sortguard.go` with `ValidateSortKey` and `ValidateSortOrder` plus unit tests.
- Add `internal/api/sort.go` with per-endpoint allowlists (`allowedArtistSort`, `allowedViolationSort`, `allowedImageSearchSort`) and the `validateSortParam` / `validateOrderParam` boundary helpers; every handler that reads `sort` or `order` from request input now runs through them and returns `400 {"error": "invalid sort key: ..."}` on unknown values.
- Migrated handlers: `handlers_artist.go` (list + page), `handlers_artist_lock.go`, `handlers_notifications.go` (params parser + caller signature), `handlers_report.go` (compliance + 2 export call sites), `handlers_image.go` (search + websearch).
- Existing `validatedOrderClause` and `buildViolationOrderClause` keep their default-fallback branches as defense-in-depth for internal non-HTTP callers; doc comments updated to describe the boundary-validated semantics.
- OpenAPI updated: `sort` enums + `default` and `400` responses added to `/artists`, `/artists/locked`, `/reports/compliance`, `/reports/compliance/export`, `/notifications`, `/notifications/export`, `/artists/{id}/images/search`, `/artists/{id}/images/websearch`.
- This PR **blocks W5** (coverage agents will assert the new 400 behavior).

## Test plan

- [x] `go test -race -count=1 ./internal/dbutil/...`
- [x] `go test -race -count=1 ./internal/artist/... ./internal/rule/... ./internal/api/...`
- [x] `bash scripts/pre-push-gate.sh` (patch coverage 74.36%, no breaking openapi changes after enum/400 additions)
- [x] UAT against running binary:
  - `GET /api/v1/artists?sort=name` -> 200
  - `GET /api/v1/artists?sort=DROP+TABLE` -> 400 `{"error":"invalid sort key: DROP TABLE"}`
  - `GET /api/v1/artists?order=sideways` -> 400
  - `GET /api/v1/notifications?sort=severity` -> 200
  - `GET /api/v1/notifications?sort=evil` -> 400
  - `GET /api/v1/reports/compliance?sort=evil` -> 400
- [x] Grep verification: `git grep -nE '(r\.URL\.Query\(\)|req\.URL\.Query\(\)|q\.Get)\("sort"\)' internal/` returns zero unguarded matches outside the helpers themselves.

Closes #1372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Endpoints now validate sort and order query parameters and return 400 Bad Request for invalid values instead of silently accepting or normalizing them.

* **Documentation**
  * API docs updated to enumerate allowed sort/order values and document 400 responses for affected endpoints.

* **Tests**
  * Added end-to-end and unit tests covering sort/order allowlists, validation, and error responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1478)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->