### PR TITLE
refactor(api): split handleRevertHistory into validate/revert/render stages

### DIFF
--- a/internal/api/handlers_history.go
+++ b/internal/api/handlers_history.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -312,6 +313,148 @@ func (r *Router) handleArtistHistoryTab(w http.ResponseWriter, req *http.Request
 	renderTempl(w, req, templates.ArtistHistoryTab(data))
 }
 
+// errRevertNotTrackable is returned by validateRevertable when the field is
+// not tracked by the history system.
+var errRevertNotTrackable = errors.New("field is not revertible")
+
+// errRevertOfRevert is returned by validateRevertable when the caller attempts
+// to revert an entry that was itself produced by a revert.
+var errRevertOfRevert = errors.New("revert entries cannot be reverted")
+
+// validateRevertable returns an error if the change is ineligible for revert.
+// It checks two conditions independently so tests can cover each in isolation:
+// (a) the field must be tracked by the history system, and (b) the source must
+// not already be "revert" (reverting a revert would create infinite chains).
+func validateRevertable(change *artist.MetadataChange) error {
+	if !artist.IsTrackableField(change.Field) {
+		return errRevertNotTrackable
+	}
+	if change.Source == "revert" {
+		return errRevertOfRevert
+	}
+	return nil
+}
+
+// performRevert applies the revert mutation for a single metadata change.
+// It injects "revert" as the history source and pre-assigns a deterministic
+// change ID (returned as revertChangeID) via ContextWithHistoryID so the
+// caller can fetch the resulting history row by ID without racing against
+// concurrent writers to the same field. The returned revertChangeID is the
+// ID pre-assigned to the new history row; callers should fetch it with
+// GetByID after this call returns.
+//
+// ClearField/UpdateField currently succeed silently when the artist ID does
+// not exist (UPDATE affects zero rows). The ErrNotFound guards are defensive:
+// they activate if the repo layer is updated to check RowsAffected.
+func (r *Router) performRevert(ctx context.Context, change *artist.MetadataChange) (revertChangeID string, err error) {
+	revertChangeID = uuid.New().String()
+	ctx = artist.ContextWithSource(ctx, "revert")
+	ctx = artist.ContextWithHistoryID(ctx, revertChangeID)
+
+	if change.OldValue == "" {
+		err = r.artistService.ClearField(ctx, change.ArtistID, change.Field)
+	} else {
+		err = r.artistService.UpdateField(ctx, change.ArtistID, change.Field, change.OldValue)
+	}
+	return revertChangeID, err
+}
+
+// renderActivityRevertFragment renders the HTMX fragment for a revert that was
+// triggered from the global activity feed. It fetches the artist name, applies
+// the active source and date filters, and falls through to the generic fallback
+// if the new revert row does not belong in the current view.
+// Returns true when a rich fragment was written to w; false signals the caller
+// should write the generic fallback instead.
+func (r *Router) renderActivityRevertFragment(
+	w http.ResponseWriter, req *http.Request,
+	origChangeID string,
+	revertChange *artist.MetadataChange,
+) bool {
+	artistRow, artistErr := r.artistService.GetByID(req.Context(), revertChange.ArtistID)
+	if artistErr != nil {
+		r.logger.Error("fetching artist for revert fragment",
+			"artist_id", revertChange.ArtistID, "error", artistErr)
+		return false
+	}
+
+	newChange := artist.MetadataChangeWithArtist{
+		MetadataChange: *revertChange,
+		ArtistName:     artistRow.Name,
+	}
+
+	// Rebuild the active filter from query params carried in HX-Current-URL
+	// so the "showing X of Y" counter stays accurate relative to the feed.
+	activeFilter := buildGlobalFilterFromURL(req.Header.Get("HX-Current-URL"))
+
+	// If the active feed filter restricts sources and does not include
+	// "revert", the new row is outside the current view. Skip injection to
+	// avoid inserting a row that would not normally appear in the feed.
+	// Also suppress when SourcePrefixes is non-empty: "revert" does not
+	// match any provider:/rule: prefix pattern.
+	allowsRevert := (len(activeFilter.Sources) == 0 && len(activeFilter.SourcePrefixes) == 0) ||
+		sliceContains(activeFilter.Sources, "revert")
+	if !allowsRevert {
+		return false
+	}
+
+	// Guard against active date-range bounds: skip if the revert row falls
+	// outside the from/to window.
+	createdAt := newChange.CreatedAt
+	if (!activeFilter.From.IsZero() && createdAt.Before(activeFilter.From)) ||
+		(!activeFilter.To.IsZero() && createdAt.After(activeFilter.To)) {
+		return false
+	}
+
+	userID := middleware.UserIDFromContext(req.Context())
+	limit := r.getUserPageSize(req.Context(), userID, 0)
+	activeFilter.Limit = limit
+	_, total, _ := r.historyService.ListGlobal(req.Context(), activeFilter)
+	// Compute fallback from offset+limit. After Load-more the browser URL
+	// does not push offset, so this only matches reality when no Load-more
+	// clicks have occurred. The client-supplied hx-vals showing hint is
+	// preferred when present (see resolveShowingCount).
+	fallback := activeFilter.Offset + limit
+	if fallback > total {
+		fallback = total
+	}
+	showing := resolveShowingCount(req, fallback, total, r.logger)
+	renderTempl(w, req, templates.ActivityRevertFragment(origChangeID, newChange, r.basePath, showing, total))
+	return true
+}
+
+// renderArtistTabRevertFragment renders the HTMX fragment for a revert that
+// was triggered from the artist detail page's history tab. It calls List once
+// to get the page total for the counter and delegates to resolveShowingCount
+// to honor the hx-vals showing hint when present.
+// Returns true when a rich fragment was written to w.
+func (r *Router) renderArtistTabRevertFragment(
+	w http.ResponseWriter, req *http.Request,
+	origChangeID string,
+	origChange *artist.MetadataChange,
+	revertChange *artist.MetadataChange,
+) bool {
+	userID := middleware.UserIDFromContext(req.Context())
+	limit := r.getUserPageSize(req.Context(), userID, 0)
+	changes, total, listErr := r.historyService.List(req.Context(), origChange.ArtistID, limit, 0)
+	if listErr != nil {
+		r.logger.Error("fetching revert confirmation", "change_id", origChangeID, "error", listErr)
+		return false
+	}
+	// The fragment hides the reverted row and prepends the new revert row so
+	// the visible count is unchanged (+1 prepended, -1 hidden). DB total grew
+	// by exactly 1 and len(changes) from the first page overstates visible rows
+	// by 1 when the list fits on one page. Compensate by subtracting 1
+	// (clamped at 0). When Load-more has been used the hx-vals showing hint
+	// overrides this fallback via resolveShowingCount.
+	fallback := len(changes) - 1
+	if fallback < 0 {
+		fallback = 0
+	}
+	showing := resolveShowingCount(req, fallback, total, r.logger)
+	renderTempl(w, req, templates.HistoryRevertFragment(origChangeID, *revertChange, showing, total))
+	return true
+}
+
 // handleRevertHistory reverts a single metadata change by restoring the old value.
 // POST /api/v1/history/{id}/revert
 func (r *Router) handleRevertHistory(w http.ResponseWriter, req *http.Request) {
@@ -336,190 +479,82 @@ func (r *Router) handleRevertHistory(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if !artist.IsTrackableField(change.Field) {
-		writeError(w, req, http.StatusBadRequest, "field is not revertible")
+	if err := validateRevertable(change); err != nil {
+		writeError(w, req, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	if change.Source == "revert" {
-		writeError(w, req, http.StatusBadRequest, "revert entries cannot be reverted")
+	revertChangeID, err := r.performRevert(req.Context(), change)
+	if err != nil {
+		if errors.Is(err, artist.ErrNotFound) {
+			writeError(w, req, http.StatusNotFound, "artist not found")
+			return
+		}
+		r.logger.Error("performing revert", "change_id", changeID, "error", err)
+		writeError(w, req, http.StatusInternalServerError, "revert failed")
 		return
-	}
-
-	// Inject "revert" as the history source so the auto-recorded change
-	// is distinguishable from manual edits. Pre-assign the change ID via
-	// ContextWithHistoryID so we can fetch the resulting row deterministically
-	// with GetByID below; otherwise the post-mutation lookup races against any
-	// concurrent writer that touches the same field at the same instant
-	// (e.g. a metadata refresh, an automated rule fix, or a parallel revert).
-	revertChangeID := uuid.New().String()
-	ctx := artist.ContextWithSource(req.Context(), "revert")
-	ctx = artist.ContextWithHistoryID(ctx, revertChangeID)
-
-	// ClearField/UpdateField currently succeed silently when the artist ID
-	// does not exist (UPDATE affects zero rows). The ErrNotFound guards below
-	// are defensive: they will activate if the repo layer is updated to check
-	// RowsAffected and return ErrNotFound for missing artists.
-	if change.OldValue == "" {
-		if err := r.artistService.ClearField(ctx, change.ArtistID, change.Field); err != nil {
-			if errors.Is(err, artist.ErrNotFound) {
-				writeError(w, req, http.StatusNotFound, "artist not found")
-				return
-			}
-			r.logger.Error("reverting change (clear)", "change_id", changeID, "error", err)
-			writeError(w, req, http.StatusInternalServerError, "revert failed")
-			return
-		}
-	} else {
-		if err := r.artistService.UpdateField(ctx, change.ArtistID, change.Field, change.OldValue); err != nil {
-			if errors.Is(err, artist.ErrNotFound) {
-				writeError(w, req, http.StatusNotFound, "artist not found")
-				return
-			}
-			r.logger.Error("reverting change (update)", "change_id", changeID, "error", err)
-			writeError(w, req, http.StatusInternalServerError, "revert failed")
-			return
-		}
 	}
 
 	// For HTMX requests (undo button click), return an HTML fragment showing
-	// the new history entry that was created by the revert. For API callers,
-	// return JSON.
-	if isHTMXRequest(req) {
-		// Determine whether the undo was triggered from the activity page or
-		// the artist history tab so we can render the correct fragment type.
-		fromActivity := strings.Contains(req.Header.Get("HX-Current-URL"), "/activity")
-
-		// Fetch the new revert change row deterministically by its pre-assigned
-		// ID. This avoids the prior "find most recent revert for this field"
-		// pattern, which races against any concurrent writer to the same field.
-		revertChange, err := r.historyService.GetByID(req.Context(), revertChangeID)
-		if err != nil {
-			// A missing revert history row is an expected edge case: the revert
-			// can become a no-op (e.g. the field already matched OldValue so
-			// UpdateField/ClearField recorded nothing) or history recording was
-			// best-effort. Log at Info in that case to avoid noisy error logs
-			// from user-initiated reverts; reserve Error for genuine failures.
-			if errors.Is(err, artist.ErrChangeNotFound) {
-				r.logger.Info("revert change history row not found; rendering fallback fragment",
-					"change_id", changeID, "revert_change_id", revertChangeID)
-			} else {
-				r.logger.Error("fetching revert change by id",
-					"change_id", changeID, "revert_change_id", revertChangeID, "error", err)
-			}
-		}
-
-		if fromActivity && revertChange != nil {
-			// Activity feed needs MetadataChangeWithArtist (includes artist name).
-			// Fetch the artist name separately since GetByID returns only the
-			// metadata_changes row.
-			artistRow, artistErr := r.artistService.GetByID(req.Context(), revertChange.ArtistID)
-			if artistErr != nil {
-				r.logger.Error("fetching artist for revert fragment",
-					"artist_id", revertChange.ArtistID, "error", artistErr)
-			}
-			if artistErr == nil {
-				newChange := artist.MetadataChangeWithArtist{
-					MetadataChange: *revertChange,
-					ArtistName:     artistRow.Name,
-				}
-
-				// Rebuild the active filter from query params carried in
-				// HX-Current-URL so the "showing X of Y" counter stays
-				// accurate relative to the current feed view.
-				activeFilter := buildGlobalFilterFromURL(req.Header.Get("HX-Current-URL"))
-
-				// If the active feed filter restricts sources and does not
-				// include "revert", the new revert row is outside the current
-				// view. Skip the fragment injection so we don't insert a row
-				// that would not normally appear in the feed.
-				// Also suppress when SourcePrefixes is non-empty: "revert" does
-				// not match any provider:/rule: prefix pattern.
-				allowsRevert := (len(activeFilter.Sources) == 0 && len(activeFilter.SourcePrefixes) == 0) ||
-					sliceContains(activeFilter.Sources, "revert")
-				sourceFiltered := !allowsRevert
-
-				// Guard against active date-range bounds: if the new revert row
-				// falls outside the current feed's from/to window, skip fragment
-				// injection so we don't insert a row that would not appear in the feed.
-				createdAt := newChange.CreatedAt
-				dateFiltered := (!activeFilter.From.IsZero() && createdAt.Before(activeFilter.From)) ||
-					(!activeFilter.To.IsZero() && createdAt.After(activeFilter.To))
-
-				if !sourceFiltered && !dateFiltered {
-					userID := middleware.UserIDFromContext(req.Context())
-					limit := r.getUserPageSize(req.Context(), userID, 0)
-					activeFilter.Limit = limit
-					_, total, _ := r.historyService.ListGlobal(req.Context(), activeFilter)
-					// Compute the fallback showing count from offset+limit. After
-					// Load-more the browser URL does not push offset, so this
-					// fallback only matches reality when no Load-more clicks have
-					// occurred. The client-supplied hx-vals showing hint is
-					// preferred when present.
-					fallback := activeFilter.Offset + limit
-					if fallback > total {
-						fallback = total
-					}
-					showing := resolveShowingCount(req, fallback, total, r.logger)
-					renderTempl(w, req, templates.ActivityRevertFragment(changeID, newChange, r.basePath, showing, total))
-					return
-				}
-			}
-		} else if !fromActivity && revertChange != nil {
-			// Artist history tab needs MetadataChange (no artist name needed).
-			// Use the deterministically-fetched revertChange and call List only
-			// to get the page total for the "showing X of Y" counter.
-			userID := middleware.UserIDFromContext(req.Context())
-			limit := r.getUserPageSize(req.Context(), userID, 0)
-			changes, total, listErr := r.historyService.List(req.Context(), change.ArtistID, limit, 0)
-			if listErr != nil {
-				r.logger.Error("fetching revert confirmation", "change_id", changeID, "error", listErr)
-			} else {
-				// The fragment hides the reverted row and prepends the new
-				// revert row, so the number of visible rows is unchanged
-				// (+1 prepended, -1 hidden). This branch only runs when
-				// revertChange != nil (the revert history row exists), so
-				// DB total grew by exactly 1 and len(changes) from the
-				// first page overstates visible rows by 1 when the list
-				// fits on one page. Compensate by subtracting 1 (clamped
-				// at 0). This fallback assumes a single page was loaded;
-				// when Load-more has been used, the hx-vals showing hint is
-				// authoritative.
-				fallback := len(changes) - 1
-				if fallback < 0 {
-					fallback = 0
-				}
-				showing := resolveShowingCount(req, fallback, total, r.logger)
-				renderTempl(w, req, templates.HistoryRevertFragment(changeID, *revertChange, showing, total))
-				return
-			}
-		}
-
-		// Fallback: the revert succeeded but we could not render the rich
-		// confirmation. The cause is one of (a) the new revert row falls
-		// outside the active feed filter, (b) GetByID/artist lookup returned
-		// an error already logged above, or (c) the row is genuinely missing.
-		// Logged at INFO when revertChange was found (filter mismatch is the
-		// expected branch), WARN otherwise so genuine misses stand out.
-		if revertChange != nil {
-			r.logger.Info("revert succeeded; fragment suppressed by active filter",
-				"change_id", changeID, "revert_change_id", revertChangeID,
-				"field", change.Field, "artist_id", change.ArtistID)
-		} else {
-			r.logger.Warn("revert record not located after mutation, using fallback confirmation",
-				"change_id", changeID, "revert_change_id", revertChangeID,
-				"field", change.Field, "artist_id", change.ArtistID)
-		}
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`<div class="border-l-2 border-amber-400 dark:border-amber-500 pl-4 py-2"><p class="text-sm text-amber-600 dark:text-amber-400">Change reverted. Refresh the page to see the updated entry.</p></div>`))
+	// the new history entry. For plain API callers, return JSON.
+	if !isHTMXRequest(req) {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"reverted":  true,
+			"change_id": changeID,
+		})
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{
-		"reverted":  true,
-		"change_id": changeID,
-	})
+	// Fetch the new revert history row by its pre-assigned ID. This avoids
+	// the prior "find most recent revert for this field" pattern, which races
+	// against any concurrent writer to the same field at the same instant
+	// (e.g. a metadata refresh, an automated rule fix, or a parallel revert).
+	revertChange, err := r.historyService.GetByID(req.Context(), revertChangeID)
+	if err != nil {
+		// A missing revert history row is an expected edge case: the revert
+		// can become a no-op (e.g. the field already matched OldValue so
+		// UpdateField/ClearField recorded nothing) or history recording was
+		// best-effort. Log at Info rather than Error to avoid noise.
+		if errors.Is(err, artist.ErrChangeNotFound) {
+			r.logger.Info("revert change history row not found; rendering fallback fragment",
+				"change_id", changeID, "revert_change_id", revertChangeID)
+		} else {
+			r.logger.Error("fetching revert change by id",
+				"change_id", changeID, "revert_change_id", revertChangeID, "error", err)
+		}
+	}
+
+	// Determine whether the undo was triggered from the activity page or the
+	// artist history tab, then delegate to the appropriate render helper.
+	fromActivity := strings.Contains(req.Header.Get("HX-Current-URL"), "/activity")
+	if revertChange != nil {
+		if fromActivity {
+			if r.renderActivityRevertFragment(w, req, changeID, revertChange) {
+				return
+			}
+		} else {
+			if r.renderArtistTabRevertFragment(w, req, changeID, change, revertChange) {
+				return
+			}
+		}
+	}
+
+	// Fallback: the revert succeeded but we could not render the rich
+	// confirmation fragment. Causes: (a) new row is outside the active feed
+	// filter, (b) a lookup failed (already logged above), or (c) the row is
+	// genuinely missing. Log level distinguishes the cases.
+	if revertChange != nil {
+		r.logger.Info("revert succeeded; fragment suppressed by active filter",
+			"change_id", changeID, "revert_change_id", revertChangeID,
+			"field", change.Field, "artist_id", change.ArtistID)
+	} else {
+		r.logger.Warn("revert record not located after mutation, using fallback confirmation",
+			"change_id", changeID, "revert_change_id", revertChangeID,
+			"field", change.Field, "artist_id", change.ArtistID)
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`<div class="border-l-2 border-amber-400 dark:border-amber-500 pl-4 py-2"><p class="text-sm text-amber-600 dark:text-amber-400">Change reverted. Refresh the page to see the updated entry.</p></div>`))
 }
 
 // handleListGlobalHistory returns paginated metadata changes across all artists.

--- a/internal/api/handlers_history.go
+++ b/internal/api/handlers_history.go
@@ -408,7 +408,12 @@ func (r *Router) renderActivityRevertFragment(
 	userID := middleware.UserIDFromContext(req.Context())
 	limit := r.getUserPageSize(req.Context(), userID, 0)
 	activeFilter.Limit = limit
-	_, total, _ := r.historyService.ListGlobal(req.Context(), activeFilter)
+	_, total, listErr := r.historyService.ListGlobal(req.Context(), activeFilter)
+	if listErr != nil {
+		r.logger.Error("fetching global history for revert counter",
+			"artist_id", revertChange.ArtistID, "error", listErr)
+		return false
+	}
 	// Compute fallback from offset+limit. After Load-more the browser URL
 	// does not push offset, so this only matches reality when no Load-more
 	// clicks have occurred. The client-supplied hx-vals showing hint is

--- a/internal/api/handlers_history_test.go
+++ b/internal/api/handlers_history_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -895,6 +896,135 @@ func TestHandleRevertHistory_ActivityShowingCounter_LoadMoreHint(t *testing.T) {
 			t.Errorf("non-numeric hint not rejected: body missing 'Showing 6 of 6'\nbody: %s", body)
 		}
 	})
+}
+
+// TestValidateRevertable exercises the eligibility checks in isolation.
+// These rules must be enforced at the validate stage before any mutation.
+func TestValidateRevertable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		field   string
+		source  string
+		wantErr error
+	}{
+		{"trackable field, non-revert source", "biography", "manual", nil},
+		{"trackable field, provider source", "genres", "provider:musicbrainz", nil},
+		{"untrackable field", "unknown_field_xyz", "manual", errRevertNotTrackable},
+		{"revert source is rejected", "biography", "revert", errRevertOfRevert},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			change := &artist.MetadataChange{
+				Field:  tc.field,
+				Source: tc.source,
+			}
+			err := validateRevertable(change)
+			if tc.wantErr == nil && err != nil {
+				t.Errorf("validateRevertable() = %v, want nil", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Errorf("validateRevertable() = %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestPerformRevert_ClearBranch verifies that performRevert calls ClearField
+// when change.OldValue is empty and records a new history entry with source
+// "revert". The returned revertChangeID must match the row written to the DB.
+func TestPerformRevert_ClearBranch(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, historySvc := testRouterWithHistory(t)
+	artistSvc.SetHistoryService(historySvc)
+
+	a := addTestArtist(t, artistSvc, "PerformRevert Clear Artist")
+
+	// Set biography to non-empty so ClearField has something to clear.
+	ctx := artist.ContextWithSource(context.Background(), "manual")
+	if err := artistSvc.UpdateField(ctx, a.ID, "biography", "some bio"); err != nil {
+		t.Fatalf("UpdateField: %v", err)
+	}
+
+	change := &artist.MetadataChange{
+		ArtistID: a.ID,
+		Field:    "biography",
+		OldValue: "", // triggers ClearField
+		NewValue: "some bio",
+		Source:   "manual",
+	}
+
+	revertChangeID, err := r.performRevert(context.Background(), change)
+	if err != nil {
+		t.Fatalf("performRevert: %v", err)
+	}
+	if revertChangeID == "" {
+		t.Fatal("revertChangeID is empty")
+	}
+
+	// The artist's biography should now be cleared.
+	updated, err := artistSvc.GetByID(context.Background(), a.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if updated.Biography != "" {
+		t.Errorf("Biography = %q, want empty after clear revert", updated.Biography)
+	}
+
+	// A history row with source "revert" and the pre-assigned ID must exist.
+	row, err := historySvc.GetByID(context.Background(), revertChangeID)
+	if err != nil {
+		t.Fatalf("GetByID(revert row): %v", err)
+	}
+	if row.Source != "revert" {
+		t.Errorf("row.Source = %q, want revert", row.Source)
+	}
+	if row.ID != revertChangeID {
+		t.Errorf("row.ID = %q, want %q", row.ID, revertChangeID)
+	}
+}
+
+// TestPerformRevert_UpdateBranch verifies that performRevert calls UpdateField
+// when change.OldValue is non-empty, restoring the old value.
+func TestPerformRevert_UpdateBranch(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, historySvc := testRouterWithHistory(t)
+	artistSvc.SetHistoryService(historySvc)
+
+	a := addTestArtist(t, artistSvc, "PerformRevert Update Artist")
+
+	change := &artist.MetadataChange{
+		ArtistID: a.ID,
+		Field:    "biography",
+		OldValue: "original bio", // triggers UpdateField
+		NewValue: "changed bio",
+		Source:   "manual",
+	}
+
+	revertChangeID, err := r.performRevert(context.Background(), change)
+	if err != nil {
+		t.Fatalf("performRevert: %v", err)
+	}
+
+	// The artist's biography should be restored to the old value.
+	updated, err := artistSvc.GetByID(context.Background(), a.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if updated.Biography != "original bio" {
+		t.Errorf("Biography = %q, want 'original bio'", updated.Biography)
+	}
+
+	// Verify the revert history row was recorded with the deterministic ID.
+	row, err := historySvc.GetByID(context.Background(), revertChangeID)
+	if err != nil {
+		t.Fatalf("GetByID(revert row): %v", err)
+	}
+	if row.Source != "revert" {
+		t.Errorf("row.Source = %q, want revert", row.Source)
+	}
 }
 
 // TestHandleRevertHistory_ArtistTabShowingCounter_LoadMoreHint covers the same

--- a/internal/api/handlers_history_test.go
+++ b/internal/api/handlers_history_test.go
@@ -1399,3 +1399,165 @@ func TestBuildGlobalFilterFromURL(t *testing.T) {
 		}
 	})
 }
+
+// TestHandleRevertHistory_MissingPathParam verifies that the handler writes a
+// 400 response when the "id" path parameter is absent (RequirePathParam fails).
+func TestHandleRevertHistory_MissingPathParam(t *testing.T) {
+	t.Parallel()
+	r, _, historySvc := testRouterWithHistory(t)
+	r.historyService = historySvc
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/history//revert", nil)
+	w := httptest.NewRecorder()
+	r.handleRevertHistory(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+// TestHandleRevertHistory_UntrackableField verifies that the handler returns
+// 400 when the change's field is not in the revertable field set.
+func TestHandleRevertHistory_UntrackableField(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, historySvc := testRouterWithHistory(t)
+	artistSvc.SetHistoryService(historySvc)
+
+	a := addTestArtist(t, artistSvc, "Untrackable Field Artist")
+	addHistoryChange(t, historySvc, a.ID, "unknown_field_xyz", "old", "new", "manual")
+	changes, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
+	if err != nil || len(changes) == 0 {
+		t.Fatalf("List: err=%v len=%d", err, len(changes))
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/history/"+changes[0].ID+"/revert", nil)
+	req.SetPathValue("id", changes[0].ID)
+	w := httptest.NewRecorder()
+	r.handleRevertHistory(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
+// TestHandleRevertHistory_ActivitySourceFilter verifies that when the active
+// activity feed filter restricts sources and excludes "revert", the handler
+// suppresses the rich HTMX fragment and writes the plain fallback instead.
+func TestHandleRevertHistory_ActivitySourceFilter(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, historySvc := testRouterWithHistory(t)
+	artistSvc.SetHistoryService(historySvc)
+
+	a := addTestArtist(t, artistSvc, "Source Filter Artist")
+	ctx := artist.ContextWithSource(context.Background(), "manual")
+	if err := artistSvc.UpdateField(ctx, a.ID, "biography", "filter bio"); err != nil {
+		t.Fatalf("UpdateField: %v", err)
+	}
+	changes, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
+	if err != nil || len(changes) == 0 {
+		t.Fatalf("List: err=%v len=%d", err, len(changes))
+	}
+	changeID := changes[0].ID
+
+	// HX-Current-URL carries source=manual; "revert" is excluded, so the rich
+	// fragment must be suppressed and the plain amber fallback written instead.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/history/"+changeID+"/revert", nil)
+	req.SetPathValue("id", changeID)
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("HX-Current-URL", "http://localhost:1973/activity?source=manual")
+	w := httptest.NewRecorder()
+	r.handleRevertHistory(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	body := w.Body.String()
+	if strings.Contains(body, `id="activity-entries"`) {
+		t.Errorf("expected fallback fragment, got rich activity fragment; body: %s", body)
+	}
+	if !strings.Contains(body, "border-amber") {
+		t.Errorf("expected fallback amber div in body: %s", body)
+	}
+}
+
+// TestHandleRevertHistory_ActivityDateRangeFilter verifies that when the
+// activity feed has a date-range upper bound in the past, the revert row
+// (created now) falls outside the window and the fallback fragment is written.
+func TestHandleRevertHistory_ActivityDateRangeFilter(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, historySvc := testRouterWithHistory(t)
+	artistSvc.SetHistoryService(historySvc)
+
+	a := addTestArtist(t, artistSvc, "Date Range Artist")
+	ctx := artist.ContextWithSource(context.Background(), "manual")
+	if err := artistSvc.UpdateField(ctx, a.ID, "biography", "range bio"); err != nil {
+		t.Fatalf("UpdateField: %v", err)
+	}
+	changes, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
+	if err != nil || len(changes) == 0 {
+		t.Fatalf("List: err=%v len=%d", err, len(changes))
+	}
+	changeID := changes[0].ID
+
+	// "to=2020-01-01" places the upper bound before now; the revert row is
+	// created at the current time and therefore falls outside the filter.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/history/"+changeID+"/revert", nil)
+	req.SetPathValue("id", changeID)
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("HX-Current-URL", "http://localhost:1973/activity?to=2020-01-01")
+	w := httptest.NewRecorder()
+	r.handleRevertHistory(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), `id="activity-entries"`) {
+		t.Errorf("expected fallback fragment, got rich activity fragment")
+	}
+}
+
+// TestHandleRevertHistory_NoopRevertFallback verifies the Warn-level fallback
+// branch: the revert mutation succeeds but the history service skips recording
+// (oldValue == newValue), so GetByID(revertChangeID) returns ErrChangeNotFound
+// and the handler falls through to the amber warning fragment.
+func TestHandleRevertHistory_NoopRevertFallback(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, historySvc := testRouterWithHistory(t)
+	artistSvc.SetHistoryService(historySvc)
+
+	a := addTestArtist(t, artistSvc, "Noop Revert Artist")
+	// Record a change whose OldValue ("noop-bio") we will pre-load into the
+	// artist so the revert UpdateField call is a no-op.
+	addHistoryChange(t, historySvc, a.ID, "biography", "noop-bio", "current-bio", "manual")
+	changes, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
+	if err != nil || len(changes) == 0 {
+		t.Fatalf("List: err=%v len=%d", err, len(changes))
+	}
+	changeID := changes[0].ID
+
+	// Set biography to "noop-bio" directly so UpdateField("biography","noop-bio")
+	// sees oldValue==newValue and skips history recording. revertChangeID is
+	// therefore not found by GetByID, leaving revertChange nil.
+	if _, err := r.db.ExecContext(context.Background(),
+		"UPDATE artists SET biography = ? WHERE id = ?", "noop-bio", a.ID); err != nil {
+		t.Fatalf("pre-loading biography: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/history/"+changeID+"/revert", nil)
+	req.SetPathValue("id", changeID)
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("HX-Current-URL", "http://localhost:1973/artists/"+a.ID)
+	w := httptest.NewRecorder()
+	r.handleRevertHistory(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	body := w.Body.String()
+	if strings.Contains(body, `id="history-change-list"`) {
+		t.Errorf("expected fallback fragment, got rich artist-tab fragment; body: %s", body)
+	}
+	if !strings.Contains(body, "border-amber") {
+		t.Errorf("expected fallback amber div in body: %s", body)
+	}
+}

--- a/internal/api/handlers_history_test.go
+++ b/internal/api/handlers_history_test.go
@@ -1274,3 +1274,128 @@ func TestHandleRevertHistory_ActivityFromArtistPageRoute(t *testing.T) {
 		t.Errorf("artist-page route did not render history tab fragment\nbody: %s", bodyArt)
 	}
 }
+
+func TestParseFilterValues(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   []string
+		want []string
+	}{
+		{[]string{"manual", "+scan", "-provider:mb"}, []string{"manual", "scan"}},
+		{[]string{"", "  ", "+good"}, []string{"good"}},
+		{[]string{"-only-excludes"}, nil},
+		{[]string{}, nil},
+	}
+	for _, tc := range cases {
+		got := parseFilterValues(tc.in)
+		if len(got) != len(tc.want) {
+			t.Errorf("input %v: got %v, want %v", tc.in, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("input %v index %d: got %q, want %q", tc.in, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+func TestSliceContains(t *testing.T) {
+	t.Parallel()
+	if !sliceContains([]string{"a", "b", "c"}, "b") {
+		t.Error("expected true for present element")
+	}
+	if sliceContains([]string{"a", "b", "c"}, "d") {
+		t.Error("expected false for absent element")
+	}
+	if sliceContains(nil, "a") {
+		t.Error("expected false for nil slice")
+	}
+}
+
+func TestIsPlainDate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		s    string
+		want bool
+	}{
+		{"2024-01-15", true},
+		{"2024-1-15", false},  // too short
+		{"2024-01-1", false},  // too short
+		{"2024/01/15", false}, // wrong separator
+		{"20240115", false},   // no separators
+		{"abcd-ef-gh", false}, // non-digit body
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := isPlainDate(tc.s)
+		if got != tc.want {
+			t.Errorf("isPlainDate(%q) = %v, want %v", tc.s, got, tc.want)
+		}
+	}
+}
+
+func TestParseTimeValue(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty returns zero", func(t *testing.T) {
+		if !parseTimeValue("", "from").IsZero() {
+			t.Error("expected zero time for empty input")
+		}
+	})
+
+	t.Run("unparsable returns zero", func(t *testing.T) {
+		if !parseTimeValue("not-a-date", "from").IsZero() {
+			t.Error("expected zero time for unparsable input")
+		}
+	})
+
+	t.Run("RFC3339 parsed correctly", func(t *testing.T) {
+		got := parseTimeValue("2024-06-01T12:00:00Z", "from")
+		if got.IsZero() {
+			t.Error("expected non-zero time for RFC3339 input")
+		}
+	})
+
+	t.Run("plain date from is midnight UTC", func(t *testing.T) {
+		got := parseTimeValue("2024-06-01", "from")
+		if got.Hour() != 0 || got.Minute() != 0 {
+			t.Errorf("from date: expected midnight UTC, got %v", got)
+		}
+	})
+
+	t.Run("plain date to is end-of-day UTC", func(t *testing.T) {
+		got := parseTimeValue("2024-06-01", "to")
+		if got.Hour() != 23 || got.Minute() != 59 {
+			t.Errorf("to date: expected end-of-day UTC, got %v", got)
+		}
+	})
+}
+
+func TestBuildGlobalFilterFromURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid URL returns empty filter", func(t *testing.T) {
+		f := buildGlobalFilterFromURL("://not-a-url")
+		if f.ArtistID != "" || f.Offset != 0 {
+			t.Errorf("expected empty filter for invalid URL, got %+v", f)
+		}
+	})
+
+	t.Run("negative offset clamped to zero", func(t *testing.T) {
+		f := buildGlobalFilterFromURL("http://localhost/activity?offset=-5")
+		if f.Offset != 0 {
+			t.Errorf("expected offset=0 for negative input, got %d", f.Offset)
+		}
+	})
+
+	t.Run("source prefix extracted", func(t *testing.T) {
+		f := buildGlobalFilterFromURL("http://localhost/activity?source=provider:*&artist_id=abc")
+		if f.ArtistID != "abc" {
+			t.Errorf("ArtistID = %q, want abc", f.ArtistID)
+		}
+		if len(f.SourcePrefixes) != 1 || f.SourcePrefixes[0] != "provider:" {
+			t.Errorf("SourcePrefixes = %v, want [provider:]", f.SourcePrefixes)
+		}
+	})
+}

--- a/internal/api/handlers_history_test.go
+++ b/internal/api/handlers_history_test.go
@@ -473,6 +473,76 @@ func TestHandleRevertHistory(t *testing.T) {
 	})
 }
 
+// TestHandleRevertHistory_HTMXActivityFragment verifies that an HTMX POST from
+// the activity feed returns an HTML fragment (200, Content-Type text/html).
+func TestHandleRevertHistory_HTMXActivityFragment(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, historySvc := testRouterWithHistory(t)
+	artistSvc.SetHistoryService(historySvc)
+
+	a := addTestArtist(t, artistSvc, "HTMX Activity Artist")
+	ctx := artist.ContextWithSource(context.Background(), "manual")
+	if err := artistSvc.UpdateField(ctx, a.ID, "biography", "some bio"); err != nil {
+		t.Fatalf("UpdateField: %v", err)
+	}
+	changes, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
+	if err != nil || len(changes) == 0 {
+		t.Fatalf("List: err=%v len=%d", err, len(changes))
+	}
+	changeID := changes[0].ID
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/history/"+changeID+"/revert", nil)
+	req.SetPathValue("id", changeID)
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("HX-Current-URL", "http://localhost:1973/activity")
+	w := httptest.NewRecorder()
+
+	r.handleRevertHistory(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	ct := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html prefix", ct)
+	}
+}
+
+// TestHandleRevertHistory_HTMXArtistTabFragment verifies that an HTMX POST from
+// the artist history tab returns an HTML fragment (200, Content-Type text/html).
+func TestHandleRevertHistory_HTMXArtistTabFragment(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, historySvc := testRouterWithHistory(t)
+	artistSvc.SetHistoryService(historySvc)
+
+	a := addTestArtist(t, artistSvc, "HTMX Tab Artist")
+	ctx := artist.ContextWithSource(context.Background(), "manual")
+	if err := artistSvc.UpdateField(ctx, a.ID, "biography", "tab bio"); err != nil {
+		t.Fatalf("UpdateField: %v", err)
+	}
+	changes, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
+	if err != nil || len(changes) == 0 {
+		t.Fatalf("List: err=%v len=%d", err, len(changes))
+	}
+	changeID := changes[0].ID
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/history/"+changeID+"/revert", nil)
+	req.SetPathValue("id", changeID)
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("HX-Current-URL", "http://localhost:1973/artists/"+a.ID)
+	w := httptest.NewRecorder()
+
+	r.handleRevertHistory(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	ct := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html prefix", ct)
+	}
+}
+
 func TestHandleListGlobalHistory(t *testing.T) {
 	t.Parallel()
 	r, artistSvc, historySvc := testRouterWithHistory(t)


### PR DESCRIPTION
## Summary

- Splits `handleRevertHistory` (cyclomatic 32, ~180 lines) into a thin orchestrator plus four focused helpers
- `validateRevertable(change) error` -- checks field trackability and source != "revert"; returns sentinel errors safe to surface to clients
- `(*Router).performRevert(ctx, change)` -- handles the clear/update branch split; pre-assigns the deterministic revert change ID via `ContextWithHistoryID`
- `(*Router).renderActivityRevertFragment(...)` -- activity feed path with source filter, date filter, and counter
- `(*Router).renderArtistTabRevertFragment(...)` -- artist history tab path with page total and counter
- Handler is now ~50 lines; all original eligibility checks, mutation branches, and HTMX/JSON rendering preserved byte-identically

## Test plan

- [ ] `go test -race ./internal/api/... -timeout 300s` -- all pass
- [ ] Pre-push gate clean (exit 0)
- [ ] `TestValidateRevertable` (4 cases), `TestPerformRevert_ClearBranch`, `TestPerformRevert_UpdateBranch`

Closes #1399

Part of M49.5 (Code Health and Hardening) W1.1E.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined history revert flow with clearer revert eligibility errors, deterministic revert IDs, and unified revert execution.
  * Improved HTMX undo rendering: activity feed and artist-tab fragments, smarter suppression when current filters exclude the revert, and accurate "showing X of Y" counts.
  * Handler now returns JSON for non-HTMX callers and HTML fragments for HTMX requests.

* **Tests**
  * Added extensive tests covering HTMX fragment responses, revert validation and execution branches, filter parsing utilities, and various error/no-op scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1499)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->