### PR TITLE
fix(scripts): atomic lock around pre-push-gate to prevent same-worktree races

### DIFF
--- a/scripts/lib/run-paths.sh
+++ b/scripts/lib/run-paths.sh
@@ -14,9 +14,11 @@
 # Why deterministic (no mktemp XXXXXX):
 #   - Same worktree always writes the same path -- trivial to inspect, diff
 #     across runs, and clean up (`rm -rf $SW_RUN_DIR`).
-#   - Same-worktree concurrent runs WOULD clobber each other, but
-#     `feedback_no_parallel_heavy_gates` already bans that; the scope of
-#     "multi-agent safe" we want is ACROSS worktrees, which this delivers.
+#   - Same-worktree concurrent runs WOULD clobber each other; the scope of
+#     "multi-agent safe" this lib delivers is ACROSS worktrees. Callers that
+#     need exclusive same-worktree access (e.g. pre-push-gate.sh, which
+#     writes cover.out) must take their own lock under $SW_RUN_DIR; the gate
+#     uses an atomic `mkdir $SW_RUN_DIR/.gate-lock` for that purpose.
 #
 # Why source instead of inline:
 #   - Single place to evolve the convention. Future scripts get the same

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -26,10 +26,51 @@ fi
 # scripts/lib/run-paths.sh for the full rationale.
 . "$SCRIPT_DIR/lib/run-paths.sh"
 
+# Acquire an exclusive lock on this worktree's run-dir. Two gate invocations
+# in the same worktree both write to $SW_RUN_DIR/cover.out; without the lock,
+# whichever finishes last leaves a truncated profile and the patch-coverage
+# step then fails with "profile not found or empty". `mkdir` is atomic, so
+# the first caller wins; the loser exits with a clear pointer at the live
+# pid. Stale lock recovery: if the recorded pid no longer exists (gate was
+# killed, terminal was closed, machine rebooted), the lock is cleared and
+# re-acquired once. Lives in $SW_RUN_DIR so it cleans up when callers want
+# a fresh slate via `rm -rf $SW_RUN_DIR`.
+LOCK_DIR="$SW_RUN_DIR/.gate-lock"
+acquire_lock() {
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    echo "$$" > "$LOCK_DIR/pid"
+    return 0
+  fi
+  local holder stale=0
+  holder=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+  # A lock is stale when the recorded pid is missing/malformed (race between
+  # `mkdir` and `echo $$ > pid`, or the previous run crashed before writing
+  # pid), or when the recorded pid is no longer alive. Treating empty/garbage
+  # pid as "not stale" would block every future run with a permanent exit 2.
+  if [[ ! "$holder" =~ ^[0-9]+$ ]]; then
+    stale=1
+  elif ! kill -0 "$holder" 2>/dev/null; then
+    stale=1
+  fi
+  if [ "$stale" -eq 1 ]; then
+    echo "pre-push-gate: clearing stale lock (pid='${holder:-empty}')" >&2
+    rm -rf "$LOCK_DIR"
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      echo "$$" > "$LOCK_DIR/pid"
+      return 0
+    fi
+  fi
+  echo "FAIL: another pre-push-gate is running in this worktree (pid ${holder:-unknown})." >&2
+  echo "      Wait for it to finish or kill it before retrying." >&2
+  exit 2
+}
+acquire_lock
+
 COVER_OUT="$SW_RUN_DIR/cover.out"
 tmp_openapi=""
 cleanup() {
   rm -f "${COVER_OUT:-}" "${tmp_openapi:-}"
+  rm -rf "${LOCK_DIR:-}"
 }
 trap cleanup EXIT
 

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -36,6 +36,14 @@ fi
 # re-acquired once. Lives in $SW_RUN_DIR so it cleans up when callers want
 # a fresh slate via `rm -rf $SW_RUN_DIR`.
 LOCK_DIR="$SW_RUN_DIR/.gate-lock"
+# Grace window before an empty/malformed pid file counts as stale. The only
+# legitimate way to observe an empty $LOCK_DIR/pid is by racing into the
+# window between `mkdir "$LOCK_DIR"` and `echo $$ > $LOCK_DIR/pid`, which
+# lasts microseconds. A few seconds of grace covers any plausible scheduler
+# delay; a previous run that crashed between those two lines recovers after
+# the window elapses. Kept small so a legitimately-killed gate is recovered
+# quickly on the next attempt.
+LOCK_INIT_GRACE_SECONDS=5
 acquire_lock() {
   if mkdir "$LOCK_DIR" 2>/dev/null; then
     echo "$$" > "$LOCK_DIR/pid"
@@ -43,12 +51,31 @@ acquire_lock() {
   fi
   local holder stale=0
   holder=$(cat "$LOCK_DIR/pid" 2>/dev/null || true)
+  # `stat -c` is GNU (Linux CI); `stat -f` is BSD (macOS dev). Fall back to
+  # epoch=0 (=> "old enough to be stale") only if both fail, so a missing
+  # stat does not leave the lock un-recoverable.
+  local now lock_mtime lock_age
+  now=$(date +%s)
+  lock_mtime=$(stat -c %Y "$LOCK_DIR" 2>/dev/null \
+            || stat -f %m "$LOCK_DIR" 2>/dev/null \
+            || echo 0)
+  lock_age=$(( now - lock_mtime ))
   # A lock is stale when the recorded pid is missing/malformed (race between
   # `mkdir` and `echo $$ > pid`, or the previous run crashed before writing
-  # pid), or when the recorded pid is no longer alive. Treating empty/garbage
-  # pid as "not stale" would block every future run with a permanent exit 2.
+  # pid), or when the recorded pid is no longer alive. The age gate avoids
+  # the TOCTOU window where a racer reads empty pid right after another
+  # caller's mkdir and clobbers a live lock; only treat missing/malformed
+  # pid as stale after the grace window. Treating empty/garbage pid as
+  # "not stale" indefinitely would block every future run with a permanent
+  # exit 2 if a gate was killed mid-init, so the age gate is the recovery
+  # path for that case too.
   if [[ ! "$holder" =~ ^[0-9]+$ ]]; then
-    stale=1
+    if [ "$lock_age" -ge "$LOCK_INIT_GRACE_SECONDS" ]; then
+      stale=1
+    else
+      echo "FAIL: pre-push-gate lock is initializing in this worktree; retry in a moment." >&2
+      exit 2
+    fi
   elif ! kill -0 "$holder" 2>/dev/null; then
     stale=1
   fi


### PR DESCRIPTION
## Summary

Two parallel `pre-push-gate.sh` invocations in the same worktree race on `$SW_RUN_DIR/cover.out`. Whichever finishes last leaves a truncated profile and the patch-coverage step then fails with `profile not found or empty`, which masks the actual concurrent-run cause and rejects a legitimate push.

The lib previously documented this trade-off (`scripts/lib/run-paths.sh` comment: "Same-worktree concurrent runs WOULD clobber each other, but feedback_no_parallel_heavy_gates already bans that") and relied on user discipline. Hit during M49 W5 5A push when a duplicate push attempt produced two parallel gates -- the kill that "fixed" it just made the survivor fail the same way.

Atomic `mkdir $SW_RUN_DIR/.gate-lock` at gate entry; second invocation reads the recorded pid, prints a clear pointer at the live gate, exits 2 (matching the existing exit-2 convention for setup-state failures). Stale lock cleanup: if the recorded pid is no longer alive (terminal closed, machine rebooted, gate killed), the lock is cleared and re-acquired once.

Run-paths.sh comment updated to reflect that exclusive same-worktree access is now caller-owned.

## Test plan

- [x] First acquire succeeds (exit 0, pid recorded)
- [x] Second acquire fails fast against live pid (exit 2, clear error)
- [x] Stale-pid recovery clears lock and re-acquires (exit 0)
- [x] `bash -n scripts/pre-push-gate.sh` syntax-clean
- [x] `bash scripts/pre-push-gate.sh` end-to-end gate run passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent concurrent pre-push gate runs from interfering with each other by enforcing an exclusive per-worktree lock.
  * Automatically detect and clear stale locks from interrupted runs.
  * Provide clear user guidance when a gate run is already in progress, with instructions to wait or terminate the existing process.

* **Documentation**
  * Clarified multi-agent safety semantics and caller-managed locking requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1481)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->