### PR TITLE
refactor(updater): thread ctx through Service.Apply instead of discarding it

### DIFF
--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -809,11 +809,11 @@ func (s *Service) Apply(ctx context.Context) error {
 		return ErrAlreadyRunning
 	}
 
-	// Use a background context so the apply goroutine outlives the initiating
-	// HTTP request. The handler already detaches via context.WithoutCancel, but
-	// using context.Background() here makes the intent explicit at the service
-	// layer and avoids any inherited deadline or cancellation from the caller.
-	go s.runApply(context.Background(), "") //nolint:gosec,contextcheck // gosec G118 + contextcheck both fire on this line; apply goroutine intentionally outlives request context (handler already detaches via WithoutCancel)
+	// Pass ctx directly. The handler wraps req.Context() in context.WithoutCancel
+	// before calling Apply, so ctx carries request-scoped values (log/trace
+	// correlation) but has no deadline or cancellation signal. The goroutine
+	// therefore outlives the HTTP request while still inheriting those values.
+	go s.runApply(ctx, "")
 	return nil
 }
 


### PR DESCRIPTION
## Summary

`Service.Apply` accepted a `ctx context.Context` parameter but immediately discarded it, launching `go s.runApply(context.Background(), "")`. The handler passed `context.WithoutCancel(req.Context())` -- a ceremony that produced a value that was then thrown away. Structured log lines inside `runApply` (checksum verified, binary updated successfully) could not be correlated to the originating HTTP request.

Chose **Option B**: pass `ctx` through to `runApply`. The handler's existing `WithoutCancel` call strips cancellation but preserves request-scoped values (logger, trace span), so the goroutine correctly outlives the HTTP request while now carrying request correlation. Both `//nolint:gosec,contextcheck` directives on the goroutine launch were removed -- with a non-`Background` ctx neither linter fires.

## Test plan

- [ ] `go test -race ./internal/updater/...` passes
- [ ] `go test -race ./internal/api/...` passes

Closes #1464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved asynchronous operation handling to preserve request-scoped metadata (such as trace and log correlation) for background work while ensuring those background tasks are not cancelled by transient request lifecycles. This enhances stability and observability of long-running operations without changing public APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->