### PR TITLE
test(api): plug goroutine leak in pre-existing CSRF tests

### DIFF
--- a/internal/api/middleware/csrf_test.go
+++ b/internal/api/middleware/csrf_test.go
@@ -11,6 +11,7 @@ import (
 func TestCSRF_SafeMethodSetsToken(t *testing.T) {
 	t.Parallel()
 	csrf := NewCSRF()
+	t.Cleanup(csrf.Close)
 	handler := csrf.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -44,6 +45,7 @@ func TestCSRF_SafeMethodSetsToken(t *testing.T) {
 func TestCSRF_UnsafeMethodWithoutToken(t *testing.T) {
 	t.Parallel()
 	csrf := NewCSRF()
+	t.Cleanup(csrf.Close)
 	handler := csrf.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -60,6 +62,7 @@ func TestCSRF_UnsafeMethodWithoutToken(t *testing.T) {
 func TestCSRF_UnsafeMethodWithValidHeaderToken(t *testing.T) {
 	t.Parallel()
 	csrf := NewCSRF()
+	t.Cleanup(csrf.Close)
 	token := csrf.generate()
 
 	handler := csrf.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -79,6 +82,7 @@ func TestCSRF_UnsafeMethodWithValidHeaderToken(t *testing.T) {
 func TestCSRF_UnsafeMethodWithInvalidToken(t *testing.T) {
 	t.Parallel()
 	csrf := NewCSRF()
+	t.Cleanup(csrf.Close)
 	handler := csrf.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -96,6 +100,7 @@ func TestCSRF_UnsafeMethodWithInvalidToken(t *testing.T) {
 func TestCSRF_ExistingValidCookieNotReplaced(t *testing.T) {
 	t.Parallel()
 	csrf := NewCSRF()
+	t.Cleanup(csrf.Close)
 	token := csrf.generate()
 
 	handler := csrf.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -234,6 +239,7 @@ func generateRandomTokenForTest(t *testing.T) string {
 func TestCSRF_HeadAndOptionsAreSafe(t *testing.T) {
 	t.Parallel()
 	csrf := NewCSRF()
+	t.Cleanup(csrf.Close)
 	handler := csrf.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))


### PR DESCRIPTION
## Summary

Follow-up to #1477. CodeRabbit's review on #1477 flagged a Major outside-diff finding in the review body that was missed at merge time: the six pre-existing CSRF tests (`TestCSRF_SafeMethodSetsToken`, `TestCSRF_UnsafeMethodWithoutToken`, `TestCSRF_UnsafeMethodWithValidHeaderToken`, `TestCSRF_UnsafeMethodWithInvalidToken`, `TestCSRF_ExistingValidCookieNotReplaced`, `TestCSRF_HeadAndOptionsAreSafe`) call `NewCSRF()` but never `Close()`. The ticker-based cleanup introduced in #1477 starts a long-running goroutine from `NewCSRF`, so every one of those tests now leaks one goroutine per run.

Add `t.Cleanup(csrf.Close)` to each of the six pre-existing tests. The three new tests added by #1477 (`TestCSRF_CleanupRemovesExpiredTokens`, `TestCSRF_CleanupKeepsLiveTokens`, `TestCSRF_CloseStopsGoroutine`) already do this.

## Test plan

- [x] `go test -race -count=1 ./internal/api/middleware/...` (passes)
- [x] 6 t.Cleanup(csrf.Close) additions confirmed via grep

Refs the outside-diff finding from CodeRabbit's review on #1477 (review id 4269373633).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved CSRF middleware test reliability by ensuring proper resource cleanup after each test execution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1479)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->