### PR TITLE
test(api): adopt kin-openapi validator in image coverage tests

### DIFF
--- a/internal/api/handlers_image_coverage_test.go
+++ b/internal/api/handlers_image_coverage_test.go
@@ -19,9 +19,23 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/provider"
 )
+
+// init registers a text/html body decoder for the kin-openapi validator. The
+// image search / info / websearch endpoints negotiate JSON vs HTML responses
+// via the HX-Request header, and several tests exercise the HTML arm so that
+// regressions flipping the arm (or dropping the Content-Type) surface here.
+// kin-openapi ships decoders only for application/json, text/plain, etc.;
+// without a text/html decoder ValidateResponse fatals with "unsupported
+// content type" before checking the schema. Registering PlainBodyDecoder
+// treats the body as an opaque string, which matches how the spec declares
+// these responses (`text/html: schema: type: string`).
+func init() {
+	openapi3filter.RegisterBodyDecoder("text/html", openapi3filter.PlainBodyDecoder)
+}
 
 // newImageHandlerTestServer builds a Router with the platform service wired,
 // an empty orchestrator + web-search registry (both required by the search
@@ -95,9 +109,8 @@ func TestHandleImageFetch_ArtistNotFound(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/missing/images/fetch", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("id", "missing")
-	w := httptest.NewRecorder()
 
-	r.handleImageFetch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageFetch), req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", w.Code)
 	}
@@ -117,6 +130,10 @@ func TestHandleImageFetch_InvalidImageType(t *testing.T) {
 	req.SetPathValue("id", a.ID)
 	w := httptest.NewRecorder()
 
+	// Pattern B: spec's request body declares `type` enum [thumb,fanart,logo,banner].
+	// Sending `poster` would be rejected by the request validator before
+	// reaching the handler; this test exercises the handler's own
+	// defense-in-depth rejection, so call the handler directly.
 	r.handleImageFetch(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
@@ -135,9 +152,8 @@ func TestHandleImageFetch_MissingURL(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fetch", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleImageFetch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageFetch), req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", w.Code)
 	}
@@ -155,9 +171,8 @@ func TestHandleImageFetch_NonHTTPScheme(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fetch", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleImageFetch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageFetch), req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", w.Code)
 	}
@@ -178,9 +193,8 @@ func TestHandleImageFetch_PrivateURL_Rejected(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fetch", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleImageFetch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageFetch), req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
 	}
@@ -204,9 +218,8 @@ func TestHandleImageFetch_FetchFails_BadGateway(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fetch?skip_crop=true", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleImageFetch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageFetch), req)
 	if w.Code != http.StatusBadGateway {
 		t.Fatalf("status = %d, want 502; body: %s", w.Code, w.Body.String())
 	}
@@ -236,9 +249,8 @@ func TestHandleImageFetch_NeedsCrop(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fetch", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleImageFetch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageFetch), req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
@@ -267,9 +279,8 @@ func TestHandleImageFetch_FormEncoded_Success(t *testing.T) {
 		strings.NewReader(form))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleImageFetch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageFetch), req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
@@ -291,9 +302,8 @@ func TestHandleImageFetch_FanartAppend(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fetch?skip_crop=true", body)
 	req.Header.Set("Content-Type", "application/json")
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleImageFetch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageFetch), req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
@@ -331,6 +341,9 @@ func TestHandleImageFetch_InvalidJSON(t *testing.T) {
 	req.SetPathValue("id", a.ID)
 	w := httptest.NewRecorder()
 
+	// Pattern B: malformed JSON is rejected by the wrapper's request validator
+	// before the handler sees it; this test exercises the handler's own
+	// decode-error path, so call the handler directly.
 	r.handleImageFetch(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", w.Code)
@@ -352,9 +365,8 @@ func TestHandleImageFetch_HTMXSuccess(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("HX-Request", "true")
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleImageFetch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageFetch), req)
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want 204; body: %s", w.Code, w.Body.String())
 	}
@@ -373,9 +385,8 @@ func TestHandleImageSearch_ArtistNotFound(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/missing/images/search", nil)
 	req.SetPathValue("id", "missing")
-	w := httptest.NewRecorder()
 
-	r.handleImageSearch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageSearch), req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", w.Code)
 	}
@@ -391,9 +402,8 @@ func TestHandleImageSearch_NoMBID(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/images/search", nil)
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleImageSearch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageSearch), req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
 	}
@@ -411,6 +421,9 @@ func TestHandleImageSearch_InvalidSort(t *testing.T) {
 	req.SetPathValue("id", a.ID)
 	w := httptest.NewRecorder()
 
+	// Pattern B: spec declares sort enum [likes,resolution]; the wrapper would
+	// reject `evil` before the handler runs. This test exercises the handler's
+	// own enum check, so call directly.
 	r.handleImageSearch(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", w.Code)
@@ -427,9 +440,8 @@ func TestHandleImageSearch_EmptyResults_JSON(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/images/search?type=thumb", nil)
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleImageSearch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageSearch), req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
@@ -455,9 +467,8 @@ func TestHandleImageSearch_HTMXFanart(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/images/search?type=fanart", nil)
 	req.Header.Set("HX-Request", "true")
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleImageSearch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageSearch), req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
@@ -477,9 +488,8 @@ func TestHandleImageSearch_HTMXNonFanart(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/images/search?type=thumb", nil)
 	req.Header.Set("HX-Request", "true")
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleImageSearch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageSearch), req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
@@ -496,9 +506,8 @@ func TestHandleWebImageSearch_ArtistNotFound(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/artists/missing/images/websearch?type=thumb", nil)
 	req.SetPathValue("id", "missing")
-	w := httptest.NewRecorder()
 
-	r.handleWebImageSearch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleWebImageSearch), req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", w.Code)
 	}
@@ -516,6 +525,9 @@ func TestHandleWebImageSearch_MissingType(t *testing.T) {
 	req.SetPathValue("id", a.ID)
 	w := httptest.NewRecorder()
 
+	// Pattern B: spec marks `type` query param required. Wrapper rejects the
+	// missing param before the handler runs; this test exercises the handler's
+	// own check, so call directly.
 	r.handleWebImageSearch(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", w.Code)
@@ -535,6 +547,8 @@ func TestHandleWebImageSearch_InvalidType(t *testing.T) {
 	req.SetPathValue("id", a.ID)
 	w := httptest.NewRecorder()
 
+	// Pattern B: spec declares type enum [thumb,fanart,logo,banner]. Wrapper
+	// rejects `poster`; this test exercises the handler's own enum check.
 	r.handleWebImageSearch(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", w.Code)
@@ -554,6 +568,8 @@ func TestHandleWebImageSearch_InvalidSort(t *testing.T) {
 	req.SetPathValue("id", a.ID)
 	w := httptest.NewRecorder()
 
+	// Pattern B: spec declares sort enum [likes,resolution]. Wrapper rejects
+	// `evil`; this test exercises the handler's own enum check.
 	r.handleWebImageSearch(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", w.Code)
@@ -571,9 +587,8 @@ func TestHandleWebImageSearch_EmptyResults_JSON(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/v1/artists/"+a.ID+"/images/websearch?type=thumb", nil)
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleWebImageSearch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleWebImageSearch), req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
@@ -607,9 +622,8 @@ func TestHandleWebImageSearch_HTMX(t *testing.T) {
 		"/api/v1/artists/"+a.ID+"/images/websearch?type=thumb", nil)
 	req.Header.Set("HX-Request", "true")
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleWebImageSearch(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleWebImageSearch), req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
@@ -636,6 +650,8 @@ func TestHandleImageInfo_InvalidType(t *testing.T) {
 	req.SetPathValue("type", "poster")
 	w := httptest.NewRecorder()
 
+	// Pattern B: spec restricts the path `type` to enum [thumb,fanart,logo,banner].
+	// Wrapper rejects `poster`; this test exercises the handler's own check.
 	r.handleImageInfo(w, req)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", w.Code)
@@ -649,9 +665,8 @@ func TestHandleImageInfo_ArtistNotFound(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/missing/images/thumb/info", nil)
 	req.SetPathValue("id", "missing")
 	req.SetPathValue("type", "thumb")
-	w := httptest.NewRecorder()
 
-	r.handleImageInfo(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageInfo), req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", w.Code)
 	}
@@ -670,9 +685,8 @@ func TestHandleImageInfo_NoImageDir(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/images/thumb/info", nil)
 	req.SetPathValue("id", a.ID)
 	req.SetPathValue("type", "thumb")
-	w := httptest.NewRecorder()
 
-	r.handleImageInfo(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageInfo), req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", w.Code)
 	}
@@ -689,9 +703,8 @@ func TestHandleImageInfo_FileMissing(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/images/thumb/info", nil)
 	req.SetPathValue("id", a.ID)
 	req.SetPathValue("type", "thumb")
-	w := httptest.NewRecorder()
 
-	r.handleImageInfo(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageInfo), req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", w.Code)
 	}
@@ -711,9 +724,8 @@ func TestHandleImageInfo_Success_JSON(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/images/thumb/info", nil)
 	req.SetPathValue("id", a.ID)
 	req.SetPathValue("type", "thumb")
-	w := httptest.NewRecorder()
 
-	r.handleImageInfo(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageInfo), req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
@@ -752,9 +764,8 @@ func TestHandleImageInfo_Success_HTMX(t *testing.T) {
 	req.Header.Set("HX-Request", "true")
 	req.SetPathValue("id", a.ID)
 	req.SetPathValue("type", "thumb")
-	w := httptest.NewRecorder()
 
-	r.handleImageInfo(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleImageInfo), req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", w.Code)
 	}
@@ -775,6 +786,12 @@ func TestHandleLogoTrim_ArtistNotFound(t *testing.T) {
 	req.SetPathValue("id", "missing")
 	w := httptest.NewRecorder()
 
+	// Sentinel direct call: TestOperationIDCoverage scans test files for
+	// CallExprs whose Fun is `r.handleX`; the other LogoTrim cases go through
+	// serveValidated(http.HandlerFunc(r.handleLogoTrim), ...), which the AST
+	// walker reads as a HandlerFunc CallExpr (not a handleLogoTrim CallExpr)
+	// and so doesn't count toward `trimLogo` operationId coverage. Keep one
+	// raw call so the ratchet sees the reference.
 	r.handleLogoTrim(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", w.Code)
@@ -791,9 +808,8 @@ func TestHandleLogoTrim_LogoNotFound(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/logo/trim", nil)
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleLogoTrim(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleLogoTrim), req)
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404; body: %s", w.Code, w.Body.String())
 	}
@@ -826,9 +842,8 @@ func TestHandleLogoTrim_Success_JSON(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/logo/trim", nil)
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleLogoTrim(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleLogoTrim), req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
 	}
@@ -850,9 +865,8 @@ func TestHandleLogoTrim_HTMX_Success(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/logo/trim", nil)
 	req.Header.Set("HX-Request", "true")
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleLogoTrim(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleLogoTrim), req)
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want 204; body: %s", w.Code, w.Body.String())
 	}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -2992,14 +2992,12 @@ paths:
                 type: object
                 properties:
                   images:
-                    type: array
-                    nullable: true
+                    type: [array, "null"]
                     items:
                       type: object
                     description: List of available images from providers. May be null when no providers returned results.
                   errors:
-                    type: array
-                    nullable: true
+                    type: [array, "null"]
                     items:
                       type: string
                     description: Errors encountered during the image search. May be null when no errors occurred.
@@ -9876,8 +9874,7 @@ paths:
                 type: object
                 properties:
                   images:
-                    type: array
-                    nullable: true
+                    type: [array, "null"]
                     items:
                       type: object
                     description: Image results from web search providers. May be null when no providers returned results.

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -2933,12 +2933,32 @@ paths:
                   image_data:
                     type: string
                     description: Base64-encoded data URI of the fetched image. Present only when needs_crop is true, for use in a client-side crop tool.
+        "204":
+          description: Image fetched and saved (HTMX request); HX-Refresh response header tells the client to reload.
+        "400":
+          description: Invalid request (missing or unsupported URL, unsupported image type, malformed body, or non-public URL)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Artist not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         "409":
           description: Write blocked by the conflict ledger
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ConflictWriteBlock"
+        "502":
+          description: Upstream image fetch failed (network error, non-2xx response, or decode failure)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /artists/{id}/images/search:
     get:
@@ -2973,19 +2993,27 @@ paths:
                 properties:
                   images:
                     type: array
+                    nullable: true
                     items:
                       type: object
-                    description: List of available images from providers.
+                    description: List of available images from providers. May be null when no providers returned results.
                   errors:
                     type: array
+                    nullable: true
                     items:
                       type: string
-                    description: Errors encountered during the image search.
+                    description: Errors encountered during the image search. May be null when no errors occurred.
             text/html:
               schema:
                 type: string
         "400":
           description: Invalid sort parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Artist not found
           content:
             application/json:
               schema:
@@ -9849,14 +9877,21 @@ paths:
                 properties:
                   images:
                     type: array
+                    nullable: true
                     items:
                       type: object
-                    description: Image results from web search providers.
+                    description: Image results from web search providers. May be null when no providers returned results.
             text/html:
               schema:
                 type: string
         "400":
           description: Invalid sort parameter
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Artist not found
           content:
             application/json:
               schema:
@@ -9889,6 +9924,8 @@ paths:
                     items:
                       type: string
                     description: Platform sync warnings, including failures and reasons why sync was skipped. Empty only when there are no warnings.
+        "204":
+          description: Logo trimmed (HTMX request); HX-Refresh response header tells the client to reload.
         "404":
           description: Artist or logo not found
           content:


### PR DESCRIPTION
## Summary

Third adoption PR of [#1094](https://github.com/sydlexius/stillwater/issues/1094). Wraps 25 Pattern A invocations in `handlers_image_coverage_test.go` with `serveValidated` (the wrapper landed via #1486). 8 invocations stay raw with explanatory inline comments.

## Why some calls stay raw

- **7 negative-input tests** (InvalidImageType, InvalidJSON, InvalidSort variants, MissingType, etc.): the hostile input violates the spec's enum or required-param declarations, so the wrapper would reject the request before the handler can produce the 400 the test expects.
- **1 LogoTrim ArtistNotFound**: kept as a direct call so the operationId coverage ratchet still counts `trimLogo`. (Same root cause as the connection PR -- ratchet walks `CallExpr.Fun`, and wrapping moves the handler name into an argument position.)

## text/html decoder registration

Adds an `init()` in this test file that registers `openapi3filter.PlainBodyDecoder` for `text/html`. Several `/artists/{id}/images/...` operations declare `text/html` responses with `schema: type: string` for HX-Request HTML fragments. kin-openapi ships no text/html decoder by default; without registration the validator would `t.Fatalf` with "unsupported content type" before checking the schema. PlainBodyDecoder treats the body as an opaque string, matching the spec's declaration. Scoped to the test binary only; no production impact.

## Spec drift surfaced and fixed

All drift was the spec lagging actual handler behavior; no handler bugs found.

- `POST /artists/{id}/images/fetch`: added 204 (HTMX HX-Refresh), 400, 404, 502.
- `GET /artists/{id}/images/search`: added 404; marked `images` and `errors` arrays `nullable: true`. Handler returns Go `nil` slices in the empty-result path, which JSON-encode to `null`, not `[]` -- the kind of contract drift kin-openapi catches that nothing else does.
- `GET /artists/{id}/images/websearch`: added 404; same `images` nullable fix.
- `POST /artists/{id}/images/logo/trim`: added 204 (HTMX HX-Refresh).

## Test plan

- [x] `go test -count=1 -timeout 180s ./internal/api/...` passes
- [x] `make check-openapi` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `TestOperationIDCoverage` passes (ratchet maintained via the LogoTrim sentinel raw call)
- [ ] CI green
- [ ] CodeRabbit review

Part of #1094.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified API response contracts for image fetch, search, websearch, and logo-trim endpoints.
  * Documented HTMX-compatible 204 outcomes for fetch and logo-trim operations.
  * Standardized documented 400, 404, 409, and 502 error responses to use the shared Error schema.

* **Bug Fixes**
  * Image search/websearch responses now allow nullable image and error arrays.
  * HTML response content types are accepted for image-related endpoints.

* **Tests**
  * Endpoint tests updated to run through response-validation wrappers; comments added for negative-input cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1490)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->