### PR TITLE
build(release): use signed-tag annotation as the release body

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,6 +89,16 @@ docker_signs:
       - ${artifact}@${digest}
 
 changelog:
+  # The signed annotated tag's body is the source of truth for release
+  # notes (see release.header below, where {{ .TagBody }} is injected).
+  # Auto-generated commit-title dumps were overwriting hand-crafted
+  # release prose; v1.0.5 had to be patched with `gh release edit
+  # --notes-file` after the fact. Tag with:
+  #   git tag -s vX.Y.Z -F path/to/notes.md
+  # If the tag annotation is empty, the release body will simply omit
+  # the changelog section -- preferable to silently restoring the
+  # commit dump, which is the bug we're fixing.
+  disable: true
   sort: asc
   use: github
   groups:
@@ -125,10 +135,16 @@ release:
     name: stillwater
   prerelease: auto
   make_latest: false
+  # The body of a signed annotated tag (everything below the subject
+  # line of `git tag -s -F notes.md`) is injected here via {{ .TagBody }}.
+  # Footer below appends Docker pull + full-changelog link regardless,
+  # so even a minimal tag annotation produces a useful release page.
   header: |
     ## Stillwater {{ .Tag }}
 
     {{ if .Prerelease }}> This is a pre-release version. Use the `beta` Docker tag to try it out.{{ end }}
+
+    {{ .TagBody }}
   footer: |
     **Docker:** `docker pull ghcr.io/sydlexius/stillwater:{{ .Version }}`
 


### PR DESCRIPTION
## Summary

Closes #1332.

Switches the GitHub Release body for stable tags from goreleaser's auto-generated commit-title dump to the signed annotated tag's body, injected as `{{ .TagBody }}` in `release.header`. The auto-changelog is disabled in `.goreleaser.yml`, so the commit dump cannot reassert itself.

v1.0.5 was tagged with prose via `git tag -s v1.0.5 -F notes.md` but the workflow still published a `feat: ... / fix: ...` dump that had to be replaced manually with `gh release edit --notes-file`. That manual rescue is what this PR eliminates.

The nightly config (`.goreleaser.nightly.yml`) is **intentionally untouched** -- nightly tags carry no prose annotation, so the commit-title dump remains the right behavior there.

## Behavior

- Tag with `git tag -s vX.Y.Z -F /path/to/notes.md` -> Release body = the prose annotation, wrapped by the existing `## Stillwater {{ .Tag }}` header and the existing Docker / changelog-link footer.
- Tag with no body (just a subject line) -> Release body = header + (empty middle) + footer. The missing prose fails loud, which is intentional: preferable to silently restoring the commit dump, which is the bug we're fixing.

## Test plan

- [x] `goreleaser check` passes against the new config.
- [x] Nightly config (`.goreleaser.nightly.yml`) unchanged; nightly behavior preserved.
- [ ] At the next stable tag (v1.1.0 or later), confirm the GitHub Release body renders the tag annotation prose and no longer contains commit-title groups. Cannot be validated end-to-end before merge -- the release workflow only fires on a stable tag push.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Generated with Claude Code (https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation to prevent auto-generated content from overwriting hand-crafted release notes and to include tag information in GitHub releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1511)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->