### PR TITLE
test(api): adopt kin-openapi validator in nfo conflict tests

### DIFF
--- a/internal/api/handlers_nfo_conflict_test.go
+++ b/internal/api/handlers_nfo_conflict_test.go
@@ -120,9 +120,8 @@ func TestHandleNFOConflictCheck_NoConflict(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/nfo/conflict", nil)
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleNFOConflictCheck(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleNFOConflictCheck), req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
@@ -176,9 +175,8 @@ func TestHandleNFOConflictCheck_DetectedConflict(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/nfo/conflict", nil)
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleNFOConflictCheck(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleNFOConflictCheck), req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
@@ -218,9 +216,8 @@ func TestHandleNFOConflictCheck_NoSnapshotFallback(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/nfo/conflict", nil)
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleNFOConflictCheck(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleNFOConflictCheck), req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
@@ -242,6 +239,15 @@ func TestHandleNFOConflictCheck_NoSnapshotFallback(t *testing.T) {
 
 // TestHandleNFOConflictCheck_NotFound covers the early-return on
 // artistService.GetByID failure.
+//
+// Sentinel: this is the ONE test in the file that invokes
+// handleNFOConflictCheck directly rather than through serveValidated. The
+// operationId coverage walker at internal/api/operationid_coverage_test.go
+// scans CallExpr.Fun for handler-name selectors; wrapping with
+// http.HandlerFunc(r.handleNFOConflictCheck) demotes the handler to an
+// argument, making it invisible to the walker. Keeping one direct call
+// preserves the "covered" entry in testdata/openapi-coverage.json for the
+// checkNFOConflict operationId. Do NOT "fix" this by also wrapping it.
 func TestHandleNFOConflictCheck_NotFound(t *testing.T) {
 	t.Parallel()
 	r, _, _, _ := newNFOTestServer(t)
@@ -317,9 +323,8 @@ func TestHandleNFOConflictCheck_LidarrWriterFlagged(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/nfo/conflict", nil)
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleNFOConflictCheck(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleNFOConflictCheck), req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
@@ -387,9 +392,8 @@ func TestHandleNFOConflictCheck_DisabledConnectionIgnored(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/nfo/conflict", nil)
 	req.SetPathValue("id", a.ID)
-	w := httptest.NewRecorder()
 
-	r.handleNFOConflictCheck(w, req)
+	w := serveValidated(t, http.HandlerFunc(r.handleNFOConflictCheck), req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -3115,6 +3115,12 @@ paths:
                     type: string
                     format: date-time
                     description: Present when the NFO file exists and is accessible; contains the file's last-modified timestamp regardless of conflict status. Omitted when the file does not exist or cannot be accessed (pathless artists, missing file, or filesystem errors).
+        "404":
+          description: Artist not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /history/{id}/revert:
     post:


### PR DESCRIPTION
## Summary

Fifth adoption PR of [#1094](https://github.com/sydlexius/stillwater/issues/1094). Wraps 5 Pattern A `handleNFOConflictCheck` invocations in `handlers_nfo_conflict_test.go` with `serveValidated`. 2 invocations stay raw with inline rationale.

## Why some stay raw

- **`TestHandleNFOConflictCheck_NotFound`**: operationId ratchet sentinel. All six unit tests target the same handler / operationId. Wrapping all of them makes `handleNFOConflictCheck` invisible to the `*ast.CallExpr.Fun` walker in `operationid_coverage_test.go:411` (it moves into an `http.HandlerFunc` argument). The 4-line NotFound test is the simplest sentinel.
- **`FuzzHandleNFOConflictCheck`**: fuzz is out of scope for the wrapper per the established convention -- hostile input would fail request validation on nearly every iteration.

## Spec drift surfaced and fixed

- `POST /artists/{id}/nfo/conflict`: added `404` response declaration. The handler at `handlers_nfo.go:111` emits 404 via `writeError` when `artistService.GetByID` fails (asserted by the NotFound sentinel test). Follows the #1489/#1490 precedent of declaring statuses the handler obviously emits.

No handler bugs found.

Part of #1094.

## Test plan

- [x] `go test -count=1 -timeout 180s ./internal/api/...` passes
- [x] `make check-openapi` passes
- [x] `golangci-lint run ./...` reports 0 issues
- [x] `TestOperationIDCoverage` passes
- [ ] CI green
- [ ] CodeRabbit review

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation for the artist NFO conflict endpoint to specify 404 responses when an artist is not found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1492)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->