### PR TITLE
chore(scripts): add safe-push wrapper that verifies the remote ref

### DIFF
--- a/docs/pr-workflow.md
+++ b/docs/pr-workflow.md
@@ -6,6 +6,33 @@ Run `bash scripts/pre-push-gate.sh` before anything else. It runs tests, OpenAPI
 
 Then run `/pr-review-toolkit:review-pr` for code review. Fix all critical/important findings before pushing.
 
+## Parallel pushes from sibling worktrees
+
+Multiple agents pushing concurrently from sibling worktrees (`../stillwater-<slug>/`) is supported. The gate path is fully per-worktree isolated:
+
+- `$SW_RUN_DIR` (which holds `cover.out` and `openapi-base.yaml`) keys off the worktree's basename plus a 12-char sha256 of its absolute path -- see `scripts/lib/run-paths.sh`. Two worktrees that share a basename across separate parent directories still get disjoint dirs.
+- The pre-push gate takes an atomic `mkdir`-based lock at `$SW_RUN_DIR/.gate-lock` to block same-worktree concurrent runs (PR #1481). Sibling worktrees take separate locks.
+- `golangci-lint`'s shared cache is safe under `allow-parallel-runners: true` in `.golangci.yml`.
+- Go's build cache (`$GOCACHE`) is documented concurrent-safe.
+
+What is **not** robust is the common invocation pattern that hides push failures:
+
+```bash
+git push -u origin "$branch" 2>&1 | tail -30   # AVOID
+```
+
+Without `set -o pipefail`, the pipeline returns `tail`'s exit code (always 0), masking a real `git push` failure -- transient SSH blip, remote ref rejection, hook abort, network drop. The visible output then looks identical to a quiet success, and the next step opens a PR against a branch that never reached the remote.
+
+Use `scripts/safe-push.sh` instead:
+
+```bash
+bash scripts/safe-push.sh                  # push current branch -u origin
+bash scripts/safe-push.sh "$branch"        # push named branch
+bash scripts/safe-push.sh "$branch" --force-with-lease   # extra flags forwarded
+```
+
+It writes the full push transcript to `$SW_RUN_DIR/safe-push.log`, queries `git ls-remote origin <branch>` after the push returns, and exits non-zero with a clear message if the remote SHA does not match the local HEAD. Catches silent failures that `cmd | tail` would have swallowed.
+
 ## Squash before first push
 
 Squash all development/fixup commits into clean, logical commits before the first push. Copilot's initial review covers the full diff present when the PR is first opened; incremental commits added after opening are not automatically re-reviewed (see Copilot review policy below).

--- a/scripts/safe-push.sh
+++ b/scripts/safe-push.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# safe-push.sh -- run `git push` and verify the remote actually received it.
+#
+# The pre-push gate is well-isolated for parallel agents (per-worktree run
+# dirs, per-worktree gate lock, golangci-lint allow-parallel-runners). What
+# is NOT robust is the common invocation pattern:
+#
+#   git push -u origin <branch> 2>&1 | tail -30
+#
+# Without `set -o pipefail`, the pipeline returns tail's exit code, which
+# is virtually always 0 -- masking a real git push failure (transient SSH
+# blip, remote ref rejection, hook abort, network drop). The visible output
+# then looks identical to a quiet success, and the agent moves on to open a
+# PR against a branch that never reached the remote.
+#
+# This wrapper:
+#   1. Resolves the local HEAD and the branch (or current symbolic-ref).
+#   2. Runs `git push` with full output captured to $SW_RUN_DIR/safe-push.log
+#      and mirrored to stderr so the caller can stream it.
+#   3. After push returns, queries `git ls-remote origin <branch>` and
+#      verifies the remote SHA matches local HEAD.
+#   4. Exits non-zero with a clear message if push's exit code OR the post-push
+#      ref check disagrees.
+#
+# Usage:
+#   bash scripts/safe-push.sh                  # push current branch -u origin
+#   bash scripts/safe-push.sh <branch>         # push named branch -u origin
+#   bash scripts/safe-push.sh <branch> --force # forwarded to git push
+#
+# Exit codes:
+#   0 -- push succeeded AND the remote ref matches local HEAD
+#   1 -- push exited non-zero, or the remote ref does not match local HEAD
+#   2 -- invalid invocation / cannot resolve branch or worktree
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/lib/run-paths.sh"
+
+LOG="$SW_RUN_DIR/safe-push.log"
+
+branch="${1:-}"
+shift_count=0
+if [ -n "$branch" ] && [ "${branch#-}" = "$branch" ]; then
+  shift_count=1
+else
+  branch=""
+fi
+
+if [ -z "$branch" ]; then
+  branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  if [ -z "$branch" ]; then
+    echo "safe-push: HEAD is detached and no branch argument given" >&2
+    exit 2
+  fi
+fi
+
+# Drop the consumed positional so the remaining "$@" can flow into git push
+# as extra flags (--force-with-lease, --no-verify, etc.). Quoted so flags with
+# spaces survive intact.
+if [ "$shift_count" -gt 0 ]; then
+  shift
+fi
+
+local_sha=$(git rev-parse --verify "refs/heads/$branch" 2>/dev/null || true)
+if [ -z "$local_sha" ]; then
+  echo "safe-push: local branch 'refs/heads/$branch' does not exist" >&2
+  exit 2
+fi
+
+# Capture full output to a log AND mirror to stderr. `tee` writes to both;
+# `set -o pipefail` ensures git push's non-zero exit propagates through the
+# pipeline rather than being hidden by tee's exit (which is the bug this
+# wrapper exists to prevent).
+echo "safe-push: pushing $branch ($local_sha) to origin" >&2
+push_status=0
+set -o pipefail
+if ! git push -u origin "$branch" "$@" 2>&1 | tee "$LOG" >&2; then
+  push_status=$?
+fi
+set +o pipefail
+
+# Independent verification: read the remote ref directly. ls-remote bypasses
+# any local cache (no `git fetch` needed) and returns the authoritative SHA
+# from GitHub. A successful push that somehow didn't update the ref (the
+# silent-failure mode this wrapper guards against) will show here.
+remote_line=$(git ls-remote origin "refs/heads/$branch" 2>/dev/null || true)
+remote_sha=${remote_line%%$'\t'*}
+
+if [ "$push_status" -ne 0 ]; then
+  echo "safe-push: git push exited $push_status -- see $LOG" >&2
+  exit 1
+fi
+
+if [ -z "$remote_sha" ]; then
+  echo "safe-push: git push exited 0 but origin has no '$branch' ref" >&2
+  echo "          local HEAD: $local_sha" >&2
+  echo "          full log:   $LOG" >&2
+  exit 1
+fi
+
+if [ "$remote_sha" != "$local_sha" ]; then
+  echo "safe-push: git push exited 0 but origin/'$branch' does not match local HEAD" >&2
+  echo "          local:  $local_sha" >&2
+  echo "          remote: $remote_sha" >&2
+  echo "          full log: $LOG" >&2
+  exit 1
+fi
+
+echo "safe-push: verified origin/$branch -> $remote_sha" >&2
+exit 0

--- a/scripts/safe-push.sh
+++ b/scripts/safe-push.sh
@@ -76,7 +76,12 @@ fi
 echo "safe-push: pushing $branch ($local_sha) to origin" >&2
 push_status=0
 set -o pipefail
-if ! git push -u origin "$branch" "$@" 2>&1 | tee "$LOG" >&2; then
+# Capture git push's real exit code. `if ! cmd; then` would set $? to the
+# negated value (0) inside the then-block, masking the actual failure --
+# the exact silent-failure mode this wrapper exists to prevent.
+if git push -u origin "$branch" "$@" 2>&1 | tee "$LOG" >&2; then
+  push_status=0
+else
   push_status=$?
 fi
 set +o pipefail


### PR DESCRIPTION
## Summary

The pre-push gate is already correctly isolated for parallel agents (per-worktree run dirs, per-worktree gate lock, golangci-lint allow-parallel-runners) -- audit summary in the new docs section. The remaining failure mode lives at the **consumer layer**:

\`\`\`bash
git push -u origin \"\$branch\" 2>&1 | tail -30   # silent-failure trap
\`\`\`

Without \`set -o pipefail\`, the pipeline returns \`tail\`'s exit code (effectively always 0), masking a real \`git push\` failure -- transient SSH blip, remote ref rejection, hook abort, network drop. The visible output then looks identical to a quiet success, and the agent moves on to open a PR against a branch that never reached origin. Observed in this session: first push of #1511 exited 0 with no remote update; retry succeeded.

\`scripts/safe-push.sh\` wraps the push, mirrors full output to \`\$SW_RUN_DIR/safe-push.log\`, and after \`git push\` returns, queries \`git ls-remote origin <branch>\` to verify the remote SHA matches local HEAD. Returns non-zero with a clear diagnostic on any mismatch.

\`docs/pr-workflow.md\` gains a \"Parallel pushes from sibling worktrees\" section documenting the isolation guarantees, the \`cmd | tail\` anti-pattern, and the helper.

## Behavior

- \`bash scripts/safe-push.sh\` -- push current branch \`-u origin\`
- \`bash scripts/safe-push.sh <branch>\` -- push named branch
- \`bash scripts/safe-push.sh <branch> --force-with-lease\` -- extra flags forwarded to git push
- Exit codes: 0 = pushed AND remote matches local; 1 = push failed OR remote mismatch; 2 = invalid invocation (detached HEAD, missing local branch)

## Test plan

- [x] \`bash -n scripts/safe-push.sh\` syntax clean
- [x] Self-test: this branch was pushed using \`bash scripts/safe-push.sh\` -- gate ran, push reached remote, post-push verification confirmed \`origin/chore/safe-push-and-docs\` matches local HEAD (see push log).
- [ ] Failure-path manual verification (push to a tag that already exists, or invalid remote) -- not exercised here; the code paths are simple and the log lives in \`\$SW_RUN_DIR/safe-push.log\` for diagnosis.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Generated with Claude Code (https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PR workflow with guidance for parallel worktrees, concurrency-safe gating, and recommended safe-push practices.

* **Chores**
  * Added a safe-push utility that records push output, enforces pipefail semantics, and verifies the remote ref matches the local branch to prevent silent push failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1515)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->