### PR TITLE
feat(logging): add slog scrubber for sensitive field redaction

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -327,8 +327,14 @@ func buildWriter(cfg Config) (io.Writer, io.Closer) {
 
 // buildHandler creates a slog.Handler with the given writer, leveler, and format.
 // AddSource is enabled so that log entries include the source file and line number.
+// RedactingReplaceAttr is wired in to ensure sensitive field values never appear
+// in log output.
 func buildHandler(w io.Writer, leveler slog.Leveler, format string) slog.Handler {
-	opts := &slog.HandlerOptions{Level: leveler, AddSource: true}
+	opts := &slog.HandlerOptions{
+		Level:       leveler,
+		AddSource:   true,
+		ReplaceAttr: RedactingReplaceAttr,
+	}
 	if format == "text" {
 		return slog.NewTextHandler(w, opts)
 	}

--- a/internal/logging/redact.go
+++ b/internal/logging/redact.go
@@ -1,0 +1,65 @@
+package logging
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// sensitiveKeys is the set of field names whose values must be redacted from
+// log output. Matching is case-insensitive.
+var sensitiveKeys = []string{
+	"api_key",
+	"apikey",
+	"api-key",
+	"password",
+	"passwd",
+	"secret",
+	"client_secret",
+	"token",
+	"access_token",
+	"refresh_token",
+	"private_key",
+	"privatekey",
+	"authorization",
+	"hmac_secret",
+}
+
+// isSensitiveKey reports whether name is a known sensitive field name.
+// Comparison is case-insensitive.
+func isSensitiveKey(name string) bool {
+	lower := strings.ToLower(name)
+	for _, k := range sensitiveKeys {
+		if lower == k {
+			return true
+		}
+	}
+	return false
+}
+
+// RedactingReplaceAttr is a slog ReplaceAttr function that redacts the values
+// of known sensitive field names. Wire it into every slog.HandlerOptions.ReplaceAttr
+// to ensure credentials never appear in log output.
+//
+// The sensitive field set covers common credential key names (api_key, password,
+// secret, token, authorization, etc.). Matching is case-insensitive and applies
+// regardless of nesting depth (groups context is checked but does not suppress
+// redaction).
+//
+// Empty or zero-value attributes are left unchanged: there is no value to protect
+// and preserving the absence helps distinguish "field not set" from "field redacted".
+func RedactingReplaceAttr(groups []string, a slog.Attr) slog.Attr {
+	// Resolve the attr to its final form before inspecting it.
+	a.Value = a.Value.Resolve()
+
+	// Never redact empty/zero values -- there is nothing sensitive to hide and
+	// preserving zero values lets callers distinguish "unset" from "redacted".
+	if a.Value.Equal(slog.Value{}) || a.Value.String() == "" {
+		return a
+	}
+
+	if isSensitiveKey(a.Key) {
+		return slog.Attr{Key: a.Key, Value: slog.StringValue("[REDACTED]")}
+	}
+
+	return a
+}

--- a/internal/logging/redact_test.go
+++ b/internal/logging/redact_test.go
@@ -1,0 +1,170 @@
+package logging
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestRedactingReplaceAttr_SensitiveFields verifies that every known sensitive
+// field name produces a "[REDACTED]" value regardless of the original type.
+func TestRedactingReplaceAttr_SensitiveFields(t *testing.T) {
+	sensitive := []string{
+		"api_key",
+		"apikey",
+		"api-key",
+		"password",
+		"passwd",
+		"secret",
+		"client_secret",
+		"token",
+		"access_token",
+		"refresh_token",
+		"private_key",
+		"privatekey",
+		"authorization",
+		"hmac_secret",
+	}
+
+	for _, key := range sensitive {
+		t.Run(key, func(t *testing.T) {
+			a := slog.String(key, "supersecret")
+			got := RedactingReplaceAttr(nil, a)
+			if got.Value.String() != "[REDACTED]" {
+				t.Errorf("key %q: expected [REDACTED], got %q", key, got.Value.String())
+			}
+		})
+	}
+}
+
+// TestRedactingReplaceAttr_NonSensitiveFields verifies that non-sensitive
+// fields are passed through unchanged.
+func TestRedactingReplaceAttr_NonSensitiveFields(t *testing.T) {
+	cases := []struct {
+		key   string
+		value string
+	}{
+		{"artist", "Beethoven"},
+		{"user_id", "42"},
+		{"component", "scanner"},
+		{"level", "info"},
+		{"message", "hello world"},
+		{"duration_ms", "150"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			a := slog.String(tc.key, tc.value)
+			got := RedactingReplaceAttr(nil, a)
+			if got.Value.String() != tc.value {
+				t.Errorf("key %q: expected %q unchanged, got %q", tc.key, tc.value, got.Value.String())
+			}
+		})
+	}
+}
+
+// TestRedactingReplaceAttr_CaseInsensitive verifies that key matching is
+// case-insensitive so that API_KEY, Password, TOKEN etc. are all redacted.
+func TestRedactingReplaceAttr_CaseInsensitive(t *testing.T) {
+	cases := []string{
+		"API_KEY",
+		"ApiKey",
+		"APIKEY",
+		"Password",
+		"PASSWORD",
+		"TOKEN",
+		"Token",
+		"Authorization",
+		"AUTHORIZATION",
+		"Secret",
+		"SECRET",
+		"Client_Secret",
+		"CLIENT_SECRET",
+	}
+
+	for _, key := range cases {
+		t.Run(key, func(t *testing.T) {
+			a := slog.String(key, "sensitive-value")
+			got := RedactingReplaceAttr(nil, a)
+			if got.Value.String() != "[REDACTED]" {
+				t.Errorf("key %q: expected [REDACTED], got %q", key, got.Value.String())
+			}
+		})
+	}
+}
+
+// TestRedactingReplaceAttr_NestedGroups verifies that sensitive fields are
+// redacted even when the groups context is non-empty (i.e. nested in a group).
+func TestRedactingReplaceAttr_NestedGroups(t *testing.T) {
+	groups := []string{"connection", "credentials"}
+	a := slog.String("api_key", "sk-abcdef")
+	got := RedactingReplaceAttr(groups, a)
+	if got.Value.String() != "[REDACTED]" {
+		t.Errorf("nested group: expected [REDACTED], got %q", got.Value.String())
+	}
+}
+
+// TestRedactingReplaceAttr_EmptyValue verifies that an empty string value is
+// NOT changed to "[REDACTED]". Preserving zero values lets callers distinguish
+// "field not set" from "field was redacted".
+func TestRedactingReplaceAttr_EmptyValue(t *testing.T) {
+	a := slog.String("api_key", "")
+	got := RedactingReplaceAttr(nil, a)
+	if got.Value.String() == "[REDACTED]" {
+		t.Error("empty api_key value should not be changed to [REDACTED]")
+	}
+	// The key and empty value should be preserved as-is.
+	if got.Key != "api_key" {
+		t.Errorf("key changed unexpectedly: got %q", got.Key)
+	}
+}
+
+// TestRedactingReplaceAttr_Integration constructs a real slog.Logger backed by
+// a JSON handler with RedactingReplaceAttr wired in, logs a record that
+// contains api_key="secret123", and asserts the raw secret does not appear in
+// the captured output.
+func TestRedactingReplaceAttr_Integration(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		ReplaceAttr: RedactingReplaceAttr,
+	})
+	logger := slog.New(handler)
+
+	logger.Info("connection established", "api_key", "secret123", "host", "example.com")
+
+	output := buf.String()
+	if strings.Contains(output, "secret123") {
+		t.Errorf("raw secret found in log output: %s", output)
+	}
+	if !strings.Contains(output, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] in output but did not find it: %s", output)
+	}
+	// Non-sensitive fields must still appear.
+	if !strings.Contains(output, "example.com") {
+		t.Errorf("non-sensitive field 'host' missing from output: %s", output)
+	}
+}
+
+// TestRedactingReplaceAttr_IntegrationPassword is a second integration test
+// covering the password field specifically.
+func TestRedactingReplaceAttr_IntegrationPassword(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		ReplaceAttr: RedactingReplaceAttr,
+	})
+	logger := slog.New(handler)
+
+	logger.Warn("auth attempt", "user", "alice", "password", "hunter2")
+
+	output := buf.String()
+	if strings.Contains(output, "hunter2") {
+		t.Errorf("password found in log output: %s", output)
+	}
+	if !strings.Contains(output, "[REDACTED]") {
+		t.Errorf("expected [REDACTED] in output: %s", output)
+	}
+	if !strings.Contains(output, "alice") {
+		t.Errorf("non-sensitive 'user' field missing: %s", output)
+	}
+}

--- a/internal/logging/ringhandler.go
+++ b/internal/logging/ringhandler.go
@@ -75,9 +75,12 @@ func (h *RingHandler) Handle(_ context.Context, r slog.Record) error {
 	}
 
 	// Collect attributes: start with pre-stored attrs from WithAttrs,
-	// then append the record's own attrs.
+	// then append the record's own attrs. Each attribute is passed through
+	// RedactingReplaceAttr so that sensitive field values are scrubbed in
+	// the ring buffer (log viewer) as well as in the primary handler.
 	attrs := make(map[string]any)
 	for _, a := range h.attrs {
+		a = RedactingReplaceAttr(nil, a)
 		key := a.Key
 		if h.group != "" {
 			key = h.group + "." + key
@@ -90,6 +93,7 @@ func (h *RingHandler) Handle(_ context.Context, r slog.Record) error {
 	}
 
 	r.Attrs(func(a slog.Attr) bool {
+		a = RedactingReplaceAttr(nil, a)
 		key := a.Key
 		if h.group != "" {
 			key = h.group + "." + key

--- a/internal/logging/ringhandler.go
+++ b/internal/logging/ringhandler.go
@@ -78,31 +78,40 @@ func (h *RingHandler) Handle(_ context.Context, r slog.Record) error {
 	// then append the record's own attrs. Each attribute is passed through
 	// RedactingReplaceAttr so that sensitive field values are scrubbed in
 	// the ring buffer (log viewer) as well as in the primary handler.
+	// addAttr recurses into slog.KindGroup so nested sensitive keys are
+	// redacted rather than stored verbatim.
 	attrs := make(map[string]any)
-	for _, a := range h.attrs {
+	var addAttr func(prefix string, a slog.Attr)
+	addAttr = func(prefix string, a slog.Attr) {
+		a.Value = a.Value.Resolve()
+		if a.Value.Kind() == slog.KindGroup {
+			next := a.Key
+			if prefix != "" {
+				next = prefix + "." + next
+			}
+			for _, ga := range a.Value.Group() {
+				addAttr(next, ga)
+			}
+			return
+		}
 		a = RedactingReplaceAttr(nil, a)
 		key := a.Key
-		if h.group != "" {
-			key = h.group + "." + key
+		if prefix != "" {
+			key = prefix + "." + key
 		}
 		if key == "component" {
 			entry.Component = a.Value.String()
-		} else {
-			attrs[key] = a.Value.Any()
+			return
 		}
+		attrs[key] = a.Value.Any()
+	}
+
+	for _, a := range h.attrs {
+		addAttr(h.group, a)
 	}
 
 	r.Attrs(func(a slog.Attr) bool {
-		a = RedactingReplaceAttr(nil, a)
-		key := a.Key
-		if h.group != "" {
-			key = h.group + "." + key
-		}
-		if key == "component" {
-			entry.Component = a.Value.String()
-		} else {
-			attrs[key] = a.Value.Any()
-		}
+		addAttr(h.group, a)
 		return true
 	})
 

--- a/internal/logging/ringhandler_test.go
+++ b/internal/logging/ringhandler_test.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -160,6 +161,41 @@ func TestRingHandler_AddSourcePopulatesSource(t *testing.T) {
 	}
 	if !strings.Contains(entries[0].Source, ":") {
 		t.Errorf("expected Source to contain file:line format, got %q", entries[0].Source)
+	}
+}
+
+func TestRingHandler_NestedGroupRedaction(t *testing.T) {
+	rb := NewRingBuffer(10)
+	h := NewRingHandler(rb, slog.LevelDebug, false)
+	logger := slog.New(h)
+
+	logger.Info("auth event", slog.Group("credentials",
+		slog.String("api_key", "sk-supersecret"),
+		slog.String("user", "alice"),
+	))
+
+	entries := rb.Entries(LogFilter{Limit: 10})
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	// Sensitive key inside the group must be redacted.
+	if v, ok := entries[0].Attrs["credentials.api_key"]; !ok {
+		t.Error("expected credentials.api_key in attrs")
+	} else if v != "[REDACTED]" {
+		t.Errorf("expected credentials.api_key=[REDACTED], got %v", v)
+	}
+
+	// Raw secret must not appear in any attr value.
+	for k, v := range entries[0].Attrs {
+		if strings.Contains(strings.ToLower(strings.Join([]string{k, fmt.Sprintf("%v", v)}, "")), "supersecret") {
+			t.Errorf("raw secret found in attrs: key=%q value=%v", k, v)
+		}
+	}
+
+	// Non-sensitive sibling field must survive.
+	if v, ok := entries[0].Attrs["credentials.user"]; !ok || v != "alice" {
+		t.Errorf("expected credentials.user=alice in attrs, got %v", entries[0].Attrs)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds \`internal/logging/redact.go\` with \`RedactingReplaceAttr\`, a \`slog.ReplaceAttr\` function that case-insensitively redacts 14 known sensitive field names (\`api_key\`, \`password\`, \`secret\`, \`token\`, \`client_secret\`, \`private_key\`, \`authorization\`, \`hmac_secret\`, and variants)
- Wired into every \`slog.HandlerOptions.ReplaceAttr\` call in \`internal/logging/\`, including the ring-buffer handler used by the in-app log viewer
- Empty/zero-value fields pass through unchanged; all other sensitive values become \`[REDACTED]\`
- Credential sweep of existing \`slog.\` call sites found no unprotected raw credential values in production paths

Closes #1405

## Test plan

- [x] Per-key redaction for all 14 sensitive names
- [x] Non-sensitive fields pass through unchanged
- [x] Case-insensitivity (\`API_KEY\`, \`Password\`, \`TOKEN\` all redacted)
- [x] Nested group fields still redacted
- [x] Empty-value fields not changed to \`[REDACTED]\`
- [x] Integration test: real \`slog.Logger\` with scrubber wired, raw secret string absent from captured output
- [x] Ring-buffer handler scrubs entries before storing in memory
- [x] Pre-push gate: PASS (100% patch coverage)
- [x] UAT: server starts cleanly, no credential leakage in startup logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive fields (passwords, API keys, secrets, tokens, etc.) are now consistently redacted from all log outputs—including structured JSON, nested groups, and component fields—to prevent accidental exposure.

* **Tests**
  * Added comprehensive tests covering sensitive-field redaction, case-insensitive matching, nested-group handling, empty-value behavior, and integration-level verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1510)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->