### PR TITLE
refactor(artist): replace buildWhereClause switch ladders with typed predicate map

### DIFF
--- a/internal/artist/scan.go
+++ b/internal/artist/scan.go
@@ -191,6 +191,127 @@ func validatedOrderClause(params ListParams) string {
 	return col + " " + dir
 }
 
+// filterPredicate maps an include/exclude state to a SQL fragment and its bound
+// arguments. An empty fragment signals that the state is not applicable (e.g.
+// an unrecognized state string); the caller skips such entries.
+type filterPredicate func(state string) (fragment string, args []any)
+
+// imageExistsClause builds a single NOT EXISTS / EXISTS sub-select for the
+// artist_images table. Keeping the template here avoids repeating the table
+// name and column list in every predicate definition.
+func imageExistsClause(imageType string, exists bool) string {
+	if exists {
+		return "EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = '" + imageType + "' AND exists_flag = 1)"
+	}
+	return "NOT EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = '" + imageType + "' AND exists_flag = 1)"
+}
+
+// legacyImageTypes is the ordered set of image types used by the missing_images
+// multi-EXISTS predicate. Order is stable so generated SQL is deterministic.
+var legacyImageTypes = []string{"thumb", "fanart", "logo", "banner"}
+
+// missingImagesPredicate returns a compound SQL fragment that matches artists
+// missing ANY image type (include) or having ALL image types (exclude).
+func missingImagesPredicate(state string) (string, []any) {
+	parts := make([]string, len(legacyImageTypes))
+	switch state {
+	case "include":
+		// Match artists missing ANY of the tracked image types.
+		for i, t := range legacyImageTypes {
+			parts[i] = imageExistsClause(t, false)
+		}
+		return "(" + strings.Join(parts, " OR ") + ")", nil
+	case "exclude":
+		// Match artists that have ALL of the tracked image types (drops the missing ones).
+		for i, t := range legacyImageTypes {
+			parts[i] = imageExistsClause(t, true)
+		}
+		return "(" + strings.Join(parts, " AND ") + ")", nil
+	}
+	return "", nil
+}
+
+// artistFilterPredicates maps flyout filter keys to their predicate functions.
+// Keys here are the canonical names from ListParams.Filters. Each predicate
+// receives the filter state ("include" or "exclude") and returns the SQL
+// fragment and any bound arguments for that state. Predicates that produce no
+// SQL for a given state return an empty fragment.
+//
+// Type filters (type_person, type_group, type_orchestra) and library filters
+// (library_{id}) are NOT in this map; they aggregate across multiple keys and
+// are handled separately in buildWhereClause.
+var artistFilterPredicates = map[string]filterPredicate{
+	"missing_meta": func(state string) (string, []any) {
+		switch state {
+		case "include":
+			return "nfo_exists = 0", nil
+		case "exclude":
+			return "nfo_exists = 1", nil
+		}
+		return "", nil
+	},
+	"missing_images": missingImagesPredicate,
+	"missing_mbid": func(state string) (string, []any) {
+		switch state {
+		case "include":
+			return "NOT EXISTS (SELECT 1 FROM artist_provider_ids WHERE artist_id = artists.id AND provider = 'musicbrainz')", nil
+		case "exclude":
+			return "EXISTS (SELECT 1 FROM artist_provider_ids WHERE artist_id = artists.id AND provider = 'musicbrainz')", nil
+		}
+		return "", nil
+	},
+	"excluded": func(state string) (string, []any) {
+		switch state {
+		case "include":
+			return "is_excluded = 1", nil
+		case "exclude":
+			return "is_excluded = 0", nil
+		}
+		return "", nil
+	},
+	"locked": func(state string) (string, []any) {
+		switch state {
+		case "include":
+			return "locked = 1", nil
+		case "exclude":
+			return "locked = 0", nil
+		}
+		return "", nil
+	},
+}
+
+// typeFilterKeys maps flyout type-filter keys to their database type name
+// values. type_person maps to two values because MusicBrainz stores Person as
+// "solo" while legacy imports may use "person".
+var typeFilterKeys = map[string][]string{
+	"type_person":    {"person", "solo"},
+	"type_group":     {"group"},
+	"type_orchestra": {"orchestra"},
+}
+
+// buildPlaceholders returns a comma-separated "?,?,?" string of length n.
+func buildPlaceholders(n int) string {
+	ph := strings.Repeat("?,", n)
+	return ph[:len(ph)-1]
+}
+
+// legacyFilterSQL maps the legacy single-value params.Filter strings to fixed
+// SQL fragments. These use only literal values (no user input is interpolated).
+var legacyFilterSQL = map[string]string{
+	"missing_nfo":    "nfo_exists = 0",
+	"missing_thumb":  imageExistsClause("thumb", false),
+	"missing_fanart": imageExistsClause("fanart", false),
+	"missing_logo":   imageExistsClause("logo", false),
+	"missing_banner": imageExistsClause("banner", false),
+	"missing_mbid":   "NOT EXISTS (SELECT 1 FROM artist_provider_ids WHERE artist_id = artists.id AND provider = 'musicbrainz')",
+	"excluded":       "is_excluded = 1",
+	"not_excluded":   "is_excluded = 0",
+	"locked":         "locked = 1",
+	"not_locked":     "locked = 0",
+	"compliant":      "health_score >= 100",
+	"non_compliant":  "health_score < 100",
+}
+
 // buildWhereClause constructs WHERE conditions from list parameters.
 func buildWhereClause(params ListParams) (string, []any) {
 	var conditions []string
@@ -227,154 +348,81 @@ func buildWhereClause(params ListParams) (string, []any) {
 		args = append(args, params.LibraryID)
 	}
 
-	switch params.Filter {
-	case "missing_nfo":
-		conditions = append(conditions, "nfo_exists = 0")
-	case "missing_thumb":
-		conditions = append(conditions, "NOT EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = 'thumb' AND exists_flag = 1)")
-	case "missing_fanart":
-		conditions = append(conditions, "NOT EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = 'fanart' AND exists_flag = 1)")
-	case "missing_logo":
-		conditions = append(conditions, "NOT EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = 'logo' AND exists_flag = 1)")
-	case "missing_banner":
-		conditions = append(conditions, "NOT EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = 'banner' AND exists_flag = 1)")
-	case "missing_mbid":
-		conditions = append(conditions, "NOT EXISTS (SELECT 1 FROM artist_provider_ids WHERE artist_id = artists.id AND provider = 'musicbrainz')")
-	case "excluded":
-		conditions = append(conditions, "is_excluded = 1")
-	case "not_excluded":
-		conditions = append(conditions, "is_excluded = 0")
-	case "locked":
-		conditions = append(conditions, "locked = 1")
-	case "not_locked":
-		conditions = append(conditions, "locked = 0")
-	case "compliant":
-		conditions = append(conditions, "health_score >= 100")
-	case "non_compliant":
-		conditions = append(conditions, "health_score < 100")
+	// Legacy single-filter param: maps a fixed set of filter names to SQL.
+	if frag, ok := legacyFilterSQL[params.Filter]; ok {
+		conditions = append(conditions, frag)
 	}
 
-	// Apply flyout-driven multi-filter conditions. Each key maps to "include"
-	// (add positive condition) or "exclude" (add negative condition). The
-	// "missing_images" key matches any artist missing at least one image type.
-	for key, state := range params.Filters {
-		switch key {
-		case "missing_meta":
-			switch state {
-			case "include":
-				conditions = append(conditions, "nfo_exists = 0")
-			case "exclude":
-				conditions = append(conditions, "nfo_exists = 1")
-			}
-		case "missing_images":
-			switch state {
-			case "include":
-				// Include artists missing ANY of thumb, fanart, logo, or banner.
-				conditions = append(conditions, "(NOT EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = 'thumb' AND exists_flag = 1) OR NOT EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = 'fanart' AND exists_flag = 1) OR NOT EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = 'logo' AND exists_flag = 1) OR NOT EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = 'banner' AND exists_flag = 1))")
-			case "exclude":
-				// Exclude artists that have ALL of thumb, fanart, logo, and banner.
-				conditions = append(conditions, "(EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = 'thumb' AND exists_flag = 1) AND EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = 'fanart' AND exists_flag = 1) AND EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = 'logo' AND exists_flag = 1) AND EXISTS (SELECT 1 FROM artist_images WHERE artist_id = artists.id AND image_type = 'banner' AND exists_flag = 1))")
-			}
-		case "missing_mbid":
-			switch state {
-			case "include":
-				conditions = append(conditions, "NOT EXISTS (SELECT 1 FROM artist_provider_ids WHERE artist_id = artists.id AND provider = 'musicbrainz')")
-			case "exclude":
-				conditions = append(conditions, "EXISTS (SELECT 1 FROM artist_provider_ids WHERE artist_id = artists.id AND provider = 'musicbrainz')")
-			}
-		case "excluded":
-			switch state {
-			case "include":
-				conditions = append(conditions, "is_excluded = 1")
-			case "exclude":
-				conditions = append(conditions, "is_excluded = 0")
-			}
-		case "locked":
-			switch state {
-			case "include":
-				conditions = append(conditions, "locked = 1")
-			case "exclude":
-				conditions = append(conditions, "locked = 0")
-			}
-		}
-	}
-
-	// Aggregate artist-type filters into IN/NOT IN conditions so that
-	// including multiple types produces OR logic (not impossible AND logic).
+	// Flyout multi-filter: each key dispatches through the predicate map.
+	// Type and library keys are accumulated separately below.
 	var typeIncludes, typeExcludes []string
+	var libIncludes, libExcludes []string
+
 	for key, state := range params.Filters {
-		var typeNames []string
-		switch key {
-		case "type_person":
-			// MusicBrainz stores Person as "solo"; match both for
-			// compatibility with manually-set "person" values.
-			typeNames = []string{"person", "solo"}
-		case "type_group":
-			typeNames = []string{"group"}
-		case "type_orchestra":
-			typeNames = []string{"orchestra"}
-		default:
+		if typeNames, ok := typeFilterKeys[key]; ok {
+			switch state {
+			case "include":
+				typeIncludes = append(typeIncludes, typeNames...)
+			case "exclude":
+				typeExcludes = append(typeExcludes, typeNames...)
+			}
 			continue
 		}
-		switch state {
-		case "include":
-			typeIncludes = append(typeIncludes, typeNames...)
-		case "exclude":
-			typeExcludes = append(typeExcludes, typeNames...)
+		if strings.HasPrefix(key, "library_") {
+			libID := key[len("library_"):]
+			if libID == "" {
+				continue
+			}
+			switch state {
+			case "include":
+				libIncludes = append(libIncludes, libID)
+			case "exclude":
+				libExcludes = append(libExcludes, libID)
+			}
+			continue
+		}
+		if pred, ok := artistFilterPredicates[key]; ok {
+			if frag, pArgs := pred(state); frag != "" {
+				conditions = append(conditions, frag)
+				args = append(args, pArgs...)
+			}
 		}
 	}
+
+	// Aggregate type filters into a single IN / NOT IN clause so that
+	// selecting multiple types produces OR logic (not impossible AND).
 	if len(typeIncludes) > 0 {
-		ph := strings.Repeat("?,", len(typeIncludes))
-		conditions = append(conditions, "type IN ("+ph[:len(ph)-1]+")")
+		conditions = append(conditions, "type IN ("+buildPlaceholders(len(typeIncludes))+")")
 		for _, t := range typeIncludes {
 			args = append(args, t)
 		}
 	}
 	if len(typeExcludes) > 0 {
-		ph := strings.Repeat("?,", len(typeExcludes))
-		conditions = append(conditions, "type NOT IN ("+ph[:len(ph)-1]+")")
+		conditions = append(conditions, "type NOT IN ("+buildPlaceholders(len(typeExcludes))+")")
 		for _, t := range typeExcludes {
 			args = append(args, t)
 		}
 	}
 
-	// Aggregate per-library filters into IN/NOT IN conditions.
-	var libIncludes, libExcludes []string
-	for key, state := range params.Filters {
-		if !strings.HasPrefix(key, "library_") {
-			continue
-		}
-		libID := key[len("library_"):]
-		if libID == "" {
-			continue
-		}
-		switch state {
-		case "include":
-			libIncludes = append(libIncludes, libID)
-		case "exclude":
-			libExcludes = append(libExcludes, libID)
-		}
-	}
+	// Aggregate per-library filters into EXISTS / NOT EXISTS sub-selects.
 	if len(libIncludes) > 0 {
-		ph := strings.Repeat("?,", len(libIncludes))
 		// Match artists with membership in ANY of the included libraries.
 		conditions = append(conditions, `EXISTS (
 			SELECT 1 FROM artist_libraries al
 			WHERE al.artist_id = artists.id
-			  AND al.library_id IN (`+ph[:len(ph)-1]+`)
+			  AND al.library_id IN (`+buildPlaceholders(len(libIncludes))+`)
 		)`)
 		for _, id := range libIncludes {
 			args = append(args, id)
 		}
 	}
 	if len(libExcludes) > 0 {
-		ph := strings.Repeat("?,", len(libExcludes))
 		// Drop artists with membership in any excluded library. Artists
 		// with no membership in the excluded set pass through.
 		conditions = append(conditions, `NOT EXISTS (
 			SELECT 1 FROM artist_libraries al
 			WHERE al.artist_id = artists.id
-			  AND al.library_id IN (`+ph[:len(ph)-1]+`)
+			  AND al.library_id IN (`+buildPlaceholders(len(libExcludes))+`)
 		)`)
 		for _, id := range libExcludes {
 			args = append(args, id)

--- a/internal/artist/scan.go
+++ b/internal/artist/scan.go
@@ -252,11 +252,14 @@ var artistFilterPredicates = map[string]filterPredicate{
 	},
 	"missing_images": missingImagesPredicate,
 	"missing_mbid": func(state string) (string, []any) {
+		// Check for a non-empty provider_id, not just row existence.
+		// UpsertAll inserts a musicbrainz row even when no MBID was found
+		// (provider_id == ""), so a bare EXISTS would misclassify those artists.
 		switch state {
 		case "include":
-			return "NOT EXISTS (SELECT 1 FROM artist_provider_ids WHERE artist_id = artists.id AND provider = 'musicbrainz')", nil
+			return "NOT EXISTS (SELECT 1 FROM artist_provider_ids WHERE artist_id = artists.id AND provider = 'musicbrainz' AND provider_id IS NOT NULL AND provider_id <> '')", nil
 		case "exclude":
-			return "EXISTS (SELECT 1 FROM artist_provider_ids WHERE artist_id = artists.id AND provider = 'musicbrainz')", nil
+			return "EXISTS (SELECT 1 FROM artist_provider_ids WHERE artist_id = artists.id AND provider = 'musicbrainz' AND provider_id IS NOT NULL AND provider_id <> '')", nil
 		}
 		return "", nil
 	},
@@ -303,7 +306,7 @@ var legacyFilterSQL = map[string]string{
 	"missing_fanart": imageExistsClause("fanart", false),
 	"missing_logo":   imageExistsClause("logo", false),
 	"missing_banner": imageExistsClause("banner", false),
-	"missing_mbid":   "NOT EXISTS (SELECT 1 FROM artist_provider_ids WHERE artist_id = artists.id AND provider = 'musicbrainz')",
+	"missing_mbid":   "NOT EXISTS (SELECT 1 FROM artist_provider_ids WHERE artist_id = artists.id AND provider = 'musicbrainz' AND provider_id IS NOT NULL AND provider_id <> '')",
 	"excluded":       "is_excluded = 1",
 	"not_excluded":   "is_excluded = 0",
 	"locked":         "locked = 1",

--- a/internal/artist/scan_test.go
+++ b/internal/artist/scan_test.go
@@ -1,0 +1,438 @@
+package artist
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildWhereClause_Empty verifies that no conditions produce no WHERE clause.
+func TestBuildWhereClause_Empty(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{})
+	if clause != "" {
+		t.Errorf("expected empty clause, got %q", clause)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args, got %v", args)
+	}
+}
+
+// TestBuildWhereClause_Search verifies LIKE predicate binding.
+func TestBuildWhereClause_Search(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{Search: "Beatles"})
+	if !strings.Contains(clause, "name LIKE ?") {
+		t.Errorf("expected LIKE clause, got %q", clause)
+	}
+	if len(args) != 1 || args[0] != "%Beatles%" {
+		t.Errorf("unexpected args: %v", args)
+	}
+}
+
+// TestBuildWhereClause_LibraryID verifies single-library EXISTS clause.
+func TestBuildWhereClause_LibraryID(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{LibraryID: "lib-1"})
+	if !strings.Contains(clause, "EXISTS") {
+		t.Errorf("expected EXISTS clause, got %q", clause)
+	}
+	if !strings.Contains(clause, "artist_libraries") {
+		t.Errorf("expected artist_libraries reference, got %q", clause)
+	}
+	if len(args) != 1 || args[0] != "lib-1" {
+		t.Errorf("unexpected args: %v", args)
+	}
+}
+
+// TestBuildWhereClause_IDsFilter verifies IN-clause construction and argument binding.
+func TestBuildWhereClause_IDsFilter(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{IDs: []string{"id-1", "id-2", "id-3"}})
+	if !strings.Contains(clause, "artists.id IN (?, ?, ?)") {
+		t.Errorf("expected IN clause, got %q", clause)
+	}
+	if len(args) != 3 {
+		t.Errorf("expected 3 args, got %d: %v", len(args), args)
+	}
+}
+
+// TestBuildWhereClause_HealthScore verifies numeric range bindings.
+func TestBuildWhereClause_HealthScore(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{HealthScoreMin: 50, HealthScoreMax: 90})
+	if !strings.Contains(clause, "health_score >= ?") {
+		t.Errorf("expected min condition, got %q", clause)
+	}
+	if !strings.Contains(clause, "health_score <= ?") {
+		t.Errorf("expected max condition, got %q", clause)
+	}
+	if len(args) != 2 || args[0] != 50 || args[1] != 90 {
+		t.Errorf("unexpected args: %v", args)
+	}
+}
+
+// TestBuildWhereClause_LegacyFilter covers every legacy params.Filter value to
+// ensure the map-based dispatch is complete and no key was dropped.
+func TestBuildWhereClause_LegacyFilter(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		filter  string
+		wantSQL string
+	}{
+		{"missing_nfo", "nfo_exists = 0"},
+		{"missing_thumb", "image_type = 'thumb'"},
+		{"missing_fanart", "image_type = 'fanart'"},
+		{"missing_logo", "image_type = 'logo'"},
+		{"missing_banner", "image_type = 'banner'"},
+		{"missing_mbid", "provider = 'musicbrainz'"},
+		{"excluded", "is_excluded = 1"},
+		{"not_excluded", "is_excluded = 0"},
+		{"locked", "locked = 1"},
+		{"not_locked", "locked = 0"},
+		{"compliant", "health_score >= 100"},
+		{"non_compliant", "health_score < 100"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.filter, func(t *testing.T) {
+			t.Parallel()
+			clause, args := buildWhereClause(ListParams{Filter: tc.filter})
+			if !strings.Contains(clause, tc.wantSQL) {
+				t.Errorf("filter %q: expected %q in clause %q", tc.filter, tc.wantSQL, clause)
+			}
+			// Legacy filter keys produce no bound parameters.
+			if len(args) != 0 {
+				t.Errorf("filter %q: expected no args, got %v", tc.filter, args)
+			}
+		})
+	}
+}
+
+// TestBuildWhereClause_UnknownLegacyFilter verifies that an unrecognized
+// params.Filter value is silently ignored (no panic, no WHERE clause).
+func TestBuildWhereClause_UnknownLegacyFilter(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{Filter: "does_not_exist"})
+	if clause != "" {
+		t.Errorf("expected empty clause for unknown filter, got %q", clause)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args, got %v", args)
+	}
+}
+
+// TestBuildWhereClause_MultiFilter_MissingMeta covers the missing_meta predicate
+// for both include and exclude states.
+func TestBuildWhereClause_MultiFilter_MissingMeta(t *testing.T) {
+	t.Parallel()
+	t.Run("include", func(t *testing.T) {
+		t.Parallel()
+		clause, _ := buildWhereClause(ListParams{Filters: map[string]string{"missing_meta": "include"}})
+		if !strings.Contains(clause, "nfo_exists = 0") {
+			t.Errorf("include: expected nfo_exists = 0, got %q", clause)
+		}
+	})
+	t.Run("exclude", func(t *testing.T) {
+		t.Parallel()
+		clause, _ := buildWhereClause(ListParams{Filters: map[string]string{"missing_meta": "exclude"}})
+		if !strings.Contains(clause, "nfo_exists = 1") {
+			t.Errorf("exclude: expected nfo_exists = 1, got %q", clause)
+		}
+	})
+}
+
+// TestBuildWhereClause_MultiFilter_MissingImages verifies that the compound
+// missing_images predicate generates OR clauses for include and AND for exclude.
+func TestBuildWhereClause_MultiFilter_MissingImages(t *testing.T) {
+	t.Parallel()
+	t.Run("include", func(t *testing.T) {
+		t.Parallel()
+		clause, args := buildWhereClause(ListParams{Filters: map[string]string{"missing_images": "include"}})
+		for _, imgType := range legacyImageTypes {
+			if !strings.Contains(clause, "image_type = '"+imgType+"'") {
+				t.Errorf("include: expected image_type = '%s' in clause %q", imgType, clause)
+			}
+		}
+		if !strings.Contains(clause, " OR ") {
+			t.Errorf("include: expected OR logic, got %q", clause)
+		}
+		if len(args) != 0 {
+			t.Errorf("include: expected no args, got %v", args)
+		}
+	})
+	t.Run("exclude", func(t *testing.T) {
+		t.Parallel()
+		clause, args := buildWhereClause(ListParams{Filters: map[string]string{"missing_images": "exclude"}})
+		for _, imgType := range legacyImageTypes {
+			if !strings.Contains(clause, "image_type = '"+imgType+"'") {
+				t.Errorf("exclude: expected image_type = '%s' in clause %q", imgType, clause)
+			}
+		}
+		if !strings.Contains(clause, " AND ") {
+			t.Errorf("exclude: expected AND logic, got %q", clause)
+		}
+		if len(args) != 0 {
+			t.Errorf("exclude: expected no args, got %v", args)
+		}
+	})
+}
+
+// TestBuildWhereClause_MultiFilter_MissingMBID covers the missing_mbid predicate.
+func TestBuildWhereClause_MultiFilter_MissingMBID(t *testing.T) {
+	t.Parallel()
+	t.Run("include", func(t *testing.T) {
+		t.Parallel()
+		clause, _ := buildWhereClause(ListParams{Filters: map[string]string{"missing_mbid": "include"}})
+		if !strings.Contains(clause, "NOT EXISTS") || !strings.Contains(clause, "provider = 'musicbrainz'") {
+			t.Errorf("include: expected NOT EXISTS musicbrainz, got %q", clause)
+		}
+	})
+	t.Run("exclude", func(t *testing.T) {
+		t.Parallel()
+		clause, _ := buildWhereClause(ListParams{Filters: map[string]string{"missing_mbid": "exclude"}})
+		if strings.Contains(clause, "NOT EXISTS") {
+			t.Errorf("exclude: expected EXISTS (not NOT EXISTS) for musicbrainz, got %q", clause)
+		}
+		if !strings.Contains(clause, "provider = 'musicbrainz'") {
+			t.Errorf("exclude: expected provider = 'musicbrainz', got %q", clause)
+		}
+	})
+}
+
+// TestBuildWhereClause_MultiFilter_Excluded covers the excluded predicate.
+func TestBuildWhereClause_MultiFilter_Excluded(t *testing.T) {
+	t.Parallel()
+	t.Run("include", func(t *testing.T) {
+		t.Parallel()
+		clause, _ := buildWhereClause(ListParams{Filters: map[string]string{"excluded": "include"}})
+		if !strings.Contains(clause, "is_excluded = 1") {
+			t.Errorf("include: expected is_excluded = 1, got %q", clause)
+		}
+	})
+	t.Run("exclude", func(t *testing.T) {
+		t.Parallel()
+		clause, _ := buildWhereClause(ListParams{Filters: map[string]string{"excluded": "exclude"}})
+		if !strings.Contains(clause, "is_excluded = 0") {
+			t.Errorf("exclude: expected is_excluded = 0, got %q", clause)
+		}
+	})
+}
+
+// TestBuildWhereClause_MultiFilter_Locked covers the locked predicate.
+func TestBuildWhereClause_MultiFilter_Locked(t *testing.T) {
+	t.Parallel()
+	t.Run("include", func(t *testing.T) {
+		t.Parallel()
+		clause, _ := buildWhereClause(ListParams{Filters: map[string]string{"locked": "include"}})
+		if !strings.Contains(clause, "locked = 1") {
+			t.Errorf("include: expected locked = 1, got %q", clause)
+		}
+	})
+	t.Run("exclude", func(t *testing.T) {
+		t.Parallel()
+		clause, _ := buildWhereClause(ListParams{Filters: map[string]string{"locked": "exclude"}})
+		if !strings.Contains(clause, "locked = 0") {
+			t.Errorf("exclude: expected locked = 0, got %q", clause)
+		}
+	})
+}
+
+// TestBuildWhereClause_TypeFilter_Include verifies that including multiple types
+// produces a single IN clause with OR logic (not multiple AND conditions).
+func TestBuildWhereClause_TypeFilter_Include(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{Filters: map[string]string{
+		"type_person": "include",
+		"type_group":  "include",
+	}})
+	if !strings.Contains(clause, "type IN (") {
+		t.Errorf("expected type IN clause, got %q", clause)
+	}
+	// type_person maps to "person" and "solo"; type_group maps to "group" = 3 values.
+	if len(args) != 3 {
+		t.Errorf("expected 3 type args (person, solo, group), got %d: %v", len(args), args)
+	}
+	// Must NOT produce two separate conditions, which would be impossible AND.
+	if strings.Count(clause, "type IN (") > 1 {
+		t.Errorf("expected single IN clause, got multiple in %q", clause)
+	}
+}
+
+// TestBuildWhereClause_TypeFilter_Exclude verifies that excluding types
+// produces a NOT IN clause.
+func TestBuildWhereClause_TypeFilter_Exclude(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{Filters: map[string]string{"type_orchestra": "exclude"}})
+	if !strings.Contains(clause, "type NOT IN (") {
+		t.Errorf("expected type NOT IN clause, got %q", clause)
+	}
+	if len(args) != 1 || args[0] != "orchestra" {
+		t.Errorf("expected [orchestra], got %v", args)
+	}
+}
+
+// TestBuildWhereClause_TypeFilter_IncludeExclude verifies that mixing include
+// and exclude type filters produces both IN and NOT IN clauses.
+func TestBuildWhereClause_TypeFilter_IncludeExclude(t *testing.T) {
+	t.Parallel()
+	clause, _ := buildWhereClause(ListParams{Filters: map[string]string{
+		"type_group":     "include",
+		"type_orchestra": "exclude",
+	}})
+	if !strings.Contains(clause, "type IN (") {
+		t.Errorf("expected IN clause, got %q", clause)
+	}
+	if !strings.Contains(clause, "type NOT IN (") {
+		t.Errorf("expected NOT IN clause, got %q", clause)
+	}
+}
+
+// TestBuildWhereClause_LibraryFilter_Include verifies per-library EXISTS clause.
+func TestBuildWhereClause_LibraryFilter_Include(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{Filters: map[string]string{
+		"library_lib-a": "include",
+		"library_lib-b": "include",
+	}})
+	if !strings.Contains(clause, "EXISTS") || !strings.Contains(clause, "artist_libraries") {
+		t.Errorf("expected EXISTS artist_libraries clause, got %q", clause)
+	}
+	if len(args) != 2 {
+		t.Errorf("expected 2 library args, got %d: %v", len(args), args)
+	}
+}
+
+// TestBuildWhereClause_LibraryFilter_Exclude verifies per-library NOT EXISTS clause.
+func TestBuildWhereClause_LibraryFilter_Exclude(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{Filters: map[string]string{"library_lib-x": "exclude"}})
+	if !strings.Contains(clause, "NOT EXISTS") {
+		t.Errorf("expected NOT EXISTS clause, got %q", clause)
+	}
+	if len(args) != 1 || args[0] != "lib-x" {
+		t.Errorf("expected [lib-x], got %v", args)
+	}
+}
+
+// TestBuildWhereClause_LibraryFilter_EmptyID verifies that library_ keys with
+// an empty suffix are silently skipped.
+func TestBuildWhereClause_LibraryFilter_EmptyID(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{Filters: map[string]string{"library_": "include"}})
+	if clause != "" {
+		t.Errorf("expected empty clause for empty library ID, got %q", clause)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args, got %v", args)
+	}
+}
+
+// TestBuildWhereClause_UnknownMultiFilterKey verifies that an unrecognized
+// Filters key is silently skipped.
+func TestBuildWhereClause_UnknownMultiFilterKey(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{Filters: map[string]string{"totally_unknown": "include"}})
+	if clause != "" {
+		t.Errorf("expected empty clause for unknown filter key, got %q", clause)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args, got %v", args)
+	}
+}
+
+// TestBuildWhereClause_MultiFilter_InvalidState verifies that an invalid state
+// value (not "include"/"exclude") produces no condition.
+func TestBuildWhereClause_MultiFilter_InvalidState(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{Filters: map[string]string{"missing_meta": "foobar"}})
+	if clause != "" {
+		t.Errorf("expected empty clause for invalid state, got %q", clause)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args, got %v", args)
+	}
+}
+
+// TestBuildWhereClause_Combined verifies that multiple conditions combine with AND.
+func TestBuildWhereClause_Combined(t *testing.T) {
+	t.Parallel()
+	clause, args := buildWhereClause(ListParams{
+		Search:  "Beatles",
+		Filter:  "missing_nfo",
+		Filters: map[string]string{"locked": "include"},
+	})
+	if !strings.HasPrefix(clause, " WHERE ") {
+		t.Errorf("expected clause to start with WHERE, got %q", clause)
+	}
+	if !strings.Contains(clause, " AND ") {
+		t.Errorf("expected AND separator between conditions, got %q", clause)
+	}
+	if !strings.Contains(clause, "name LIKE ?") {
+		t.Errorf("expected search condition, got %q", clause)
+	}
+	if !strings.Contains(clause, "nfo_exists = 0") {
+		t.Errorf("expected nfo condition, got %q", clause)
+	}
+	if !strings.Contains(clause, "locked = 1") {
+		t.Errorf("expected locked condition, got %q", clause)
+	}
+	if len(args) != 1 {
+		t.Errorf("expected 1 arg (search), got %d: %v", len(args), args)
+	}
+}
+
+// TestBuildWhereClause_NoUserInputInSQL verifies that SQL fragments generated by
+// the filter predicate map do not contain any parameterized user data in the
+// fragment text itself. Image type strings, provider names, and column names are
+// hard-coded literals; only Search values and IDs are bound via args.
+func TestBuildWhereClause_NoUserInputInSQL(t *testing.T) {
+	t.Parallel()
+	// Provide user-controlled input in every field that accepts it and verify
+	// that none of the literal input text appears in the SQL fragment.
+	userControlled := "'; DROP TABLE artists; --"
+	clause, _ := buildWhereClause(ListParams{
+		Search: userControlled,
+		IDs:    []string{userControlled},
+	})
+	// The fragment should contain LIKE ? and IN (?) but not the literal string.
+	if strings.Contains(clause, userControlled) {
+		t.Errorf("user input appeared in SQL fragment: %q", clause)
+	}
+}
+
+// TestBuildWhereClause_TypeFilter_AllTypes verifies that all three type filter
+// keys (type_person, type_group, type_orchestra) are wired correctly.
+func TestBuildWhereClause_TypeFilter_AllTypes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		key      string
+		wantArgs []string
+	}{
+		{"type_person", []string{"person", "solo"}},
+		{"type_group", []string{"group"}},
+		{"type_orchestra", []string{"orchestra"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.key, func(t *testing.T) {
+			t.Parallel()
+			clause, args := buildWhereClause(ListParams{Filters: map[string]string{tc.key: "include"}})
+			if !strings.Contains(clause, "type IN (") {
+				t.Errorf("%s: expected type IN clause, got %q", tc.key, clause)
+			}
+			if len(args) != len(tc.wantArgs) {
+				t.Fatalf("%s: expected %d args, got %d: %v", tc.key, len(tc.wantArgs), len(args), args)
+			}
+			// Build a set of returned args for order-independent comparison.
+			got := make(map[string]bool, len(args))
+			for _, a := range args {
+				got[a.(string)] = true
+			}
+			for _, want := range tc.wantArgs {
+				if !got[want] {
+					t.Errorf("%s: missing expected arg %q in %v", tc.key, want, args)
+				}
+			}
+		})
+	}
+}

--- a/internal/artist/scan_test.go
+++ b/internal/artist/scan_test.go
@@ -168,8 +168,15 @@ func TestBuildWhereClause_MultiFilter_MissingImages(t *testing.T) {
 				t.Errorf("exclude: expected image_type = '%s' in clause %q", imgType, clause)
 			}
 		}
-		if !strings.Contains(clause, " AND ") {
-			t.Errorf("exclude: expected AND logic, got %q", clause)
+		// Each image type produces an EXISTS(...) fragment joined with AND.
+		// Counting "EXISTS (" proves the top-level join is AND, not OR -- a bare
+		// " AND " check is satisfied by ANDs inside each subquery.
+		existsCount := strings.Count(clause, "EXISTS (")
+		if existsCount < 2 {
+			t.Errorf("exclude: expected at least 2 EXISTS ( fragments, got %d in %q", existsCount, clause)
+		}
+		if strings.Contains(clause, " OR ") {
+			t.Errorf("exclude: expected no OR logic (top-level join must be AND), got %q", clause)
 		}
 		if len(args) != 0 {
 			t.Errorf("exclude: expected no args, got %v", args)
@@ -186,6 +193,11 @@ func TestBuildWhereClause_MultiFilter_MissingMBID(t *testing.T) {
 		if !strings.Contains(clause, "NOT EXISTS") || !strings.Contains(clause, "provider = 'musicbrainz'") {
 			t.Errorf("include: expected NOT EXISTS musicbrainz, got %q", clause)
 		}
+		// Must gate on non-empty provider_id; a bare row-existence check
+		// misclassifies artists where UpsertAll stored an empty MBID.
+		if !strings.Contains(clause, "provider_id IS NOT NULL") || !strings.Contains(clause, "provider_id <> ''") {
+			t.Errorf("include: expected non-empty provider_id guard, got %q", clause)
+		}
 	})
 	t.Run("exclude", func(t *testing.T) {
 		t.Parallel()
@@ -195,6 +207,9 @@ func TestBuildWhereClause_MultiFilter_MissingMBID(t *testing.T) {
 		}
 		if !strings.Contains(clause, "provider = 'musicbrainz'") {
 			t.Errorf("exclude: expected provider = 'musicbrainz', got %q", clause)
+		}
+		if !strings.Contains(clause, "provider_id IS NOT NULL") || !strings.Contains(clause, "provider_id <> ''") {
+			t.Errorf("exclude: expected non-empty provider_id guard, got %q", clause)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- Replaces three nested switch ladders in `buildWhereClause` (~200 lines, cyclomatic 56) with a flat predicate-map dispatch model
- `legacyFilterSQL` map covers all 12 original `params.Filter` single-value keys with identical SQL
- `artistFilterPredicates` map covers `missing_meta`, `missing_images`, `missing_mbid`, `excluded`, `locked` with include/exclude state
- `typeFilterKeys` consolidates type-filter dispatch; library prefix handling preserved
- `imageExistsClause` helper eliminates duplicated EXISTS/NOT EXISTS sub-selects across four image types
- SQL injection safety preserved: all user input remains bound via `?` placeholders; `imageExistsClause` only interpolates from the package-private static `legacyImageTypes` slice
- 20 table-driven tests covering all filter paths and a SQL-injection smoke test

## Test plan

- [ ] `go test -race ./internal/artist/... -timeout 180s` -- all pass
- [ ] Pre-push gate clean (exit 0), patch coverage 94.7%

Closes #1393

Part of M49.5 (Code Health and Hardening) W1.1B.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified and data-driven filtering logic for artist queries, improving multi-filter include/exclude behavior (types, libraries, missing metadata/images/IDs) and producing more consistent, parameterized query clauses.

* **Tests**
  * Added a comprehensive test suite validating legacy and multi-filter behavior, type/library aggregation, combined conditions, edge cases, and SQL-safety (no user input leaked into query text).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1495)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->