### PR TITLE
refactor(settingsio): split ImportWithOptions into per-section import helpers

### DIFF
--- a/internal/settingsio/export.go
+++ b/internal/settingsio/export.go
@@ -539,12 +539,12 @@ func (s *Service) ImportWithOptions(ctx context.Context, env *Envelope, passphra
 		return nil, fmt.Errorf("importing users: %w", err)
 	}
 
-	// Libraries must run AFTER connections so the (type, url) -> id remap
-	// can resolve to the freshly-imported connection rows.
 	if err := s.importUserPreferences(ctx, payload.UserPreferences, result); err != nil {
 		return nil, fmt.Errorf("importing user preferences: %w", err)
 	}
 
+	// Libraries must run AFTER connections so the (type, url) -> id remap
+	// can resolve to the freshly-imported connection rows.
 	if err := s.importLibraries(ctx, payload.Libraries, result); err != nil {
 		return nil, fmt.Errorf("importing libraries: %w", err)
 	}

--- a/internal/settingsio/export.go
+++ b/internal/settingsio/export.go
@@ -495,202 +495,64 @@ func (s *Service) ImportWithOptions(ctx context.Context, env *Envelope, passphra
 
 	result := &ImportResult{}
 
-	// Import settings
-	now := time.Now().UTC().Format(time.RFC3339)
-	for k, v := range payload.Settings {
-		_, err := s.db.ExecContext(ctx,
-			`INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
-			ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
-			k, v, now)
-		if err != nil {
-			return nil, fmt.Errorf("upserting setting %q: %w", k, err)
-		}
-		result.Settings++
+	// Each per-section helper increments the relevant counter(s) on result.
+	// Sections are called in dependency order: connections must precede
+	// libraries (which remap by (type, url)), and users must precede both
+	// user_preferences and api_tokens (which remap by username).
+
+	if err := s.importSettings(ctx, payload.Settings, result); err != nil {
+		return nil, fmt.Errorf("importing settings: %w", err)
 	}
 
-	// Import provider keys
-	for name, key := range payload.ProviderKeys {
-		if err := s.providerSettings.SetAPIKey(ctx, provider.ProviderName(name), key); err != nil {
-			return nil, fmt.Errorf("setting provider key %q: %w", name, err)
-		}
-		result.ProviderKeys++
+	if err := s.importProviderKeys(ctx, payload.ProviderKeys, result); err != nil {
+		return nil, fmt.Errorf("importing provider keys: %w", err)
 	}
 
-	// Import connections: match by type + url, update or insert
-	for _, ce := range payload.Connections {
-		existing, err := s.connectionSvc.GetByTypeAndURL(ctx, ce.Type, ce.URL)
-		if err != nil {
-			return nil, fmt.Errorf("looking up connection %q: %w", ce.Name, err)
-		}
-		if existing != nil {
-			// Update existing
-			existing.Name = ce.Name
-			existing.APIKey = ce.APIKey
-			existing.Enabled = ce.Enabled
-			existing.FeatureLibraryImport = ce.FeatureLibraryImport
-			existing.FeatureNFOWrite = ce.FeatureNFOWrite
-			existing.FeatureImageWrite = ce.FeatureImageWrite
-			if err := s.connectionSvc.Update(ctx, existing); err != nil {
-				return nil, fmt.Errorf("updating connection %q: %w", ce.Name, err)
-			}
-		} else {
-			// Create new
-			c := &connection.Connection{
-				Name:                 ce.Name,
-				Type:                 ce.Type,
-				URL:                  ce.URL,
-				APIKey:               ce.APIKey,
-				Enabled:              ce.Enabled,
-				FeatureLibraryImport: ce.FeatureLibraryImport,
-				FeatureNFOWrite:      ce.FeatureNFOWrite,
-				FeatureImageWrite:    ce.FeatureImageWrite,
-			}
-			if err := s.connectionSvc.Create(ctx, c); err != nil {
-				return nil, fmt.Errorf("creating connection %q: %w", ce.Name, err)
-			}
-		}
-		result.Connections++
+	if err := s.importConnections(ctx, payload.Connections, result); err != nil {
+		return nil, fmt.Errorf("importing connections: %w", err)
 	}
 
-	// Import platform profiles: match by name, update or insert
-	for _, p := range payload.PlatformProfiles {
-		existing, err := s.platformSvc.GetByName(ctx, p.Name)
-		if err != nil {
-			return nil, fmt.Errorf("looking up platform profile %q: %w", p.Name, err)
-		}
-		if existing != nil {
-			p.ID = existing.ID
-			if err := s.platformSvc.Update(ctx, &p); err != nil {
-				return nil, fmt.Errorf("updating platform profile %q: %w", p.Name, err)
-			}
-		} else {
-			p.ID = ""          // Let Create generate a new ID
-			p.IsActive = false // Avoid creating multiple active profiles on import
-			if err := s.platformSvc.Create(ctx, &p); err != nil {
-				return nil, fmt.Errorf("creating platform profile %q: %w", p.Name, err)
-			}
-		}
-		result.Profiles++
+	if err := s.importPlatformProfiles(ctx, payload.PlatformProfiles, result); err != nil {
+		return nil, fmt.Errorf("importing platform profiles: %w", err)
 	}
 
-	// Import webhooks: match by name + url, upsert
-	for _, w := range payload.Webhooks {
-		existing, err := s.webhookSvc.GetByNameAndURL(ctx, w.Name, w.URL)
-		if err != nil {
-			return nil, fmt.Errorf("looking up webhook %q: %w", w.Name, err)
-		}
-		if existing != nil {
-			w.ID = existing.ID
-			if err := s.webhookSvc.Update(ctx, &w); err != nil {
-				return nil, fmt.Errorf("updating webhook %q: %w", w.Name, err)
-			}
-		} else {
-			w.ID = "" // Let Create generate a new ID
-			if err := s.webhookSvc.Create(ctx, &w); err != nil {
-				return nil, fmt.Errorf("creating webhook %q: %w", w.Name, err)
-			}
-		}
-		result.Webhooks++
+	if err := s.importWebhooks(ctx, payload.Webhooks, result); err != nil {
+		return nil, fmt.Errorf("importing webhooks: %w", err)
 	}
 
-	// Import provider priorities
-	for _, p := range payload.ProviderPriorities {
-		if err := s.providerSettings.SetPriority(ctx, p.Field, p.Providers); err != nil {
-			return nil, fmt.Errorf("setting priority for %q: %w", p.Field, err)
-		}
-		if len(p.Disabled) > 0 {
-			if err := s.providerSettings.SetDisabledProviders(ctx, p.Field, p.Disabled); err != nil {
-				return nil, fmt.Errorf("setting disabled providers for %q: %w", p.Field, err)
-			}
-		}
-		result.Priorities++
+	if err := s.importProviderPriorities(ctx, payload.ProviderPriorities, result); err != nil {
+		return nil, fmt.Errorf("importing provider priorities: %w", err)
 	}
 
-	// Import rule configuration (only mutable fields: enabled, automation_mode, config).
-	// Rules are matched by ID; unknown IDs are silently skipped to allow exports from
-	// newer application versions to be imported without error.
-	if s.ruleService != nil {
-		for _, re := range payload.Rules {
-			if re.ID == "" {
-				continue
-			}
-			existing, err := s.ruleService.GetByID(ctx, re.ID)
-			if err != nil {
-				// Unknown rule IDs (newer export, older binary) are expected -- skip.
-				// Other errors (DB connection, corruption) must surface instead of
-				// silently dropping rule imports.
-				if errors.Is(err, rule.ErrNotFound) {
-					continue
-				}
-				return nil, fmt.Errorf("looking up rule %q: %w", re.ID, err)
-			}
-			// Validate automation_mode before writing to the DB. A tampered or
-			// stale payload could carry an unrecognized value. Only the two
-			// constants defined in the rule package are valid; "disabled" is not
-			// a valid automation_mode -- use enabled=false to disable a rule.
-			switch re.AutomationMode {
-			case rule.AutomationModeAuto, rule.AutomationModeManual:
-				// valid
-			default:
-				slog.Warn("import: skipping rule with invalid automation_mode",
-					"rule_id", re.ID,
-					"automation_mode", re.AutomationMode,
-				)
-				continue
-			}
-			existing.Enabled = re.Enabled
-			existing.AutomationMode = re.AutomationMode
-			existing.Config = re.Config
-			if err := s.ruleService.Update(ctx, existing); err != nil {
-				return nil, fmt.Errorf("updating rule %q: %w", re.ID, err)
-			}
-			result.Rules++
-		}
+	if err := s.importRules(ctx, payload.Rules, result); err != nil {
+		return nil, fmt.Errorf("importing rules: %w", err)
 	}
 
-	// Import scraper configurations. Each scope is upserted via SaveConfig which
-	// performs an ON CONFLICT update internally.
-	if s.scraperService != nil {
-		for _, sce := range payload.ScraperConfigs {
-			if sce.Scope == "" {
-				continue
-			}
-			// Clear the ID so SaveConfig resolves it from the DB, avoiding ID
-			// collisions when importing across instances.
-			sce.Config.ID = ""
-			if err := s.scraperService.SaveConfig(ctx, sce.Scope, &sce.Config, sce.Overrides); err != nil {
-				return nil, fmt.Errorf("saving scraper config for scope %q: %w", sce.Scope, err)
-			}
-			result.ScraperConfigs++
-		}
+	if err := s.importScraperPreferences(ctx, payload.ScraperConfigs, result); err != nil {
+		return nil, fmt.Errorf("importing scraper preferences: %w", err)
 	}
 
-	// Import users from the envelope FIRST (before user_preferences and
-	// api_tokens) so absent owners are recreated and their downstream rows
-	// can attribute back to them via the username -> user_id lookup. Users
-	// that already exist on the target are left untouched; the operator's
-	// existing setup wins over the envelope (#1283).
+	// Users must precede user_preferences and api_tokens so absent owners
+	// are recreated from the envelope before the downstream remap lookups
+	// run. See importUsers for the "existing users left untouched" policy.
 	if err := s.importUsers(ctx, payload.Users, result); err != nil {
 		return nil, fmt.Errorf("importing users: %w", err)
 	}
 
-	// Import user preferences. Preferences are matched by username; rows for users
-	// that do not exist on this instance are silently skipped.
+	// Libraries must run AFTER connections so the (type, url) -> id remap
+	// can resolve to the freshly-imported connection rows.
 	if err := s.importUserPreferences(ctx, payload.UserPreferences, result); err != nil {
 		return nil, fmt.Errorf("importing user preferences: %w", err)
 	}
 
-	// Import libraries. Must run AFTER connections so the (type, url) -> id
-	// remap can resolve to the freshly-imported connection rows.
 	if err := s.importLibraries(ctx, payload.Libraries, result); err != nil {
 		return nil, fmt.Errorf("importing libraries: %w", err)
 	}
 
-	// Import API tokens. Must run AFTER importUsers so the username ->
-	// user_id lookup sees the final user set on the target instance,
-	// including any users just recreated from the envelope. The opts
-	// parameter controls the admin-fallback opt-in behavior for tokens
-	// whose original owner is still absent after user import.
+	// API tokens must run AFTER importUsers so the username -> user_id
+	// lookup sees the final user set, including any users just recreated
+	// from the envelope. The opts parameter controls the admin-fallback
+	// opt-in behavior for tokens whose owner is still absent after user import.
 	if err := s.importAPITokens(ctx, payload.APITokens, result, opts); err != nil {
 		return nil, fmt.Errorf("importing api tokens: %w", err)
 	}

--- a/internal/settingsio/import_sections.go
+++ b/internal/settingsio/import_sections.go
@@ -148,10 +148,12 @@ func (s *Service) importProviderPriorities(ctx context.Context, priorities []Pri
 		if err := s.providerSettings.SetPriority(ctx, p.Field, p.Providers); err != nil {
 			return fmt.Errorf("setting priority for %q: %w", p.Field, err)
 		}
-		if len(p.Disabled) > 0 {
-			if err := s.providerSettings.SetDisabledProviders(ctx, p.Field, p.Disabled); err != nil {
-				return fmt.Errorf("setting disabled providers for %q: %w", p.Field, err)
-			}
+		disabled := p.Disabled
+		if disabled == nil {
+			disabled = []provider.ProviderName{}
+		}
+		if err := s.providerSettings.SetDisabledProviders(ctx, p.Field, disabled); err != nil {
+			return fmt.Errorf("setting disabled providers for %q: %w", p.Field, err)
 		}
 		result.Priorities++
 	}

--- a/internal/settingsio/import_sections.go
+++ b/internal/settingsio/import_sections.go
@@ -1,0 +1,230 @@
+package settingsio
+
+// import_sections.go contains the per-section import helpers extracted from
+// ImportWithOptions. Each function handles exactly one payload section and
+// increments the relevant counter(s) on result. The orchestrator in export.go
+// calls them in dependency order.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/sydlexius/stillwater/internal/connection"
+	"github.com/sydlexius/stillwater/internal/platform"
+	"github.com/sydlexius/stillwater/internal/provider"
+	"github.com/sydlexius/stillwater/internal/rule"
+	"github.com/sydlexius/stillwater/internal/webhook"
+)
+
+// importSettings upserts every key-value pair from the exported settings map
+// into the settings KV table. The timestamp is fixed for the entire batch so
+// that multiple calls within a single import produce a consistent updated_at.
+func (s *Service) importSettings(ctx context.Context, settings map[string]string, result *ImportResult) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	for k, v := range settings {
+		_, err := s.db.ExecContext(ctx,
+			`INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
+			ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+			k, v, now)
+		if err != nil {
+			return fmt.Errorf("upserting setting %q: %w", k, err)
+		}
+		result.Settings++
+	}
+	return nil
+}
+
+// importProviderKeys writes each provider API key via the provider settings
+// service, which handles at-rest encryption. An empty key map is a no-op.
+func (s *Service) importProviderKeys(ctx context.Context, keys map[string]string, result *ImportResult) error {
+	for name, key := range keys {
+		if err := s.providerSettings.SetAPIKey(ctx, provider.ProviderName(name), key); err != nil {
+			return fmt.Errorf("setting provider key %q: %w", name, err)
+		}
+		result.ProviderKeys++
+	}
+	return nil
+}
+
+// importConnections upserts connections by matching on (type, url). When a
+// connection with the same (type, url) exists on the target it is updated in
+// place; otherwise a new connection is created. The internal connection ID is
+// never exported; only the natural key (type, url) crosses the wire.
+func (s *Service) importConnections(ctx context.Context, conns []ConnectionExport, result *ImportResult) error {
+	for _, ce := range conns {
+		existing, err := s.connectionSvc.GetByTypeAndURL(ctx, ce.Type, ce.URL)
+		if err != nil {
+			return fmt.Errorf("looking up connection %q: %w", ce.Name, err)
+		}
+		if existing != nil {
+			existing.Name = ce.Name
+			existing.APIKey = ce.APIKey
+			existing.Enabled = ce.Enabled
+			existing.FeatureLibraryImport = ce.FeatureLibraryImport
+			existing.FeatureNFOWrite = ce.FeatureNFOWrite
+			existing.FeatureImageWrite = ce.FeatureImageWrite
+			if err := s.connectionSvc.Update(ctx, existing); err != nil {
+				return fmt.Errorf("updating connection %q: %w", ce.Name, err)
+			}
+		} else {
+			c := &connection.Connection{
+				Name:                 ce.Name,
+				Type:                 ce.Type,
+				URL:                  ce.URL,
+				APIKey:               ce.APIKey,
+				Enabled:              ce.Enabled,
+				FeatureLibraryImport: ce.FeatureLibraryImport,
+				FeatureNFOWrite:      ce.FeatureNFOWrite,
+				FeatureImageWrite:    ce.FeatureImageWrite,
+			}
+			if err := s.connectionSvc.Create(ctx, c); err != nil {
+				return fmt.Errorf("creating connection %q: %w", ce.Name, err)
+			}
+		}
+		result.Connections++
+	}
+	return nil
+}
+
+// importPlatformProfiles upserts platform profiles by name. An existing profile
+// with the same name has its ID preserved and its fields updated; absent profiles
+// are created with a new ID. IsActive is forced to false on create to prevent
+// multiple active profiles from being introduced during import.
+func (s *Service) importPlatformProfiles(ctx context.Context, profiles []platform.Profile, result *ImportResult) error {
+	for _, p := range profiles {
+		existing, err := s.platformSvc.GetByName(ctx, p.Name)
+		if err != nil {
+			return fmt.Errorf("looking up platform profile %q: %w", p.Name, err)
+		}
+		if existing != nil {
+			p.ID = existing.ID
+			if err := s.platformSvc.Update(ctx, &p); err != nil {
+				return fmt.Errorf("updating platform profile %q: %w", p.Name, err)
+			}
+		} else {
+			p.ID = ""          // Let Create generate a new ID.
+			p.IsActive = false // Avoid creating multiple active profiles on import.
+			if err := s.platformSvc.Create(ctx, &p); err != nil {
+				return fmt.Errorf("creating platform profile %q: %w", p.Name, err)
+			}
+		}
+		result.Profiles++
+	}
+	return nil
+}
+
+// importWebhooks upserts webhooks by matching on (name, url). An existing
+// webhook is updated in place with its ID preserved; absent webhooks are
+// created with a new ID.
+func (s *Service) importWebhooks(ctx context.Context, webhooks []webhook.Webhook, result *ImportResult) error {
+	for _, w := range webhooks {
+		existing, err := s.webhookSvc.GetByNameAndURL(ctx, w.Name, w.URL)
+		if err != nil {
+			return fmt.Errorf("looking up webhook %q: %w", w.Name, err)
+		}
+		if existing != nil {
+			w.ID = existing.ID
+			if err := s.webhookSvc.Update(ctx, &w); err != nil {
+				return fmt.Errorf("updating webhook %q: %w", w.Name, err)
+			}
+		} else {
+			w.ID = "" // Let Create generate a new ID.
+			if err := s.webhookSvc.Create(ctx, &w); err != nil {
+				return fmt.Errorf("creating webhook %q: %w", w.Name, err)
+			}
+		}
+		result.Webhooks++
+	}
+	return nil
+}
+
+// importProviderPriorities writes the ordered provider list and the disabled
+// provider set for each exported field. An empty priorities slice is a no-op.
+func (s *Service) importProviderPriorities(ctx context.Context, priorities []PriorityExport, result *ImportResult) error {
+	for _, p := range priorities {
+		if err := s.providerSettings.SetPriority(ctx, p.Field, p.Providers); err != nil {
+			return fmt.Errorf("setting priority for %q: %w", p.Field, err)
+		}
+		if len(p.Disabled) > 0 {
+			if err := s.providerSettings.SetDisabledProviders(ctx, p.Field, p.Disabled); err != nil {
+				return fmt.Errorf("setting disabled providers for %q: %w", p.Field, err)
+			}
+		}
+		result.Priorities++
+	}
+	return nil
+}
+
+// importRules applies exported rule configuration (enabled, automation_mode,
+// config) to the matching local rules. Rules are matched by ID. Unknown IDs
+// (exported by a newer binary that this instance does not have) are silently
+// skipped so cross-version imports do not abort. Entries with an empty ID or
+// an unrecognized automation_mode are also skipped with a warning. This method
+// is a no-op when ruleService is nil.
+func (s *Service) importRules(ctx context.Context, rules []RuleExport, result *ImportResult) error {
+	if s.ruleService == nil {
+		return nil
+	}
+	for _, re := range rules {
+		if re.ID == "" {
+			continue
+		}
+		existing, err := s.ruleService.GetByID(ctx, re.ID)
+		if err != nil {
+			// Unknown rule IDs (newer export, older binary) are expected -- skip.
+			// Other errors (DB connection, corruption) must surface.
+			if errors.Is(err, rule.ErrNotFound) {
+				continue
+			}
+			return fmt.Errorf("looking up rule %q: %w", re.ID, err)
+		}
+		// Validate automation_mode before writing. A tampered or stale payload
+		// could carry an unrecognized value. Only the two constants defined in
+		// the rule package are valid; "disabled" is not a valid automation_mode
+		// -- use enabled=false to disable a rule.
+		switch re.AutomationMode {
+		case rule.AutomationModeAuto, rule.AutomationModeManual:
+			// valid
+		default:
+			slog.Warn("import: skipping rule with invalid automation_mode",
+				"rule_id", re.ID,
+				"automation_mode", re.AutomationMode,
+			)
+			continue
+		}
+		existing.Enabled = re.Enabled
+		existing.AutomationMode = re.AutomationMode
+		existing.Config = re.Config
+		if err := s.ruleService.Update(ctx, existing); err != nil {
+			return fmt.Errorf("updating rule %q: %w", re.ID, err)
+		}
+		result.Rules++
+	}
+	return nil
+}
+
+// importScraperPreferences upserts scraper configurations for every scope in
+// the exported payload. Each scope is written via SaveConfig which performs an
+// ON CONFLICT update internally. Entries with an empty scope are skipped.
+// This method is a no-op when scraperService is nil.
+func (s *Service) importScraperPreferences(ctx context.Context, configs []ScraperConfigExport, result *ImportResult) error {
+	if s.scraperService == nil {
+		return nil
+	}
+	for _, sce := range configs {
+		if sce.Scope == "" {
+			continue
+		}
+		// Clear the ID so SaveConfig resolves it from the DB, avoiding ID
+		// collisions when importing across instances.
+		sce.Config.ID = ""
+		if err := s.scraperService.SaveConfig(ctx, sce.Scope, &sce.Config, sce.Overrides); err != nil {
+			return fmt.Errorf("saving scraper config for scope %q: %w", sce.Scope, err)
+		}
+		result.ScraperConfigs++
+	}
+	return nil
+}

--- a/internal/settingsio/import_sections_test.go
+++ b/internal/settingsio/import_sections_test.go
@@ -1,0 +1,650 @@
+package settingsio
+
+// import_sections_test.go contains focused unit tests for the per-section
+// import helpers. Each test exercises a specific section in isolation,
+// using a real SQLite DB (copied from the pre-migrated template) so schema
+// constraints are enforced exactly as in production.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"log/slog"
+
+	"github.com/sydlexius/stillwater/internal/platform"
+	"github.com/sydlexius/stillwater/internal/provider"
+	"github.com/sydlexius/stillwater/internal/rule"
+	"github.com/sydlexius/stillwater/internal/scraper"
+	"github.com/sydlexius/stillwater/internal/webhook"
+)
+
+// --- importSettings ---
+
+// TestImportSettings_UpsertAndCount verifies that importSettings upserts
+// every key in the map and increments result.Settings once per key.
+func TestImportSettings_UpsertAndCount(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	settings := map[string]string{
+		"section.key_a": "val_a",
+		"section.key_b": "val_b",
+	}
+	result := &ImportResult{}
+	if err := svc.importSettings(ctx, settings, result); err != nil {
+		t.Fatalf("importSettings: %v", err)
+	}
+	if result.Settings != 2 {
+		t.Errorf("Settings count: got %d, want 2", result.Settings)
+	}
+
+	for k, want := range settings {
+		var got string
+		if err := db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, k).Scan(&got); err != nil {
+			t.Fatalf("reading %s: %v", k, err)
+		}
+		if got != want {
+			t.Errorf("%s: got %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestImportSettings_IdempotentUpsert confirms that calling importSettings
+// twice with the same map updates the value and does not add duplicate rows.
+func TestImportSettings_IdempotentUpsert(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	settings := map[string]string{"idem.key": "first"}
+	if err := svc.importSettings(ctx, settings, &ImportResult{}); err != nil {
+		t.Fatalf("first importSettings: %v", err)
+	}
+	settings["idem.key"] = "second"
+	if err := svc.importSettings(ctx, settings, &ImportResult{}); err != nil {
+		t.Fatalf("second importSettings: %v", err)
+	}
+
+	var got string
+	if err := db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = 'idem.key'`).Scan(&got); err != nil {
+		t.Fatalf("reading idem.key: %v", err)
+	}
+	if got != "second" {
+		t.Errorf("upsert: got %q, want second", got)
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM settings WHERE key = 'idem.key'`).Scan(&count); err != nil {
+		t.Fatalf("counting idem.key rows: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("row count after two upserts: got %d, want 1", count)
+	}
+}
+
+// TestImportSettings_EmptyMapIsNoOp confirms that an empty settings map
+// leaves result.Settings at zero and does not fail.
+func TestImportSettings_EmptyMapIsNoOp(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	result := &ImportResult{}
+	if err := svc.importSettings(ctx, map[string]string{}, result); err != nil {
+		t.Fatalf("importSettings with empty map: %v", err)
+	}
+	if result.Settings != 0 {
+		t.Errorf("Settings count: got %d, want 0", result.Settings)
+	}
+}
+
+// --- importProviderKeys ---
+
+// TestImportProviderKeys_CountsAndPersists verifies that importProviderKeys
+// writes the provided key and increments result.ProviderKeys.
+func TestImportProviderKeys_CountsAndPersists(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	keys := map[string]string{string(provider.NameFanartTV): "fanart-test-key"}
+	result := &ImportResult{}
+	if err := svc.importProviderKeys(ctx, keys, result); err != nil {
+		t.Fatalf("importProviderKeys: %v", err)
+	}
+	if result.ProviderKeys != 1 {
+		t.Errorf("ProviderKeys count: got %d, want 1", result.ProviderKeys)
+	}
+	got, err := provSettings.GetAPIKey(ctx, provider.NameFanartTV)
+	if err != nil {
+		t.Fatalf("reading provider key: %v", err)
+	}
+	if got != "fanart-test-key" {
+		t.Errorf("provider key: got %q, want fanart-test-key", got)
+	}
+}
+
+// --- importConnections ---
+
+// TestImportConnections_CreateAndUpdate verifies that importConnections
+// creates a new connection when none matches (type, url), and updates the
+// existing connection when one does.
+func TestImportConnections_CreateAndUpdate(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	// First call: insert.
+	conns := []ConnectionExport{
+		{Name: "Emby A", Type: "emby", URL: "http://emby.local:8096", APIKey: "key1", Enabled: true},
+	}
+	result := &ImportResult{}
+	if err := svc.importConnections(ctx, conns, result); err != nil {
+		t.Fatalf("importConnections (insert): %v", err)
+	}
+	if result.Connections != 1 {
+		t.Errorf("Connections count after insert: got %d, want 1", result.Connections)
+	}
+
+	// Second call with same (type, url) but updated name and key: update.
+	conns[0].Name = "Emby A Renamed"
+	conns[0].APIKey = "key2"
+	result2 := &ImportResult{}
+	if err := svc.importConnections(ctx, conns, result2); err != nil {
+		t.Fatalf("importConnections (update): %v", err)
+	}
+	if result2.Connections != 1 {
+		t.Errorf("Connections count after update: got %d, want 1", result2.Connections)
+	}
+
+	all, err := connSvc.List(ctx)
+	if err != nil {
+		t.Fatalf("listing connections: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 connection, got %d", len(all))
+	}
+	if all[0].Name != "Emby A Renamed" {
+		t.Errorf("connection name: got %q, want Emby A Renamed", all[0].Name)
+	}
+}
+
+// --- importPlatformProfiles ---
+
+// TestImportPlatformProfiles_CreateAndUpdate confirms the upsert-by-name
+// logic: a new name produces a new row, and the same name updates the existing
+// row without duplicating it.
+func TestImportPlatformProfiles_CreateAndUpdate(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	profiles := []platform.Profile{
+		{Name: "Test Profile", NFOEnabled: true, NFOFormat: "kodi"},
+	}
+	result := &ImportResult{}
+	if err := svc.importPlatformProfiles(ctx, profiles, result); err != nil {
+		t.Fatalf("importPlatformProfiles (create): %v", err)
+	}
+	if result.Profiles != 1 {
+		t.Errorf("Profiles count after create: got %d, want 1", result.Profiles)
+	}
+
+	// Re-import the same profile with a changed NFOFormat: must update, not insert.
+	profiles[0].NFOFormat = "emby"
+	result2 := &ImportResult{}
+	if err := svc.importPlatformProfiles(ctx, profiles, result2); err != nil {
+		t.Fatalf("importPlatformProfiles (update): %v", err)
+	}
+
+	all, err := platSvc.List(ctx)
+	if err != nil {
+		t.Fatalf("listing profiles: %v", err)
+	}
+	var found *platform.Profile
+	for i := range all {
+		if all[i].Name == "Test Profile" {
+			found = &all[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("Test Profile not found after import")
+	}
+	if found.NFOFormat != "emby" {
+		t.Errorf("NFOFormat: got %q, want emby", found.NFOFormat)
+	}
+}
+
+// --- importWebhooks ---
+
+// TestImportWebhooks_CreateAndUpdate verifies upsert-by-(name,url) semantics.
+func TestImportWebhooks_CreateAndUpdate(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	hooks := []webhook.Webhook{
+		{Name: "Hook A", URL: "https://hook.example/a", Type: "generic", Events: []string{"artist.new"}, Enabled: true},
+	}
+	result := &ImportResult{}
+	if err := svc.importWebhooks(ctx, hooks, result); err != nil {
+		t.Fatalf("importWebhooks (create): %v", err)
+	}
+	if result.Webhooks != 1 {
+		t.Errorf("Webhooks count after create: got %d, want 1", result.Webhooks)
+	}
+
+	// Re-import with disabled=true: must update, not duplicate.
+	hooks[0].Enabled = false
+	result2 := &ImportResult{}
+	if err := svc.importWebhooks(ctx, hooks, result2); err != nil {
+		t.Fatalf("importWebhooks (update): %v", err)
+	}
+
+	all, err := whSvc.List(ctx)
+	if err != nil {
+		t.Fatalf("listing webhooks: %v", err)
+	}
+	// Locate "Hook A" -- the DB may already have other webhooks.
+	var found *webhook.Webhook
+	for i := range all {
+		if all[i].Name == "Hook A" {
+			found = &all[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("Hook A not found after import")
+	}
+	if found.Enabled {
+		t.Error("expected Enabled=false after update, got true")
+	}
+}
+
+// --- importRules ---
+
+// TestImportRules_SkipsNilService confirms that importRules is a no-op when
+// the rule service is not attached (WithRuleService was not called).
+func TestImportRules_SkipsNilService(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc) // no WithRuleService
+
+	rules := []RuleExport{
+		{ID: "thumb_exists", Enabled: false, AutomationMode: "auto"},
+	}
+	result := &ImportResult{}
+	if err := svc.importRules(ctx, rules, result); err != nil {
+		t.Fatalf("importRules with nil service: %v", err)
+	}
+	if result.Rules != 0 {
+		t.Errorf("Rules count: got %d, want 0 (service nil)", result.Rules)
+	}
+}
+
+// TestImportRules_SkipsEmptyID verifies that a rule export with an empty ID
+// is skipped without error.
+func TestImportRules_SkipsEmptyID(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	ruleSvc := rule.NewService(db)
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithRuleService(ruleSvc)
+
+	result := &ImportResult{}
+	if err := svc.importRules(ctx, []RuleExport{{ID: "", Enabled: true, AutomationMode: "auto"}}, result); err != nil {
+		t.Fatalf("importRules with empty ID: %v", err)
+	}
+	if result.Rules != 0 {
+		t.Errorf("Rules count: got %d, want 0 (empty ID skipped)", result.Rules)
+	}
+}
+
+// TestImportRules_SkipsUnknownID verifies that an ID not present on this
+// instance (e.g. from a newer binary) is silently skipped.
+func TestImportRules_SkipsUnknownID(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	ruleSvc := rule.NewService(db)
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithRuleService(ruleSvc)
+
+	result := &ImportResult{}
+	if err := svc.importRules(ctx, []RuleExport{{ID: "future_unknown_rule", Enabled: true, AutomationMode: "auto"}}, result); err != nil {
+		t.Fatalf("importRules with unknown ID: %v", err)
+	}
+	if result.Rules != 0 {
+		t.Errorf("Rules count: got %d, want 0 (unknown ID skipped)", result.Rules)
+	}
+}
+
+// TestImportRules_SkipsInvalidAutomationMode verifies that an entry with an
+// unrecognized automation_mode is skipped and the DB is not mutated.
+func TestImportRules_SkipsInvalidAutomationMode(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	ruleSvc := rule.NewService(db)
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithRuleService(ruleSvc)
+
+	// Read the current mode so we can assert it is not changed.
+	before, err := ruleSvc.GetByID(ctx, rule.RuleThumbExists)
+	if err != nil {
+		t.Fatalf("getting rule before: %v", err)
+	}
+	originalMode := before.AutomationMode
+
+	result := &ImportResult{}
+	if err := svc.importRules(ctx, []RuleExport{
+		{ID: rule.RuleThumbExists, Enabled: true, AutomationMode: "invalid_value"},
+	}, result); err != nil {
+		t.Fatalf("importRules with invalid mode: %v", err)
+	}
+	if result.Rules != 0 {
+		t.Errorf("Rules count: got %d, want 0 (invalid mode skipped)", result.Rules)
+	}
+
+	after, err := ruleSvc.GetByID(ctx, rule.RuleThumbExists)
+	if err != nil {
+		t.Fatalf("getting rule after: %v", err)
+	}
+	if after.AutomationMode != originalMode {
+		t.Errorf("automation_mode mutated to %q despite invalid value; original was %q", after.AutomationMode, originalMode)
+	}
+}
+
+// TestImportRules_UpdatesValidRule confirms that a rule with a valid
+// automation_mode is applied to the DB and result.Rules is incremented.
+func TestImportRules_UpdatesValidRule(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	ruleSvc := rule.NewService(db)
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithRuleService(ruleSvc)
+
+	result := &ImportResult{}
+	if err := svc.importRules(ctx, []RuleExport{
+		{ID: rule.RuleThumbExists, Enabled: false, AutomationMode: rule.AutomationModeAuto},
+	}, result); err != nil {
+		t.Fatalf("importRules: %v", err)
+	}
+	if result.Rules != 1 {
+		t.Errorf("Rules count: got %d, want 1", result.Rules)
+	}
+
+	updated, err := ruleSvc.GetByID(ctx, rule.RuleThumbExists)
+	if err != nil {
+		t.Fatalf("getting updated rule: %v", err)
+	}
+	if updated.Enabled {
+		t.Error("expected Enabled=false after import")
+	}
+	if updated.AutomationMode != rule.AutomationModeAuto {
+		t.Errorf("AutomationMode: got %q, want auto", updated.AutomationMode)
+	}
+}
+
+// --- importScraperPreferences ---
+
+// TestImportScraperPreferences_SkipsNilService confirms no-op when the
+// scraper service is not attached.
+func TestImportScraperPreferences_SkipsNilService(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc) // no WithScraperService
+
+	result := &ImportResult{}
+	if err := svc.importScraperPreferences(ctx, []ScraperConfigExport{
+		{Scope: "global"},
+	}, result); err != nil {
+		t.Fatalf("importScraperPreferences with nil service: %v", err)
+	}
+	if result.ScraperConfigs != 0 {
+		t.Errorf("ScraperConfigs count: got %d, want 0 (service nil)", result.ScraperConfigs)
+	}
+}
+
+// TestImportScraperPreferences_SkipsEmptyScope verifies that a config with an
+// empty scope is skipped without error.
+func TestImportScraperPreferences_SkipsEmptyScope(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	scraperSvc := scraper.NewService(db, slog.Default())
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithScraperService(scraperSvc)
+
+	result := &ImportResult{}
+	if err := svc.importScraperPreferences(ctx, []ScraperConfigExport{{Scope: ""}}, result); err != nil {
+		t.Fatalf("importScraperPreferences with empty scope: %v", err)
+	}
+	if result.ScraperConfigs != 0 {
+		t.Errorf("ScraperConfigs count: got %d, want 0 (empty scope skipped)", result.ScraperConfigs)
+	}
+}
+
+// TestImportScraperPreferences_UpsertAndCount verifies that a non-empty scope
+// is written and result.ScraperConfigs is incremented.
+func TestImportScraperPreferences_UpsertAndCount(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	scraperSvc := scraper.NewService(db, slog.Default())
+	if err := scraperSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding scraper defaults: %v", err)
+	}
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithScraperService(scraperSvc)
+
+	configs := []ScraperConfigExport{
+		{Scope: "global", Config: scraper.ScraperConfig{}},
+		{Scope: "custom-scope", Config: scraper.ScraperConfig{}},
+	}
+	result := &ImportResult{}
+	if err := svc.importScraperPreferences(ctx, configs, result); err != nil {
+		t.Fatalf("importScraperPreferences: %v", err)
+	}
+	if result.ScraperConfigs != 2 {
+		t.Errorf("ScraperConfigs count: got %d, want 2", result.ScraperConfigs)
+	}
+}
+
+// --- importProviderPriorities ---
+
+// TestImportProviderPriorities_CountsAndPersists verifies that priorities are
+// written and result.Priorities is incremented for each entry.
+func TestImportProviderPriorities_CountsAndPersists(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	priorities := []PriorityExport{
+		{
+			Field:     "biography",
+			Providers: []provider.ProviderName{provider.NameMusicBrainz, provider.NameWikipedia},
+		},
+	}
+	result := &ImportResult{}
+	if err := svc.importProviderPriorities(ctx, priorities, result); err != nil {
+		t.Fatalf("importProviderPriorities: %v", err)
+	}
+	if result.Priorities != 1 {
+		t.Errorf("Priorities count: got %d, want 1", result.Priorities)
+	}
+}
+
+// --- API token orphan / FK-skip unit tests (section-level) ---
+
+// TestImportAPITokens_OrphanTokenSkipped tests that a token whose owner is
+// absent on the target is skipped (not inserted) and APITokensSkipped is
+// incremented when admin-fallback is off.
+func TestImportAPITokens_OrphanTokenSkipped(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	// No users seeded -- "ghost" does not exist.
+	tokens := []APITokenExport{
+		{Name: "Orphan", TokenHash: "orphan-hash", Scopes: "read,write", Username: "ghost", Status: "active"},
+	}
+	result := &ImportResult{}
+	if err := svc.importAPITokens(ctx, tokens, result, ImportOptions{}); err != nil {
+		t.Fatalf("importAPITokens: %v", err)
+	}
+	if result.APITokensSkipped != 1 {
+		t.Errorf("APITokensSkipped: got %d, want 1", result.APITokensSkipped)
+	}
+	if result.APITokens != 0 {
+		t.Errorf("APITokens: got %d, want 0", result.APITokens)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_tokens WHERE token_hash = 'orphan-hash'`).Scan(&count); err != nil {
+		t.Fatalf("counting orphan token: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("orphan token was inserted despite missing owner: count=%d", count)
+	}
+}
+
+// TestImportAPITokens_EmptyHashSkipped verifies that a token with an empty
+// hash is skipped and APITokensSkipped is incremented.
+func TestImportAPITokens_EmptyHashSkipped(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO users (id, username, role, auth_provider, is_active, created_at, updated_at) VALUES ('u1', 'alice', 'administrator', 'local', 1, ?, ?)`,
+		now, now); err != nil {
+		t.Fatalf("seeding user: %v", err)
+	}
+
+	tokens := []APITokenExport{
+		{Name: "Bad Token", TokenHash: "", Scopes: "read,write", Username: "alice", Status: "active"},
+	}
+	result := &ImportResult{}
+	if err := svc.importAPITokens(ctx, tokens, result, ImportOptions{}); err != nil {
+		t.Fatalf("importAPITokens: %v", err)
+	}
+	if result.APITokensSkipped != 1 {
+		t.Errorf("APITokensSkipped: got %d, want 1", result.APITokensSkipped)
+	}
+}
+
+// TestImportAPITokens_AdminFallbackAssignsToken verifies that when admin-
+// fallback is enabled and the owner is absent, the token is assigned to the
+// importing admin and OwnershipReassigned is incremented.
+func TestImportAPITokens_AdminFallbackAssignsToken(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO users (id, username, role, auth_provider, is_active, created_at, updated_at) VALUES ('u-admin', 'admin', 'administrator', 'local', 1, ?, ?)`,
+		now, now); err != nil {
+		t.Fatalf("seeding admin: %v", err)
+	}
+
+	// "ghost" does not exist; admin-fallback should assign the token to "admin".
+	tokens := []APITokenExport{
+		{Name: "Ghost Token", TokenHash: "ghost-hash", Scopes: "read,write", Username: "ghost", Status: "active", CreatedAt: now},
+	}
+	result := &ImportResult{}
+	opts := ImportOptions{AdminFallbackTokens: true, ImportingAdminUserID: "u-admin"}
+	if err := svc.importAPITokens(ctx, tokens, result, opts); err != nil {
+		t.Fatalf("importAPITokens: %v", err)
+	}
+	if result.APITokens != 1 || result.APITokensSkipped != 0 {
+		t.Errorf("tokens: imported=%d skipped=%d, want 1/0", result.APITokens, result.APITokensSkipped)
+	}
+	if result.OwnershipReassigned != 1 {
+		t.Errorf("OwnershipReassigned: got %d, want 1", result.OwnershipReassigned)
+	}
+
+	var userID string
+	if err := db.QueryRowContext(ctx, `SELECT user_id FROM api_tokens WHERE token_hash = 'ghost-hash'`).Scan(&userID); err != nil {
+		t.Fatalf("reading token user_id: %v", err)
+	}
+	if userID != "u-admin" {
+		t.Errorf("user_id: got %q, want u-admin", userID)
+	}
+}
+
+// TestImportAPITokens_ConflictResolution_UpdatesExistingRow verifies that
+// re-importing a token whose hash already exists in the DB updates the
+// metadata on the existing row rather than inserting a duplicate.
+func TestImportAPITokens_ConflictResolution_UpdatesExistingRow(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO users (id, username, role, auth_provider, is_active, created_at, updated_at) VALUES ('u-owner', 'owner', 'operator', 'local', 1, ?, ?)`,
+		now, now); err != nil {
+		t.Fatalf("seeding user: %v", err)
+	}
+	// Pre-seed the token row.
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO api_tokens (id, name, token_hash, scopes, user_id, created_at, status)
+		VALUES ('tok-pre', 'Old Name', 'stable-hash', 'read', 'u-owner', ?, 'active')
+	`, now); err != nil {
+		t.Fatalf("seeding token: %v", err)
+	}
+
+	tokens := []APITokenExport{
+		{Name: "New Name", TokenHash: "stable-hash", Scopes: "read,write", Username: "owner", Status: "active", CreatedAt: now},
+	}
+	result := &ImportResult{}
+	if err := svc.importAPITokens(ctx, tokens, result, ImportOptions{}); err != nil {
+		t.Fatalf("importAPITokens: %v", err)
+	}
+	if result.APITokens != 1 {
+		t.Errorf("APITokens: got %d, want 1", result.APITokens)
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM api_tokens WHERE token_hash = 'stable-hash'`).Scan(&count); err != nil {
+		t.Fatalf("counting rows: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("row count after upsert: got %d, want 1 (no duplicate)", count)
+	}
+
+	var name string
+	if err := db.QueryRowContext(ctx, `SELECT name FROM api_tokens WHERE token_hash = 'stable-hash'`).Scan(&name); err != nil {
+		t.Fatalf("reading name: %v", err)
+	}
+	if name != "New Name" {
+		t.Errorf("name after upsert: got %q, want New Name", name)
+	}
+}

--- a/internal/settingsio/import_sections_test.go
+++ b/internal/settingsio/import_sections_test.go
@@ -495,6 +495,79 @@ func TestImportProviderPriorities_CountsAndPersists(t *testing.T) {
 	}
 }
 
+// TestImportProviderPriorities_DisabledPersisted verifies that a non-empty
+// Disabled list is written alongside the priority order.
+func TestImportProviderPriorities_DisabledPersisted(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	priorities := []PriorityExport{
+		{
+			Field:     "biography",
+			Providers: []provider.ProviderName{provider.NameMusicBrainz, provider.NameWikipedia},
+			Disabled:  []provider.ProviderName{provider.NameWikipedia},
+		},
+	}
+	result := &ImportResult{}
+	if err := svc.importProviderPriorities(ctx, priorities, result); err != nil {
+		t.Fatalf("importProviderPriorities: %v", err)
+	}
+
+	fps, err := provSettings.GetPriorities(ctx)
+	if err != nil {
+		t.Fatalf("GetPriorities: %v", err)
+	}
+	var got []provider.ProviderName
+	for _, fp := range fps {
+		if fp.Field == "biography" {
+			got = fp.Disabled
+			break
+		}
+	}
+	if len(got) != 1 || got[0] != provider.NameWikipedia {
+		t.Errorf("Disabled: got %v, want [%s]", got, provider.NameWikipedia)
+	}
+}
+
+// TestImportProviderPriorities_EmptyDisabledClears verifies that importing an
+// entry with no Disabled providers clears any previously-stored disabled list,
+// ensuring idempotent restore behavior.
+func TestImportProviderPriorities_EmptyDisabledClears(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	// Seed a disabled entry directly so we can verify it gets cleared.
+	if err := provSettings.SetDisabledProviders(ctx, "biography", []provider.ProviderName{provider.NameWikipedia}); err != nil {
+		t.Fatalf("SetDisabledProviders seed: %v", err)
+	}
+
+	priorities := []PriorityExport{
+		{
+			Field:     "biography",
+			Providers: []provider.ProviderName{provider.NameMusicBrainz, provider.NameWikipedia},
+			// Disabled is intentionally nil -- import should clear the seeded value.
+		},
+	}
+	result := &ImportResult{}
+	if err := svc.importProviderPriorities(ctx, priorities, result); err != nil {
+		t.Fatalf("importProviderPriorities: %v", err)
+	}
+
+	fps, err := provSettings.GetPriorities(ctx)
+	if err != nil {
+		t.Fatalf("GetPriorities: %v", err)
+	}
+	for _, fp := range fps {
+		if fp.Field == "biography" && len(fp.Disabled) > 0 {
+			t.Errorf("expected disabled list cleared, got %v", fp.Disabled)
+		}
+	}
+}
+
 // --- API token orphan / FK-skip unit tests (section-level) ---
 
 // TestImportAPITokens_OrphanTokenSkipped tests that a token whose owner is

--- a/internal/settingsio/import_sections_test.go
+++ b/internal/settingsio/import_sections_test.go
@@ -501,6 +501,28 @@ func TestImportProviderPriorities_CountsAndPersists(t *testing.T) {
 	if result.Priorities != 1 {
 		t.Errorf("Priorities count: got %d, want 1", result.Priorities)
 	}
+	fps, err := provSettings.GetPriorities(ctx)
+	if err != nil {
+		t.Fatalf("GetPriorities: %v", err)
+	}
+	foundBio := false
+	for _, fp := range fps {
+		if fp.Field != "biography" {
+			continue
+		}
+		foundBio = true
+		// GetPriorities appends defaults not in the stored list, so check that
+		// the imported providers appear first in the correct order.
+		if len(fp.Providers) < 2 ||
+			fp.Providers[0] != provider.NameMusicBrainz ||
+			fp.Providers[1] != provider.NameWikipedia {
+			t.Errorf("Providers prefix: got %v, want [%s %s] first", fp.Providers, provider.NameMusicBrainz, provider.NameWikipedia)
+		}
+		break
+	}
+	if !foundBio {
+		t.Fatal("biography priorities not found after import")
+	}
 }
 
 // TestImportProviderPriorities_DisabledPersisted verifies that a non-empty
@@ -569,10 +591,19 @@ func TestImportProviderPriorities_EmptyDisabledClears(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPriorities: %v", err)
 	}
+	foundBio := false
 	for _, fp := range fps {
-		if fp.Field == "biography" && len(fp.Disabled) > 0 {
+		if fp.Field != "biography" {
+			continue
+		}
+		foundBio = true
+		if len(fp.Disabled) > 0 {
 			t.Errorf("expected disabled list cleared, got %v", fp.Disabled)
 		}
+		break
+	}
+	if !foundBio {
+		t.Fatal("biography priorities not found after import")
 	}
 }
 

--- a/internal/settingsio/import_sections_test.go
+++ b/internal/settingsio/import_sections_test.go
@@ -209,11 +209,15 @@ func TestImportPlatformProfiles_CreateAndUpdate(t *testing.T) {
 		t.Fatalf("listing profiles: %v", err)
 	}
 	var found *platform.Profile
+	foundCount := 0
 	for i := range all {
 		if all[i].Name == "Test Profile" {
+			foundCount++
 			found = &all[i]
-			break
 		}
+	}
+	if foundCount != 1 {
+		t.Fatalf("expected exactly 1 Test Profile row, got %d", foundCount)
 	}
 	if found == nil {
 		t.Fatal("Test Profile not found after import")
@@ -256,11 +260,15 @@ func TestImportWebhooks_CreateAndUpdate(t *testing.T) {
 	}
 	// Locate "Hook A" -- the DB may already have other webhooks.
 	var found *webhook.Webhook
+	foundCount := 0
 	for i := range all {
 		if all[i].Name == "Hook A" {
+			foundCount++
 			found = &all[i]
-			break
 		}
+	}
+	if foundCount != 1 {
+		t.Fatalf("expected exactly 1 Hook A row, got %d", foundCount)
 	}
 	if found == nil {
 		t.Fatal("Hook A not found after import")
@@ -565,6 +573,118 @@ func TestImportProviderPriorities_EmptyDisabledClears(t *testing.T) {
 		if fp.Field == "biography" && len(fp.Disabled) > 0 {
 			t.Errorf("expected disabled list cleared, got %v", fp.Disabled)
 		}
+	}
+}
+
+// --- error-path coverage (closed-DB) ---
+
+// TestImportSettings_DBError verifies that a DB failure propagates as an error.
+func TestImportSettings_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+	_ = db.Close()
+	err := svc.importSettings(t.Context(), map[string]string{"k": "v"}, &ImportResult{})
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportProviderKeys_DBError verifies that a provider key write failure propagates.
+func TestImportProviderKeys_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+	_ = db.Close()
+	err := svc.importProviderKeys(t.Context(), map[string]string{string(provider.NameFanartTV): "key"}, &ImportResult{})
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportConnections_DBError verifies that a connection lookup failure propagates.
+func TestImportConnections_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+	_ = db.Close()
+	conns := []ConnectionExport{{Name: "x", Type: "emby", URL: "http://localhost:8096"}}
+	err := svc.importConnections(t.Context(), conns, &ImportResult{})
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportPlatformProfiles_DBError verifies that a profile lookup failure propagates.
+func TestImportPlatformProfiles_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+	_ = db.Close()
+	profiles := []platform.Profile{{Name: "Test"}}
+	err := svc.importPlatformProfiles(t.Context(), profiles, &ImportResult{})
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportWebhooks_DBError verifies that a webhook lookup failure propagates.
+func TestImportWebhooks_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+	_ = db.Close()
+	hooks := []webhook.Webhook{{Name: "h", URL: "https://example.com/h", Type: "generic"}}
+	err := svc.importWebhooks(t.Context(), hooks, &ImportResult{})
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportProviderPriorities_DBError verifies that a priority write failure propagates.
+func TestImportProviderPriorities_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+	_ = db.Close()
+	priorities := []PriorityExport{{Field: "biography", Providers: []provider.ProviderName{provider.NameMusicBrainz}}}
+	err := svc.importProviderPriorities(t.Context(), priorities, &ImportResult{})
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportRules_DBError verifies that a non-ErrNotFound DB error propagates
+// instead of being silently swallowed as an unknown-rule skip.
+func TestImportRules_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	ruleSvc := rule.NewService(db)
+	if err := ruleSvc.SeedDefaults(t.Context()); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithRuleService(ruleSvc)
+	_ = db.Close()
+	// Use a known rule ID so the GetByID path is exercised (unknown IDs are
+	// silently skipped; a closed-DB error is not ErrNotFound and must surface).
+	rules := []RuleExport{{ID: rule.RuleThumbExists, Enabled: false, AutomationMode: rule.AutomationModeAuto}}
+	err := svc.importRules(t.Context(), rules, &ImportResult{})
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportScraperPreferences_DBError verifies that a SaveConfig failure propagates.
+func TestImportScraperPreferences_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	scraperSvc := scraper.NewService(db, slog.Default())
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithScraperService(scraperSvc)
+	_ = db.Close()
+	configs := []ScraperConfigExport{{Scope: "global", Config: scraper.ScraperConfig{}}}
+	err := svc.importScraperPreferences(t.Context(), configs, &ImportResult{})
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Extracts 8 per-section helpers from `ImportWithOptions` (cyclomatic 47, ~250 lines) into a new `import_sections.go`
- `importSettings`, `importProviderKeys`, `importConnections`, `importPlatformProfiles`, `importWebhooks`, `importProviderPriorities`, `importRules`, `importScraperPreferences`
- Each helper returns its own counter-update; the orchestrator sequences them with consistent `fmt.Errorf("importing X: %w", err)` wrapping
- All import semantics preserved: create-or-update branching, orphan token skipping, FK-cascade behavior, nil-service guards
- `FuzzImportEnvelope` untouched and confirmed building/running (4913 execs in 2s, no crashes)
- 20 dedicated unit tests covering create vs. update, nil inputs, invalid automation_mode, empty scope/ID, idempotent upsert, API token orphan/FK-skip/admin-fallback

## Test plan

- [ ] `go test -race ./internal/settingsio/... -timeout 180s` -- all pass
- [ ] Pre-push gate clean (exit 0); note: unrelated `TestRunListeners_TLSSplitPort` flaked under load (filed as #1496)

Closes #1394

Part of M49.5 (Code Health and Hardening) W1.1C.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Settings import split into dedicated per-section handlers with explicit import ordering, clearer section-specific error reporting, idempotent upserts, and safer handling of identifiers, provider priorities, disabled lists, scraper-config collisions, user/token ordering, and library remapping.
* **Tests**
  * Added comprehensive SQLite-backed tests covering each import section: upsert semantics, create-vs-update, counters, validation/no-op cases, DB error propagation, and API token edge cases (orphan skipping, admin fallback assignment, conflict resolution).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1497)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->