### PR TITLE
ci(fuzz): target single package per matrix entry

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -118,7 +118,7 @@ jobs:
             -fuzz=^${{ matrix.fuzz_func }}$ \
             -fuzztime=60s \
             -run=^$ \
-            ./${{ matrix.package }}/...
+            ./${{ matrix.package }}
 
       - name: Upload crash corpus on failure
         if: failure()


### PR DESCRIPTION
## Summary

- `go test -fuzz` rejects multi-package selectors: *cannot use -fuzz flag with multiple packages*.
- The scheduled fuzz workflow ran `./internal/api/...`, which expands to `internal/api` + `internal/api/middleware`, failing all three api fuzz jobs (`FuzzHandleAddAlias`, `FuzzHandleFieldUpdate`, `FuzzHandleBulkAction`) in run 26019897576.
- The matrix already pins one `package` per row, so dropping the trailing `/...` is sufficient. nfo/image jobs were unaffected only because those trees happen to have no subpackages — latent footgun, now closed.

## Test plan

- [ ] Next scheduled fuzz run (or manual `workflow_dispatch`) reports all 7 matrix entries green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined internal testing workflow to narrow the scope of automated fuzz test runs.

---

Note: No user-facing changes; this update only adjusts internal test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->