### PR TITLE
test(api): adopt kin-openapi validator in identify tier2 tests

### DIFF
--- a/internal/api/handlers_identify_tier2_test.go
+++ b/internal/api/handlers_identify_tier2_test.go
@@ -737,8 +737,7 @@ func TestBulkIdentify_ResetsAfterPanic(t *testing.T) {
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/bulk-identify", nil)
-	w := httptest.NewRecorder()
-	r.handleBulkIdentify(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleBulkIdentify), req)
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("first POST status = %d, want %d; body: %s", w.Code, http.StatusAccepted, w.Body.String())
 	}
@@ -769,8 +768,7 @@ func TestBulkIdentify_ResetsAfterPanic(t *testing.T) {
 	// still has no MBID — the linking never completed — so
 	// handleBulkIdentify rediscovers it and returns 202 accepted.
 	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/artists/bulk-identify", nil)
-	w2 := httptest.NewRecorder()
-	r.handleBulkIdentify(w2, req2)
+	w2 := serveValidated(t, http.HandlerFunc(r.handleBulkIdentify), req2)
 	if w2.Code != http.StatusAccepted {
 		t.Fatalf("second POST status = %d, want %d (panic slot not released cleanly); body: %s",
 			w2.Code, http.StatusAccepted, w2.Body.String())


### PR DESCRIPTION
## Summary

Fourth adoption PR of [#1094](https://github.com/sydlexius/stillwater/issues/1094). Wraps the 2 Pattern A `handleBulkIdentify` invocations in `handlers_identify_tier2_test.go` with `serveValidated`.

Tiny diff (6-line change). The rest of the file calls internal sub-handlers and helpers directly (Pattern B): `identifyArtist`, `enrichAndScoreTier2`, `evaluateTier2`, `runBulkIdentify`, `convertToScoredCandidates`. None of those decode JSON bodies, so they stay raw.

## No spec edits

The `/artists/identify/bulk` POST spec already declares 200/202/400/409/500/503 responses with the matching shapes. Request body is `required: false`, so nil-body iterations validate. No drift surfaced.

## Ratchet

The operationId coverage ratchet still sees `startBulkIdentify` as covered through six direct `handleBulkIdentify` calls in the sibling file `handlers_identify_test.go`. No sentinel raw call needed in this file.

Part of #1094.

## Test plan

- [x] `go test -count=1 -timeout 180s ./internal/api/...` passes
- [x] `make check-openapi` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [ ] CI green
- [ ] CodeRabbit review

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure for bulk identify handler verification to use a consistent helper method.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1491)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->