### PR TITLE
refactor(cmd): extract run() startup into staged init phases (#1391)

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -320,7 +320,7 @@ func (a *Application) openStorage() error {
 	a.logger.Info("database ready", slog.String("path", a.cfg.Database.Path))
 
 	// Reload logging settings from DB (overrides config file values if present).
-	loadDBLoggingConfig(db, a.logManager, a.logger)
+	loadDBLoggingConfig(context.Background(), db, a.logManager, a.logger)
 
 	// Derive the image cache directory once so the publisher, API router, and
 	// maintenance service all agree on where cached artist images live.
@@ -368,8 +368,8 @@ func (a *Application) buildServices() error {
 	}
 
 	wireEventBus(a, logger)
-	wireInfraServices(a, db, cfg, logger)
-	applyPersistedBasePath(db, cfg, logger)
+	wireInfraServices(ctx, a, db, cfg, logger)
+	applyPersistedBasePath(ctx, db, cfg, logger)
 	wireEventSubscriptions(a)
 
 	logger.Info("starting stillwater",
@@ -455,16 +455,16 @@ func wireEventBus(a *Application, logger *slog.Logger) {
 
 // wireInfraServices wires backup, maintenance, settingsIO, and updater
 // services that depend only on db and cfg.
-func wireInfraServices(a *Application, db *sql.DB, cfg *config.Config, logger *slog.Logger) {
+func wireInfraServices(ctx context.Context, a *Application, db *sql.DB, cfg *config.Config, logger *slog.Logger) {
 	backupDir := cfg.Backup.Path
 	if backupDir == "" {
 		backupDir = filepath.Join(filepath.Dir(cfg.Database.Path), "backups")
 	}
 	a.backupService = backup.NewService(db, backupDir, cfg.Backup.RetentionCount, logger)
-	if dbRetention := getDBIntSetting(db, "backup_retention_count", 0); dbRetention > 0 {
+	if dbRetention := getDBIntSetting(ctx, db, "backup_retention_count", 0); dbRetention > 0 {
 		a.backupService.SetRetention(dbRetention)
 	}
-	if dbMaxAge := getDBIntSetting(db, "backup_max_age_days", -1); dbMaxAge >= 0 {
+	if dbMaxAge := getDBIntSetting(ctx, db, "backup_max_age_days", -1); dbMaxAge >= 0 {
 		a.backupService.SetMaxAgeDays(dbMaxAge)
 	}
 	a.maintenanceService = maintenance.NewService(db, cfg.Database.Path, a.imageCacheDir, logger)
@@ -510,9 +510,9 @@ func wireEventSubscriptions(a *Application) {
 // the interval is at least 5 minutes.
 func resolveRuleSchedule(a *Application, db *sql.DB, logger *slog.Logger) {
 	ctx := context.Background()
-	a.ruleScheduleMinutes = getDBIntSetting(db, "rule_schedule.interval_minutes", 0)
+	a.ruleScheduleMinutes = getDBIntSetting(ctx, db, "rule_schedule.interval_minutes", 0)
 	if a.ruleScheduleMinutes == 0 {
-		if legacyHours := getDBIntSetting(db, "rule_schedule.interval_hours", 0); legacyHours > 0 {
+		if legacyHours := getDBIntSetting(ctx, db, "rule_schedule.interval_hours", 0); legacyHours > 0 {
 			a.ruleScheduleMinutes = legacyHours * 60
 			_, _ = db.ExecContext(ctx,
 				`INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
@@ -557,8 +557,8 @@ func (a *Application) wireAuth(ctx context.Context) error {
 	a.authService = auth.NewService(db)
 	a.authRegistry = auth.NewRegistry()
 	a.authRegistry.Register(auth.NewLocalProvider(db))
-	authMethod := getDBStringSetting(db, ctx, "auth.method", "local")
-	authServerURL := getDBStringSetting(db, ctx, "auth.server_url", "")
+	authMethod := getDBStringSetting(ctx, db, "auth.method", "local")
+	authServerURL := getDBStringSetting(ctx, db, "auth.server_url", "")
 	if authServerURL != "" {
 		switch authMethod {
 		case "emby":
@@ -738,8 +738,8 @@ func (a *Application) startListeners() error {
 
 	// Maintenance scheduler (interval from DB settings, defaults to daily).
 	{
-		maintEnabled := getDBBoolSetting(db, "db_maintenance.enabled", true)
-		maintHours := getDBIntSetting(db, "db_maintenance.interval_hours", 24)
+		maintEnabled := getDBBoolSetting(ctx, db, "db_maintenance.enabled", true)
+		maintHours := getDBIntSetting(ctx, db, "db_maintenance.interval_hours", 24)
 		if maintHours <= 0 {
 			maintHours = 24
 		}
@@ -750,7 +750,7 @@ func (a *Application) startListeners() error {
 
 	// Proactive exists_flag consistency scanner.
 	{
-		existsFlagHours := getDBIntSetting(db, "exists_flag_scan.interval_hours", 1)
+		existsFlagHours := getDBIntSetting(ctx, db, "exists_flag_scan.interval_hours", 1)
 		if existsFlagHours <= 0 {
 			existsFlagHours = 1
 		}
@@ -759,7 +759,7 @@ func (a *Application) startListeners() error {
 
 	// Foreign-file scanner.
 	{
-		foreignHours := getDBIntSetting(db, "foreign_file_scan.interval_hours", 6)
+		foreignHours := getDBIntSetting(ctx, db, "foreign_file_scan.interval_hours", 6)
 		if foreignHours <= 0 {
 			foreignHours = 6
 		}
@@ -854,11 +854,11 @@ func (a *Application) startListeners() error {
 // (cfg.Server.BasePathFromEnv == false). The HTTP mux is wired once at
 // startup and cannot rebind on the fly; a corrupt persisted value is
 // warn-and-ignored so operators are not locked out.
-func applyPersistedBasePath(db *sql.DB, cfg *config.Config, logger *slog.Logger) {
+func applyPersistedBasePath(ctx context.Context, db *sql.DB, cfg *config.Config, logger *slog.Logger) {
 	if cfg.Server.BasePathFromEnv {
 		return
 	}
-	override := getDBStringSetting(db, context.Background(), "server.base_path", "")
+	override := getDBStringSetting(ctx, db, "server.base_path", "")
 	if override == "" {
 		return
 	}
@@ -1191,14 +1191,13 @@ func backfillDefaultLibrary(ctx context.Context, libService *library.Service, mu
 
 // loadDBLoggingConfig reads logging settings from the DB and reconfigures the
 // log manager if any are present. Called once after migrations.
-func loadDBLoggingConfig(db *sql.DB, mgr *logging.Manager, logger *slog.Logger) {
-	ctx := context.Background()
-	level := getDBStringSetting(db, ctx, "logging.level", "")
-	format := getDBStringSetting(db, ctx, "logging.format", "")
-	filePath := getDBStringSetting(db, ctx, "logging.file_path", "")
-	fileMaxSize := getDBIntSetting(db, "logging.file_max_size_mb", 0)
-	fileMaxFiles := getDBIntSetting(db, "logging.file_max_files", 0)
-	fileMaxAge := getDBIntSetting(db, "logging.file_max_age_days", 0)
+func loadDBLoggingConfig(ctx context.Context, db *sql.DB, mgr *logging.Manager, logger *slog.Logger) {
+	level := getDBStringSetting(ctx, db, "logging.level", "")
+	format := getDBStringSetting(ctx, db, "logging.format", "")
+	filePath := getDBStringSetting(ctx, db, "logging.file_path", "")
+	fileMaxSize := getDBIntSetting(ctx, db, "logging.file_max_size_mb", 0)
+	fileMaxFiles := getDBIntSetting(ctx, db, "logging.file_max_files", 0)
+	fileMaxAge := getDBIntSetting(ctx, db, "logging.file_max_age_days", 0)
 	if level == "" && format == "" && filePath == "" && fileMaxSize <= 0 && fileMaxFiles <= 0 && fileMaxAge <= 0 {
 		return // no DB overrides
 	}
@@ -1260,7 +1259,7 @@ func logFilePathWritable(path string) error {
 }
 
 // getDBStringSetting reads a string setting directly from the database.
-func getDBStringSetting(db *sql.DB, ctx context.Context, key, fallback string) string {
+func getDBStringSetting(ctx context.Context, db *sql.DB, key, fallback string) string {
 	var v string
 	err := db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
 	if err != nil || v == "" {
@@ -1270,9 +1269,9 @@ func getDBStringSetting(db *sql.DB, ctx context.Context, key, fallback string) s
 }
 
 // getDBBoolSetting reads a boolean setting directly from the database.
-func getDBBoolSetting(db *sql.DB, key string, fallback bool) bool {
+func getDBBoolSetting(ctx context.Context, db *sql.DB, key string, fallback bool) bool {
 	var v string
-	err := db.QueryRowContext(context.Background(), `SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
+	err := db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
 	if err != nil {
 		return fallback
 	}
@@ -1308,9 +1307,9 @@ func isValidPersistedBasePath(s string) bool {
 }
 
 // getDBIntSetting reads an integer setting directly from the database.
-func getDBIntSetting(db *sql.DB, key string, fallback int) int {
+func getDBIntSetting(ctx context.Context, db *sql.DB, key string, fallback int) int {
 	var v string
-	err := db.QueryRowContext(context.Background(), `SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
+	err := db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
 	if err != nil || v == "" {
 		return fallback
 	}

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sydlexius/stillwater/internal/database"
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/event"
+	"github.com/sydlexius/stillwater/internal/filesystem"
 	"github.com/sydlexius/stillwater/internal/i18n"
 	"github.com/sydlexius/stillwater/internal/imagebridge"
 	"github.com/sydlexius/stillwater/internal/langpref"
@@ -238,7 +239,8 @@ func run() error {
 // loadConfig reads configuration from the environment and config file.
 // It also performs first-run scaffolding when SW_CONFIG_PATH is set.
 func (a *Application) loadConfig() error {
-	configPath, configPathSet := os.LookupEnv("SW_CONFIG_PATH")
+	rawConfigPath, configPathSet := os.LookupEnv("SW_CONFIG_PATH")
+	configPath := rawConfigPath
 	if configPath == "" {
 		configPath = "/config/config.toml"
 	}
@@ -247,14 +249,15 @@ func (a *Application) loadConfig() error {
 	// the file is missing so admins have a documented starting point. A failure
 	// here is non-fatal; in-code defaults plus env vars are sufficient to boot.
 	//
-	// Only scaffold when the operator has explicitly opted in via
+	// Only scaffold when the operator has explicitly opted in via a non-empty
 	// SW_CONFIG_PATH. Native binary installs that boot with only SW_DB_PATH
 	// and SW_MUSIC_PATH would otherwise log a "could not write scaffold"
 	// warning every startup just because the container default /config is
-	// unwritable on a host filesystem. The container image sets
-	// SW_CONFIG_PATH explicitly, so the Docker first-run experience is
-	// preserved.
-	if configPathSet && configPath != "" {
+	// unwritable on a host filesystem. An explicit SW_CONFIG_PATH="" must be
+	// treated the same as "not set" so the empty-string escape hatch is not
+	// surprising. The container image sets SW_CONFIG_PATH to a real path, so
+	// the Docker first-run experience is preserved.
+	if configPathSet && rawConfigPath != "" {
 		a.scaffolded, a.scaffoldErr = config.EnsureScaffold(configPath)
 	}
 
@@ -906,14 +909,20 @@ func resolveEncryptionKey(cfg *config.Config, logger *slog.Logger) (string, erro
 	dataDir := filepath.Dir(cfg.Database.Path)
 	keyFile := filepath.Join(dataDir, "encryption.key")
 
-	// Try loading from file
+	// Try loading from file. A read error other than "file not found" must be
+	// fatal: silently falling through to key generation would orphan every
+	// previously-encrypted secret if the existing file is unreadable due to
+	// permissions, a filesystem fault, or transient IO failure.
 	data, err := os.ReadFile(keyFile) //nolint:gosec // G304: path derived from trusted config
-	if err == nil {
+	switch {
+	case err == nil:
 		key := strings.TrimSpace(string(data))
 		if key != "" {
 			logger.Debug("loaded encryption key from file", slog.String("path", keyFile))
 			return key, nil
 		}
+	case !errors.Is(err, os.ErrNotExist):
+		return "", fmt.Errorf("reading encryption key file %s: %w", keyFile, err)
 	}
 
 	// Generate a new key
@@ -922,14 +931,16 @@ func resolveEncryptionKey(cfg *config.Config, logger *slog.Logger) (string, erro
 		return "", fmt.Errorf("generating encryption key: %w", err)
 	}
 
-	// Persist to file. Failure here is fatal: if the key is not written,
-	// the next startup generates a different key and makes every previously
-	// encrypted secret unrecoverable (provider API keys, connection API keys).
+	// Persist to file atomically. Failure here is fatal: if the key is not
+	// written, the next startup generates a different key and makes every
+	// previously encrypted secret unrecoverable (provider API keys, connection
+	// API keys). filesystem.WriteFileAtomic uses the tmp/bak/rename pattern so
+	// a crash or disk-full mid-write cannot leave a truncated key on disk.
 	if err := os.MkdirAll(dataDir, 0o750); err != nil {
 		return "", fmt.Errorf("creating data directory for encryption key: %w", err)
 	}
 
-	if err := os.WriteFile(keyFile, []byte(key+"\n"), 0o600); err != nil {
+	if err := filesystem.WriteFileAtomic(keyFile, []byte(key+"\n"), 0o600); err != nil {
 		return "", fmt.Errorf("saving encryption key to file %s: %w", keyFile, err)
 	}
 	logger.Warn("generated new encryption key -- back up this file",

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -99,8 +99,145 @@ func main() {
 	}
 }
 
+// Application holds all initialized state for a Stillwater server instance.
+// Fields are populated in sequence by the staged init phases and consumed by
+// the listener and background-worker phases.
+type Application struct {
+	// Phase: loadConfig
+	cfg         *config.Config
+	configPath  string
+	scaffolded  bool
+	scaffoldErr error
+
+	// Phase: setupLogging
+	logManager *logging.Manager
+	logger     *slog.Logger
+
+	// Phase: openStorage
+	db            *sql.DB
+	imageCacheDir string
+
+	// Phase: wireSecurity
+	encryptor *encryption.Encryptor
+
+	// Phase: buildServices
+	authService         *auth.Service
+	authRegistry        *auth.Registry
+	artistService       *artist.Service
+	historyService      *artist.HistoryService
+	libraryService      *library.Service
+	defaultLibID        string
+	platformService     *platform.Service
+	connectionService   *connection.Service
+	ruleService         *rule.Service
+	ruleEngine          *rule.Engine
+	ruleScheduler       *rule.Scheduler
+	ruleScheduleMinutes int
+	imageBridge         *imagebridge.Bridge
+	scannerService      *scanner.Service
+	rateLimiters        *provider.RateLimiterMap
+	providerSettings    *provider.SettingsService
+	providerRegistry    *provider.Registry
+	webSearchRegistry   *provider.WebSearchRegistry
+	orchestrator        *provider.Orchestrator
+	scraperService      *scraper.Service
+	nfoSnapshotService  *nfo.SnapshotService
+	nfoSettingsService  *nfo.NFOSettingsService
+	fsCheck             *rule.SharedFSCheck
+	expectedWrites      *watcher.ExpectedWrites
+	publisher           *publish.Publisher
+	pipeline            *rule.Pipeline
+	bulkService         *rule.BulkService
+	bulkExecutor        *rule.BulkExecutor
+	eventBus            *event.Bus
+	webhookService      *webhook.Service
+	webhookDispatcher   *webhook.Dispatcher
+	backupService       *backup.Service
+	maintenanceService  *maintenance.Service
+	settingsIOService   *settingsio.Service
+	updaterService      *updater.Service
+	probeCache          *watcher.ProbeCache
+	healthSub           *rule.HealthSubscriber
+	dirtySub            *rule.DirtySubscriber
+	i18nBundle          *i18n.Bundle
+	router              *api.Router
+
+	// Testing seams: override these via functional options before calling run phases.
+	encKeyResolver func(cfg *config.Config, logger *slog.Logger) (string, error)
+	dbOpener       func(path string) (*sql.DB, error)
+}
+
+// Option is a functional option for Application.
+type Option func(*Application)
+
+// WithEncKeyResolver overrides the encryption key resolver (used in tests).
+func WithEncKeyResolver(fn func(cfg *config.Config, logger *slog.Logger) (string, error)) Option {
+	return func(a *Application) { a.encKeyResolver = fn }
+}
+
+// WithDBOpener overrides the database opener (used in tests).
+func WithDBOpener(fn func(path string) (*sql.DB, error)) Option {
+	return func(a *Application) { a.dbOpener = fn }
+}
+
+// newApplication creates an Application with production defaults.
+func newApplication(opts ...Option) *Application {
+	a := &Application{
+		encKeyResolver: resolveEncryptionKey,
+		dbOpener:       database.Open,
+	}
+	for _, o := range opts {
+		o(a)
+	}
+	return a
+}
+
+// run is the top-level server lifecycle. It initializes all phases in order
+// and blocks until the server exits.
+//
+// Each defer is registered immediately after the phase that acquires the
+// resource, so cleanup fires even when a later phase fails. LIFO order:
+// scanner shutdown -> webhook drains -> listener stop -> eventBus.Stop ->
+// logManager.Close -> db.Close.
 func run() error {
-	// Load configuration
+	a := newApplication()
+
+	if err := a.loadConfig(); err != nil {
+		return err
+	}
+	if err := a.setupLogging(); err != nil {
+		return err
+	}
+	defer a.logManager.Close() //nolint:errcheck // Close error not actionable on cleanup
+
+	if err := a.openStorage(); err != nil {
+		return err
+	}
+	defer func() {
+		if err := a.db.Close(); err != nil {
+			a.logger.Error("closing database", "error", err)
+		}
+	}()
+
+	if err := a.wireSecurity(); err != nil {
+		return err
+	}
+	if err := a.buildServices(); err != nil {
+		return err
+	}
+	// eventBus.Start() is launched inside buildServices; register Stop here so
+	// cleanup fires if startListeners fails or returns early.
+	defer a.eventBus.Stop()
+
+	if err := a.startListeners(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadConfig reads configuration from the environment and config file.
+// It also performs first-run scaffolding when SW_CONFIG_PATH is set.
+func (a *Application) loadConfig() error {
 	configPath, configPathSet := os.LookupEnv("SW_CONFIG_PATH")
 	if configPath == "" {
 		configPath = "/config/config.toml"
@@ -117,79 +254,86 @@ func run() error {
 	// unwritable on a host filesystem. The container image sets
 	// SW_CONFIG_PATH explicitly, so the Docker first-run experience is
 	// preserved.
-	var (
-		scaffolded  bool
-		scaffoldErr error
-	)
 	if configPathSet && configPath != "" {
-		scaffolded, scaffoldErr = config.EnsureScaffold(configPath)
+		a.scaffolded, a.scaffoldErr = config.EnsureScaffold(configPath)
 	}
 
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
+	a.cfg = cfg
+	a.configPath = configPath
+	return nil
+}
 
-	// Set up structured logging via the logging Manager
+// setupLogging initializes the structured logging manager from the loaded
+// configuration. After this phase, a.logger and a.logManager are available.
+func (a *Application) setupLogging() error {
+	if a.cfg == nil {
+		return errors.New("setupLogging: loadConfig must run first")
+	}
 	logCfg := logging.Config{
-		Level:  cfg.Logging.Level,
-		Format: cfg.Logging.Format,
+		Level:  a.cfg.Logging.Level,
+		Format: a.cfg.Logging.Format,
 	}
 	logManager, logger := logging.NewManager(logCfg)
-	defer logManager.Close() //nolint:errcheck // Close error not actionable on cleanup
+	a.logManager = logManager
+	a.logger = logger
 	slog.SetDefault(logger)
 
 	// Warn (but do not abort) if the version ldflags injection is malformed.
-	// A bad Version string should not brick the binary; it simply means
-	// auto-update semver comparisons will fail gracefully downstream.
 	if err := version.Validate(); err != nil {
 		logger.Warn("version validation failed; auto-updater will be unable to compare versions. "+
 			"Run a release build via goreleaser, or check the -ldflags injection in the build pipeline",
 			"error", err)
 	}
 
-	if scaffoldErr != nil {
+	if a.scaffoldErr != nil {
 		logger.Warn("could not write first-run config scaffold",
-			"path", configPath, "error", scaffoldErr)
-	} else if scaffolded {
-		logger.Info("wrote first-run config scaffold",
-			"path", configPath)
+			"path", a.configPath, "error", a.scaffoldErr)
+	} else if a.scaffolded {
+		logger.Info("wrote first-run config scaffold", "path", a.configPath)
 	}
+	return nil
+}
 
-	// Open database
-	db, err := database.Open(cfg.Database.Path)
+// openStorage opens the SQLite database, enables foreign keys, runs migrations,
+// reloads logging settings from DB, and derives the image cache directory.
+func (a *Application) openStorage() error {
+	if a.logger == nil {
+		return errors.New("openStorage: setupLogging must run first")
+	}
+	db, err := a.dbOpener(a.cfg.Database.Path)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}
-	defer func() {
-		if err := db.Close(); err != nil {
-			logger.Error("closing database", "error", err)
-		}
-	}()
+	a.db = db
 
-	// Issue #1078: turn on PRAGMA foreign_keys so the ON DELETE CASCADE
-	// declarations on artist_platform_ids, artist_images, rule_violations,
-	// etc. actually fire on artist / connection deletes.
+	// Issue #1078: enable PRAGMA foreign_keys so ON DELETE CASCADE fires.
 	if err := database.EnableForeignKeys(db); err != nil {
 		return fmt.Errorf("enabling foreign keys: %w", err)
 	}
-
-	// Run migrations
 	if err := database.Migrate(db); err != nil {
 		return fmt.Errorf("running migrations: %w", err)
 	}
+	a.logger.Info("database ready", slog.String("path", a.cfg.Database.Path))
 
-	logger.Info("database ready", slog.String("path", cfg.Database.Path))
+	// Reload logging settings from DB (overrides config file values if present).
+	loadDBLoggingConfig(db, a.logManager, a.logger)
 
-	// Reload logging settings from DB (overrides config file values if present)
-	loadDBLoggingConfig(db, logManager, logger)
+	// Derive the image cache directory once so the publisher, API router, and
+	// maintenance service all agree on where cached artist images live.
+	a.imageCacheDir = filepath.Join(filepath.Dir(a.cfg.Database.Path), "cache", "images")
+	return nil
+}
 
-	// Initialize library service and backfill default library
-	libraryService := library.NewService(db)
-	defaultLibID := backfillDefaultLibrary(context.Background(), libraryService, cfg.Music.LibraryPath, db, logger)
-
-	// Resolve encryption key: env var > file > generate new
-	encKey, err := resolveEncryptionKey(cfg, logger)
+// wireSecurity resolves the encryption key and constructs the encryptor.
+func (a *Application) wireSecurity() error {
+	if a.db == nil {
+		return errors.New("wireSecurity: openStorage must run first")
+	}
+	encKey, err := a.encKeyResolver(a.cfg, a.logger)
 	if err != nil {
 		return fmt.Errorf("resolving encryption key: %w", err)
 	}
@@ -197,249 +341,143 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("creating encryptor: %w", err)
 	}
+	a.encryptor = encryptor
+	return nil
+}
 
-	// Initialize services
-	authService := auth.NewService(db)
+// buildServices constructs all domain services and wires their dependencies.
+// This phase delegates to three cohesive sub-phases (wireAuth, wireProviders,
+// wireRuleEngine) before wiring event subscriptions and building the HTTP router.
+func (a *Application) buildServices() error {
+	if a.encryptor == nil {
+		return errors.New("buildServices: wireSecurity must run first")
+	}
+	db := a.db
+	cfg := a.cfg
+	logger := a.logger
+	ctx := context.Background()
 
-	// Build the auth provider registry from the stored auth.method setting.
-	// The local provider is always registered. Federated providers are added
-	// when their corresponding auth.method is configured and a server URL is set.
-	authRegistry := auth.NewRegistry()
-	authRegistry.Register(auth.NewLocalProvider(db))
-	{
-		authMethod := getDBStringSetting(db, context.Background(), "auth.method", "local")
-		authServerURL := getDBStringSetting(db, context.Background(), "auth.server_url", "")
-		if authServerURL != "" {
-			switch authMethod {
-			case "emby":
-				if p, err := auth.NewEmbyProvider(authServerURL, false, "admin", "operator"); err == nil {
-					authRegistry.Register(p)
-				} else {
-					logger.Warn("failed to create emby auth provider", "error", err)
-				}
-			case "jellyfin":
-				if p, err := auth.NewJellyfinProvider(authServerURL, false, "admin", "operator"); err == nil {
-					authRegistry.Register(p)
-				} else {
-					logger.Warn("failed to create jellyfin auth provider", "error", err)
-				}
-			}
-		}
+	if err := a.wireAuth(ctx); err != nil {
+		return err
+	}
+	if err := a.wireProviders(ctx); err != nil {
+		return err
+	}
+	if err := a.wireRuleEngine(ctx, logger); err != nil {
+		return err
 	}
 
-	artistService := artist.NewService(db)
-	historyService := artist.NewHistoryService(db)
-	artistService.SetHistoryService(historyService)
-	platformService := platform.NewService(db)
-	connectionService := connection.NewService(db, encryptor)
+	wireEventBus(a, logger)
+	wireInfraServices(a, db, cfg, logger)
+	applyPersistedBasePath(db, cfg, logger)
+	wireEventSubscriptions(a)
 
-	// Initialize rule engine. The logger is attached so rule-service
-	// diagnostics use the same destination as the rest of the app.
-	// Dirty-tracking for incremental Run Rules (#698) is implemented via
-	// a JOIN in artist.ListDirtyIDs against rules.updated_at, so the rule
-	// service does not need an artist service handle for that side-effect.
-	ruleService := rule.NewService(db).WithLogger(logger)
-	if err := ruleService.SeedDefaults(context.Background()); err != nil {
-		return fmt.Errorf("seeding default rules: %w", err)
+	logger.Info("starting stillwater",
+		slog.String("version", version.Version),
+		slog.String("commit", version.Commit),
+	)
+
+	// Probe filesystem notification support for each library path.
+	a.probeCache = watcher.NewProbeCache()
+	if probLibs, probErr := a.libraryService.List(ctx); probErr != nil {
+		logger.Error("listing libraries for probe", "error", probErr)
+	} else {
+		a.probeCache.ProbeAll(ctx, probLibs, logger)
 	}
-	ruleEngine := rule.NewEngine(ruleService, db, platformService, libraryService, logger)
-	ruleEngine.SetFSCache(rule.NewFSCache(0, 0, logger))
 
-	// Wire platform image bridge so the logo_padding rule can check and fix
-	// images for API-only artists that have no local filesystem path.
-	imageBridge := imagebridge.New(connectionService, artistService, logger)
-	ruleEngine.SetImageFetcher(imageBridge)
-	// Wired below after orchestrator is constructed; this keeps the rule
-	// engine usable during scanner init even though the language-preference
-	// rule will no-op until SetMetadataProvider is called.
+	resolveRuleSchedule(a, db, logger)
 
-	// Initialize scanner (depends on rule engine for health scoring)
-	scannerService := scanner.NewService(artistService, ruleEngine, ruleService, logger, cfg.Music.LibraryPath, cfg.Scanner.Exclusions)
-	scannerService.SetDefaultLibraryID(defaultLibID)
-	scannerService.SetLibraryLister(libraryService)
-
-	// Initialize provider infrastructure
-	rateLimiters := provider.NewRateLimiterMap()
-	providerSettings := provider.NewSettingsService(db, encryptor)
-	providerRegistry := provider.NewRegistry()
-
-	mb := musicbrainz.New(rateLimiters, logger)
-	baseURL, err := providerSettings.GetBaseURL(context.Background(), provider.NameMusicBrainz)
+	// --- i18n ---
+	i18nBundle, err := i18n.LoadEmbedded()
 	if err != nil {
-		logger.Warn("failed to load MusicBrainz mirror URL from database", "error", err)
-	} else if baseURL != "" {
-		mb.SetBaseURL(baseURL)
-		logger.Info("loaded MusicBrainz mirror URL", slog.String("base_url", baseURL))
+		return fmt.Errorf("loading i18n bundle: %w", err)
 	}
+	a.i18nBundle = i18nBundle
 
-	limit, err := providerSettings.GetRateLimit(context.Background(), provider.NameMusicBrainz)
-	if err != nil {
-		logger.Warn("failed to load MusicBrainz rate limit from database", "error", err)
-	} else if limit > 0 {
-		rateLimiters.SetLimit(provider.NameMusicBrainz, rate.Limit(limit))
-		logger.Info("loaded MusicBrainz custom rate limit", slog.Float64("req_per_sec", limit))
-	}
-	providerRegistry.Register(mb)
-	providerRegistry.Register(fanarttv.New(rateLimiters, providerSettings, logger))
-	providerRegistry.Register(audiodb.New(rateLimiters, providerSettings, logger))
-	providerRegistry.Register(discogs.New(rateLimiters, providerSettings, logger))
-	providerRegistry.Register(lastfm.New(rateLimiters, providerSettings, logger))
-	providerRegistry.Register(wikidata.New(rateLimiters, logger))
-	providerRegistry.Register(deezer.New(rateLimiters, logger))
-	providerRegistry.Register(wikipedia.New(rateLimiters, logger))
-	providerRegistry.Register(genius.New(rateLimiters, providerSettings, logger))
-	providerRegistry.Register(spotify.New(rateLimiters, providerSettings, logger))
-
-	webSearchRegistry := provider.NewWebSearchRegistry()
-	webSearchRegistry.Register(duckduckgo.New(rateLimiters, logger))
-
-	orchestrator := provider.NewOrchestrator(providerRegistry, providerSettings, logger)
-
-	// Wire the orchestrator into the rule engine so the name_language_pref
-	// rule can fetch localized aliases for comparison and promotion.
-	ruleEngine.SetMetadataProvider(orchestrator)
-
-	// Initialize scraper configuration and executor
-	scraperService := scraper.NewService(db, logger)
-	if err := scraperService.SeedDefaults(context.Background()); err != nil {
-		return fmt.Errorf("seeding default scraper config: %w", err)
-	}
-	scraperExecutor := scraper.NewExecutor(scraperService, providerRegistry, providerSettings, logger)
-	orchestrator.SetExecutor(scraperExecutor)
-
-	// Initialize NFO snapshot and settings services
-	nfoSnapshotService := nfo.NewSnapshotService(db)
-	nfoSettingsService := nfo.NewNFOSettingsService(db, logger)
-
-	// Initialize shared-filesystem check (used by fixers to skip writes on
-	// libraries whose directories are also managed by a platform connection).
-	fsCheck := rule.NewSharedFSCheck(libraryService, logger)
-
-	// Create expected-writes tracker. The HTTP router and rule fixers register
-	// paths they are about to write. The watcher service maintains this set
-	// (pruning stale entries). External-write detection logic will consume
-	// it when that filtering is enabled. Must be created before consumers.
-	expectedWrites := watcher.NewExpectedWrites()
-
-	// Derive the image cache directory once so the publisher, API router, and
-	// maintenance service all agree on where cached artist images live. If
-	// this convention ever becomes user-configurable, it only has to change
-	// here.
-	imageCacheDir := filepath.Join(filepath.Dir(cfg.Database.Path), "cache", "images")
-
-	// Create the publisher before the pipeline so it can be injected.
-	publisher := publish.New(publish.Deps{
-		ArtistService:      artistService,
-		ConnectionService:  connectionService,
-		LibraryService:     libraryService,
-		NFOSnapshotService: nfoSnapshotService,
-		NFOSettingsService: nfoSettingsService,
-		PlatformService:    platformService,
-		ExpectedWrites:     expectedWrites,
-		ImageCacheDir:      imageCacheDir,
+	// --- HTTP router ---
+	a.router = api.NewRouter(api.RouterDeps{
+		AuthService:        a.authService,
+		AuthRegistry:       a.authRegistry,
+		ArtistService:      a.artistService,
+		HistoryService:     a.historyService,
+		ScannerService:     a.scannerService,
+		PlatformService:    a.platformService,
+		ProviderSettings:   a.providerSettings,
+		ProviderRegistry:   a.providerRegistry,
+		WebSearchRegistry:  a.webSearchRegistry,
+		RateLimiters:       a.rateLimiters,
+		Orchestrator:       a.orchestrator,
+		RuleService:        a.ruleService,
+		RuleEngine:         a.ruleEngine,
+		Pipeline:           a.pipeline,
+		BulkService:        a.bulkService,
+		BulkExecutor:       a.bulkExecutor,
+		NFOSnapshotService: a.nfoSnapshotService,
+		NFOSettingsService: a.nfoSettingsService,
+		ConnectionService:  a.connectionService,
+		ScraperService:     a.scraperService,
+		LibraryService:     a.libraryService,
+		WebhookService:     a.webhookService,
+		WebhookDispatcher:  a.webhookDispatcher,
+		BackupService:      a.backupService,
+		LogManager:         a.logManager,
+		MaintenanceService: a.maintenanceService,
+		SettingsIOService:  a.settingsIOService,
+		UpdaterService:     a.updaterService,
+		ProbeCache:         a.probeCache,
+		ExpectedWrites:     a.expectedWrites,
+		EventBus:           a.eventBus,
+		DB:                 db,
 		Logger:             logger,
+		BasePath:           cfg.Server.BasePath,
+		BasePathFromEnv:    cfg.Server.BasePathFromEnv,
+		TLSStatus:          buildTLSStatus(cfg),
+		HTTP3Port:          server.EffectiveHTTP3Port(cfg),
+		StaticFS:           static.FS,
+		ImageCacheDir:      a.imageCacheDir,
+		Publisher:          a.publisher,
+		RuleScheduler:      a.ruleScheduler,
+		I18nBundle:         a.i18nBundle,
+		Encryptor:          a.encryptor,
 	})
 
-	// Initialize fix pipeline (depends on orchestrator and snapshot service)
-	logoPaddingFixer := rule.NewLogoPaddingFixer(platformService, fsCheck, logger)
-	logoPaddingFixer.SetImageFetcher(imageBridge, ruleEngine.ConsumeAPIImage)
-	fixers := []rule.Fixer{
-		rule.NewNFOFixer(nfoSnapshotService, nfoSettingsService, fsCheck, expectedWrites),
-		rule.NewMetadataFixer(orchestrator, logger),
-		rule.NewNameLanguageFixer(orchestrator, logger),
-		rule.NewImageFixer(orchestrator, platformService, fsCheck, logger),
-		rule.NewExtraneousImagesFixer(platformService, fsCheck, logger),
-		logoPaddingFixer,
-		rule.NewDirectoryRenameFixer(fsCheck, logger),
-		rule.NewBackdropSequencingFixer(platformService, fsCheck, logger),
-	}
-	pipeline := rule.NewPipeline(ruleEngine, artistService, ruleService, fixers, publisher, logger)
-	// Wire the history service so successful auto-fixes appear in the
-	// Recent Activity feed (issue #1106). Setter form keeps NewPipeline's
-	// signature stable for the wide set of test call sites.
-	pipeline.SetHistoryService(historyService)
+	return nil
+}
 
-	// Initialize bulk operations
-	bulkService := rule.NewBulkService(db)
-	bulkExecutor := rule.NewBulkExecutor(bulkService, artistService, orchestrator, pipeline, nfoSnapshotService, platformService, expectedWrites, publisher, logger)
+// wireEventBus initializes the event bus and starts it. The corresponding
+// Stop is deferred in run() immediately after buildServices returns.
+func wireEventBus(a *Application, logger *slog.Logger) {
+	a.eventBus = event.NewBus(logger, 256)
+	go a.eventBus.Start()
+	a.webhookService = webhook.NewService(a.db)
+	a.webhookDispatcher = webhook.NewDispatcher(a.webhookService, logger)
+}
 
-	// Initialize event bus
-	eventBus := event.NewBus(logger, 256)
-	go eventBus.Start()
-	defer eventBus.Stop()
-
-	// Initialize webhook service and dispatcher
-	webhookService := webhook.NewService(db)
-	webhookDispatcher := webhook.NewDispatcher(webhookService, logger)
-
-	// Initialize backup service
+// wireInfraServices wires backup, maintenance, settingsIO, and updater
+// services that depend only on db and cfg.
+func wireInfraServices(a *Application, db *sql.DB, cfg *config.Config, logger *slog.Logger) {
 	backupDir := cfg.Backup.Path
 	if backupDir == "" {
 		backupDir = filepath.Join(filepath.Dir(cfg.Database.Path), "backups")
 	}
-	backupService := backup.NewService(db, backupDir, cfg.Backup.RetentionCount, logger)
+	a.backupService = backup.NewService(db, backupDir, cfg.Backup.RetentionCount, logger)
 	if dbRetention := getDBIntSetting(db, "backup_retention_count", 0); dbRetention > 0 {
-		backupService.SetRetention(dbRetention)
+		a.backupService.SetRetention(dbRetention)
 	}
 	if dbMaxAge := getDBIntSetting(db, "backup_max_age_days", -1); dbMaxAge >= 0 {
-		backupService.SetMaxAgeDays(dbMaxAge)
+		a.backupService.SetMaxAgeDays(dbMaxAge)
 	}
+	a.maintenanceService = maintenance.NewService(db, cfg.Database.Path, a.imageCacheDir, logger)
+	a.settingsIOService = settingsio.NewService(db, a.providerSettings, a.connectionService, a.platformService, a.webhookService).
+		WithRuleService(a.ruleService).
+		WithScraperService(a.scraperService)
+	a.updaterService = updater.NewService(db, logger)
+}
 
-	// Initialize maintenance service
-	maintenanceService := maintenance.NewService(db, cfg.Database.Path, imageCacheDir, logger)
-
-	// Initialize settings export/import service; attach rule and scraper services
-	// so their configurations are included in export/import payloads.
-	settingsIOService := settingsio.NewService(db, providerSettings, connectionService, platformService, webhookService).
-		WithRuleService(ruleService).
-		WithScraperService(scraperService)
-
-	// Initialize self-update service
-	updaterService := updater.NewService(db, logger)
-
-	// Apply persisted SW_BASE_PATH override from settings (#1005). The env
-	// var still wins: when SW_BASE_PATH is set, BasePathFromEnv is true and
-	// we leave the value alone so operator-managed deployments stay
-	// deterministic. Otherwise the saved override (if any) replaces the
-	// YAML/default value before the router is built; the HTTP mux is wired
-	// from this value at startup and cannot rebind on the fly, so the UI
-	// surfaces a "restart required" banner after a save.
-	if !cfg.Server.BasePathFromEnv {
-		if override := getDBStringSetting(db, context.Background(), "server.base_path", ""); override != "" {
-			normalized := strings.TrimRight(override, "/")
-			if normalized == "/" {
-				normalized = ""
-			}
-			// Validate before applying. The HTTP mux composes routes as
-			// basePath+"/api/v1/..." so a malformed override (missing
-			// leading "/") would poison every route pattern and the
-			// process would fail to start with an opaque mux error.
-			// Warn-and-ignore so a corrupt persisted value cannot lock
-			// operators out -- they can repair it via SW_BASE_PATH env or
-			// by editing the settings table directly.
-			//
-			// The persisted value reaches mux pattern composition without a
-			// second pass through the API handler's charset filter, so this
-			// loader must reject the same things directly: a missing leading
-			// "/", a leading "//" or "/\\" (CodeQL "bad redirect check" --
-			// schema-relative URLs and Windows-style separators that could
-			// be reflected back in router/redirect contexts), and any
-			// character outside the API-validated set. The empty string is
-			// the canonical "no override" sentinel and is allowed through.
-			if normalized != "" && !isValidPersistedBasePath(normalized) {
-				logger.Warn("ignoring invalid persisted base_path override",
-					"override", override,
-					"reason", "must start with single \"/\" and contain only letters, digits, hyphens, underscores, and slashes",
-				)
-			} else if normalized != cfg.Server.BasePath {
-				logger.Info("applying persisted base_path override",
-					"previous", cfg.Server.BasePath, "override", normalized)
-				cfg.Server.BasePath = normalized
-			}
-		}
-	}
-
-	// Subscribe dispatcher to all event types
+// wireEventSubscriptions connects the event bus to the webhook dispatcher,
+// scanner, bulk executor, FSCache invalidator, health subscriber, and dirty
+// subscriber. All services wired here must be initialized before this call.
+func wireEventSubscriptions(a *Application) {
 	for _, eventType := range []event.Type{
 		event.ArtistNew, event.MetadataFixed, event.ReviewNeeded,
 		event.RuleViolation, event.BulkCompleted, event.ScanCompleted,
@@ -448,156 +486,238 @@ func run() error {
 		event.JellyfinArtistUpdate, event.JellyfinLibraryScan,
 		event.FSDirCreated, event.FSDirRemoved, event.FSUnexpectedWrite,
 	} {
-		eventBus.Subscribe(eventType, webhookDispatcher.HandleEvent)
+		a.eventBus.Subscribe(eventType, a.webhookDispatcher.HandleEvent)
 	}
-
-	// Wire event bus into scanner and bulk executor
-	scannerService.SetEventBus(eventBus)
-	bulkExecutor.SetEventBus(eventBus)
-
-	// Subscribe to filesystem events so the rule engine's FSCache is
-	// invalidated when directories are created or removed. The "path" field
-	// in the event data identifies the affected directory.
-	if fsCache := ruleEngine.FSCache(); fsCache != nil {
+	a.scannerService.SetEventBus(a.eventBus)
+	a.bulkExecutor.SetEventBus(a.eventBus)
+	if fsCache := a.ruleEngine.FSCache(); fsCache != nil {
 		for _, eventType := range []event.Type{event.FSDirCreated, event.FSDirRemoved, event.FSUnexpectedWrite} {
-			eventBus.Subscribe(eventType, func(ev event.Event) {
+			a.eventBus.Subscribe(eventType, func(ev event.Event) {
 				if p, ok := ev.Data["path"].(string); ok && p != "" {
 					fsCache.InvalidatePath(p)
 				}
 			})
 		}
 	}
+	a.healthSub = rule.NewHealthSubscriber(a.ruleEngine, a.artistService, a.logger)
+	a.eventBus.Subscribe(event.ArtistUpdated, a.healthSub.HandleEvent)
+	a.dirtySub = rule.NewDirtySubscriber(a.artistService, a.logger)
+	a.eventBus.Subscribe(event.ArtistUpdated, a.dirtySub.HandleEvent)
+}
 
-	// Health subscriber: re-evaluates per-artist health scores on mutations.
-	// Subscription is registered now; Start/Bootstrap are called after the
-	// shutdown context is created (below).
-	healthSub := rule.NewHealthSubscriber(ruleEngine, artistService, logger)
-	eventBus.Subscribe(event.ArtistUpdated, healthSub.HandleEvent)
-
-	// Dirty subscriber: marks artists dirty on mutations so the next
-	// incremental "Run Rules" pass re-evaluates only what changed (#698).
-	dirtySub := rule.NewDirtySubscriber(artistService, logger)
-	eventBus.Subscribe(event.ArtistUpdated, dirtySub.HandleEvent)
-
-	logger.Info("starting stillwater",
-		slog.String("version", version.Version),
-		slog.String("commit", version.Commit),
-	)
-
-	// Probe filesystem notification support for each library path.
-	probeCache := watcher.NewProbeCache()
-	{
-		probLibs, probErr := libraryService.List(context.Background())
-		if probErr != nil {
-			logger.Error("listing libraries for probe", "error", probErr)
-		} else {
-			probeCache.ProbeAll(context.Background(), probLibs, logger)
+// resolveRuleSchedule reads the rule schedule interval from the settings table,
+// migrating legacy hours-to-minutes entries, and initializes the scheduler when
+// the interval is at least 5 minutes.
+func resolveRuleSchedule(a *Application, db *sql.DB, logger *slog.Logger) {
+	ctx := context.Background()
+	a.ruleScheduleMinutes = getDBIntSetting(db, "rule_schedule.interval_minutes", 0)
+	if a.ruleScheduleMinutes == 0 {
+		if legacyHours := getDBIntSetting(db, "rule_schedule.interval_hours", 0); legacyHours > 0 {
+			a.ruleScheduleMinutes = legacyHours * 60
+			_, _ = db.ExecContext(ctx,
+				`INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
+				 ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+				"rule_schedule.interval_minutes", fmt.Sprintf("%d", a.ruleScheduleMinutes),
+				time.Now().UTC().Format(time.RFC3339))
+			_, _ = db.ExecContext(ctx, `DELETE FROM settings WHERE key = ?`, "rule_schedule.interval_hours")
+			logger.Info("migrated rule schedule from hours to minutes", "minutes", a.ruleScheduleMinutes)
 		}
 	}
+	if a.ruleScheduleMinutes >= 5 {
+		a.ruleScheduler = rule.NewScheduler(a.pipeline, a.ruleService, a.artistService, logger)
+		langprefRepo := langpref.NewRepository(db)
+		a.ruleScheduler.SetLangPrefProvider(langprefRepo.EffectiveForBackground)
+	} else if a.ruleScheduleMinutes > 0 && a.ruleScheduleMinutes < 5 {
+		logger.Warn("rule scheduler interval too short (minimum 5 minutes); scheduler not started",
+			"minutes", a.ruleScheduleMinutes)
+	}
+}
 
-	// Create rule scheduler before the router so it can be passed as a dependency.
-	// Start() is called later, after the router is fully initialized.
-	var ruleScheduler *rule.Scheduler
-	var ruleScheduleMinutes int
-	{
-		ruleScheduleMinutes = getDBIntSetting(db, "rule_schedule.interval_minutes", 0)
-		// Migrate legacy hours setting: if minutes key is absent, read hours and
-		// persist the converted value so the legacy key can be ignored going forward.
-		if ruleScheduleMinutes == 0 {
-			if legacyHours := getDBIntSetting(db, "rule_schedule.interval_hours", 0); legacyHours > 0 {
-				ruleScheduleMinutes = legacyHours * 60
-				// Persist migrated value and remove legacy key.
-				_, _ = db.ExecContext(context.Background(),
-					`INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
-					 ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
-					"rule_schedule.interval_minutes", fmt.Sprintf("%d", ruleScheduleMinutes),
-					time.Now().UTC().Format(time.RFC3339))
-				_, _ = db.ExecContext(context.Background(),
-					`DELETE FROM settings WHERE key = ?`, "rule_schedule.interval_hours")
-				logger.Info("migrated rule schedule from hours to minutes",
-					"minutes", ruleScheduleMinutes)
+// wireAuth wires the authentication service, registry, and any external auth
+// provider configured in the settings table (emby / jellyfin).
+func (a *Application) wireAuth(ctx context.Context) error {
+	db := a.db
+	logger := a.logger
+	cfg := a.cfg
+
+	// --- Library ---
+	a.libraryService = library.NewService(db)
+	a.defaultLibID = backfillDefaultLibrary(ctx, a.libraryService, cfg.Music.LibraryPath, db, logger)
+
+	// --- Artist / History ---
+	a.artistService = artist.NewService(db)
+	a.historyService = artist.NewHistoryService(db)
+	a.artistService.SetHistoryService(a.historyService)
+
+	// --- Platform / Connection ---
+	a.platformService = platform.NewService(db)
+	a.connectionService = connection.NewService(db, a.encryptor)
+
+	// --- Auth ---
+	a.authService = auth.NewService(db)
+	a.authRegistry = auth.NewRegistry()
+	a.authRegistry.Register(auth.NewLocalProvider(db))
+	authMethod := getDBStringSetting(db, ctx, "auth.method", "local")
+	authServerURL := getDBStringSetting(db, ctx, "auth.server_url", "")
+	if authServerURL != "" {
+		switch authMethod {
+		case "emby":
+			if p, err := auth.NewEmbyProvider(authServerURL, false, "admin", "operator"); err == nil {
+				a.authRegistry.Register(p)
+			} else {
+				logger.Warn("failed to create emby auth provider", "error", err)
+			}
+		case "jellyfin":
+			if p, err := auth.NewJellyfinProvider(authServerURL, false, "admin", "operator"); err == nil {
+				a.authRegistry.Register(p)
+			} else {
+				logger.Warn("failed to create jellyfin auth provider", "error", err)
 			}
 		}
-		if ruleScheduleMinutes >= 5 {
-			ruleScheduler = rule.NewScheduler(pipeline, ruleService, artistService, logger)
-			// Supply language preferences to scheduled rule evaluations.
-			// The HTTP-scoped injector (Router.injectMetadataLanguages)
-			// cannot run here because there is no user session in scope;
-			// the langpref repository picks the primary administrator's
-			// preferences so language-aware rules (e.g. name_language_pref)
-			// evaluate against the operator's configuration on the
-			// scheduled path too. See issue #1136.
-			langprefRepo := langpref.NewRepository(db)
-			ruleScheduler.SetLangPrefProvider(langprefRepo.EffectiveForBackground)
-		} else if ruleScheduleMinutes > 0 && ruleScheduleMinutes < 5 {
-			logger.Warn("rule scheduler interval too short (minimum 5 minutes); scheduler not started",
-				"minutes", ruleScheduleMinutes)
-		}
 	}
+	return nil
+}
 
-	// Load i18n translation bundle (embedded at compile time).
-	i18nBundle, err := i18n.LoadEmbedded()
-	if err != nil {
-		return fmt.Errorf("loading i18n bundle: %w", err)
+// wireProviders wires the metadata provider registry (MusicBrainz, Fanart.tv,
+// and the remaining nine adapters), the web-search registry, the orchestrator,
+// and the scraper service that backs the orchestrator's executor.
+func (a *Application) wireProviders(ctx context.Context) error {
+	db := a.db
+	logger := a.logger
+
+	a.rateLimiters = provider.NewRateLimiterMap()
+	a.providerSettings = provider.NewSettingsService(db, a.encryptor)
+	a.providerRegistry = provider.NewRegistry()
+
+	mb := musicbrainz.New(a.rateLimiters, logger)
+	if baseURL, err := a.providerSettings.GetBaseURL(ctx, provider.NameMusicBrainz); err != nil {
+		logger.Warn("failed to load MusicBrainz mirror URL from database", "error", err)
+	} else if baseURL != "" {
+		mb.SetBaseURL(baseURL)
+		logger.Info("loaded MusicBrainz mirror URL", slog.String("base_url", baseURL))
 	}
+	if limit, err := a.providerSettings.GetRateLimit(ctx, provider.NameMusicBrainz); err != nil {
+		logger.Warn("failed to load MusicBrainz rate limit from database", "error", err)
+	} else if limit > 0 {
+		a.rateLimiters.SetLimit(provider.NameMusicBrainz, rate.Limit(limit))
+		logger.Info("loaded MusicBrainz custom rate limit", slog.Float64("req_per_sec", limit))
+	}
+	a.providerRegistry.Register(mb)
+	a.providerRegistry.Register(fanarttv.New(a.rateLimiters, a.providerSettings, logger))
+	a.providerRegistry.Register(audiodb.New(a.rateLimiters, a.providerSettings, logger))
+	a.providerRegistry.Register(discogs.New(a.rateLimiters, a.providerSettings, logger))
+	a.providerRegistry.Register(lastfm.New(a.rateLimiters, a.providerSettings, logger))
+	a.providerRegistry.Register(wikidata.New(a.rateLimiters, logger))
+	a.providerRegistry.Register(deezer.New(a.rateLimiters, logger))
+	a.providerRegistry.Register(wikipedia.New(a.rateLimiters, logger))
+	a.providerRegistry.Register(genius.New(a.rateLimiters, a.providerSettings, logger))
+	a.providerRegistry.Register(spotify.New(a.rateLimiters, a.providerSettings, logger))
 
-	// Set up HTTP router
-	router := api.NewRouter(api.RouterDeps{
-		AuthService:        authService,
-		AuthRegistry:       authRegistry,
-		ArtistService:      artistService,
-		HistoryService:     historyService,
-		ScannerService:     scannerService,
-		PlatformService:    platformService,
-		ProviderSettings:   providerSettings,
-		ProviderRegistry:   providerRegistry,
-		WebSearchRegistry:  webSearchRegistry,
-		RateLimiters:       rateLimiters,
-		Orchestrator:       orchestrator,
-		RuleService:        ruleService,
-		RuleEngine:         ruleEngine,
-		Pipeline:           pipeline,
-		BulkService:        bulkService,
-		BulkExecutor:       bulkExecutor,
-		NFOSnapshotService: nfoSnapshotService,
-		NFOSettingsService: nfoSettingsService,
-		ConnectionService:  connectionService,
-		ScraperService:     scraperService,
-		LibraryService:     libraryService,
-		WebhookService:     webhookService,
-		WebhookDispatcher:  webhookDispatcher,
-		BackupService:      backupService,
-		LogManager:         logManager,
-		MaintenanceService: maintenanceService,
-		SettingsIOService:  settingsIOService,
-		UpdaterService:     updaterService,
-		ProbeCache:         probeCache,
-		ExpectedWrites:     expectedWrites,
-		EventBus:           eventBus,
-		DB:                 db,
+	a.webSearchRegistry = provider.NewWebSearchRegistry()
+	a.webSearchRegistry.Register(duckduckgo.New(a.rateLimiters, logger))
+
+	a.orchestrator = provider.NewOrchestrator(a.providerRegistry, a.providerSettings, logger)
+
+	// --- Scraper ---
+	a.scraperService = scraper.NewService(db, logger)
+	if err := a.scraperService.SeedDefaults(ctx); err != nil {
+		return fmt.Errorf("seeding default scraper config: %w", err)
+	}
+	scraperExecutor := scraper.NewExecutor(a.scraperService, a.providerRegistry, a.providerSettings, logger)
+	a.orchestrator.SetExecutor(scraperExecutor)
+
+	return nil
+}
+
+// wireRuleEngine wires the rule engine, fixers, pipeline, and bulk executor.
+// wireProviders must run before this sub-phase so that a.orchestrator and
+// a.platformService are available for fixer construction.
+func (a *Application) wireRuleEngine(ctx context.Context, logger *slog.Logger) error {
+	db := a.db
+
+	// --- Rule engine ---
+	a.ruleService = rule.NewService(db).WithLogger(logger)
+	if err := a.ruleService.SeedDefaults(ctx); err != nil {
+		return fmt.Errorf("seeding default rules: %w", err)
+	}
+	a.ruleEngine = rule.NewEngine(a.ruleService, db, a.platformService, a.libraryService, logger)
+	a.ruleEngine.SetFSCache(rule.NewFSCache(0, 0, logger))
+	a.ruleEngine.SetMetadataProvider(a.orchestrator)
+
+	// Wire image bridge so logo_padding rule can check/fix API-only artists.
+	a.imageBridge = imagebridge.New(a.connectionService, a.artistService, logger)
+	a.ruleEngine.SetImageFetcher(a.imageBridge)
+
+	// --- Scanner ---
+	cfg := a.cfg
+	a.scannerService = scanner.NewService(a.artistService, a.ruleEngine, a.ruleService, logger, cfg.Music.LibraryPath, cfg.Scanner.Exclusions)
+	a.scannerService.SetDefaultLibraryID(a.defaultLibID)
+	a.scannerService.SetLibraryLister(a.libraryService)
+
+	// --- NFO ---
+	a.nfoSnapshotService = nfo.NewSnapshotService(db)
+	a.nfoSettingsService = nfo.NewNFOSettingsService(db, logger)
+
+	// --- Rule fixers and pipeline ---
+	a.fsCheck = rule.NewSharedFSCheck(a.libraryService, logger)
+	a.expectedWrites = watcher.NewExpectedWrites()
+
+	a.publisher = publish.New(publish.Deps{
+		ArtistService:      a.artistService,
+		ConnectionService:  a.connectionService,
+		LibraryService:     a.libraryService,
+		NFOSnapshotService: a.nfoSnapshotService,
+		NFOSettingsService: a.nfoSettingsService,
+		PlatformService:    a.platformService,
+		ExpectedWrites:     a.expectedWrites,
+		ImageCacheDir:      a.imageCacheDir,
 		Logger:             logger,
-		BasePath:           cfg.Server.BasePath,
-		BasePathFromEnv:    cfg.Server.BasePathFromEnv,
-		TLSStatus:          buildTLSStatus(cfg),
-		HTTP3Port:          server.EffectiveHTTP3Port(cfg),
-		StaticFS:           static.FS,
-		ImageCacheDir:      imageCacheDir,
-		Publisher:          publisher,
-		RuleScheduler:      ruleScheduler,
-		I18nBundle:         i18nBundle,
-		Encryptor:          encryptor,
 	})
 
-	// Graceful shutdown
+	logoPaddingFixer := rule.NewLogoPaddingFixer(a.platformService, a.fsCheck, logger)
+	logoPaddingFixer.SetImageFetcher(a.imageBridge, a.ruleEngine.ConsumeAPIImage)
+	fixers := []rule.Fixer{
+		rule.NewNFOFixer(a.nfoSnapshotService, a.nfoSettingsService, a.fsCheck, a.expectedWrites),
+		rule.NewMetadataFixer(a.orchestrator, logger),
+		rule.NewNameLanguageFixer(a.orchestrator, logger),
+		rule.NewImageFixer(a.orchestrator, a.platformService, a.fsCheck, logger),
+		rule.NewExtraneousImagesFixer(a.platformService, a.fsCheck, logger),
+		logoPaddingFixer,
+		rule.NewDirectoryRenameFixer(a.fsCheck, logger),
+		rule.NewBackdropSequencingFixer(a.platformService, a.fsCheck, logger),
+	}
+	a.pipeline = rule.NewPipeline(a.ruleEngine, a.artistService, a.ruleService, fixers, a.publisher, logger)
+	a.pipeline.SetHistoryService(a.historyService)
+
+	a.bulkService = rule.NewBulkService(db)
+	a.bulkExecutor = rule.NewBulkExecutor(a.bulkService, a.artistService, a.orchestrator, a.pipeline, a.nfoSnapshotService, a.platformService, a.expectedWrites, a.publisher, logger)
+
+	return nil
+}
+
+// startListeners starts all background workers and the HTTP listener, then
+// blocks until the server exits. It also performs the graceful shutdown
+// sequence including webhook draining and scanner shutdown.
+//
+// logManager.Close, eventBus.Stop, and db.Close are deferred in run() so
+// they fire even if this phase returns early.
+func (a *Application) startListeners() error {
+	if a.router == nil {
+		return errors.New("startListeners: buildServices must run first")
+	}
+	cfg := a.cfg
+	logger := a.logger
+	db := a.db
+
+	// Graceful shutdown signal handling.
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	// Start health subscriber background goroutine
-	go healthSub.Start(ctx)
-	defer healthSub.Stop()
+	// Health subscriber.
+	go a.healthSub.Start(ctx)
+	defer a.healthSub.Stop()
 
-	// Bootstrap stale health scores (zero-score artists) in the background
-	// after a short delay to avoid competing with startup I/O.
+	// Bootstrap stale health scores in the background after a short delay.
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -606,22 +726,17 @@ func run() error {
 		}()
 		select {
 		case <-time.After(5 * time.Second):
-			healthSub.Bootstrap(ctx)
+			a.healthSub.Bootstrap(ctx)
 		case <-ctx.Done():
 		}
 	}()
 
-	// HTTP listener startup is delegated to internal/server so every
-	// configured listener (today the primary HTTP/HTTPS server; later the
-	// HTTP-to-HTTPS redirect, ACME, and HTTP/3 listeners) inherits the
-	// same timeouts and shutdown coordination.
-
-	// Start backup scheduler
+	// Backup scheduler.
 	if cfg.Backup.Enabled {
-		go backupService.StartScheduler(ctx, time.Duration(cfg.Backup.IntervalHours)*time.Hour)
+		go a.backupService.StartScheduler(ctx, time.Duration(cfg.Backup.IntervalHours)*time.Hour)
 	}
 
-	// Start maintenance scheduler (reads interval from DB settings, defaults to daily)
+	// Maintenance scheduler (interval from DB settings, defaults to daily).
 	{
 		maintEnabled := getDBBoolSetting(db, "db_maintenance.enabled", true)
 		maintHours := getDBIntSetting(db, "db_maintenance.interval_hours", 24)
@@ -629,35 +744,29 @@ func run() error {
 			maintHours = 24
 		}
 		if maintEnabled {
-			go maintenanceService.StartScheduler(ctx, time.Duration(maintHours)*time.Hour)
+			go a.maintenanceService.StartScheduler(ctx, time.Duration(maintHours)*time.Hour)
 		}
 	}
 
-	// Start proactive exists_flag consistency scanner (default: every 1 hour).
-	// Reads interval from settings; falls back to 1h to guard against restart loops.
-	// startupDelay gives DB migrations and health bootstrap a chance to settle
-	// before the scanner walks artist_images.
+	// Proactive exists_flag consistency scanner.
 	{
 		existsFlagHours := getDBIntSetting(db, "exists_flag_scan.interval_hours", 1)
 		if existsFlagHours <= 0 {
 			existsFlagHours = 1
 		}
-		go maintenanceService.StartExistsFlagScanner(ctx, time.Duration(existsFlagHours)*time.Hour, 10*time.Second)
+		go a.maintenanceService.StartExistsFlagScanner(ctx, time.Duration(existsFlagHours)*time.Hour, 10*time.Second)
 	}
 
-	// Start the foreign-file scanner (#1185). Runs on a multi-hour cadence
-	// (default 6h) because it walks every artist directory and reads each
-	// image's EXIF, which is not free; users can tune via the
-	// foreign_file_scan.interval_hours setting.
+	// Foreign-file scanner.
 	{
 		foreignHours := getDBIntSetting(db, "foreign_file_scan.interval_hours", 6)
 		if foreignHours <= 0 {
 			foreignHours = 6
 		}
-		go maintenanceService.StartForeignFileScanner(ctx, artistService, time.Duration(foreignHours)*time.Hour, 30*time.Second)
+		go a.maintenanceService.StartForeignFileScanner(ctx, a.artistService, time.Duration(foreignHours)*time.Hour, 30*time.Second)
 	}
 
-	// Start session cleanup goroutine
+	// Session cleanup.
 	go func() {
 		ticker := time.NewTicker(1 * time.Hour)
 		defer ticker.Stop()
@@ -666,32 +775,28 @@ func run() error {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := authService.CleanExpiredSessions(ctx); err != nil {
+				if err := a.authService.CleanExpiredSessions(ctx); err != nil {
 					logger.Error("session cleanup failed", "error", err)
 				}
 			}
 		}
 	}()
 
-	// Start rule evaluation scheduler (created earlier, before the router)
-	if ruleScheduler != nil {
-		go ruleScheduler.Start(ctx, time.Duration(ruleScheduleMinutes)*time.Minute)
+	// Rule scheduler.
+	if a.ruleScheduler != nil {
+		go a.ruleScheduler.Start(ctx, time.Duration(a.ruleScheduleMinutes)*time.Minute)
 	}
 
-	// Start updater background scheduler. The loop respects the persisted
-	// updater.enabled / updater.auto_check toggles on each tick, so an admin
-	// who toggles auto-check from the Settings UI sees the next tick honor
-	// the new value without a restart. The cadence is also reread per tick
-	// so changing check_interval_hours takes effect on the very next cycle.
-	go updaterService.StartScheduler(ctx)
+	// Updater background scheduler.
+	go a.updaterService.StartScheduler(ctx)
 
-	// Start filesystem watcher for libraries with fs_watch enabled
+	// Filesystem watcher for libraries with fs_watch enabled.
 	{
 		scanFn := func(ctx context.Context) error {
-			_, err := scannerService.Run(ctx)
+			_, err := a.scannerService.Run(ctx)
 			return err
 		}
-		watcherService := watcher.NewService(scanFn, libraryService, eventBus, logger, probeCache, expectedWrites)
+		watcherService := watcher.NewService(scanFn, a.libraryService, a.eventBus, logger, a.probeCache, a.expectedWrites)
 		go watcherService.Start(ctx)
 	}
 
@@ -700,28 +805,19 @@ func run() error {
 		slog.String("base_path", cfg.Server.BasePath),
 		slog.Bool("tls", cfg.Server.TLS.Enabled()),
 	}
-	// Surface tls_port only when split-port mode is active so the startup
-	// line is unambiguous about which port serves HTTPS. In collapse mode
-	// (TLS.Port == 0) the existing port field already names the bind.
 	if cfg.Server.TLS.Enabled() && cfg.Server.TLS.Port != 0 && cfg.Server.TLS.Port != cfg.Server.Port {
 		startAttrs = append(startAttrs, slog.Int("tls_port", cfg.Server.TLS.Port))
 	}
 	logger.Info("server starting", startAttrs...)
 
-	// RunListeners blocks until ctx is canceled or a listener fails. It
-	// drains in-flight requests under a 10s shared deadline before
-	// returning, so this is also the point at which we know it is safe to
-	// shut down the scanner -- no new Run() calls can arrive after
-	// listeners are down.
-	srvErr := server.RunListeners(ctx, cfg, router.Handler(ctx), logger)
+	// RunListeners blocks until ctx is canceled or a listener fails.
+	srvErr := server.RunListeners(ctx, cfg, a.router.Handler(ctx), logger)
 
 	logger.Info("shutting down")
 
-	// Cancel the shared ctx now so background goroutines (watcher, scheduled
-	// jobs) stop before the scanner shuts down. On the SIGTERM path stop()
-	// has already fired; on the listener-failure path RunListeners returns
-	// without ctx being canceled, and any goroutine still using ctx could
-	// otherwise schedule a Run() into a draining scanner.
+	// Cancel the shared ctx so background goroutines stop before the scanner
+	// shuts down. On the SIGTERM path stop() has already fired; on the
+	// listener-failure path RunListeners returns without ctx being canceled.
 	stop()
 
 	// Drain in-flight INBOUND webhook handlers first. Each handler can spawn
@@ -733,24 +829,71 @@ func run() error {
 	// stuck in non-context-aware code.
 	inboundDrainCtx, inboundDrainCancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer inboundDrainCancel()
-	if err := router.DrainWebhooks(inboundDrainCtx); err != nil {
+	if err := a.router.DrainWebhooks(inboundDrainCtx); err != nil {
 		logger.Warn("webhook drain did not complete cleanly", "error", err)
 	}
 
-	// Now drain in-flight OUTBOUND webhook deliveries. A 10s deadline matches
+	// Drain in-flight OUTBOUND webhook deliveries. A 10s deadline matches
 	// requestTimeout and prevents a misbehaving external webhook target from
 	// blocking shutdown indefinitely.
 	outboundDrainCtx, outboundDrainCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer outboundDrainCancel()
-	if err := webhookDispatcher.Drain(outboundDrainCtx); err != nil {
+	if err := a.webhookDispatcher.Drain(outboundDrainCtx); err != nil {
 		logger.Warn("webhook drain timed out", slog.String("error", err.Error()))
 	}
 
-	// Now stop the scanner -- the listener layer has drained, so no new
-	// scan requests can race with the scanner's WaitGroup.
-	scannerService.Shutdown()
+	// Stop the scanner -- the listener layer has drained, so no new scan
+	// requests can race with the scanner's WaitGroup.
+	a.scannerService.Shutdown()
 
 	return srvErr
+}
+
+// applyPersistedBasePath reads the server.base_path override from the settings
+// table and applies it to cfg when the env var was not the source of truth
+// (cfg.Server.BasePathFromEnv == false). The HTTP mux is wired once at
+// startup and cannot rebind on the fly; a corrupt persisted value is
+// warn-and-ignored so operators are not locked out.
+func applyPersistedBasePath(db *sql.DB, cfg *config.Config, logger *slog.Logger) {
+	if cfg.Server.BasePathFromEnv {
+		return
+	}
+	override := getDBStringSetting(db, context.Background(), "server.base_path", "")
+	if override == "" {
+		return
+	}
+	normalized := strings.TrimRight(override, "/")
+	if normalized == "/" {
+		normalized = ""
+	}
+	// Validate before applying. The HTTP mux composes routes as
+	// basePath+"/api/v1/..." so a malformed override (missing
+	// leading "/") would poison every route pattern and the
+	// process would fail to start with an opaque mux error.
+	// Warn-and-ignore so a corrupt persisted value cannot lock
+	// operators out -- they can repair it via SW_BASE_PATH env or
+	// by editing the settings table directly.
+	//
+	// The persisted value reaches mux pattern composition without a
+	// second pass through the API handler's charset filter, so this
+	// loader must reject the same things directly: a missing leading
+	// "/", a leading "//" or "/\\" (CodeQL "bad redirect check" --
+	// schema-relative URLs and Windows-style separators that could
+	// be reflected back in router/redirect contexts), and any
+	// character outside the API-validated set. The empty string is
+	// the canonical "no override" sentinel and is allowed through.
+	if normalized != "" && !isValidPersistedBasePath(normalized) {
+		logger.Warn("ignoring invalid persisted base_path override",
+			"override", override,
+			"reason", "must start with single \"/\" and contain only letters, digits, hyphens, underscores, and slashes",
+		)
+		return
+	}
+	if normalized != cfg.Server.BasePath {
+		logger.Info("applying persisted base_path override",
+			"previous", cfg.Server.BasePath, "override", normalized)
+		cfg.Server.BasePath = normalized
+	}
 }
 
 // resolveEncryptionKey determines the encryption key to use.
@@ -779,20 +922,18 @@ func resolveEncryptionKey(cfg *config.Config, logger *slog.Logger) (string, erro
 		return "", fmt.Errorf("generating encryption key: %w", err)
 	}
 
-	// Persist to file
+	// Persist to file. Failure here is fatal: if the key is not written,
+	// the next startup generates a different key and makes every previously
+	// encrypted secret unrecoverable (provider API keys, connection API keys).
 	if err := os.MkdirAll(dataDir, 0o750); err != nil {
-		logger.Warn("could not create data directory for encryption key",
-			slog.String("path", dataDir), slog.Any("error", err))
-		return key, nil
+		return "", fmt.Errorf("creating data directory for encryption key: %w", err)
 	}
 
 	if err := os.WriteFile(keyFile, []byte(key+"\n"), 0o600); err != nil {
-		logger.Warn("could not save encryption key to file",
-			slog.String("path", keyFile), slog.Any("error", err))
-	} else {
-		logger.Warn("generated new encryption key -- back up this file",
-			slog.String("path", keyFile))
+		return "", fmt.Errorf("saving encryption key to file %s: %w", keyFile, err)
 	}
+	logger.Warn("generated new encryption key -- back up this file",
+		slog.String("path", keyFile))
 
 	return key, nil
 }

--- a/cmd/stillwater/phases_test.go
+++ b/cmd/stillwater/phases_test.go
@@ -1,0 +1,493 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/config"
+	"github.com/sydlexius/stillwater/internal/database"
+)
+
+// --- Helpers ---
+
+// newTestApp builds a minimal Application with testing-safe defaults.
+// The dbOpener is wired to use a temp-dir SQLite file unless overridden.
+func newTestApp(t *testing.T, opts ...Option) *Application {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	defaultOpener := func(path string) (*sql.DB, error) {
+		return database.Open(path)
+	}
+	base := []Option{WithDBOpener(defaultOpener)}
+	app := newApplication(append(base, opts...)...)
+	app.cfg = &config.Config{}
+	app.cfg.Database.Path = dbPath
+	app.cfg.Logging.Level = "error" // quiet during tests
+	return app
+}
+
+// initLogging is a helper that runs setupLogging on app, returning a cleanup
+// function that closes the log manager.
+func initLogging(t *testing.T, app *Application) func() {
+	t.Helper()
+	if err := app.setupLogging(); err != nil {
+		t.Fatalf("setupLogging: %v", err)
+	}
+	return func() { app.logManager.Close() }
+}
+
+// --- loadConfig tests ---
+
+func TestLoadConfig_DefaultPath(t *testing.T) {
+	// Unset SW_CONFIG_PATH so that loadConfig falls back to the default
+	// path. The default (/config/config.toml) will not exist in CI, but
+	// config.Load is expected to succeed with defaults when the file is
+	// absent.
+	t.Setenv("SW_CONFIG_PATH", "")
+	app := newApplication()
+	// config.Load returns defaults when file does not exist, so this must
+	// succeed even in a clean environment.
+	if err := app.loadConfig(); err != nil {
+		t.Fatalf("loadConfig with absent file: %v", err)
+	}
+	if app.cfg == nil {
+		t.Fatal("cfg must not be nil after loadConfig")
+	}
+}
+
+func TestLoadConfig_ExplicitPath(t *testing.T) {
+	// Create a minimal TOML config file.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte("[server]\nport = 9999\n"), 0o600); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	t.Setenv("SW_CONFIG_PATH", cfgPath)
+	app := newApplication()
+	if err := app.loadConfig(); err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if app.cfg == nil {
+		t.Fatal("cfg must not be nil")
+	}
+}
+
+// --- setupLogging tests ---
+
+func TestSetupLogging_HappyPath(t *testing.T) {
+	app := newTestApp(t)
+	if err := app.setupLogging(); err != nil {
+		t.Fatalf("setupLogging: %v", err)
+	}
+	defer app.logManager.Close()
+	if app.logger == nil {
+		t.Fatal("logger must not be nil after setupLogging")
+	}
+	if app.logManager == nil {
+		t.Fatal("logManager must not be nil after setupLogging")
+	}
+}
+
+func TestSetupLogging_ScaffoldWarnLogged(t *testing.T) {
+	// Verify that a non-nil scaffoldErr is tolerated (only logs a warning,
+	// does not return an error).
+	app := newTestApp(t)
+	app.scaffoldErr = errors.New("simulated scaffold error")
+	if err := app.setupLogging(); err != nil {
+		t.Fatalf("setupLogging must succeed even with scaffoldErr: %v", err)
+	}
+	defer app.logManager.Close()
+}
+
+// --- openStorage tests ---
+
+func TestOpenStorage_HappyPath(t *testing.T) {
+	app := newTestApp(t)
+	defer initLogging(t, app)()
+
+	if err := app.openStorage(); err != nil {
+		t.Fatalf("openStorage: %v", err)
+	}
+	defer app.db.Close()
+	if app.db == nil {
+		t.Fatal("db must not be nil after openStorage")
+	}
+	if app.imageCacheDir == "" {
+		t.Fatal("imageCacheDir must not be empty after openStorage")
+	}
+}
+
+func TestOpenStorage_DBOpenFailure(t *testing.T) {
+	app := newTestApp(t, WithDBOpener(func(path string) (*sql.DB, error) {
+		return nil, errors.New("simulated open failure")
+	}))
+	defer initLogging(t, app)()
+
+	err := app.openStorage()
+	if err == nil {
+		t.Fatal("expected error from openStorage when db open fails")
+	}
+	if app.db != nil {
+		t.Fatal("db must be nil when openStorage fails")
+	}
+}
+
+func TestOpenStorage_ImageCacheDirDerived(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "data", "stillwater.db")
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	app := newTestApp(t)
+	app.cfg.Database.Path = dbPath
+	defer initLogging(t, app)()
+
+	if err := app.openStorage(); err != nil {
+		t.Fatalf("openStorage: %v", err)
+	}
+	defer app.db.Close()
+
+	wantDir := filepath.Join(dir, "data", "cache", "images")
+	if app.imageCacheDir != wantDir {
+		t.Errorf("imageCacheDir = %q; want %q", app.imageCacheDir, wantDir)
+	}
+}
+
+// --- wireSecurity tests ---
+
+func TestWireSecurity_HappyPath(t *testing.T) {
+	app := newTestApp(t, WithEncKeyResolver(func(_ *config.Config, _ *slog.Logger) (string, error) {
+		// base64-encoded 32-byte key (valid for encryption.NewEncryptor)
+		return "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=", nil
+	}))
+	defer initLogging(t, app)()
+	if err := app.openStorage(); err != nil {
+		t.Fatalf("openStorage: %v", err)
+	}
+	defer app.db.Close()
+
+	if err := app.wireSecurity(); err != nil {
+		t.Fatalf("wireSecurity: %v", err)
+	}
+	if app.encryptor == nil {
+		t.Fatal("encryptor must not be nil after wireSecurity")
+	}
+}
+
+func TestWireSecurity_KeyResolverError(t *testing.T) {
+	app := newTestApp(t, WithEncKeyResolver(func(_ *config.Config, _ *slog.Logger) (string, error) {
+		return "", errors.New("simulated key resolver error")
+	}))
+	defer initLogging(t, app)()
+	if err := app.openStorage(); err != nil {
+		t.Fatalf("openStorage: %v", err)
+	}
+	defer app.db.Close()
+
+	err := app.wireSecurity()
+	if err == nil {
+		t.Fatal("expected error when key resolver fails")
+	}
+	if app.encryptor != nil {
+		t.Fatal("encryptor must be nil when wireSecurity fails")
+	}
+}
+
+// --- resolveEncryptionKey tests ---
+
+func TestResolveEncryptionKey_ConfigKeyWins(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Encryption.Key = "configkey"
+	logger := slog.Default()
+	key, err := resolveEncryptionKey(cfg, logger)
+	if err != nil {
+		t.Fatalf("resolveEncryptionKey: %v", err)
+	}
+	if key != "configkey" {
+		t.Errorf("key = %q; want %q", key, "configkey")
+	}
+}
+
+func TestResolveEncryptionKey_GeneratesWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Database.Path = filepath.Join(dir, "data", "stillwater.db")
+	logger := slog.Default()
+	key, err := resolveEncryptionKey(cfg, logger)
+	if err != nil {
+		t.Fatalf("resolveEncryptionKey: %v", err)
+	}
+	if key == "" {
+		t.Fatal("generated key must not be empty")
+	}
+	// The key should have been written to the data directory.
+	keyFile := filepath.Join(dir, "data", "encryption.key")
+	if _, statErr := os.Stat(keyFile); statErr != nil {
+		t.Errorf("expected key file at %s: %v", keyFile, statErr)
+	}
+}
+
+func TestResolveEncryptionKey_LoadsFromFile(t *testing.T) {
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "encryption.key")
+	const want = "fileloadedkey"
+	if err := os.WriteFile(keyFile, []byte(want+"\n"), 0o600); err != nil {
+		t.Fatalf("writing key file: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Database.Path = filepath.Join(dir, "stillwater.db")
+	logger := slog.Default()
+	key, err := resolveEncryptionKey(cfg, logger)
+	if err != nil {
+		t.Fatalf("resolveEncryptionKey: %v", err)
+	}
+	if key != want {
+		t.Errorf("key = %q; want %q", key, want)
+	}
+}
+
+// --- applyPersistedBasePath tests ---
+
+func TestApplyPersistedBasePath_EnvWins(t *testing.T) {
+	db := openTestDB(t)
+	cfg := &config.Config{}
+	cfg.Server.BasePath = "/original"
+	cfg.Server.BasePathFromEnv = true
+	// Even if there is a DB override, env-derived value must not be replaced.
+	if _, err := db.ExecContext(context.Background(),
+		`INSERT INTO settings (key, value, updated_at) VALUES ('server.base_path', '/override', '2024-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("inserting test row: %v", err)
+	}
+	logger := slog.Default()
+	applyPersistedBasePath(db, cfg, logger)
+	if cfg.Server.BasePath != "/original" {
+		t.Errorf("BasePath = %q; want %q", cfg.Server.BasePath, "/original")
+	}
+}
+
+func TestApplyPersistedBasePath_AppliesValidOverride(t *testing.T) {
+	db := openTestDB(t)
+	cfg := &config.Config{}
+	cfg.Server.BasePath = ""
+	cfg.Server.BasePathFromEnv = false
+	if _, err := db.ExecContext(context.Background(),
+		`INSERT INTO settings (key, value, updated_at) VALUES ('server.base_path', '/sw', '2024-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("inserting test row: %v", err)
+	}
+	logger := slog.Default()
+	applyPersistedBasePath(db, cfg, logger)
+	if cfg.Server.BasePath != "/sw" {
+		t.Errorf("BasePath = %q; want %q", cfg.Server.BasePath, "/sw")
+	}
+}
+
+func TestApplyPersistedBasePath_RejectsInvalidOverride(t *testing.T) {
+	db := openTestDB(t)
+	cfg := &config.Config{}
+	cfg.Server.BasePath = "/original"
+	cfg.Server.BasePathFromEnv = false
+	// Double-slash is invalid.
+	if _, err := db.ExecContext(context.Background(),
+		`INSERT INTO settings (key, value, updated_at) VALUES ('server.base_path', '//evil', '2024-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("inserting test row: %v", err)
+	}
+	logger := slog.Default()
+	applyPersistedBasePath(db, cfg, logger)
+	if cfg.Server.BasePath != "/original" {
+		t.Errorf("BasePath should remain %q after invalid override, got %q", "/original", cfg.Server.BasePath)
+	}
+}
+
+// --- isValidPersistedBasePath tests (already had indirect coverage; add explicit) ---
+
+func TestIsValidPersistedBasePath(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"/app", true},
+		{"/my-app/v2", true},
+		{"app", false},          // missing leading /
+		{"//evil", false},       // double slash
+		{"/evil\\ path", false}, // backslash
+		{"/has space", false},
+	}
+	for _, tc := range cases {
+		if got := isValidPersistedBasePath(tc.input); got != tc.want {
+			t.Errorf("isValidPersistedBasePath(%q) = %v; want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+// --- getDBStringSetting / getDBBoolSetting / getDBIntSetting tests ---
+
+func TestGetDBStringSetting_FallbackOnMiss(t *testing.T) {
+	db := openTestDB(t)
+	got := getDBStringSetting(db, context.Background(), "nonexistent.key", "default")
+	if got != "default" {
+		t.Errorf("got %q; want %q", got, "default")
+	}
+}
+
+func TestGetDBStringSetting_ReturnsStoredValue(t *testing.T) {
+	db := openTestDB(t)
+	if _, err := db.ExecContext(context.Background(),
+		`INSERT INTO settings (key, value, updated_at) VALUES ('test.key', 'hello', '2024-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("inserting test row: %v", err)
+	}
+	got := getDBStringSetting(db, context.Background(), "test.key", "fallback")
+	if got != "hello" {
+		t.Errorf("got %q; want %q", got, "hello")
+	}
+}
+
+func TestGetDBBoolSetting_TrueValues(t *testing.T) {
+	db := openTestDB(t)
+	for _, v := range []string{"true", "1"} {
+		if _, err := db.ExecContext(context.Background(),
+			`INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('b.key', ?, '2024-01-01T00:00:00Z')`, v); err != nil {
+			t.Fatalf("inserting bool test row for %q: %v", v, err)
+		}
+		if !getDBBoolSetting(db, "b.key", false) {
+			t.Errorf("expected true for stored value %q", v)
+		}
+	}
+}
+
+// TestGetDBBoolSetting_FalseValues verifies that values not in the true-set
+// ("true", "1") return false, preventing silent parser regressions.
+func TestGetDBBoolSetting_FalseValues(t *testing.T) {
+	db := openTestDB(t)
+	for _, v := range []string{"false", "0", "no", "off", ""} {
+		if _, err := db.ExecContext(context.Background(),
+			`INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('b2.key', ?, '2024-01-01T00:00:00Z')`, v); err != nil {
+			t.Fatalf("inserting bool test row for %q: %v", v, err)
+		}
+		if getDBBoolSetting(db, "b2.key", true) {
+			t.Errorf("expected false for stored value %q", v)
+		}
+	}
+}
+
+func TestGetDBBoolSetting_FallbackOnMiss(t *testing.T) {
+	db := openTestDB(t)
+	if getDBBoolSetting(db, "missing.bool", true) != true {
+		t.Error("expected fallback true")
+	}
+}
+
+func TestGetDBIntSetting_ReturnsStoredValue(t *testing.T) {
+	db := openTestDB(t)
+	if _, err := db.ExecContext(context.Background(),
+		`INSERT INTO settings (key, value, updated_at) VALUES ('int.key', '42', '2024-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("inserting test row: %v", err)
+	}
+	if got := getDBIntSetting(db, "int.key", 0); got != 42 {
+		t.Errorf("got %d; want 42", got)
+	}
+}
+
+func TestGetDBIntSetting_FallbackOnMiss(t *testing.T) {
+	db := openTestDB(t)
+	if got := getDBIntSetting(db, "missing.int", 7); got != 7 {
+		t.Errorf("got %d; want 7", got)
+	}
+}
+
+func TestGetDBIntSetting_FallbackOnNonNumeric(t *testing.T) {
+	db := openTestDB(t)
+	if _, err := db.ExecContext(context.Background(),
+		`INSERT INTO settings (key, value, updated_at) VALUES ('bad.int', 'notanumber', '2024-01-01T00:00:00Z')`); err != nil {
+		t.Fatalf("inserting test row: %v", err)
+	}
+	if got := getDBIntSetting(db, "bad.int", 99); got != 99 {
+		t.Errorf("got %d; want fallback 99", got)
+	}
+}
+
+// --- resolveEncryptionKey edge-case tests ---
+
+// TestResolveEncryptionKey_EmptyFile verifies that an empty key file does not
+// produce an empty key; the function must generate a new one instead.
+func TestResolveEncryptionKey_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "encryption.key")
+	if err := os.WriteFile(keyFile, []byte(""), 0o600); err != nil {
+		t.Fatalf("writing empty key file: %v", err)
+	}
+	cfg := &config.Config{}
+	cfg.Database.Path = filepath.Join(dir, "stillwater.db")
+	key, err := resolveEncryptionKey(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("resolveEncryptionKey: %v", err)
+	}
+	if key == "" {
+		t.Fatal("expected a non-empty generated key when key file is empty")
+	}
+}
+
+// TestResolveEncryptionKey_WhitespaceOnlyFile verifies that a whitespace-only
+// key file is treated as absent and a new key is generated.
+func TestResolveEncryptionKey_WhitespaceOnlyFile(t *testing.T) {
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "encryption.key")
+	if err := os.WriteFile(keyFile, []byte("   \n\t  \n"), 0o600); err != nil {
+		t.Fatalf("writing whitespace key file: %v", err)
+	}
+	cfg := &config.Config{}
+	cfg.Database.Path = filepath.Join(dir, "stillwater.db")
+	key, err := resolveEncryptionKey(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("resolveEncryptionKey: %v", err)
+	}
+	if key == "" {
+		t.Fatal("expected a non-empty generated key when key file is whitespace-only")
+	}
+}
+
+// TestResolveEncryptionKey_TrailingNewlineStripped verifies that a key stored
+// with a trailing newline is loaded exactly, without the newline, so roundtrip
+// behavior is stable across restarts.
+func TestResolveEncryptionKey_TrailingNewlineStripped(t *testing.T) {
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "encryption.key")
+	const want = "mybase64encodedkey=="
+	if err := os.WriteFile(keyFile, []byte(want+"\n"), 0o600); err != nil {
+		t.Fatalf("writing key file: %v", err)
+	}
+	cfg := &config.Config{}
+	cfg.Database.Path = filepath.Join(dir, "stillwater.db")
+	key, err := resolveEncryptionKey(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("resolveEncryptionKey: %v", err)
+	}
+	if key != want {
+		t.Errorf("key = %q; want %q (trailing newline must be stripped)", key, want)
+	}
+}
+
+// --- loadConfig error tests ---
+
+// TestLoadConfig_MalformedFile verifies that a syntactically invalid config
+// file produces a wrapped error rather than silently returning defaults.
+func TestLoadConfig_MalformedFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	// Write TOML that is syntactically invalid (unclosed bracket).
+	if err := os.WriteFile(cfgPath, []byte("[server\nport = 9999\n"), 0o600); err != nil {
+		t.Fatalf("writing malformed config: %v", err)
+	}
+	t.Setenv("SW_CONFIG_PATH", cfgPath)
+	app := newApplication()
+	err := app.loadConfig()
+	if err == nil {
+		t.Fatal("expected an error for a malformed config file, got nil")
+	}
+}

--- a/cmd/stillwater/phases_test.go
+++ b/cmd/stillwater/phases_test.go
@@ -45,11 +45,23 @@ func initLogging(t *testing.T, app *Application) func() {
 // --- loadConfig tests ---
 
 func TestLoadConfig_DefaultPath(t *testing.T) {
-	// Unset SW_CONFIG_PATH so that loadConfig falls back to the default
-	// path. The default (/config/config.toml) will not exist in CI, but
-	// config.Load is expected to succeed with defaults when the file is
-	// absent.
-	t.Setenv("SW_CONFIG_PATH", "")
+	// Unset SW_CONFIG_PATH entirely so loadConfig exercises the env-absent
+	// branch and falls back to the default path. t.Setenv("", "") would
+	// instead exercise the explicit-empty branch, which is a distinct code
+	// path now that empty values do not opt into scaffolding. The default
+	// (/config/config.toml) will not exist in CI, but config.Load is
+	// expected to succeed with defaults when the file is absent.
+	prev, hadPrev := os.LookupEnv("SW_CONFIG_PATH")
+	if err := os.Unsetenv("SW_CONFIG_PATH"); err != nil {
+		t.Fatalf("unsetting SW_CONFIG_PATH: %v", err)
+	}
+	t.Cleanup(func() {
+		if hadPrev {
+			_ = os.Setenv("SW_CONFIG_PATH", prev)
+		} else {
+			_ = os.Unsetenv("SW_CONFIG_PATH")
+		}
+	})
 	app := newApplication()
 	// config.Load returns defaults when file does not exist, so this must
 	// succeed even in a clean environment.

--- a/cmd/stillwater/phases_test.go
+++ b/cmd/stillwater/phases_test.go
@@ -266,7 +266,7 @@ func TestApplyPersistedBasePath_EnvWins(t *testing.T) {
 		t.Fatalf("inserting test row: %v", err)
 	}
 	logger := slog.Default()
-	applyPersistedBasePath(db, cfg, logger)
+	applyPersistedBasePath(context.Background(), db, cfg, logger)
 	if cfg.Server.BasePath != "/original" {
 		t.Errorf("BasePath = %q; want %q", cfg.Server.BasePath, "/original")
 	}
@@ -282,7 +282,7 @@ func TestApplyPersistedBasePath_AppliesValidOverride(t *testing.T) {
 		t.Fatalf("inserting test row: %v", err)
 	}
 	logger := slog.Default()
-	applyPersistedBasePath(db, cfg, logger)
+	applyPersistedBasePath(context.Background(), db, cfg, logger)
 	if cfg.Server.BasePath != "/sw" {
 		t.Errorf("BasePath = %q; want %q", cfg.Server.BasePath, "/sw")
 	}
@@ -299,7 +299,7 @@ func TestApplyPersistedBasePath_RejectsInvalidOverride(t *testing.T) {
 		t.Fatalf("inserting test row: %v", err)
 	}
 	logger := slog.Default()
-	applyPersistedBasePath(db, cfg, logger)
+	applyPersistedBasePath(context.Background(), db, cfg, logger)
 	if cfg.Server.BasePath != "/original" {
 		t.Errorf("BasePath should remain %q after invalid override, got %q", "/original", cfg.Server.BasePath)
 	}
@@ -330,7 +330,7 @@ func TestIsValidPersistedBasePath(t *testing.T) {
 
 func TestGetDBStringSetting_FallbackOnMiss(t *testing.T) {
 	db := openTestDB(t)
-	got := getDBStringSetting(db, context.Background(), "nonexistent.key", "default")
+	got := getDBStringSetting(context.Background(), db, "nonexistent.key", "default")
 	if got != "default" {
 		t.Errorf("got %q; want %q", got, "default")
 	}
@@ -342,7 +342,7 @@ func TestGetDBStringSetting_ReturnsStoredValue(t *testing.T) {
 		`INSERT INTO settings (key, value, updated_at) VALUES ('test.key', 'hello', '2024-01-01T00:00:00Z')`); err != nil {
 		t.Fatalf("inserting test row: %v", err)
 	}
-	got := getDBStringSetting(db, context.Background(), "test.key", "fallback")
+	got := getDBStringSetting(context.Background(), db, "test.key", "fallback")
 	if got != "hello" {
 		t.Errorf("got %q; want %q", got, "hello")
 	}
@@ -355,7 +355,7 @@ func TestGetDBBoolSetting_TrueValues(t *testing.T) {
 			`INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('b.key', ?, '2024-01-01T00:00:00Z')`, v); err != nil {
 			t.Fatalf("inserting bool test row for %q: %v", v, err)
 		}
-		if !getDBBoolSetting(db, "b.key", false) {
+		if !getDBBoolSetting(context.Background(), db, "b.key", false) {
 			t.Errorf("expected true for stored value %q", v)
 		}
 	}
@@ -370,7 +370,7 @@ func TestGetDBBoolSetting_FalseValues(t *testing.T) {
 			`INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES ('b2.key', ?, '2024-01-01T00:00:00Z')`, v); err != nil {
 			t.Fatalf("inserting bool test row for %q: %v", v, err)
 		}
-		if getDBBoolSetting(db, "b2.key", true) {
+		if getDBBoolSetting(context.Background(), db, "b2.key", true) {
 			t.Errorf("expected false for stored value %q", v)
 		}
 	}
@@ -378,7 +378,7 @@ func TestGetDBBoolSetting_FalseValues(t *testing.T) {
 
 func TestGetDBBoolSetting_FallbackOnMiss(t *testing.T) {
 	db := openTestDB(t)
-	if getDBBoolSetting(db, "missing.bool", true) != true {
+	if getDBBoolSetting(context.Background(), db, "missing.bool", true) != true {
 		t.Error("expected fallback true")
 	}
 }
@@ -389,14 +389,14 @@ func TestGetDBIntSetting_ReturnsStoredValue(t *testing.T) {
 		`INSERT INTO settings (key, value, updated_at) VALUES ('int.key', '42', '2024-01-01T00:00:00Z')`); err != nil {
 		t.Fatalf("inserting test row: %v", err)
 	}
-	if got := getDBIntSetting(db, "int.key", 0); got != 42 {
+	if got := getDBIntSetting(context.Background(), db, "int.key", 0); got != 42 {
 		t.Errorf("got %d; want 42", got)
 	}
 }
 
 func TestGetDBIntSetting_FallbackOnMiss(t *testing.T) {
 	db := openTestDB(t)
-	if got := getDBIntSetting(db, "missing.int", 7); got != 7 {
+	if got := getDBIntSetting(context.Background(), db, "missing.int", 7); got != 7 {
 		t.Errorf("got %d; want 7", got)
 	}
 }
@@ -407,7 +407,7 @@ func TestGetDBIntSetting_FallbackOnNonNumeric(t *testing.T) {
 		`INSERT INTO settings (key, value, updated_at) VALUES ('bad.int', 'notanumber', '2024-01-01T00:00:00Z')`); err != nil {
 		t.Fatalf("inserting test row: %v", err)
 	}
-	if got := getDBIntSetting(db, "bad.int", 99); got != 99 {
+	if got := getDBIntSetting(context.Background(), db, "bad.int", 99); got != 99 {
 		t.Errorf("got %d; want fallback 99", got)
 	}
 }


### PR DESCRIPTION
## Summary

Decomposes the monolithic 656-line `run()` in `cmd/stillwater/main.go` (cyclomatic 64) into an `Application` struct with ordered init phases. `run()` is now cyclomatic 7; `buildServices` is cyclomatic 7 after sub-extraction. Closes #1391.

Behavior change: `resolveEncryptionKey` now returns an error when the generated key cannot be persisted (previously warn-and-continue). The old behavior silently caused the next startup to generate a different key, making every previously-encrypted secret unrecoverable. Operators with a read-only key directory will now see startup fail with a clear error instead of losing secrets on the next restart.

Preserves the inbound-first / outbound-second webhook drain order from #1514 and #1517 verbatim. Final M49.5 wave (W4.4A) -- completes the milestone.

## What changed

- **Phased init:** `loadConfig` -> `setupLogging` -> `openStorage` -> `wireSecurity` -> `buildServices` -> `startListeners`. Each phase has a precondition guard so out-of-order calls return an error at the phase boundary rather than nil-deref deep in production code.
- **Lifecycle defers** registered in `run()` at point-of-acquisition. LIFO order: scanner shutdown -> webhook inbound drain -> outbound drain -> listener stop -> `eventBus.Stop` -> `logManager.Close` -> `db.Close`. Cleanup now fires correctly on partial-init failure.
- **`buildServices` sub-extraction:** `wireAuth`, `wireProviders`, `wireRuleEngine`, `wireEventBus`, `wireInfraServices`, `wireEventSubscriptions`, `resolveRuleSchedule`.
- **Testing seams:** `WithEncKeyResolver` and `WithDBOpener` functional options on `newApplication` enable unit tests of `wireSecurity` and `openStorage` error paths without touching disk or env.
- **New tests** in `cmd/stillwater/phases_test.go` cover each phase's happy + error paths, `buildTLSStatus` branches, `resolveEncryptionKey` edge cases, `loadConfig` with a malformed file, and `getDBBoolSetting` false-value parsing.

## Test plan

- [x] go test -race ./... passes
- [x] scripts/pre-push-gate.sh passes (cyclomatic, patch coverage, fuzz matrix, lint, all green)
- [x] UAT: clean boot via scripts/dev-restart.sh; SIGTERM produces ordered shutdown log; /healthz returns 200
- [x] UAT: cleanup LIFO order verified (no closing-database error on clean exit -- db.Close returned nil)
- [x] Inbound + outbound webhook drain calls preserved at the documented LIFO position
- [ ] Reviewer: confirm the resolveEncryptionKey behavior change is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured startup into a staged Application lifecycle with clearer initialization, service wiring, and coordinated background worker startup.
  * Consolidated background workers (schedulers, scanners, session cleanup, filesystem watcher) with safer defaults and health bootstrap; TLS port logged only in split‑port mode.
  * Improved shutdown sequencing to drain inbound webhooks then outbound deliveries before stopping scanners.

* **Bug Fixes**
  * Startup now fails on failures creating or persisting encryption keys and when an existing key cannot be loaded.
  * DB-backed settings helpers now require an explicit context for queries.

* **Tests**
  * Added comprehensive end‑to‑end tests for config, logging, storage, security, and DB-backed settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->