### PR TITLE
refactor(test): table-drive TestParse_BasicNFO and TestGetArtist to reduce cyclo

### DIFF
--- a/internal/nfo/parser_test.go
+++ b/internal/nfo/parser_test.go
@@ -19,72 +19,82 @@ func TestParse_BasicNFO(t *testing.T) {
 		t.Fatalf("Parse: %v", err)
 	}
 
-	if nfo.Name != "Nirvana" {
-		t.Errorf("Name = %q, want %q", nfo.Name, "Nirvana")
-	}
-	if nfo.SortName != "Nirvana" {
-		t.Errorf("SortName = %q, want %q", nfo.SortName, "Nirvana")
-	}
-	if nfo.Type != "group" {
-		t.Errorf("Type = %q, want %q", nfo.Type, "group")
-	}
-	if nfo.Disambiguation != "US grunge band" {
-		t.Errorf("Disambiguation = %q, want %q", nfo.Disambiguation, "US grunge band")
-	}
-	if nfo.MusicBrainzArtistID != "5b11f4ce-a62d-471e-81fc-a69a8278c7da" {
-		t.Errorf("MusicBrainzArtistID = %q", nfo.MusicBrainzArtistID)
-	}
-	if nfo.AudioDBArtistID != "111239" {
-		t.Errorf("AudioDBArtistID = %q", nfo.AudioDBArtistID)
-	}
-	if nfo.DeezerArtistID != "67549" {
-		t.Errorf("DeezerArtistID = %q, want %q", nfo.DeezerArtistID, "67549")
-	}
-	if nfo.SpotifyArtistID != "6olE6TJLqED3rqDCT0FyPh" {
-		t.Errorf("SpotifyArtistID = %q, want %q", nfo.SpotifyArtistID, "6olE6TJLqED3rqDCT0FyPh")
-	}
-	if len(nfo.Genres) != 3 {
-		t.Errorf("Genres count = %d, want 3", len(nfo.Genres))
-	} else if nfo.Genres[0] != "Rock" || nfo.Genres[1] != "Grunge" {
-		t.Errorf("Genres = %v", nfo.Genres)
-	}
-	if len(nfo.Styles) != 2 {
-		t.Errorf("Styles count = %d, want 2", len(nfo.Styles))
-	}
-	if len(nfo.Moods) != 2 {
-		t.Errorf("Moods count = %d, want 2", len(nfo.Moods))
-	}
-	if nfo.YearsActive != "1987 - 1994" {
-		t.Errorf("YearsActive = %q", nfo.YearsActive)
-	}
-	if nfo.Formed != "1987" {
-		t.Errorf("Formed = %q", nfo.Formed)
-	}
-	if nfo.Disbanded != "1994" {
-		t.Errorf("Disbanded = %q", nfo.Disbanded)
-	}
-	if !strings.Contains(nfo.Biography, "American rock band") {
-		t.Errorf("Biography doesn't contain expected text: %q", nfo.Biography[:50])
-	}
+	t.Run("scalar fields", func(t *testing.T) {
+		if nfo.Name != "Nirvana" {
+			t.Errorf("Name = %q, want %q", nfo.Name, "Nirvana")
+		}
+		if nfo.SortName != "Nirvana" {
+			t.Errorf("SortName = %q, want %q", nfo.SortName, "Nirvana")
+		}
+		if nfo.Type != "group" {
+			t.Errorf("Type = %q, want %q", nfo.Type, "group")
+		}
+		if nfo.Disambiguation != "US grunge band" {
+			t.Errorf("Disambiguation = %q, want %q", nfo.Disambiguation, "US grunge band")
+		}
+		if nfo.YearsActive != "1987 - 1994" {
+			t.Errorf("YearsActive = %q", nfo.YearsActive)
+		}
+		if nfo.Formed != "1987" {
+			t.Errorf("Formed = %q", nfo.Formed)
+		}
+		if nfo.Disbanded != "1994" {
+			t.Errorf("Disbanded = %q", nfo.Disbanded)
+		}
+		if !strings.Contains(nfo.Biography, "American rock band") {
+			t.Errorf("Biography doesn't contain expected text: %q", nfo.Biography[:50])
+		}
+	})
 
-	// Thumbs
-	if len(nfo.Thumbs) != 2 {
-		t.Fatalf("Thumbs count = %d, want 2", len(nfo.Thumbs))
-	}
-	if nfo.Thumbs[0].Aspect != "poster" {
-		t.Errorf("Thumb[0].Aspect = %q, want %q", nfo.Thumbs[0].Aspect, "poster")
-	}
-	if nfo.Thumbs[1].Preview != "https://example.com/preview.jpg" {
-		t.Errorf("Thumb[1].Preview = %q", nfo.Thumbs[1].Preview)
-	}
+	t.Run("provider IDs", func(t *testing.T) {
+		if nfo.MusicBrainzArtistID != "5b11f4ce-a62d-471e-81fc-a69a8278c7da" {
+			t.Errorf("MusicBrainzArtistID = %q", nfo.MusicBrainzArtistID)
+		}
+		if nfo.AudioDBArtistID != "111239" {
+			t.Errorf("AudioDBArtistID = %q", nfo.AudioDBArtistID)
+		}
+		if nfo.DeezerArtistID != "67549" {
+			t.Errorf("DeezerArtistID = %q, want %q", nfo.DeezerArtistID, "67549")
+		}
+		if nfo.SpotifyArtistID != "6olE6TJLqED3rqDCT0FyPh" {
+			t.Errorf("SpotifyArtistID = %q, want %q", nfo.SpotifyArtistID, "6olE6TJLqED3rqDCT0FyPh")
+		}
+	})
 
-	// Fanart
-	if nfo.Fanart == nil {
-		t.Fatal("expected Fanart to be non-nil")
-	}
-	if len(nfo.Fanart.Thumbs) != 2 {
-		t.Errorf("Fanart.Thumbs count = %d, want 2", len(nfo.Fanart.Thumbs))
-	}
+	t.Run("genres styles moods", func(t *testing.T) {
+		if len(nfo.Genres) != 3 {
+			t.Errorf("Genres count = %d, want 3", len(nfo.Genres))
+		} else if nfo.Genres[0] != "Rock" || nfo.Genres[1] != "Grunge" {
+			t.Errorf("Genres = %v", nfo.Genres)
+		}
+		if len(nfo.Styles) != 2 {
+			t.Errorf("Styles count = %d, want 2", len(nfo.Styles))
+		}
+		if len(nfo.Moods) != 2 {
+			t.Errorf("Moods count = %d, want 2", len(nfo.Moods))
+		}
+	})
+
+	t.Run("thumbs", func(t *testing.T) {
+		if len(nfo.Thumbs) != 2 {
+			t.Fatalf("Thumbs count = %d, want 2", len(nfo.Thumbs))
+		}
+		if nfo.Thumbs[0].Aspect != "poster" {
+			t.Errorf("Thumb[0].Aspect = %q, want %q", nfo.Thumbs[0].Aspect, "poster")
+		}
+		if nfo.Thumbs[1].Preview != "https://example.com/preview.jpg" {
+			t.Errorf("Thumb[1].Preview = %q", nfo.Thumbs[1].Preview)
+		}
+	})
+
+	t.Run("fanart", func(t *testing.T) {
+		if nfo.Fanart == nil {
+			t.Fatal("expected Fanart to be non-nil")
+		}
+		if len(nfo.Fanart.Thumbs) != 2 {
+			t.Errorf("Fanart.Thumbs count = %d, want 2", len(nfo.Fanart.Thumbs))
+		}
+	})
 }
 
 func TestParse_WithBOM(t *testing.T) {

--- a/internal/provider/musicbrainz/musicbrainz_test.go
+++ b/internal/provider/musicbrainz/musicbrainz_test.go
@@ -180,60 +180,66 @@ func TestGetArtist(t *testing.T) {
 		t.Fatalf("GetArtist: %v", err)
 	}
 
-	if meta.Name != "Radiohead" {
-		t.Errorf("expected name Radiohead, got %s", meta.Name)
-	}
-	if meta.MusicBrainzID != "a74b1b7f-71a5-4011-9441-d0b5e4122711" {
-		t.Errorf("unexpected MBID: %s", meta.MusicBrainzID)
-	}
-	if meta.Type != "group" {
-		t.Errorf("expected type group, got %s", meta.Type)
-	}
-	if meta.Origin != "United Kingdom" {
-		t.Errorf("expected origin United Kingdom, got %s", meta.Origin)
-	}
-	if meta.Formed != "1991" {
-		t.Errorf("expected formed 1991, got %s", meta.Formed)
-	}
+	t.Run("scalar fields", func(t *testing.T) {
+		if meta.Name != "Radiohead" {
+			t.Errorf("expected name Radiohead, got %s", meta.Name)
+		}
+		if meta.MusicBrainzID != "a74b1b7f-71a5-4011-9441-d0b5e4122711" {
+			t.Errorf("unexpected MBID: %s", meta.MusicBrainzID)
+		}
+		if meta.Type != "group" {
+			t.Errorf("expected type group, got %s", meta.Type)
+		}
+		if meta.Origin != "United Kingdom" {
+			t.Errorf("expected origin United Kingdom, got %s", meta.Origin)
+		}
+		if meta.Formed != "1991" {
+			t.Errorf("expected formed 1991, got %s", meta.Formed)
+		}
+	})
 
-	// Genres
-	if len(meta.Genres) != 3 {
-		t.Fatalf("expected 3 genres, got %d", len(meta.Genres))
-	}
-	if meta.Genres[0] != "alternative rock" {
-		t.Errorf("expected first genre 'alternative rock', got %s", meta.Genres[0])
-	}
+	t.Run("genres", func(t *testing.T) {
+		if len(meta.Genres) != 3 {
+			t.Fatalf("expected 3 genres, got %d", len(meta.Genres))
+		}
+		if meta.Genres[0] != "alternative rock" {
+			t.Errorf("expected first genre 'alternative rock', got %s", meta.Genres[0])
+		}
+	})
 
-	// Aliases
-	if len(meta.Aliases) != 1 {
-		t.Fatalf("expected 1 alias, got %d", len(meta.Aliases))
-	}
+	t.Run("aliases", func(t *testing.T) {
+		if len(meta.Aliases) != 1 {
+			t.Fatalf("expected 1 alias, got %d", len(meta.Aliases))
+		}
+	})
 
-	// Members
-	if len(meta.Members) != 5 {
-		t.Fatalf("expected 5 members, got %d", len(meta.Members))
-	}
-	thom := meta.Members[0]
-	if thom.Name != "Thom Yorke" {
-		t.Errorf("expected first member Thom Yorke, got %s", thom.Name)
-	}
-	if thom.MBID != "8bfac288-ccc5-448d-9573-c33ea2aa5c30" {
-		t.Errorf("unexpected MBID for Thom Yorke: %s", thom.MBID)
-	}
-	if len(thom.Instruments) != 2 {
-		t.Errorf("expected 2 instruments for Thom Yorke, got %d", len(thom.Instruments))
-	}
-	if !thom.IsActive {
-		t.Error("expected Thom Yorke to be active")
-	}
+	t.Run("members", func(t *testing.T) {
+		if len(meta.Members) != 5 {
+			t.Fatalf("expected 5 members, got %d", len(meta.Members))
+		}
+		thom := meta.Members[0]
+		if thom.Name != "Thom Yorke" {
+			t.Errorf("expected first member Thom Yorke, got %s", thom.Name)
+		}
+		if thom.MBID != "8bfac288-ccc5-448d-9573-c33ea2aa5c30" {
+			t.Errorf("unexpected MBID for Thom Yorke: %s", thom.MBID)
+		}
+		if len(thom.Instruments) != 2 {
+			t.Errorf("expected 2 instruments for Thom Yorke, got %d", len(thom.Instruments))
+		}
+		if !thom.IsActive {
+			t.Error("expected Thom Yorke to be active")
+		}
+	})
 
-	// URLs
-	if meta.URLs["official"] != "https://www.radiohead.com/" {
-		t.Errorf("unexpected official URL: %s", meta.URLs["official"])
-	}
-	if meta.URLs["wikipedia"] != "https://en.wikipedia.org/wiki/Radiohead" {
-		t.Errorf("unexpected wikipedia URL: %s", meta.URLs["wikipedia"])
-	}
+	t.Run("URLs", func(t *testing.T) {
+		if meta.URLs["official"] != "https://www.radiohead.com/" {
+			t.Errorf("unexpected official URL: %s", meta.URLs["official"])
+		}
+		if meta.URLs["wikipedia"] != "https://en.wikipedia.org/wiki/Radiohead" {
+			t.Errorf("unexpected wikipedia URL: %s", meta.URLs["wikipedia"])
+		}
+	})
 }
 
 func TestGetArtistNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

- `TestParse_BasicNFO` (`internal/nfo/parser_test.go`): refactored from a flat chain of ~18 inline assertions (cyclo 23) into 5 named subtests covering scalar fields, provider IDs, genres/styles/moods, thumbs, and fanart. Top-level function now has 2 decision points.
- `TestGetArtist` (`internal/provider/musicbrainz/musicbrainz_test.go`): refactored from a flat chain of ~15 inline assertions (cyclo 17) into 5 named subtests covering scalar fields, genres, aliases, members, and URLs. Top-level function now has 1 decision point.

Pure structural refactor -- no test cases added or removed, no assertions changed.

## Test plan

- [ ] `go test -race ./internal/nfo/...` passes
- [ ] `go test -race ./internal/provider/musicbrainz/...` passes

Closes #988
Closes #995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test structure for improved clarity and maintainability with better subtest organization.

---

**Note:** These changes are internal test improvements with no impact on user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1513)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->