### PR TITLE
fix(ui): sanitize pagination hrefs to prevent scheme injection

### DIFF
--- a/web/components/pagination.templ
+++ b/web/components/pagination.templ
@@ -7,6 +7,21 @@ import (
 	"strings"
 )
 
+// safeBaseURL returns base if it starts with "/" (a relative path), or if it
+// has an http/https scheme. Any other value -- including javascript:, data:,
+// and vbscript: -- is replaced with "/" so pageURL never produces a link with
+// a dangerous scheme, regardless of how PaginationData.BaseURL is set.
+func safeBaseURL(base string) string {
+	if strings.HasPrefix(base, "/") {
+		return base
+	}
+	lower := strings.ToLower(base)
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return base
+	}
+	return "/"
+}
+
 // PaginationData holds the state for pagination controls.
 type PaginationData struct {
 	CurrentPage    int
@@ -73,7 +88,7 @@ func (p PaginationData) pageURL(page int) string {
 		// expects on the server side.
 		v.Set("ids", strings.Join(p.IDs, ","))
 	}
-	return p.BaseURL + "?" + v.Encode()
+	return safeBaseURL(p.BaseURL) + "?" + v.Encode()
 }
 
 // LoadMore renders an append-style pagination button that fetches the next page
@@ -123,7 +138,7 @@ templ Pagination(data PaginationData) {
 			<div class="flex flex-1 justify-between sm:justify-end gap-2">
 				if data.CurrentPage > 1 {
 					<a
-						href={ templ.SafeURL(data.pageURL(data.CurrentPage - 1)) }
+						href={ templ.URL(data.pageURL(data.CurrentPage - 1)) }
 						hx-get={ data.pageURL(data.CurrentPage - 1) }
 						hx-target={ data.target() }
 						hx-swap="outerHTML"
@@ -134,7 +149,7 @@ templ Pagination(data PaginationData) {
 				}
 				if data.CurrentPage < data.TotalPages {
 					<a
-						href={ templ.SafeURL(data.pageURL(data.CurrentPage + 1)) }
+						href={ templ.URL(data.pageURL(data.CurrentPage + 1)) }
 						hx-get={ data.pageURL(data.CurrentPage + 1) }
 						hx-target={ data.target() }
 						hx-swap="outerHTML"

--- a/web/components/pagination.templ
+++ b/web/components/pagination.templ
@@ -7,12 +7,15 @@ import (
 	"strings"
 )
 
-// safeBaseURL returns base if it starts with "/" (a relative path), or if it
-// has an http/https scheme. Any other value -- including javascript:, data:,
-// and vbscript: -- is replaced with "/" so pageURL never produces a link with
-// a dangerous scheme, regardless of how PaginationData.BaseURL is set.
+// safeBaseURL returns base if it is a same-origin relative path or carries an
+// http/https scheme. A leading "/" is required, BUT "//" is rejected: browsers
+// resolve "//attacker.tld/path" as a protocol-relative cross-origin URL, which
+// would defeat this hardening boundary. Any other value -- including
+// javascript:, data:, vbscript:, and protocol-relative -- is replaced with "/"
+// so pageURL never produces a link with a dangerous scheme regardless of how
+// PaginationData.BaseURL is set.
 func safeBaseURL(base string) string {
-	if strings.HasPrefix(base, "/") {
+	if strings.HasPrefix(base, "/") && !strings.HasPrefix(base, "//") {
 		return base
 	}
 	lower := strings.ToLower(base)
@@ -88,7 +91,19 @@ func (p PaginationData) pageURL(page int) string {
 		// expects on the server side.
 		v.Set("ids", strings.Join(p.IDs, ","))
 	}
-	return safeBaseURL(p.BaseURL) + "?" + v.Encode()
+	// Parse the base rather than concatenating: if BaseURL already carries
+	// "?" or "#", string concatenation would leak prior state into the
+	// pagination link and produce malformed URLs. RawQuery is REPLACED so
+	// the pagination component's query contract is authoritative; fragment
+	// is dropped because paging anchors don't carry meaning here.
+	base := safeBaseURL(p.BaseURL)
+	u, err := url.Parse(base)
+	if err != nil {
+		u = &url.URL{Path: "/"}
+	}
+	u.RawQuery = v.Encode()
+	u.Fragment = ""
+	return u.String()
 }
 
 // LoadMore renders an append-style pagination button that fetches the next page

--- a/web/components/pagination_templ.go
+++ b/web/components/pagination_templ.go
@@ -15,12 +15,15 @@ import (
 	"strings"
 )
 
-// safeBaseURL returns base if it starts with "/" (a relative path), or if it
-// has an http/https scheme. Any other value -- including javascript:, data:,
-// and vbscript: -- is replaced with "/" so pageURL never produces a link with
-// a dangerous scheme, regardless of how PaginationData.BaseURL is set.
+// safeBaseURL returns base if it is a same-origin relative path or carries an
+// http/https scheme. A leading "/" is required, BUT "//" is rejected: browsers
+// resolve "//attacker.tld/path" as a protocol-relative cross-origin URL, which
+// would defeat this hardening boundary. Any other value -- including
+// javascript:, data:, vbscript:, and protocol-relative -- is replaced with "/"
+// so pageURL never produces a link with a dangerous scheme regardless of how
+// PaginationData.BaseURL is set.
 func safeBaseURL(base string) string {
-	if strings.HasPrefix(base, "/") {
+	if strings.HasPrefix(base, "/") && !strings.HasPrefix(base, "//") {
 		return base
 	}
 	lower := strings.ToLower(base)
@@ -96,7 +99,19 @@ func (p PaginationData) pageURL(page int) string {
 		// expects on the server side.
 		v.Set("ids", strings.Join(p.IDs, ","))
 	}
-	return safeBaseURL(p.BaseURL) + "?" + v.Encode()
+	// Parse the base rather than concatenating: if BaseURL already carries
+	// "?" or "#", string concatenation would leak prior state into the
+	// pagination link and produce malformed URLs. RawQuery is REPLACED so
+	// the pagination component's query contract is authoritative; fragment
+	// is dropped because paging anchors don't carry meaning here.
+	base := safeBaseURL(p.BaseURL)
+	u, err := url.Parse(base)
+	if err != nil {
+		u = &url.URL{Path: "/"}
+	}
+	u.RawQuery = v.Encode()
+	u.Fragment = ""
+	return u.String()
 }
 
 // LoadMore renders an append-style pagination button that fetches the next page
@@ -133,7 +148,7 @@ func LoadMore(remaining, pageSize int, hxGet, hxTarget string) templ.Component {
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(hxGet)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 105, Col: 18}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 120, Col: 18}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -146,7 +161,7 @@ func LoadMore(remaining, pageSize int, hxGet, hxTarget string) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(hxTarget)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 106, Col: 24}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 121, Col: 24}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -159,7 +174,7 @@ func LoadMore(remaining, pageSize int, hxGet, hxTarget string) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Load %d more of %d remaining items", min(pageSize, remaining), remaining))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 109, Col: 103}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 124, Col: 103}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -172,7 +187,7 @@ func LoadMore(remaining, pageSize int, hxGet, hxTarget string) templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(min(pageSize, remaining)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 114, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 129, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -185,7 +200,7 @@ func LoadMore(remaining, pageSize int, hxGet, hxTarget string) templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(remaining))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 114, Col: 82}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 129, Col: 82}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -229,7 +244,7 @@ func Pagination(data PaginationData) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(data.CurrentPage))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 134, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 149, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -242,7 +257,7 @@ func Pagination(data PaginationData) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(data.TotalPages))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 134, Col: 83}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 149, Col: 83}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -255,7 +270,7 @@ func Pagination(data PaginationData) templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(data.TotalItems))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 135, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 150, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -273,7 +288,7 @@ func Pagination(data PaginationData) templ.Component {
 				var templ_7745c5c3_Var11 templ.SafeURL
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(data.pageURL(data.CurrentPage - 1)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 141, Col: 58}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 156, Col: 58}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
@@ -286,7 +301,7 @@ func Pagination(data PaginationData) templ.Component {
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(data.pageURL(data.CurrentPage - 1))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 142, Col: 49}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 157, Col: 49}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -299,7 +314,7 @@ func Pagination(data PaginationData) templ.Component {
 				var templ_7745c5c3_Var13 string
 				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(data.target())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 143, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 158, Col: 31}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 				if templ_7745c5c3_Err != nil {
@@ -318,7 +333,7 @@ func Pagination(data PaginationData) templ.Component {
 				var templ_7745c5c3_Var14 templ.SafeURL
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(data.pageURL(data.CurrentPage + 1)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 152, Col: 58}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 167, Col: 58}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -331,7 +346,7 @@ func Pagination(data PaginationData) templ.Component {
 				var templ_7745c5c3_Var15 string
 				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(data.pageURL(data.CurrentPage + 1))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 153, Col: 49}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 168, Col: 49}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 				if templ_7745c5c3_Err != nil {
@@ -344,7 +359,7 @@ func Pagination(data PaginationData) templ.Component {
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(data.target())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 154, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 169, Col: 31}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 				if templ_7745c5c3_Err != nil {

--- a/web/components/pagination_templ.go
+++ b/web/components/pagination_templ.go
@@ -15,6 +15,21 @@ import (
 	"strings"
 )
 
+// safeBaseURL returns base if it starts with "/" (a relative path), or if it
+// has an http/https scheme. Any other value -- including javascript:, data:,
+// and vbscript: -- is replaced with "/" so pageURL never produces a link with
+// a dangerous scheme, regardless of how PaginationData.BaseURL is set.
+func safeBaseURL(base string) string {
+	if strings.HasPrefix(base, "/") {
+		return base
+	}
+	lower := strings.ToLower(base)
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return base
+	}
+	return "/"
+}
+
 // PaginationData holds the state for pagination controls.
 type PaginationData struct {
 	CurrentPage    int
@@ -81,7 +96,7 @@ func (p PaginationData) pageURL(page int) string {
 		// expects on the server side.
 		v.Set("ids", strings.Join(p.IDs, ","))
 	}
-	return p.BaseURL + "?" + v.Encode()
+	return safeBaseURL(p.BaseURL) + "?" + v.Encode()
 }
 
 // LoadMore renders an append-style pagination button that fetches the next page
@@ -118,7 +133,7 @@ func LoadMore(remaining, pageSize int, hxGet, hxTarget string) templ.Component {
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(hxGet)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 90, Col: 18}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 105, Col: 18}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -131,7 +146,7 @@ func LoadMore(remaining, pageSize int, hxGet, hxTarget string) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(hxTarget)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 91, Col: 24}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 106, Col: 24}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -144,7 +159,7 @@ func LoadMore(remaining, pageSize int, hxGet, hxTarget string) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Load %d more of %d remaining items", min(pageSize, remaining), remaining))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 94, Col: 103}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 109, Col: 103}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -157,7 +172,7 @@ func LoadMore(remaining, pageSize int, hxGet, hxTarget string) templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(min(pageSize, remaining)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 99, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 114, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -170,7 +185,7 @@ func LoadMore(remaining, pageSize int, hxGet, hxTarget string) templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(remaining))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 99, Col: 82}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 114, Col: 82}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -214,7 +229,7 @@ func Pagination(data PaginationData) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(data.CurrentPage))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 119, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 134, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -227,7 +242,7 @@ func Pagination(data PaginationData) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(data.TotalPages))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 119, Col: 83}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 134, Col: 83}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -240,7 +255,7 @@ func Pagination(data PaginationData) templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprint(data.TotalItems))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 120, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 135, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -256,9 +271,9 @@ func Pagination(data PaginationData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var11 templ.SafeURL
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.pageURL(data.CurrentPage - 1)))
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(data.pageURL(data.CurrentPage - 1)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 126, Col: 62}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 141, Col: 58}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
@@ -271,7 +286,7 @@ func Pagination(data PaginationData) templ.Component {
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(data.pageURL(data.CurrentPage - 1))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 127, Col: 49}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 142, Col: 49}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -284,7 +299,7 @@ func Pagination(data PaginationData) templ.Component {
 				var templ_7745c5c3_Var13 string
 				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(data.target())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 128, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 143, Col: 31}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 				if templ_7745c5c3_Err != nil {
@@ -301,9 +316,9 @@ func Pagination(data PaginationData) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var14 templ.SafeURL
-				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(data.pageURL(data.CurrentPage + 1)))
+				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(data.pageURL(data.CurrentPage + 1)))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 137, Col: 62}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 152, Col: 58}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -316,7 +331,7 @@ func Pagination(data PaginationData) templ.Component {
 				var templ_7745c5c3_Var15 string
 				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(data.pageURL(data.CurrentPage + 1))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 138, Col: 49}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 153, Col: 49}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 				if templ_7745c5c3_Err != nil {
@@ -329,7 +344,7 @@ func Pagination(data PaginationData) templ.Component {
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(data.target())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 139, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/components/pagination.templ`, Line: 154, Col: 31}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 				if templ_7745c5c3_Err != nil {

--- a/web/components/pagination_test.go
+++ b/web/components/pagination_test.go
@@ -1,0 +1,182 @@
+package components
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSafeBaseURL verifies that safeBaseURL rejects dangerous schemes and
+// passes through safe relative paths and absolute http/https URLs.
+func TestSafeBaseURL(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		// Safe: relative paths starting with /
+		{"/artists", "/artists"},
+		{"/reports/compliance", "/reports/compliance"},
+		{"//cdn.example.com/path", "//cdn.example.com/path"},
+
+		// Safe: absolute http/https URLs
+		{"http://example.com/page", "http://example.com/page"},
+		{"https://example.com/page", "https://example.com/page"},
+		{"HTTPS://example.com/page", "HTTPS://example.com/page"},
+
+		// Dangerous: must be replaced with "/"
+		{"javascript:alert(1)", "/"},
+		{"JAVASCRIPT:alert(1)", "/"},
+		{"data:text/html,<script>alert(1)</script>", "/"},
+		{"vbscript:msgbox(1)", "/"},
+		{"ftp://attacker.example.com", "/"},
+		{"", "/"},
+	}
+
+	for _, tc := range cases {
+		got := safeBaseURL(tc.input)
+		if got != tc.want {
+			t.Errorf("safeBaseURL(%q) = %q; want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// TestPageURLAllowlist verifies that pageURL only reflects fields from the
+// PaginationData struct and does not pass through unknown query parameters.
+// Because PaginationData is a typed struct (not a raw url.Values map), there
+// is no code path that copies unknown keys -- this test documents that
+// invariant and guards against future regressions.
+func TestPageURLAllowlist(t *testing.T) {
+	data := PaginationData{
+		CurrentPage: 2,
+		TotalPages:  10,
+		PageSize:    25,
+		BaseURL:     "/artists",
+		Sort:        "name",
+		Order:       "asc",
+		Search:      "test",
+		Filter:      "compliant",
+		View:        "grid",
+		LibraryID:   "lib1",
+		Status:      "compliant",
+	}
+
+	// Simulate an attacker who somehow gets sort=javascript:alert(1) into
+	// the struct. Because Sort passes through validateSortParam (allowlist)
+	// before being placed in the struct, this cannot happen in production.
+	// The test shows that even if it did, the value only appears as a
+	// percent-encoded query parameter value, never as the URL scheme.
+	maliciousData := PaginationData{
+		CurrentPage: 2,
+		TotalPages:  10,
+		PageSize:    25,
+		BaseURL:     "/artists",
+		Sort:        "javascript:alert(1)",
+	}
+
+	u := maliciousData.pageURL(3)
+
+	if strings.HasPrefix(u, "javascript:") {
+		t.Errorf("pageURL returned a javascript: URL: %q", u)
+	}
+	if !strings.Contains(u, "sort=") {
+		t.Errorf("pageURL missing sort parameter: %q", u)
+	}
+	// The value must be percent-encoded, not raw.
+	if strings.Contains(u, "javascript:alert") {
+		t.Errorf("pageURL contains un-encoded javascript: in sort value: %q", u)
+	}
+
+	// Verify that a normal call produces the expected known-safe parameters.
+	u2 := data.pageURL(3)
+	for _, param := range []string{"page=3", "page_size=25", "sort=name", "order=asc",
+		"search=test", "filter=compliant", "view=grid", "library_id=lib1", "status=compliant"} {
+		if !strings.Contains(u2, param) {
+			t.Errorf("pageURL missing expected param %q in %q", param, u2)
+		}
+	}
+}
+
+// TestPageURLDataSchemeInSearchValue verifies that a data: URI embedded as a
+// query parameter value does not produce a dangerous href. The value will be
+// percent-encoded by url.Values.Encode and can only appear in the query
+// string, not as the URL scheme.
+func TestPageURLDataSchemeInSearchValue(t *testing.T) {
+	data := PaginationData{
+		CurrentPage: 1,
+		TotalPages:  5,
+		PageSize:    25,
+		BaseURL:     "/artists",
+		Search:      "data:text/html,<script>alert(1)</script>",
+	}
+
+	u := data.pageURL(2)
+
+	if strings.HasPrefix(u, "data:") {
+		t.Errorf("pageURL returned a data: URL: %q", u)
+	}
+	// data: must not appear before the query string marker
+	qmark := strings.Index(u, "?")
+	if qmark < 0 {
+		t.Fatalf("pageURL produced no query string: %q", u)
+	}
+	before := u[:qmark]
+	if strings.Contains(before, "data:") {
+		t.Errorf("data: appears in the URL path portion: %q", before)
+	}
+}
+
+// TestPageURLMaliciousBaseURL verifies that safeBaseURL prevents a dangerous
+// BaseURL from producing a javascript: or data: pagination href.
+func TestPageURLMaliciousBaseURL(t *testing.T) {
+	dangerous := []string{
+		"javascript:alert(1)",
+		"JAVASCRIPT:alert(1)",
+		"data:text/html,<script>alert(1)</script>",
+		"vbscript:msgbox(1)",
+	}
+
+	for _, base := range dangerous {
+		data := PaginationData{
+			CurrentPage: 2,
+			TotalPages:  5,
+			PageSize:    25,
+			BaseURL:     base,
+		}
+
+		u := data.pageURL(3)
+
+		lower := strings.ToLower(u)
+		for _, scheme := range []string{"javascript:", "data:", "vbscript:"} {
+			if strings.HasPrefix(lower, scheme) {
+				t.Errorf("pageURL(%q) produced dangerous URL %q", base, u)
+			}
+		}
+		if !strings.HasPrefix(u, "/") {
+			t.Errorf("pageURL(%q) should start with /; got %q", base, u)
+		}
+	}
+}
+
+// TestPageURLUnknownParamsNotReflected confirms that parameters not in the
+// PaginationData allowlist cannot appear in pagination hrefs. Since
+// PaginationData is a struct, callers cannot inject arbitrary keys.
+// This test documents the structural invariant.
+func TestPageURLUnknownParamsNotReflected(t *testing.T) {
+	data := PaginationData{
+		CurrentPage: 1,
+		TotalPages:  3,
+		PageSize:    25,
+		BaseURL:     "/artists",
+		Sort:        "name",
+		Order:       "asc",
+	}
+
+	u := data.pageURL(2)
+
+	// These parameter names must not appear; they are not in the struct.
+	unknown := []string{"unknown", "evil", "inject", "callback", "redirect"}
+	for _, key := range unknown {
+		if strings.Contains(u, key+"=") {
+			t.Errorf("pageURL contains unexpected parameter %q in %q", key, u)
+		}
+	}
+}

--- a/web/components/pagination_test.go
+++ b/web/components/pagination_test.go
@@ -12,10 +12,9 @@ func TestSafeBaseURL(t *testing.T) {
 		input string
 		want  string
 	}{
-		// Safe: relative paths starting with /
+		// Safe: relative paths starting with / (and not //)
 		{"/artists", "/artists"},
 		{"/reports/compliance", "/reports/compliance"},
-		{"//cdn.example.com/path", "//cdn.example.com/path"},
 
 		// Safe: absolute http/https URLs
 		{"http://example.com/page", "http://example.com/page"},
@@ -29,6 +28,14 @@ func TestSafeBaseURL(t *testing.T) {
 		{"vbscript:msgbox(1)", "/"},
 		{"ftp://attacker.example.com", "/"},
 		{"", "/"},
+		// Dangerous: protocol-relative URLs. Browsers resolve "//host/p" as
+		// cross-origin with the page's current scheme, so an attacker who
+		// can set BaseURL to "//attacker.tld/..." would otherwise drive
+		// pagination links to their own host. Reject the same way as any
+		// other dangerous scheme.
+		{"//attacker.tld/path", "/"},
+		{"//attacker.tld", "/"},
+		{"//cdn.example.com/path", "/"},
 	}
 
 	for _, tc := range cases {
@@ -153,6 +160,37 @@ func TestPageURLMaliciousBaseURL(t *testing.T) {
 		if !strings.HasPrefix(u, "/") {
 			t.Errorf("pageURL(%q) should start with /; got %q", base, u)
 		}
+	}
+}
+
+// TestPageURLPreservesPathStripsQueryFragment verifies that pageURL replaces
+// any prior `?` query and drops any prior `#` fragment from BaseURL, so the
+// pagination component's allowlist is authoritative and stale state cannot
+// leak into the generated link.
+func TestPageURLPreservesPathStripsQueryFragment(t *testing.T) {
+	// BaseURL with a prior query: pageURL must REPLACE the query, not append.
+	data := PaginationData{
+		CurrentPage: 1,
+		TotalPages:  3,
+		PageSize:    25,
+		BaseURL:     "/artists?leftover=1&another=stale",
+	}
+	got := data.pageURL(2)
+	if strings.Contains(got, "leftover=1") || strings.Contains(got, "another=stale") {
+		t.Errorf("pageURL leaked prior query: got %q", got)
+	}
+	if !strings.Contains(got, "page=2") {
+		t.Errorf("pageURL missing page=2: got %q", got)
+	}
+	if strings.Count(got, "?") != 1 {
+		t.Errorf("pageURL produced malformed URL with %d '?' chars: %q", strings.Count(got, "?"), got)
+	}
+
+	// BaseURL with a fragment: the fragment must be dropped.
+	data.BaseURL = "/artists#top"
+	got = data.pageURL(2)
+	if strings.Contains(got, "#") {
+		t.Errorf("pageURL did not strip fragment: got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces `templ.SafeURL()` (bare type cast, skips scheme check) with `templ.URL()` on all pagination `href` attributes in `web/components/pagination.templ`
- Adds a `safeBaseURL()` helper that allows only `/`-prefixed paths and `http`/`https` URLs, blocking `javascript:`, `data:`, and other injection vectors
- Drops any pre-existing query from `BaseURL` entirely (via `u.RawQuery = v.Encode()` after `safeBaseURL` normalization), so generated links only carry the struct-driven params (`page_size`, `sort`, `order`, `search`, `filter`, `view`, `library_id`, `status`)

Part of #1407 (M49.5 W3.3D)

## Test plan

- [ ] `go test -race ./web/...` passes (templ regenerated)
- [ ] UAT: pagination links render correctly on artist list; no regressions on search/filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pagination links now sanitize base URLs, normalize dangerous schemes to a safe path, strip existing query strings and fragments, and ensure Previous/Next hrefs are rendered safely.
  * Generated pagination links include only expected query parameters.

* **Tests**
  * Added comprehensive tests for URL sanitization, allowed query params, fragment stripping, and malicious inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
