### PR TITLE
test: cache template DB and inject clock to eliminate ~9s of test sleeps

### DIFF
--- a/internal/api/handlers_apitoken_test.go
+++ b/internal/api/handlers_apitoken_test.go
@@ -6,13 +6,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/auth"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/rule"
 )
@@ -22,17 +20,7 @@ import (
 func testRouterWithAuth(t *testing.T) (*Router, *auth.Service, string) {
 	t.Helper()
 
-	dbDir := t.TempDir()
-	dbPath := filepath.Join(dbDir, "test.db")
-
-	db, err := database.Open(dbPath)
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_artist_fuzz_test.go
+++ b/internal/api/handlers_artist_fuzz_test.go
@@ -10,13 +10,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/rule"
@@ -32,16 +30,7 @@ import (
 func newArtistFuzzRouter(t testing.TB) *Router {
 	t.Helper()
 
-	dbDir := t.TempDir()
-	dbPath := filepath.Join(dbDir, "fuzz.db")
-	db, err := database.Open(dbPath)
-	if err != nil {
-		t.Fatalf("opening fuzz db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("migrating fuzz db: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_auth_setup_test.go
+++ b/internal/api/handlers_auth_setup_test.go
@@ -7,13 +7,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/rule"
@@ -31,16 +29,7 @@ import (
 func authSetupTestRouter(t *testing.T) (*Router, *encryption.Encryptor) {
 	t.Helper()
 
-	dbDir := t.TempDir()
-	dbPath := filepath.Join(dbDir, "test.db")
-	db, err := database.Open(dbPath)
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("migrating test db: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_backdrop_test.go
+++ b/internal/api/handlers_backdrop_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/conflict"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	img "github.com/sydlexius/stillwater/internal/image"
 	"github.com/sydlexius/stillwater/internal/nfo"
@@ -33,14 +32,7 @@ import (
 func testRouterForBackdrops(t *testing.T) (*Router, *artist.Service) {
 	t.Helper()
 
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_backup_test.go
+++ b/internal/api/handlers_backup_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/backup"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/rule"
 )
@@ -23,17 +22,8 @@ import (
 func testRouterWithBackup(t *testing.T) (*Router, *backup.Service) {
 	t.Helper()
 
+	db := newTestDB(t)
 	dbDir := t.TempDir()
-	dbPath := filepath.Join(dbDir, "test.db")
-
-	db, err := database.Open(dbPath)
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_bulk_actions_fuzz_test.go
+++ b/internal/api/handlers_bulk_actions_fuzz_test.go
@@ -6,13 +6,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/rule"
@@ -30,16 +28,7 @@ import (
 func newBulkActionFuzzRouter(t testing.TB) *Router {
 	t.Helper()
 
-	dbDir := t.TempDir()
-	dbPath := filepath.Join(dbDir, "fuzz.db")
-	db, err := database.Open(dbPath)
-	if err != nil {
-		t.Fatalf("opening fuzz db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("migrating fuzz db: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_conflict_integration_test.go
+++ b/internal/api/handlers_conflict_integration_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 )
 
@@ -25,14 +24,7 @@ import (
 // only includes the fields the conflict handlers consult.
 func testRouterForConflictToggle(t *testing.T) (*Router, *connection.Service) {
 	t.Helper()
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	enc, _, err := encryption.NewEncryptor("")
 	if err != nil {

--- a/internal/api/handlers_connection_coverage_test.go
+++ b/internal/api/handlers_connection_coverage_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/library"
 	"github.com/sydlexius/stillwater/internal/nfo"
@@ -29,14 +28,7 @@ import (
 func newConnectionTestRouter(t *testing.T) *Router {
 	t.Helper()
 
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("migrating: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_connection_library_test.go
+++ b/internal/api/handlers_connection_library_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sydlexius/stillwater/internal/connection/emby"
 	"github.com/sydlexius/stillwater/internal/connection/jellyfin"
 	"github.com/sydlexius/stillwater/internal/connection/lidarr"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/library"
 	"github.com/sydlexius/stillwater/internal/nfo"
@@ -35,14 +34,7 @@ import (
 func testRouterForLibraryOps(t *testing.T) *Router {
 	t.Helper()
 
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_dashboard_test.go
+++ b/internal/api/handlers_dashboard_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/artist"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/rule"
 )
 
@@ -324,16 +323,9 @@ func TestHandleDashboardActionQueue_StatsError(t *testing.T) {
 	t.Parallel()
 	r := testDashboardRouter(t, false)
 
-	// Open a separate in-memory database for the artist service so we can
-	// close it independently of the rule service database.
-	artistDB, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening artist test db: %v", err)
-	}
-	if err := database.Migrate(artistDB); err != nil {
-		_ = artistDB.Close()
-		t.Fatalf("migrating artist test db: %v", err)
-	}
+	// Open a separate database for the artist service so we can close it
+	// independently of the rule service database to simulate a stats error.
+	artistDB := newTestDB(t)
 
 	// Replace the router's artist service with one backed by the new database.
 	r.artistService = artist.NewService(artistDB)

--- a/internal/api/handlers_history_test.go
+++ b/internal/api/handlers_history_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/i18n"
 	"github.com/sydlexius/stillwater/internal/nfo"
@@ -43,14 +42,7 @@ func testI18nCtx(tb testing.TB, ctx context.Context) context.Context {
 func testRouterWithHistory(t *testing.T) (*Router, *artist.Service, *artist.HistoryService) {
 	t.Helper()
 
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("migrating test db: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_layout_test.go
+++ b/internal/api/handlers_layout_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/i18n"
 	"github.com/sydlexius/stillwater/internal/library"
@@ -435,14 +434,7 @@ func TestLayout_RendersWithoutHandlerContext(t *testing.T) {
 func TestRootRoute_RendersLayout_WithSidebar(t *testing.T) {
 	t.Parallel()
 	// Set up test database and services
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_library_test.go
+++ b/internal/api/handlers_library_test.go
@@ -24,17 +24,10 @@ import (
 func testRouterWithLibrary(t *testing.T) (*Router, *library.Service, *artist.Service) {
 	t.Helper()
 
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
+	db := newTestDB(t)
 	if err := database.EnableForeignKeys(db); err != nil {
 		t.Fatalf("enabling foreign keys: %v", err)
 	}
-	t.Cleanup(func() { _ = db.Close() })
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_nfo_conflict_test.go
+++ b/internal/api/handlers_nfo_conflict_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/library"
 	"github.com/sydlexius/stillwater/internal/nfo"
@@ -31,14 +30,7 @@ import (
 func newNFOTestServer(t testing.TB) (*Router, *artist.Service, *connection.Service, *nfo.SnapshotService) {
 	t.Helper()
 
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	enc, _, err := encryption.NewEncryptor("")

--- a/internal/api/handlers_onboarding_test.go
+++ b/internal/api/handlers_onboarding_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/i18n"
 	"github.com/sydlexius/stillwater/internal/library"
@@ -23,14 +22,7 @@ import (
 func testRouterForOnboarding(t *testing.T) *Router {
 	t.Helper()
 
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_provider_test.go
+++ b/internal/api/handlers_provider_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/internal/provider/musicbrainz"
@@ -20,14 +19,7 @@ import (
 func testRouterWithMirror(t *testing.T) *Router {
 	t.Helper()
 
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	enc, _, err := encryption.NewEncryptor("")

--- a/internal/api/handlers_report_test.go
+++ b/internal/api/handlers_report_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/conflict"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/i18n"
 	"github.com/sydlexius/stillwater/internal/library"
@@ -29,14 +28,7 @@ import (
 func testRouter(t *testing.T) (*Router, *artist.Service) {
 	t.Helper()
 
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
@@ -893,14 +885,7 @@ func TestHandleReportHealth_StoredScoresReflectNewArtists(t *testing.T) {
 
 func TestHandleReportHealthByLibrary(t *testing.T) {
 	t.Parallel()
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_run_artist_rules_stub_test.go
+++ b/internal/api/handlers_run_artist_rules_stub_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/rule"
 )
@@ -77,14 +76,7 @@ func (s *stubPipeline) FixViolation(ctx context.Context, violationID string) (*r
 func testRouterWithStubPipeline(t *testing.T, stub *stubPipeline) (*Router, *artist.Service) {
 	t.Helper()
 
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_run_artist_rules_test.go
+++ b/internal/api/handlers_run_artist_rules_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/provider"
@@ -26,14 +25,7 @@ import (
 func testRouterWithPipelineFull(t *testing.T) (*Router, *artist.Service, *rule.Service) {
 	t.Helper()
 
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/api/handlers_settings_io_test.go
+++ b/internal/api/handlers_settings_io_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -17,7 +16,6 @@ import (
 
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/platform"
@@ -35,17 +33,7 @@ import (
 func settingsIOTestDeps(t *testing.T) (*Router, *settingsio.Service, *sql.DB) {
 	t.Helper()
 
-	dbDir := t.TempDir()
-	dbPath := filepath.Join(dbDir, "test.db")
-
-	db, err := database.Open(dbPath)
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	enc, _, err := encryption.NewEncryptor("")
 	if err != nil {
@@ -130,16 +118,7 @@ func seedUserPreferences(t *testing.T, db *sql.DB, username string, prefs map[st
 // a sql.DB so helper functions can seed data without going through the service.
 func setupTestDBForIO(t *testing.T) *sql.DB {
 	t.Helper()
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.Open(dbPath)
-	if err != nil {
-		t.Fatalf("opening db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-	return db
+	return newTestDB(t)
 }
 
 // --- Export handler tests ---

--- a/internal/api/handlers_setup_fuzz_test.go
+++ b/internal/api/handlers_setup_fuzz_test.go
@@ -7,12 +7,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/rule"
@@ -207,16 +205,7 @@ func FuzzHandleSetupFederated(f *testing.F) {
 func newSetupFuzzRouter(t testing.TB) *Router {
 	t.Helper()
 
-	dbDir := t.TempDir()
-	dbPath := filepath.Join(dbDir, "fuzz.db")
-	db, err := database.Open(dbPath)
-	if err != nil {
-		t.Fatalf("opening fuzz db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("migrating fuzz db: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	// Discard logs so fuzz iterations don't flood output.
 	logger := slog.New(slog.NewTextHandler(discardWriter{}, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/internal/api/handlers_updater_test.go
+++ b/internal/api/handlers_updater_test.go
@@ -8,13 +8,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/auth"
-	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/rule"
 	"github.com/sydlexius/stillwater/internal/updater"
@@ -24,15 +22,7 @@ import (
 func testRouterWithUpdater(t *testing.T) *Router {
 	t.Helper()
 
-	dir := t.TempDir()
-	db, err := database.Open(filepath.Join(dir, "test.db"))
-	if err != nil {
-		t.Fatalf("opening db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("migrating: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	db := newTestDB(t)
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
 	updSvc := updater.NewService(db, logger)
@@ -358,15 +348,7 @@ func TestHandlePostUpdateApply_Docker(t *testing.T) {
 	r := testRouterWithUpdater(t)
 	// Replace the updater service with a Docker-mode one.
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	dir := t.TempDir()
-	db2, err := database.Open(filepath.Join(dir, "docker.db"))
-	if err != nil {
-		t.Fatalf("opening docker db: %v", err)
-	}
-	if err := database.Migrate(db2); err != nil {
-		t.Fatalf("migrating docker db: %v", err)
-	}
-	t.Cleanup(func() { _ = db2.Close() })
+	db2 := newTestDB(t)
 	r.updaterService = updater.NewDockerService(db2, logger)
 
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/updates/apply", nil)

--- a/internal/api/testmain_test.go
+++ b/internal/api/testmain_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/database"
+)
+
+// templateDBPath holds the path to the pre-migrated SQLite file that TestMain
+// creates once. Each test copies it via newTestDB instead of re-running all
+// migrations from scratch.
+var templateDBPath string
+
+// TestMain creates a single pre-migrated template database for the package,
+// then runs all tests. Each test copies the template via newTestDB so the
+// migration cost is paid once per `go test` invocation.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "api-test-template-*")
+	if err != nil {
+		panic("creating temp dir: " + err.Error())
+	}
+
+	templateDBPath = filepath.Join(dir, "template.db")
+	db, err := database.Open(templateDBPath)
+	if err != nil {
+		panic("opening template db: " + err.Error())
+	}
+	if err := database.Migrate(db); err != nil {
+		panic("migrating template db: " + err.Error())
+	}
+	// Checkpoint WAL so the template file is fully self-contained before copy.
+	if _, err := db.ExecContext(context.Background(), "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		panic("checkpointing template db: " + err.Error())
+	}
+	_ = db.Close()
+
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// newTestDB copies the pre-migrated template database into a fresh temp
+// directory and opens it. The returned *sql.DB is registered for cleanup
+// when the test ends. Accepts testing.TB so it can be called from both
+// *testing.T and *testing.F (fuzz test) contexts.
+func newTestDB(t testing.TB) *sql.DB {
+	t.Helper()
+	src, err := os.ReadFile(templateDBPath)
+	if err != nil {
+		t.Fatalf("reading template db: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "test.db")
+	if err := os.WriteFile(dst, src, 0o600); err != nil {
+		t.Fatalf("writing test db: %v", err)
+	}
+	db, err := database.Open(dst)
+	if err != nil {
+		t.Fatalf("opening test db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}

--- a/internal/artist/alias_test.go
+++ b/internal/artist/alias_test.go
@@ -3,21 +3,11 @@ package artist
 import (
 	"context"
 	"testing"
-
-	"github.com/sydlexius/stillwater/internal/database"
 )
 
 func setupAliasTest(t *testing.T) *Service {
 	t.Helper()
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { db.Close() })
-	return NewService(db)
+	return NewService(newTestDB(t))
 }
 
 func createTestArtist(t *testing.T, svc *Service, name string) *Artist {

--- a/internal/artist/history_test.go
+++ b/internal/artist/history_test.go
@@ -2,32 +2,42 @@ package artist
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"testing"
 	"time"
-
-	"github.com/sydlexius/stillwater/internal/database"
 )
 
-func setupHistoryTestDB(t *testing.T) *HistoryService {
+// setupHistoryTestDB opens a pre-migrated test database and returns the
+// HistoryService plus the underlying *sql.DB for direct SQL access (e.g.
+// seeding parent artist rows required by the FK on metadata_changes.artist_id).
+func setupHistoryTestDB(t *testing.T) (*HistoryService, *sql.DB) {
 	t.Helper()
-	db, err := database.Open(":memory:")
+	db := newTestDB(t)
+	return NewHistoryService(db), db
+}
+
+// seedTestArtist inserts a minimal artists row so that history records can
+// reference it without violating the FK constraint on metadata_changes.artist_id.
+// Uses INSERT OR IGNORE so duplicate calls are idempotent.
+func seedTestArtist(t *testing.T, db *sql.DB, id string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(),
+		`INSERT OR IGNORE INTO artists (id, name, sort_name, path) VALUES (?, ?, ?, '')`,
+		id, id, id,
+	)
 	if err != nil {
-		t.Fatalf("opening test db: %v", err)
+		t.Fatalf("seedTestArtist(%q): %v", id, err)
 	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("migrating test db: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-	return NewHistoryService(db)
 }
 
 func TestHistoryService_Record(t *testing.T) {
 	t.Parallel()
-	svc := setupHistoryTestDB(t)
+	svc, db := setupHistoryTestDB(t)
 	ctx := context.Background()
 
 	artistID := "artist-001"
+	seedTestArtist(t, db, artistID)
 
 	t.Run("records a change successfully", func(t *testing.T) {
 		err := svc.Record(ctx, artistID, "biography", "old bio", "new bio", "manual")
@@ -85,6 +95,7 @@ func TestHistoryService_Record(t *testing.T) {
 
 	t.Run("records all source types", func(t *testing.T) {
 		artistID2 := "artist-002"
+		seedTestArtist(t, db, artistID2)
 		sources := []string{
 			"manual",
 			"provider:musicbrainz",
@@ -112,9 +123,10 @@ func TestHistoryService_Record(t *testing.T) {
 
 func TestHistoryService_List(t *testing.T) {
 	t.Parallel()
-	svc := setupHistoryTestDB(t)
+	svc, db := setupHistoryTestDB(t)
 	ctx := context.Background()
 	artistID := "artist-pag"
+	seedTestArtist(t, db, artistID)
 
 	// Insert 15 changes with slight time separation to guarantee ordering.
 	for i := 0; i < 15; i++ {
@@ -225,6 +237,7 @@ func TestHistoryService_List(t *testing.T) {
 
 	t.Run("does not return changes for other artists", func(t *testing.T) {
 		otherID := "artist-other"
+		seedTestArtist(t, db, otherID)
 		if err := svc.Record(ctx, otherID, "biography", "", "value", "manual"); err != nil {
 			t.Fatalf("Record() for other artist: %v", err)
 		}
@@ -245,8 +258,9 @@ func TestHistoryService_List(t *testing.T) {
 
 func TestHistoryService_RecordPreservesTimestamp(t *testing.T) {
 	t.Parallel()
-	svc := setupHistoryTestDB(t)
+	svc, db := setupHistoryTestDB(t)
 	ctx := context.Background()
+	seedTestArtist(t, db, "artist-ts")
 
 	before := time.Now().UTC().Truncate(time.Second)
 	if err := svc.Record(ctx, "artist-ts", "biography", "", "value", "manual"); err != nil {
@@ -269,8 +283,9 @@ func TestHistoryService_RecordPreservesTimestamp(t *testing.T) {
 
 func TestHistoryService_GetByID(t *testing.T) {
 	t.Parallel()
-	svc := setupHistoryTestDB(t)
+	svc, db := setupHistoryTestDB(t)
 	ctx := context.Background()
+	seedTestArtist(t, db, "artist-get")
 
 	t.Run("returns recorded change", func(t *testing.T) {
 		if err := svc.Record(ctx, "artist-get", "biography", "old", "new", "manual"); err != nil {
@@ -318,7 +333,8 @@ func TestHistoryService_GetByID(t *testing.T) {
 // recent revert for field X" lookup that races against concurrent writers.
 func TestHistoryService_RecordUsesContextHistoryID(t *testing.T) {
 	t.Parallel()
-	svc := setupHistoryTestDB(t)
+	svc, db := setupHistoryTestDB(t)
+	seedTestArtist(t, db, "artist-ctxid")
 	preID := "00000000-0000-4000-8000-000000000abc"
 
 	ctx := ContextWithHistoryID(context.Background(), preID)
@@ -356,9 +372,8 @@ func TestHistoryService_RecordUsesContextHistoryID(t *testing.T) {
 // against an accidental sort regression.
 func TestHistoryService_ListGlobalOrderRFC3339(t *testing.T) {
 	t.Parallel()
-	svc := setupHistoryTestDB(t)
+	svc, db := setupHistoryTestDB(t)
 	ctx := context.Background()
-	db := svc.repo.(*sqliteHistoryRepo).db
 
 	if _, err := db.ExecContext(ctx,
 		`INSERT INTO artists (id, name, sort_name, path) VALUES (?, ?, ?, '')`,
@@ -408,11 +423,10 @@ func TestHistoryService_ListGlobalOrderRFC3339(t *testing.T) {
 
 func TestHistoryService_ListGlobal(t *testing.T) {
 	t.Parallel()
-	svc := setupHistoryTestDB(t)
+	svc, db := setupHistoryTestDB(t)
 	ctx := context.Background()
 
 	// Need artists in the database for the JOIN.
-	db := svc.repo.(*sqliteHistoryRepo).db
 	for _, a := range []struct{ id, name string }{
 		{"artist-a", "Alpha"},
 		{"artist-b", "Beta"},

--- a/internal/artist/platform_ids_test.go
+++ b/internal/artist/platform_ids_test.go
@@ -4,23 +4,14 @@ import (
 	"context"
 	"errors"
 	"testing"
-
-	"github.com/sydlexius/stillwater/internal/database"
 )
 
 func setupPlatformIDTest(t *testing.T) *Service {
 	t.Helper()
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { db.Close() })
+	db := newTestDB(t)
 
 	// Insert test connections for foreign key constraints.
-	_, err = db.ExecContext(context.Background(), `
+	_, err := db.ExecContext(context.Background(), `
 		INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, created_at, updated_at)
 		VALUES ('conn-1', 'Test Emby', 'emby', 'http://emby:8096', 'enc-key', 1, 'ok', datetime('now'), datetime('now'))
 	`)
@@ -247,20 +238,8 @@ func TestSetPlatformID_MultipleArtists(t *testing.T) {
 // Returns the service and db for direct SQL access in tests.
 func setupPlatformPresenceTest(t *testing.T) *Service {
 	t.Helper()
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatal(err)
-	}
-	// Mirror production: enforce foreign keys so orphan
-	// artist_libraries / artist_platform_ids writes fail loudly in tests
-	// rather than silently passing.
-	if err := database.EnableForeignKeys(db); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { db.Close() })
+	// newTestDB already enables foreign keys (see testmain_test.go).
+	db := newTestDB(t)
 
 	ctx := context.Background()
 	for _, q := range []string{

--- a/internal/artist/service_test.go
+++ b/internal/artist/service_test.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"testing"
 	"time"
-
-	"github.com/sydlexius/stillwater/internal/database"
 )
 
 // failingMembershipRepo wraps a real MembershipRepository but returns a
@@ -35,17 +33,12 @@ func (f *failingMembershipRepo) AddDerivingSource(ctx context.Context, artistID,
 	return f.err
 }
 
+// setupTestDB returns a pre-migrated test database. It delegates to newTestDB
+// (defined in testmain_test.go) so migration runs once per package via
+// TestMain rather than once per test.
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-	return db
+	return newTestDB(t)
 }
 
 // seedLibraries inserts placeholder libraries rows so that Service.Create's

--- a/internal/artist/sqlite_membership_test.go
+++ b/internal/artist/sqlite_membership_test.go
@@ -4,29 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"testing"
-
-	"github.com/sydlexius/stillwater/internal/database"
 )
 
-// openTestDB sets up an in-memory SQLite database with the production
-// migration applied + foreign keys enabled, matching the convention used in
-// internal/database/migrate_test.go. Tests share this helper so they get the
-// same schema as production startup, including the artist_libraries table
-// .
+// openTestDB returns a pre-migrated, foreign-key-enabled test database.
+// Delegates to newTestDB (testmain_test.go) so migration runs once per package.
 func openTestDB(t *testing.T) *sql.DB {
 	t.Helper()
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening db: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	if err := database.EnableForeignKeys(db); err != nil {
-		t.Fatalf("foreign keys: %v", err)
-	}
-	return db
+	return newTestDB(t)
 }
 
 // seedMembershipFixtures inserts the libraries and artists referenced by

--- a/internal/artist/testmain_test.go
+++ b/internal/artist/testmain_test.go
@@ -1,0 +1,71 @@
+package artist
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/database"
+)
+
+// templateDBPath holds the path to the pre-migrated SQLite file that TestMain
+// creates once. Each test copies it via newTestDB instead of re-running all
+// migrations from scratch.
+var templateDBPath string
+
+// TestMain creates a single pre-migrated template database for the package,
+// then runs all tests. Each test copies the template via newTestDB so the
+// migration cost is paid once per `go test` invocation.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "artist-test-template-*")
+	if err != nil {
+		panic("creating temp dir: " + err.Error())
+	}
+
+	templateDBPath = filepath.Join(dir, "template.db")
+	db, err := database.Open(templateDBPath)
+	if err != nil {
+		panic("opening template db: " + err.Error())
+	}
+	if err := database.Migrate(db); err != nil {
+		panic("migrating template db: " + err.Error())
+	}
+	if err := database.EnableForeignKeys(db); err != nil {
+		panic("enabling foreign keys on template db: " + err.Error())
+	}
+	// Checkpoint WAL so the template file is fully self-contained before copy.
+	if _, err := db.ExecContext(context.Background(), "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		panic("checkpointing template db: " + err.Error())
+	}
+	_ = db.Close()
+
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// newTestDB copies the pre-migrated template database into a fresh temp
+// directory and opens it. The returned *sql.DB is registered for cleanup
+// when the test ends.
+func newTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	src, err := os.ReadFile(templateDBPath)
+	if err != nil {
+		t.Fatalf("reading template db: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "test.db")
+	if err := os.WriteFile(dst, src, 0o600); err != nil {
+		t.Fatalf("writing test db: %v", err)
+	}
+	db, err := database.Open(dst)
+	if err != nil {
+		t.Fatalf("opening test db: %v", err)
+	}
+	if err := database.EnableForeignKeys(db); err != nil {
+		t.Fatalf("enabling foreign keys on test db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -9,26 +9,14 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/sydlexius/stillwater/internal/database"
 )
 
-// setupTestService creates an in-memory database with migrations applied
-// and returns a new auth Service. The database is closed automatically
-// when the test completes.
+// setupTestService returns a new auth Service backed by a pre-migrated test
+// database. Delegates to newTestDB (testmain_test.go) so migration runs once
+// per package via TestMain rather than once per test.
 func setupTestService(t *testing.T) *Service {
 	t.Helper()
-
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-
-	return NewService(db)
+	return NewService(newTestDB(t))
 }
 
 // createTestUser creates an admin user via Setup and returns the service.
@@ -107,13 +95,7 @@ func TestPrehashPassword_DifferentInputsDifferentOutputs(t *testing.T) {
 
 func TestNewService(t *testing.T) {
 	t.Parallel()
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-
-	svc := NewService(db)
+	svc := NewService(newTestDB(t))
 	if svc == nil {
 		t.Fatal("expected non-nil Service")
 	}

--- a/internal/auth/provider_local_test.go
+++ b/internal/auth/provider_local_test.go
@@ -4,21 +4,11 @@ import (
 	"context"
 	"errors"
 	"testing"
-
-	"github.com/sydlexius/stillwater/internal/database"
 )
 
 func TestLocalProviderAuthenticate(t *testing.T) {
 	t.Parallel()
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	if err := database.Migrate(db); err != nil {
-		t.Fatalf("running migrations: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-
+	db := newTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
 
@@ -62,13 +52,7 @@ func TestLocalProviderAuthenticate(t *testing.T) {
 
 func TestLocalProviderType(t *testing.T) {
 	t.Parallel()
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-
-	provider := NewLocalProvider(db)
+	provider := NewLocalProvider(newTestDB(t))
 	if provider.Type() != "local" {
 		t.Errorf("Type() = %q, want %q", provider.Type(), "local")
 	}
@@ -76,13 +60,7 @@ func TestLocalProviderType(t *testing.T) {
 
 func TestLocalProviderAutoProvision(t *testing.T) {
 	t.Parallel()
-	db, err := database.Open(":memory:")
-	if err != nil {
-		t.Fatalf("opening test db: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-
-	provider := NewLocalProvider(db)
+	provider := NewLocalProvider(newTestDB(t))
 	if provider.CanAutoProvision(nil) {
 		t.Error("local provider should never auto-provision")
 	}

--- a/internal/auth/testmain_test.go
+++ b/internal/auth/testmain_test.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/database"
+)
+
+// templateDBPath holds the path to the pre-migrated SQLite file that TestMain
+// creates once. Each test copies it via newTestDB instead of re-running all
+// migrations from scratch.
+var templateDBPath string
+
+// TestMain creates a single pre-migrated template database for the package,
+// then runs all tests. Each test copies the template via newTestDB so the
+// migration cost is paid once per `go test` invocation.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "auth-test-template-*")
+	if err != nil {
+		panic("creating temp dir: " + err.Error())
+	}
+
+	templateDBPath = filepath.Join(dir, "template.db")
+	db, err := database.Open(templateDBPath)
+	if err != nil {
+		panic("opening template db: " + err.Error())
+	}
+	if err := database.Migrate(db); err != nil {
+		panic("migrating template db: " + err.Error())
+	}
+	// Checkpoint WAL so the template file is fully self-contained before copy.
+	if _, err := db.ExecContext(context.Background(), "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		panic("checkpointing template db: " + err.Error())
+	}
+	_ = db.Close()
+
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// newTestDB copies the pre-migrated template database into a fresh temp
+// directory and opens it. The returned *sql.DB is registered for cleanup
+// when the test ends.
+func newTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	src, err := os.ReadFile(templateDBPath)
+	if err != nil {
+		t.Fatalf("reading template db: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "test.db")
+	if err := os.WriteFile(dst, src, 0o600); err != nil {
+		t.Fatalf("writing test db: %v", err)
+	}
+	db, err := database.Open(dst)
+	if err != nil {
+		t.Fatalf("opening test db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -24,12 +24,25 @@ type BackupInfo struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// Clock is the time source used by Service for backup filename timestamps.
+// The default implementation delegates to time.Now. Tests inject a fake clock
+// to generate unique filenames without sleeping.
+type Clock interface {
+	Now() time.Time
+}
+
+// realClock is the production Clock implementation.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now().UTC() }
+
 // Service manages database backups.
 type Service struct {
 	db         *sql.DB
 	backupDir  string
 	retention  int
 	maxAgeDays int
+	clock      Clock
 	mu         sync.RWMutex
 	logger     *slog.Logger
 }
@@ -40,8 +53,18 @@ func NewService(db *sql.DB, backupDir string, retention int, logger *slog.Logger
 		db:        db,
 		backupDir: backupDir,
 		retention: retention,
+		clock:     realClock{},
 		logger:    logger.With(slog.String("component", "backup")),
 	}
+}
+
+// WithClock attaches a clock to the service. Intended for tests that need to
+// generate unique backup filenames without sleeping.
+func (s *Service) WithClock(c Clock) *Service {
+	if c != nil {
+		s.clock = c
+	}
+	return s
 }
 
 // Backup creates a snapshot of the database using VACUUM INTO.
@@ -50,7 +73,7 @@ func (s *Service) Backup(ctx context.Context) (*BackupInfo, error) {
 		return nil, fmt.Errorf("creating backup directory: %w", err)
 	}
 
-	now := time.Now().UTC()
+	now := s.clock.Now()
 	filename := fmt.Sprintf("stillwater-%s.db", now.Format("20060102-150405"))
 	dest := filepath.Join(s.backupDir, filename)
 
@@ -196,7 +219,7 @@ func (s *Service) Prune() error {
 
 	// Age-based pruning
 	if maxAge > 0 {
-		cutoff := time.Now().UTC().AddDate(0, 0, -maxAge)
+		cutoff := s.clock.Now().AddDate(0, 0, -maxAge)
 		// Re-read after count-based pruning may have removed some
 		backups, err = s.ListBackups()
 		if err != nil {

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -6,11 +6,32 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	_ "modernc.org/sqlite"
 )
+
+// testClock is a Clock for tests. Each call to Now advances the internal
+// counter by one second so sequential Backup calls produce distinct filenames
+// without requiring time.Sleep.
+type testClock struct {
+	mu  sync.Mutex
+	cur time.Time
+}
+
+func newTestClock() *testClock {
+	return &testClock{cur: time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t := c.cur
+	c.cur = c.cur.Add(time.Second)
+	return t
+}
 
 func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
@@ -73,15 +94,16 @@ func TestListBackups(t *testing.T) {
 	db := setupTestDB(t)
 	backupDir := filepath.Join(t.TempDir(), "backups")
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	svc := NewService(db, backupDir, 7, logger)
+	// The fake clock advances by 1s per call so each Backup gets a unique
+	// filename without requiring time.Sleep.
+	svc := NewService(db, backupDir, 7, logger).WithClock(newTestClock())
 
-	// Create 3 backups with small delays
+	// Create 3 backups -- no sleep needed with the injected clock.
 	for i := 0; i < 3; i++ {
 		_, err := svc.Backup(context.Background())
 		if err != nil {
 			t.Fatalf("Backup %d: %v", i, err)
 		}
-		time.Sleep(1100 * time.Millisecond) // Ensure different timestamps
 	}
 
 	backups, err := svc.ListBackups()
@@ -102,15 +124,14 @@ func TestPrune(t *testing.T) {
 	db := setupTestDB(t)
 	backupDir := filepath.Join(t.TempDir(), "backups")
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	svc := NewService(db, backupDir, 2, logger) // Keep only 2
+	svc := NewService(db, backupDir, 2, logger).WithClock(newTestClock()) // Keep only 2
 
-	// Create 4 backups
+	// Create 4 backups -- no sleep needed with the injected clock.
 	for i := 0; i < 4; i++ {
 		_, err := svc.Backup(context.Background())
 		if err != nil {
 			t.Fatalf("Backup %d: %v", i, err)
 		}
-		time.Sleep(1100 * time.Millisecond)
 	}
 
 	if err := svc.Prune(); err != nil {

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -284,9 +284,25 @@ func DefaultRules() []Rule {
 // rows.
 const snapshotThrottleTTL = 60 * time.Second
 
+// Clock is the time source used by Service for timestamp writes. The default
+// implementation delegates to time.Now. Tests inject a fake clock to advance
+// time without sleeping.
+type Clock interface {
+	Now() time.Time
+}
+
+// realClock is the production Clock implementation.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now().UTC() }
+
 // Service provides rule data operations.
 type Service struct {
 	db *sql.DB
+
+	// clock is the time source for all timestamp writes. Defaults to realClock.
+	// Override with WithClock in tests to eliminate time.Sleep calls.
+	clock Clock
 
 	// logger is the package logger; defaults to slog.Default() and can be
 	// overridden via WithLogger for tests that want to capture output.
@@ -306,8 +322,18 @@ type Service struct {
 func NewService(db *sql.DB) *Service {
 	return &Service{
 		db:     db,
+		clock:  realClock{},
 		logger: slog.Default(),
 	}
+}
+
+// WithClock attaches a clock to the service. Intended for tests that need to
+// control the wall time seen by SeedDefaults and Update without sleeping.
+func (s *Service) WithClock(c Clock) *Service {
+	if c != nil {
+		s.clock = c
+	}
+	return s
 }
 
 // WithLogger attaches a logger for the rule service. Defaults to slog.Default()
@@ -334,7 +360,7 @@ func (s *Service) WithLogger(logger *slog.Logger) *Service {
 // Newly inserted rules naturally have updated_at = now, which is the correct
 // signal for the dirty-tracking query to schedule them on the next pass.
 func (s *Service) SeedDefaults(ctx context.Context) error {
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := s.clock.Now().Format(time.RFC3339)
 	for _, r := range defaultRules {
 		autoMode := r.AutomationMode
 		if autoMode == "" {
@@ -460,7 +486,7 @@ func (s *Service) GetByID(ctx context.Context, id string) (*Rule, error) {
 // when a fixer succeeds, so downstream consumers (compliance counts, history
 // charts) treat the two transitions identically.
 func (s *Service) Update(ctx context.Context, r *Rule) error {
-	r.UpdatedAt = time.Now().UTC()
+	r.UpdatedAt = s.clock.Now()
 	_, err := s.db.ExecContext(ctx, `
 		UPDATE rules SET enabled = ?, automation_mode = ?, config = ?, updated_at = ? WHERE id = ?
 	`, dbutil.BoolToInt(r.Enabled), r.AutomationMode, MarshalConfig(r.Config),
@@ -562,7 +588,7 @@ func (s *Service) DisableFilesystemRules(ctx context.Context) (int, error) {
 	// Flip enabled=0 in one statement.
 	disablePlaceholders := make([]string, len(toDisable))
 	disableArgs := make([]any, 0, len(toDisable)+1)
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := s.clock.Now().Format(time.RFC3339)
 	disableArgs = append(disableArgs, now)
 	for i, id := range toDisable {
 		disablePlaceholders[i] = "?"
@@ -833,7 +859,7 @@ func (s *Service) UpsertViolation(ctx context.Context, v *RuleViolation) error {
 	if v.ID == "" {
 		v.ID = uuid.New().String()
 	}
-	v.UpdatedAt = time.Now().UTC()
+	v.UpdatedAt = s.clock.Now()
 	if v.CreatedAt.IsZero() {
 		v.CreatedAt = v.UpdatedAt
 	}

--- a/internal/rule/service_dirty_test.go
+++ b/internal/rule/service_dirty_test.go
@@ -3,7 +3,6 @@ package rule
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/sydlexius/stillwater/internal/artist"
 )
@@ -17,7 +16,8 @@ import (
 func TestService_UpdateMakesPreviouslyEvaluatedArtistDirty(t *testing.T) {
 	db := setupTestDB(t)
 	artistSvc := artist.NewService(db)
-	ruleSvc := NewService(db)
+	clk := NewFakeClock(baseTestTime)
+	ruleSvc := NewService(db).WithClock(clk)
 	ctx := context.Background()
 
 	if err := ruleSvc.SeedDefaults(ctx); err != nil {
@@ -31,9 +31,9 @@ func TestService_UpdateMakesPreviouslyEvaluatedArtistDirty(t *testing.T) {
 		t.Fatalf("Create artist: %v", err)
 	}
 	// Stamp rules_evaluated_at strictly after the seed's updated_at so the
-	// artist starts clean.
-	time.Sleep(time.Second)
-	if err := artistSvc.MarkRulesEvaluated(ctx, a.ID, time.Now().UTC()); err != nil {
+	// artist starts clean. The fake clock advances by 1s each Now() call, so
+	// the evaluation timestamp is always later than the seed timestamp.
+	if err := artistSvc.MarkRulesEvaluated(ctx, a.ID, clk.Now()); err != nil {
 		t.Fatalf("MarkRulesEvaluated: %v", err)
 	}
 
@@ -67,7 +67,6 @@ func TestService_UpdateMakesPreviouslyEvaluatedArtistDirty(t *testing.T) {
 	} else {
 		r.AutomationMode = AutomationModeAuto
 	}
-	time.Sleep(time.Second)
 	if err := ruleSvc.Update(ctx, r); err != nil {
 		t.Fatalf("Update rule: %v", err)
 	}
@@ -89,7 +88,8 @@ func TestService_UpdateMakesPreviouslyEvaluatedArtistDirty(t *testing.T) {
 func TestService_DisablingRuleDoesNotMarkDirty(t *testing.T) {
 	db := setupTestDB(t)
 	artistSvc := artist.NewService(db)
-	ruleSvc := NewService(db)
+	clk := NewFakeClock(baseTestTime)
+	ruleSvc := NewService(db).WithClock(clk)
 	ctx := context.Background()
 
 	if err := ruleSvc.SeedDefaults(ctx); err != nil {
@@ -102,8 +102,7 @@ func TestService_DisablingRuleDoesNotMarkDirty(t *testing.T) {
 	if err := artistSvc.Create(ctx, a); err != nil {
 		t.Fatalf("Create artist: %v", err)
 	}
-	time.Sleep(time.Second)
-	if err := artistSvc.MarkRulesEvaluated(ctx, a.ID, time.Now().UTC()); err != nil {
+	if err := artistSvc.MarkRulesEvaluated(ctx, a.ID, clk.Now()); err != nil {
 		t.Fatalf("MarkRulesEvaluated: %v", err)
 	}
 
@@ -118,7 +117,6 @@ func TestService_DisablingRuleDoesNotMarkDirty(t *testing.T) {
 		t.Skipf("RuleNFOExists default disabled; cannot exercise disable path")
 	}
 	r.Enabled = false
-	time.Sleep(time.Second)
 	if err := ruleSvc.Update(ctx, r); err != nil {
 		t.Fatalf("Update rule: %v", err)
 	}
@@ -149,7 +147,8 @@ func TestService_DisablingRuleDoesNotMarkDirty(t *testing.T) {
 func TestService_SeedDefaultsIdempotent(t *testing.T) {
 	db := setupTestDB(t)
 	artistSvc := artist.NewService(db)
-	ruleSvc := NewService(db)
+	clk := NewFakeClock(baseTestTime)
+	ruleSvc := NewService(db).WithClock(clk)
 	ctx := context.Background()
 
 	a := &artist.Artist{
@@ -173,8 +172,9 @@ func TestService_SeedDefaultsIdempotent(t *testing.T) {
 	}
 
 	// Stamp the artist as fully evaluated so it falls out of the dirty set.
-	time.Sleep(time.Second)
-	if err := artistSvc.MarkRulesEvaluated(ctx, a.ID, time.Now().UTC()); err != nil {
+	// The fake clock advances by 1s each Now() call, ensuring the evaluation
+	// timestamp is strictly later than the seed timestamps.
+	if err := artistSvc.MarkRulesEvaluated(ctx, a.ID, clk.Now()); err != nil {
 		t.Fatalf("MarkRulesEvaluated: %v", err)
 	}
 	clean, err := artistSvc.ListDirtyIDs(ctx)
@@ -187,7 +187,6 @@ func TestService_SeedDefaultsIdempotent(t *testing.T) {
 
 	// Second seed: no rule is new, and the cosmetic refresh must not
 	// bump updated_at. A no-op seed must leave the artist clean.
-	time.Sleep(time.Second)
 	if err := ruleSvc.SeedDefaults(ctx); err != nil {
 		t.Fatalf("second SeedDefaults: %v", err)
 	}

--- a/internal/rule/service_test.go
+++ b/internal/rule/service_test.go
@@ -2775,7 +2775,7 @@ func TestListViolationsFiltered_SearchEscapesLikeWildcards(t *testing.T) {
 // perspective; only an explicit reset path may transition out of it.
 func TestUpsertViolation_PreservesDismissedStatus(t *testing.T) {
 	db := setupTestDB(t)
-	svc := NewService(db)
+	svc := NewService(db).WithClock(NewFakeClock(baseTestTime))
 	ctx := context.Background()
 
 	// Step 1: insert an open violation.
@@ -2847,8 +2847,8 @@ func TestUpsertViolation_PreservesDismissedStatus(t *testing.T) {
 	).Scan(&beforeLastFailed); err != nil && err != sql.ErrNoRows {
 		t.Fatalf("reading pre-resurrect evaluated_at: %v", err)
 	}
-	// Nudge clock so a fresh write would visibly bump the timestamp.
-	time.Sleep(1100 * time.Millisecond)
+	// The fake clock advances each Now() call by one second, so any accidental
+	// write to rule_results.evaluated_at would produce a visibly different value.
 	if err := svc.UpsertViolation(ctx, &RuleViolation{
 		RuleID: v.RuleID, ArtistID: v.ArtistID, ArtistName: v.ArtistName,
 		Severity: v.Severity, Message: v.Message, Fixable: true,

--- a/internal/rule/testmain_test.go
+++ b/internal/rule/testmain_test.go
@@ -4,10 +4,42 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/database"
 )
+
+// baseTestTime is the starting timestamp for FakeClock instances. It is set to
+// a time well ahead of any datetime('now') written into the template DB so that
+// fake clock ticks are always strictly greater than pre-seeded timestamps.
+// Using time.Now() + 1 minute (rather than a fixed historical date) prevents
+// the migration-seeded extraneous_images rule's updated_at from appearing newer
+// than the fake clock values.
+var baseTestTime = time.Now().UTC().Add(time.Minute)
+
+// FakeClock is a Clock implementation for tests. Each call to Now advances the
+// internal counter by one second, so callers that need strictly ordered
+// timestamps never need time.Sleep.
+type FakeClock struct {
+	mu  sync.Mutex
+	cur time.Time
+}
+
+// NewFakeClock returns a FakeClock starting at the given base time.
+func NewFakeClock(base time.Time) *FakeClock {
+	return &FakeClock{cur: base}
+}
+
+// Now returns the current fake time and advances the clock by one second.
+func (f *FakeClock) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t := f.cur
+	f.cur = f.cur.Add(time.Second)
+	return t
+}
 
 var templateDBPath string
 

--- a/internal/rule/testmain_test.go
+++ b/internal/rule/testmain_test.go
@@ -11,13 +11,14 @@ import (
 	"github.com/sydlexius/stillwater/internal/database"
 )
 
-// baseTestTime is the starting timestamp for FakeClock instances. It is set to
-// a time well ahead of any datetime('now') written into the template DB so that
-// fake clock ticks are always strictly greater than pre-seeded timestamps.
-// Using time.Now() + 1 minute (rather than a fixed historical date) prevents
-// the migration-seeded extraneous_images rule's updated_at from appearing newer
-// than the fake clock values.
-var baseTestTime = time.Now().UTC().Add(time.Minute)
+// baseTestTime is the starting timestamp for FakeClock instances. Initialized
+// in TestMain after the template DB is migrated, so the value is guaranteed to
+// be strictly greater than any datetime('now') the migrations wrote during
+// setup (notably the seeded extraneous_images rule's updated_at). Computing it
+// at package-init time worked in practice but left a race: anything that ran
+// slower than the test-clock-vs-migration tolerance could see the wrong
+// ordering.
+var baseTestTime time.Time
 
 // FakeClock is a Clock implementation for tests. Each call to Now advances the
 // internal counter by one second, so callers that need strictly ordered
@@ -61,6 +62,10 @@ func TestMain(m *testing.M) {
 		panic("checkpointing template db: " + err.Error())
 	}
 	_ = db.Close()
+
+	// Initialize baseTestTime here, after every datetime('now') the migrations
+	// just wrote, so FakeClock ticks always start strictly after seeded rows.
+	baseTestTime = time.Now().UTC().Add(time.Minute)
 
 	code := m.Run()
 	_ = os.RemoveAll(dir)


### PR DESCRIPTION
## Summary

- Adds a `TestMain` + template-DB copy pattern to `internal/api`, `internal/artist`, `internal/auth`, and `internal/rule` packages: migrations run once per package, each test gets a file copy. Eliminates the per-test `database.Open` + `database.Migrate` overhead across hundreds of tests.
- Introduces an injectable `Clock` interface on `rule.Service` and `backup.Service`. Production wires `time.Now()`; tests wire `FakeClock` (mutex-protected, auto-advances 1s per call). Removes all `time.Sleep(time.Second)` calls from `service_dirty_test.go`, `service_test.go`, and `backup_test.go` -- ~9.3s of guaranteed wall time eliminated.

## Test plan

- [ ] All packages pass `go test -race ./...` (verified by pre-push gate: 100% patch coverage on the two production files touched)
- [ ] `internal/rule` tests no longer sleep: `go test -v -run TestService ./internal/rule/...` completes without 1s pauses
- [ ] `internal/backup` tests no longer sleep: same check

Part of #1293
Part of #1295

Closes #1293
Closes #1295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Services now support injecting a deterministic time source so backup filenames and rule timestamps can be produced consistently.

* **Tests**
  * Centralized and pre-migrated test databases across packages for faster, more consistent test runs.
  * Replaced ad-hoc sleeps with deterministic clocks to eliminate timing-related flakiness.

* **Chores**
  * Test infrastructure optimized with template databases and shared helpers.

Note: No user-facing behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1512)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->