### PR TITLE
chore(make): add worktree target that wires hooks and appends tracker entry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,12 +125,13 @@ hooks:
 ## worktree: Create a sibling worktree with hooks wired and tracker entry appended
 ##   Usage: make worktree NAME=<slug> BRANCH=<branch> [ISSUE=<number>]
 ##   Example: make worktree NAME=m49.5-merge-policy BRANCH=refactor/m49.5-1395-merge-policy ISSUE=1395
-WORKTREES_MD := $(HOME)/.claude/projects/-Users-jesse-Developer-stillwater/memory/worktrees.md
+WORKTREES_MD ?= $(HOME)/.claude/projects/-Users-jesse-Developer-stillwater/memory/worktrees.md
 worktree:
 	@test -n "$(NAME)"   || (echo "error: NAME is required (e.g. make worktree NAME=my-feature BRANCH=feat/my-feature)"; exit 1)
 	@test -n "$(BRANCH)" || (echo "error: BRANCH is required (e.g. make worktree NAME=my-feature BRANCH=feat/my-feature)"; exit 1)
 	git worktree add ../stillwater-$(NAME) -b $(BRANCH)
 	git -C ../stillwater-$(NAME) config core.hooksPath .githooks
+	@mkdir -p "$(dir $(WORKTREES_MD))"
 	@printf "| stillwater-$(NAME) | $(BRANCH) | $(if $(ISSUE),#$(ISSUE),--) | In Progress |\n" >> "$(WORKTREES_MD)"
 	@echo "Worktree ../stillwater-$(NAME) ready on branch $(BRANCH). Hooks wired. Tracker updated."
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-shuffle test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks check-openapi hadolint scan bruno-ci
+.PHONY: build run test test-shuffle test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks worktree check-openapi hadolint scan bruno-ci
 
 # Binary name
 BINARY=stillwater
@@ -121,6 +121,18 @@ hooks:
 	@echo "Hooks installed via core.hooksPath=.githooks (covers worktrees)."
 	@echo "  pre-commit: lint, gofmt, templ freshness, build, golangci-lint, govulncheck, hadolint"
 	@echo "  pre-push:   runs scripts/pre-push-gate.sh (tests, OpenAPI, generated, patch coverage >= 70%)"
+
+## worktree: Create a sibling worktree with hooks wired and tracker entry appended
+##   Usage: make worktree NAME=<slug> BRANCH=<branch> [ISSUE=<number>]
+##   Example: make worktree NAME=m49.5-merge-policy BRANCH=refactor/m49.5-1395-merge-policy ISSUE=1395
+WORKTREES_MD := $(HOME)/.claude/projects/-Users-jesse-Developer-stillwater/memory/worktrees.md
+worktree:
+	@test -n "$(NAME)"   || (echo "error: NAME is required (e.g. make worktree NAME=my-feature BRANCH=feat/my-feature)"; exit 1)
+	@test -n "$(BRANCH)" || (echo "error: BRANCH is required (e.g. make worktree NAME=my-feature BRANCH=feat/my-feature)"; exit 1)
+	git worktree add ../stillwater-$(NAME) -b $(BRANCH)
+	git -C ../stillwater-$(NAME) config core.hooksPath .githooks
+	@printf "| stillwater-$(NAME) | $(BRANCH) | $(if $(ISSUE),#$(ISSUE),--) | In Progress |\n" >> "$(WORKTREES_MD)"
+	@echo "Worktree ../stillwater-$(NAME) ready on branch $(BRANCH). Hooks wired. Tracker updated."
 
 ## clean: Remove build artifacts
 clean:


### PR DESCRIPTION
## Summary

- Adds `make worktree NAME=<slug> BRANCH=<branch> [ISSUE=<number>]` target
- Runs `git worktree add`, then sets `core.hooksPath .githooks` in the new worktree's local config so the pre-push gate fires without manual setup
- Appends a tracker row to `~/.claude/projects/.../memory/worktrees.md`
- Exits non-zero with a usage message if NAME or BRANCH are omitted

## Motivation

During M49.5 W2 dispatch (2026-05-13), the three worktrees were created manually and `core.hooksPath` was pointing at `.git/hooks` (only `.sample` files) rather than `.githooks`. The pre-push gate did not run on the first push of one branch. This target makes the correct setup automatic.

## Test plan

- [ ] `make worktree` without args prints usage error and exits 1
- [ ] `make worktree NAME=test-wt BRANCH=test/wt-branch` creates `../stillwater-test-wt`, configures hooks, appends tracker row
- [ ] `git push` from the new worktree triggers the pre-push gate

Closes #1506

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new `make worktree` command to streamline creating and configuring git worktrees with custom branch names and optional issue tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1507)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->