### PR TITLE
fix(db): add migration 005 for foreign_files tables missing from pre-#1246 databases

### DIFF
--- a/internal/database/migrations/005_foreign_files.sql
+++ b/internal/database/migrations/005_foreign_files.sql
@@ -1,0 +1,47 @@
+-- +goose Up
+-- Issue #1246 (feat(scanner): foreign-file detection via EXIF provenance)
+-- added foreign_files and foreign_file_allowlist to 001_initial_schema.sql
+-- after existing databases had already been initialized. This migration
+-- backfills those tables for any installation that predates #1246.
+
+CREATE TABLE IF NOT EXISTS foreign_files (
+    id          TEXT NOT NULL PRIMARY KEY,
+    artist_id   TEXT NOT NULL REFERENCES artists(id) ON DELETE CASCADE,
+    file_path   TEXT NOT NULL,
+    file_name   TEXT NOT NULL,
+    size_bytes  INTEGER NOT NULL DEFAULT 0,
+    detected_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(artist_id, file_path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_foreign_files_artist ON foreign_files(artist_id);
+CREATE INDEX IF NOT EXISTS idx_foreign_files_detected_at ON foreign_files(detected_at);
+
+-- Permanent allowlist suppressing re-detection. Two scopes:
+--   scope='global'  -- match every artist; artist_id is NULL.
+--   scope='artist'  -- match a specific artist_id. file_name is the basename
+--                      (e.g. "backdrop.jpg") so the allowlist survives a
+--                      directory rename for the same artist.
+-- A NULL artist_id with scope='artist' is rejected by the writer (see
+-- internal/foreign/allowlist.go) so the partial unique indexes stay sound.
+CREATE TABLE IF NOT EXISTS foreign_file_allowlist (
+    id         TEXT NOT NULL PRIMARY KEY,
+    scope      TEXT NOT NULL CHECK (scope IN ('global','artist')),
+    artist_id  TEXT REFERENCES artists(id) ON DELETE CASCADE,
+    file_name  TEXT NOT NULL,
+    note       TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Partial unique indexes: one global entry per file_name, one artist-scoped
+-- entry per (artist_id, file_name). Modeled as two indexes because SQLite
+-- treats NULLs in a UNIQUE constraint as distinct, which would otherwise
+-- allow duplicate global rows.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_foreign_allowlist_global
+    ON foreign_file_allowlist(file_name) WHERE scope = 'global';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_foreign_allowlist_artist
+    ON foreign_file_allowlist(artist_id, file_name) WHERE scope = 'artist';
+
+-- +goose Down
+DROP TABLE IF EXISTS foreign_file_allowlist;
+DROP TABLE IF EXISTS foreign_files;


### PR DESCRIPTION
## Summary

- PR #1246 added \`foreign_files\` and \`foreign_file_allowlist\` to \`001_initial_schema.sql\` after existing installations had already applied that migration
- Goose does not re-run applied migrations, so any DB initialized before #1246 silently lacks both tables
- The foreign-file scanner logs repeated \`SQL logic error: no such table\` warnings on every startup as a result
- Adds \`005_foreign_files.sql\` with \`IF NOT EXISTS\` guards; existing installations get the tables on next startup, fresh installs are unaffected (tables already present from 001)

Closes #1508

## Test plan

- [x] \`make migrate\` on pre-#1246 DB applies 005 and creates both tables (verified locally -- DB advanced from version 4 to version 5, tables confirmed present)
- [x] \`IF NOT EXISTS\` guards make this a no-op for fresh installs that already have the tables from \`001_initial_schema.sql\`
- [x] Foreign-file scanner warnings no longer appear in startup logs after migration (surfaced during M49.5 W3 UAT 2026-05-14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and tracking of duplicate files with artist-level categorization.
  * Implemented allowlist to suppress re-detection of specific files globally or per artist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1509)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->