### PR TITLE
perf(m49.6): hot-path query reductions + mtime fast-path

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -656,6 +656,7 @@ func (a *Application) wireRuleEngine(ctx context.Context, logger *slog.Logger) e
 	a.scannerService = scanner.NewService(a.artistService, a.ruleEngine, a.ruleService, logger, cfg.Music.LibraryPath, cfg.Scanner.Exclusions)
 	a.scannerService.SetDefaultLibraryID(a.defaultLibID)
 	a.scannerService.SetLibraryLister(a.libraryService)
+	a.scannerService.SetMtimeFastPath(cfg.Scanner.MtimeFastPath)
 
 	// --- NFO ---
 	a.nfoSnapshotService = nfo.NewSnapshotService(db)

--- a/docs/site/src/reference/environment-variables.md
+++ b/docs/site/src/reference/environment-variables.md
@@ -35,6 +35,7 @@ The table below is generated from the configuration definition; do not edit it b
 | `SW_MUSIC_PATH` | path | `/music` | Default music library path used as a starting point when no library has been added through the UI. |
 | `SW_PORT` | integer | `1973` | TCP port the HTTP server listens on. Numeric values outside 1-65535 are rejected at startup. |
 | `SW_SCANNER_EXCLUSIONS` | list (comma-separated) | `Various Artists, Various, VA, Soundtrack, OST` | Comma-separated artist directory names the scanner skips. Whitespace around each token is trimmed. |
+| `SW_SCANNER_MTIME_FAST_PATH` | boolean | `true` | When true the scanner reuses cached image flags for artist directories whose mtime has not advanced since the previous scan, eliminating the per-file stat + dimension probe loop. Set to false on filesystems with unreliable mtimes (some network shares, FUSE mounts, backup-restored trees) so every scan re-probes. |
 | `SW_SESSION_SECRET` | string | unset | Long random string used to sign session cookies. When unset Stillwater generates one on first run and persists it in the config directory. |
 | `SW_TLS_CERT_FILE` | string | unset | Path to a PEM-encoded TLS certificate. When set together with SW_TLS_KEY_FILE Stillwater serves HTTPS directly instead of plain HTTP. |
 | `SW_TLS_KEY_FILE` | string | unset | Path to the PEM-encoded private key for SW_TLS_CERT_FILE. Both files must be readable by the Stillwater process. |

--- a/internal/api/handlers_bulk_actions.go
+++ b/internal/api/handlers_bulk_actions.go
@@ -321,6 +321,22 @@ func (r *Router) runBulkAction(reqCtx context.Context, action string, ids []stri
 			connIdx = r.buildConnectionIndex(ctx)
 		}
 
+		// Pre-load every artist in a single batch query instead of issuing
+		// one GetByID per loop iteration (#1410). At MaxBulkActionIDs=1000
+		// the legacy path issued 1000 + 3000 hydrate round-trips; the
+		// batched form is 1 + 3 regardless of input size. ErrNotFound is
+		// represented by a missing map entry below so the original
+		// "not-found is a skip" outcome is preserved unchanged.
+		artistsByID, loadErr := r.artistService.GetByIDsBatch(ctx, ids)
+		if loadErr != nil {
+			// A batch-wide load failure is logged once and then every ID
+			// counts as Failed in the loop below so the progress totals
+			// stay consistent with the per-ID error path the loop already
+			// understands.
+			r.logger.Warn("bulk action: batch load failed", "action", action, "ids", len(ids), "error", loadErr)
+			artistsByID = map[string]*artist.Artist{}
+		}
+
 		for _, id := range ids {
 			// Cancellation check. Break out of the loop and flag the
 			// progress as canceled so the completion path surfaces a
@@ -329,17 +345,22 @@ func (r *Router) runBulkAction(reqCtx context.Context, action string, ids []stri
 			if ctx.Err() != nil {
 				break
 			}
-			a, err := r.artistService.GetByID(ctx, id)
-			if err != nil {
+			a, ok := artistsByID[id]
+			if !ok {
 				progress.mu.Lock()
 				progress.Processed++
-				if errors.Is(err, artist.ErrNotFound) {
-					progress.Skipped++
-				} else {
+				if loadErr != nil {
+					// Whole batch failed; surface every ID as Failed so
+					// the operator sees the real outcome instead of a
+					// silent "everything skipped" run.
 					progress.Failed++
+				} else {
+					// ID was in the request but absent from the result
+					// set: same semantics as the legacy GetByID returning
+					// artist.ErrNotFound (treat as Skipped).
+					progress.Skipped++
 				}
 				progress.mu.Unlock()
-				r.logger.Warn("bulk action: load artist failed", "action", action, "id", id, "error", err)
 				continue
 			}
 

--- a/internal/artist/model.go
+++ b/internal/artist/model.go
@@ -89,6 +89,18 @@ type Artist struct {
 	UpdatedAt   time.Time          `json:"updated_at"`
 }
 
+// ArtistRef is the minimal artist record exposed by ListRefsByLibrary --
+// id, display name, filesystem path. Used by the scanner's per-library
+// removal sweep so the hot path can resolve "directory disappeared" by
+// scanning a single in-memory slice instead of paginating the full
+// hydrated artist list (#1409). Add fields here only when a caller of
+// ListRefsByLibrary needs them; the lightweight shape is the whole point.
+type ArtistRef struct {
+	ID   string
+	Name string
+	Path string
+}
+
 // DiscographyAlbum is the artist-domain representation of a single NFO
 // <album> entry. It mirrors nfo.DiscographyAlbum but lives in the artist
 // package so callers outside the nfo package can reference it without

--- a/internal/artist/repository.go
+++ b/internal/artist/repository.go
@@ -42,6 +42,27 @@ type Repository interface {
 	// all artists in the given library that have a non-empty path.
 	ListPathsByLibrary(ctx context.Context, libraryID string) (map[string]string, error)
 
+	// ListRefsByLibrary returns a lightweight (id, name, path) record for
+	// every artist whose membership includes the given library AND whose
+	// path is non-empty. Used by the scanner's detectRemoved path so a
+	// per-library removal sweep issues a single query instead of paginating
+	// the full artist list. Order is not guaranteed.
+	ListRefsByLibrary(ctx context.Context, libraryID string) ([]ArtistRef, error)
+
+	// ListByIDs returns the artist rows matching the given IDs in a single
+	// query. Order is not guaranteed; callers that need the original
+	// request order should reconstruct it from the returned slice's IDs.
+	// An empty slice argument yields an empty result with no DB round-trip.
+	// IDs filtered by this method use a bound IN-clause, so callers MUST
+	// cap the input to MaxListIDs before invoking it.
+	ListByIDs(ctx context.Context, ids []string) ([]Artist, error)
+
+	// ListByLibrary returns every artist whose membership includes the
+	// given library. Used by the scanner's processDirectory pre-load so
+	// the per-directory hot path can read from an in-memory map instead
+	// of issuing a GetByPath round-trip per directory.
+	ListByLibrary(ctx context.Context, libraryID string) ([]Artist, error)
+
 	// UpdateHealthScore sets only the health_score column for the given artist,
 	// avoiding a full row overwrite that could clobber concurrent mutations.
 	UpdateHealthScore(ctx context.Context, id string, score float64) error

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -1776,9 +1776,11 @@ func (s *Service) GetByIDsBatch(ctx context.Context, ids []string, opts ...Hydra
 	// Hard cap to match the Repository contract; SQLite's bound-parameter
 	// limit (default 32766) is well above MaxListIDs but the API-side cap
 	// (api.MaxBulkActionIDs) is sourced from MaxListIDs so staying inside
-	// it keeps the two surfaces in lockstep.
+	// it keeps the two surfaces in lockstep. Reject over-limit input
+	// explicitly so callers see the cap instead of having selections
+	// silently truncated past it.
 	if len(clean) > MaxListIDs {
-		clean = clean[:MaxListIDs]
+		return nil, fmt.Errorf("too many artist IDs: %d > %d", len(clean), MaxListIDs)
 	}
 	artists, err := s.artists.ListByIDs(ctx, clean)
 	if err != nil {

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -78,6 +78,55 @@ var trackableFields = []string{
 	"years_active", "type", "gender", "origin",
 }
 
+// HydrateOpts selects which side-table hydrations a Get*/batch call should
+// perform. Fields default to false; the zero value yields "no hydration"
+// which is useful for callers that only need the core Artist row (path
+// existence, NFO presence, image-flag bookkeeping, etc.) and can save 3
+// per-artist round-trips by skipping the side tables.
+//
+// The historical Get* methods on Service hydrate every side table by default
+// for API back-compat. Pass a HydrateOpts value to opt into a leaner load:
+//
+//	a, err := svc.GetByID(ctx, id)                      // full hydration (default)
+//	a, err := svc.GetByID(ctx, id, artist.HydrateOpts{}) // no hydration
+//	a, err := svc.GetByID(ctx, id, artist.HydrateOpts{ProviderIDs: true})
+//
+// All-true is the legacy behavior; HydrateAll is a convenience preset for
+// callers that want to make the choice explicit.
+type HydrateOpts struct {
+	// ProviderIDs hydrates the artist_provider_ids side table into the
+	// Artist's MusicBrainzID, AudioDBID, DiscogsID, etc. fields.
+	ProviderIDs bool
+	// Images hydrates the artist_images side table into the Artist's
+	// ThumbExists, FanartExists, *Placeholder, *Width/Height fields.
+	Images bool
+	// PrimaryLibrary hydrates the M:N artist_libraries membership into
+	// Artist.LibraryID (earliest membership wins).
+	PrimaryLibrary bool
+}
+
+// HydrateAll is the back-compat preset that turns on every hydration.
+// The bare Get* methods (no opts) apply this preset implicitly so existing
+// callers do not need to be updated.
+var HydrateAll = HydrateOpts{
+	ProviderIDs:    true,
+	Images:         true,
+	PrimaryLibrary: true,
+}
+
+// resolveHydrateOpts returns the effective HydrateOpts for a Get*/batch call.
+// When no opts are supplied the caller gets HydrateAll (the legacy behavior
+// so existing callers do not need to be touched). When at least one opts
+// value is passed, only the first one is honored -- variadic is used purely
+// as a back-compat shim so optional opts can be added without breaking
+// existing callers.
+func resolveHydrateOpts(opts []HydrateOpts) HydrateOpts {
+	if len(opts) == 0 {
+		return HydrateAll
+	}
+	return opts[0]
+}
+
 // Service provides artist and band member data operations.
 type Service struct {
 	artists      Repository
@@ -319,98 +368,72 @@ func (s *Service) CountEligibleArtists(ctx context.Context) (int, error) {
 	return s.artists.CountEligibleArtists(ctx)
 }
 
-// GetByID retrieves an artist by primary key, including provider IDs and image metadata.
-func (s *Service) GetByID(ctx context.Context, id string) (*Artist, error) {
+// GetByID retrieves an artist by primary key. Without opts every side-table
+// hydration runs (provider IDs, images, primary library) for API back-compat.
+// Pass a HydrateOpts value to opt into a leaner load that skips one or more
+// side-table queries; see HydrateOpts.
+func (s *Service) GetByID(ctx context.Context, id string, opts ...HydrateOpts) (*Artist, error) {
 	a, err := s.artists.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	if err := s.hydrateProviderIDs(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydrateImages(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
+	if err := s.applyHydration(ctx, a, resolveHydrateOpts(opts)); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// GetByMBID retrieves an artist by MusicBrainz ID, including provider IDs and image metadata.
-func (s *Service) GetByMBID(ctx context.Context, mbid string) (*Artist, error) {
+// GetByMBID retrieves an artist by MusicBrainz ID. See GetByID for opts
+// semantics. Returns nil, nil when no artist matches.
+func (s *Service) GetByMBID(ctx context.Context, mbid string, opts ...HydrateOpts) (*Artist, error) {
 	a, err := s.artists.GetByMBID(ctx, mbid)
 	if err != nil || a == nil {
 		return a, err
 	}
-	if err := s.hydrateProviderIDs(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydrateImages(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
+	if err := s.applyHydration(ctx, a, resolveHydrateOpts(opts)); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
-// GetByProviderID retrieves an artist by a provider-specific ID, including all provider IDs
-// and image metadata.
-// Supported providers: "musicbrainz", "audiodb", "discogs", "wikidata", "deezer", "spotify".
-func (s *Service) GetByProviderID(ctx context.Context, provider, id string) (*Artist, error) {
+// GetByProviderID retrieves an artist by a provider-specific ID. See GetByID
+// for opts semantics. Supported providers: "musicbrainz", "audiodb",
+// "discogs", "wikidata", "deezer", "spotify".
+func (s *Service) GetByProviderID(ctx context.Context, provider, id string, opts ...HydrateOpts) (*Artist, error) {
 	a, err := s.providers.GetByProviderID(ctx, provider, id)
 	if err != nil || a == nil {
 		return a, err
 	}
-	if err := s.hydrateProviderIDs(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydrateImages(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
+	if err := s.applyHydration(ctx, a, resolveHydrateOpts(opts)); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
 // GetByName retrieves an artist by case-insensitive exact name match,
-// without library scope. replacement for GetByNameAndLibrary.
+// without library scope. See GetByID for opts semantics.
 // Returns nil, nil when no match is found.
-func (s *Service) GetByName(ctx context.Context, name string) (*Artist, error) {
+func (s *Service) GetByName(ctx context.Context, name string, opts ...HydrateOpts) (*Artist, error) {
 	a, err := s.artists.GetByName(ctx, name)
 	if err != nil || a == nil {
 		return a, err
 	}
-	if err := s.hydrateProviderIDs(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydrateImages(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
+	if err := s.applyHydration(ctx, a, resolveHydrateOpts(opts)); err != nil {
 		return nil, err
 	}
 	return a, nil
 }
 
 // FindByMBIDOrNameUnscoped tries MBID first, then case-insensitive name,
-// without library scope. replacement for FindByMBIDOrName,
-// used by connection populate paths to dedupe across all libraries.
+// without library scope. See GetByID for opts semantics.
+// Used by connection populate paths to dedupe across all libraries.
 // Returns nil, nil when no match is found.
-func (s *Service) FindByMBIDOrNameUnscoped(ctx context.Context, mbid, name string) (*Artist, error) {
+func (s *Service) FindByMBIDOrNameUnscoped(ctx context.Context, mbid, name string, opts ...HydrateOpts) (*Artist, error) {
 	a, err := s.artists.FindByMBIDOrNameUnscoped(ctx, mbid, name)
 	if err != nil || a == nil {
 		return a, err
 	}
-	if err := s.hydrateProviderIDs(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydrateImages(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
+	if err := s.applyHydration(ctx, a, resolveHydrateOpts(opts)); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -453,22 +476,66 @@ func (s *Service) CountLibrariesForArtist(ctx context.Context, artistID string) 
 	return s.memberships.CountForArtist(ctx, artistID)
 }
 
-// GetByPath retrieves an artist by filesystem path, including provider IDs and image metadata.
-func (s *Service) GetByPath(ctx context.Context, path string) (*Artist, error) {
+// GetByPath retrieves an artist by filesystem path. See GetByID for opts
+// semantics.
+func (s *Service) GetByPath(ctx context.Context, path string, opts ...HydrateOpts) (*Artist, error) {
 	a, err := s.artists.GetByPath(ctx, path)
 	if err != nil || a == nil {
 		return a, err
 	}
-	if err := s.hydrateProviderIDs(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydrateImages(ctx, a); err != nil {
-		return nil, err
-	}
-	if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
+	if err := s.applyHydration(ctx, a, resolveHydrateOpts(opts)); err != nil {
 		return nil, err
 	}
 	return a, nil
+}
+
+// applyHydration runs the selected side-table hydrations on a single Artist.
+// Each branch is a separate DB round-trip; the AC for HydrateOpts depends on
+// the zero value yielding exactly one query (the original Get* call) since
+// every branch here is gated.
+func (s *Service) applyHydration(ctx context.Context, a *Artist, opts HydrateOpts) error {
+	if opts.ProviderIDs {
+		if err := s.hydrateProviderIDs(ctx, a); err != nil {
+			return err
+		}
+	}
+	if opts.Images {
+		if err := s.hydrateImages(ctx, a); err != nil {
+			return err
+		}
+	}
+	if opts.PrimaryLibrary {
+		if err := s.hydratePrimaryLibrary(ctx, a); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyHydrationBatch runs the selected side-table hydrations on a slice of
+// Artists, using the *Batch hydrate helpers so each enabled branch issues
+// exactly one DB round-trip regardless of slice length. Mirrors the gating
+// logic in applyHydration.
+func (s *Service) applyHydrationBatch(ctx context.Context, artists []Artist, opts HydrateOpts) error {
+	if len(artists) == 0 {
+		return nil
+	}
+	if opts.ProviderIDs {
+		if err := s.hydrateProviderIDsBatch(ctx, artists); err != nil {
+			return err
+		}
+	}
+	if opts.Images {
+		if err := s.hydrateImagesBatch(ctx, artists); err != nil {
+			return err
+		}
+	}
+	if opts.PrimaryLibrary {
+		if err := s.hydratePrimaryLibrariesBatch(ctx, artists); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // List returns a paginated list of artists and the total count, with provider IDs
@@ -1659,6 +1726,107 @@ func (s *Service) NewestWriteTimesByArtistForLibrary(ctx context.Context, librar
 // artists in the given library that have a non-empty path.
 func (s *Service) ListPathsByLibrary(ctx context.Context, libraryID string) (map[string]string, error) {
 	return s.artists.ListPathsByLibrary(ctx, libraryID)
+}
+
+// ListRefsByLibrary returns lightweight (id, name, path) records for every
+// artist in the given library with a non-empty path. Single-query helper
+// used by the scanner's per-library removal sweep (#1409) so detectRemoved
+// does not have to paginate the full hydrated artist list.
+func (s *Service) ListRefsByLibrary(ctx context.Context, libraryID string) ([]ArtistRef, error) {
+	return s.artists.ListRefsByLibrary(ctx, libraryID)
+}
+
+// GetByIDsBatch returns the artists matching the supplied IDs as a map keyed
+// by artist ID. Missing IDs are silently dropped (no error). The opts arg
+// controls side-table hydration with the same semantics as GetByID; without
+// opts every side-table is hydrated for back-compat. With HydrateOpts{} the
+// call issues exactly one query (the IN-clause SELECT).
+//
+// Inputs are validated and de-duplicated at the boundary:
+//   - Empty input yields an empty map with no DB round-trip.
+//   - Duplicate IDs collapse to a single lookup; the map keeps one entry.
+//   - The slice is capped at MaxListIDs as defense in depth; callers that
+//     could exceed the cap should pre-chunk their input.
+//
+// Used by the bulk-action handler (#1410) so a 50-ID kickoff issues at most
+// 4 queries (one core + three batched side tables when hydration is on)
+// instead of 50 GetByID round-trips.
+func (s *Service) GetByIDsBatch(ctx context.Context, ids []string, opts ...HydrateOpts) (map[string]*Artist, error) {
+	if len(ids) == 0 {
+		return map[string]*Artist{}, nil
+	}
+	// Dedupe + drop empties to keep the IN-clause tight and avoid double-
+	// hydration cost. Defense in depth: callers (e.g. handleBulkAction)
+	// already dedupe, but a future caller might not.
+	seen := make(map[string]struct{}, len(ids))
+	clean := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		clean = append(clean, id)
+	}
+	if len(clean) == 0 {
+		return map[string]*Artist{}, nil
+	}
+	// Hard cap to match the Repository contract; SQLite's bound-parameter
+	// limit (default 32766) is well above MaxListIDs but the API-side cap
+	// (api.MaxBulkActionIDs) is sourced from MaxListIDs so staying inside
+	// it keeps the two surfaces in lockstep.
+	if len(clean) > MaxListIDs {
+		clean = clean[:MaxListIDs]
+	}
+	artists, err := s.artists.ListByIDs(ctx, clean)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.applyHydrationBatch(ctx, artists, resolveHydrateOpts(opts)); err != nil {
+		return nil, err
+	}
+	result := make(map[string]*Artist, len(artists))
+	for i := range artists {
+		// Pin a stable pointer inside the slice; range-variable capture
+		// would yield N copies of the same loop variable's address.
+		a := artists[i]
+		result[a.ID] = &a
+	}
+	return result, nil
+}
+
+// PreloadArtistsByLibrary returns every artist in the given library as a map
+// keyed by filesystem path. Artists with an empty path are excluded so the
+// map shape matches what the scanner uses for membership lookups. Hydration
+// follows the same opts contract as GetByIDsBatch.
+//
+// Used by the scanner's processDirectory pre-load (#1411) so the per-
+// directory hot path can resolve "do we already know this artist?" by
+// reading from this map instead of issuing a GetByPath round-trip per
+// directory. With HydrateOpts{} the call issues exactly one query for an
+// arbitrarily large library.
+func (s *Service) PreloadArtistsByLibrary(ctx context.Context, libraryID string, opts ...HydrateOpts) (map[string]*Artist, error) {
+	if libraryID == "" {
+		return map[string]*Artist{}, nil
+	}
+	artists, err := s.artists.ListByLibrary(ctx, libraryID)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.applyHydrationBatch(ctx, artists, resolveHydrateOpts(opts)); err != nil {
+		return nil, err
+	}
+	result := make(map[string]*Artist, len(artists))
+	for i := range artists {
+		a := artists[i]
+		if a.Path == "" {
+			continue
+		}
+		result[a.Path] = &a
+	}
+	return result, nil
 }
 
 // hydrateImages loads image metadata from the normalized table and applies

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -1789,10 +1789,12 @@ func (s *Service) GetByIDsBatch(ctx context.Context, ids []string, opts ...Hydra
 	}
 	result := make(map[string]*Artist, len(artists))
 	for i := range artists {
-		// Pin a stable pointer inside the slice; range-variable capture
-		// would yield N copies of the same loop variable's address.
-		a := artists[i]
-		result[a.ID] = &a
+		// Point directly into the slice so each map entry has a distinct,
+		// stable address. The previous `a := artists[i]; &a` form worked
+		// because each iteration declared a fresh `a` that escaped to the
+		// heap, but `&artists[i]` is idiomatic, avoids the per-row copy,
+		// and matches the pointer-identity guard in the batch tests.
+		result[artists[i].ID] = &artists[i]
 	}
 	return result, nil
 }
@@ -1820,11 +1822,10 @@ func (s *Service) PreloadArtistsByLibrary(ctx context.Context, libraryID string,
 	}
 	result := make(map[string]*Artist, len(artists))
 	for i := range artists {
-		a := artists[i]
-		if a.Path == "" {
+		if artists[i].Path == "" {
 			continue
 		}
-		result[a.Path] = &a
+		result[artists[i].Path] = &artists[i]
 	}
 	return result, nil
 }

--- a/internal/artist/service_hydrate_opts_test.go
+++ b/internal/artist/service_hydrate_opts_test.go
@@ -2,6 +2,7 @@ package artist
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 )
@@ -308,12 +309,34 @@ func TestGetMethods_HydrateOptsVariadic(t *testing.T) {
 	ctx := context.Background()
 	first := ids[0]
 
+	// Seed an MBID + provider-id row so the success-path branch of
+	// GetByMBID and GetByProviderID is also exercised, not just the
+	// nil-result fast-path. Both methods resolve through
+	// artist_provider_ids (provider='musicbrainz').
+	mbid := "11111111-2222-3333-4444-555555555555"
+	if _, err := svc.artists.(*sqliteArtistRepo).db.ExecContext(ctx,
+		`INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
+		 VALUES (?, 'musicbrainz', ?, datetime('now'))`, first, mbid); err != nil {
+		t.Fatalf("seeding mbid row: %v", err)
+	}
+
 	if a, err := svc.GetByID(ctx, first, HydrateOpts{}); err != nil || a == nil {
 		t.Errorf("GetByID(opts): err=%v a=%v", err, a)
 	}
-	if a, err := svc.GetByMBID(ctx, "mb-none", HydrateOpts{}); err == nil && a != nil {
+	// GetByMBID success path: returns the seeded artist; HydrateOpts{}
+	// means MusicBrainzID stays at zero value (no hydration ran).
+	if a, err := svc.GetByMBID(ctx, mbid, HydrateOpts{}); err != nil || a == nil || a.ID != first {
+		t.Errorf("GetByMBID(seeded): err=%v a=%+v", err, a)
+	}
+	// GetByMBID missing path: nil-result short-circuit before hydration.
+	if a, err := svc.GetByMBID(ctx, "00000000-0000-0000-0000-000000000000", HydrateOpts{}); err == nil && a != nil {
 		t.Errorf("GetByMBID(missing): expected nil/err; got %v", a)
 	}
+	// GetByProviderID success path: same seeded row.
+	if a, err := svc.GetByProviderID(ctx, "musicbrainz", mbid, HydrateOpts{}); err != nil || a == nil || a.ID != first {
+		t.Errorf("GetByProviderID(seeded): err=%v a=%+v", err, a)
+	}
+	// GetByProviderID missing path.
 	if a, err := svc.GetByProviderID(ctx, "musicbrainz", "none", HydrateOpts{}); err == nil && a != nil {
 		t.Errorf("GetByProviderID(missing): expected nil/err; got %v", a)
 	}
@@ -325,5 +348,29 @@ func TestGetMethods_HydrateOptsVariadic(t *testing.T) {
 	}
 	if a, err := svc.GetByPath(ctx, "/music/hyd/Alpha", HydrateOpts{}); err != nil || a == nil {
 		t.Errorf("GetByPath(opts): err=%v a=%v", err, a)
+	}
+}
+
+// TestGetByIDsBatch_OverLimit pins the bulk loader's MaxListIDs guard:
+// callers that exceed the cap get an explicit error instead of having
+// their request silently truncated, so a future caller that didn't
+// pre-chunk its input sees the cap rather than mysteriously losing
+// selections past the boundary.
+func TestGetByIDsBatch_OverLimit(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	tooMany := make([]string, MaxListIDs+1)
+	for i := range tooMany {
+		tooMany[i] = fmt.Sprintf("id-%d", i)
+	}
+	got, err := svc.GetByIDsBatch(ctx, tooMany)
+	if err == nil {
+		t.Fatalf("expected error for >MaxListIDs input; got nil (result=%v)", got)
+	}
+	if got != nil {
+		t.Errorf("expected nil result on over-limit error; got %v", got)
 	}
 }

--- a/internal/artist/service_hydrate_opts_test.go
+++ b/internal/artist/service_hydrate_opts_test.go
@@ -82,6 +82,24 @@ func TestGetByIDsBatch_HappyPath(t *testing.T) {
 			t.Errorf("missing artist %s in result", id)
 		}
 	}
+	// Pointer-identity guard: every map entry must be a distinct *Artist.
+	// Catches a regression where the loop reuses a single backing variable
+	// and every map key ends up aliased to the last-seen iteration value.
+	seenPtrs := make(map[*Artist]string, len(got))
+	for id, a := range got {
+		if a == nil {
+			t.Errorf("nil *Artist for key %s", id)
+			continue
+		}
+		if existing, ok := seenPtrs[a]; ok {
+			t.Errorf("aliased pointer: keys %s and %s share the same *Artist (%p)", existing, id, a)
+			continue
+		}
+		seenPtrs[a] = id
+		if a.ID != id {
+			t.Errorf("map key %s points to artist with ID %s", id, a.ID)
+		}
+	}
 }
 
 // TestGetByIDsBatch_EmptyAndDuplicate covers the boundary paths: empty input
@@ -187,6 +205,22 @@ func TestPreloadArtistsByLibrary_HappyPath(t *testing.T) {
 	for i := range wantIDs {
 		if gotIDs[i] != wantIDs[i] {
 			t.Errorf("preload set mismatch at index %d: want %s got %s", i, wantIDs[i], gotIDs[i])
+		}
+	}
+	// Pointer-identity guard: every map entry must be a distinct *Artist.
+	seenPtrs := make(map[*Artist]string, len(got))
+	for path, a := range got {
+		if a == nil {
+			t.Errorf("nil *Artist for key %s", path)
+			continue
+		}
+		if existing, ok := seenPtrs[a]; ok {
+			t.Errorf("aliased pointer: paths %s and %s share the same *Artist (%p)", existing, path, a)
+			continue
+		}
+		seenPtrs[a] = path
+		if a.Path != path {
+			t.Errorf("map key %s points to artist with Path %s", path, a.Path)
 		}
 	}
 }

--- a/internal/artist/service_hydrate_opts_test.go
+++ b/internal/artist/service_hydrate_opts_test.go
@@ -1,0 +1,295 @@
+package artist
+
+import (
+	"context"
+	"sort"
+	"testing"
+)
+
+// TestResolveHydrateOpts pins the variadic-opts shim used by every Get* and
+// batch method: no opts -> HydrateAll (back-compat), one opts -> that opts
+// is honored verbatim, multiple opts -> only the first is honored (the
+// variadic exists only to make adding the parameter source-compatible).
+func TestResolveHydrateOpts(t *testing.T) {
+	t.Parallel()
+
+	if got := resolveHydrateOpts(nil); got != HydrateAll {
+		t.Errorf("no opts: want HydrateAll, got %+v", got)
+	}
+	zero := HydrateOpts{}
+	if got := resolveHydrateOpts([]HydrateOpts{zero}); got != zero {
+		t.Errorf("zero opts: want %+v, got %+v", zero, got)
+	}
+	only := HydrateOpts{ProviderIDs: true}
+	if got := resolveHydrateOpts([]HydrateOpts{only, HydrateAll}); got != only {
+		t.Errorf("multiple opts: want first (%+v), got %+v", only, got)
+	}
+}
+
+// seedHydrateFixtures inserts a library and three artists, two of which
+// have a path inside the library, plus one provider-id and one image row
+// per artist. Enough to verify GetByIDsBatch / PreloadArtistsByLibrary
+// hydration coverage without bringing in the entire artist test fixture.
+func seedHydrateFixtures(t *testing.T, svc *Service) []string {
+	t.Helper()
+	ctx := context.Background()
+
+	ids := []string{"hyd-1", "hyd-2", "hyd-3"}
+	paths := []string{"/music/hyd/Alpha", "/music/hyd/Bravo", "/music/hyd/Charlie"}
+	names := []string{"Alpha", "Bravo", "Charlie"}
+
+	if _, err := svc.artists.(*sqliteArtistRepo).db.ExecContext(ctx,
+		`INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)
+		 VALUES ('lib-h', 'lib-h', '/music/hyd', 'regular', 'filesystem', datetime('now'), datetime('now'))`); err != nil {
+		t.Fatalf("seeding library: %v", err)
+	}
+	for i, id := range ids {
+		a := &Artist{
+			ID: id, Name: names[i], SortName: names[i], Path: paths[i],
+		}
+		if err := svc.Create(ctx, a); err != nil {
+			t.Fatalf("creating artist %s: %v", id, err)
+		}
+		if _, err := svc.artists.(*sqliteArtistRepo).db.ExecContext(ctx,
+			`INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+			 VALUES (?, 'lib-h', 'filesystem', datetime('now'))`, id); err != nil {
+			t.Fatalf("membership for %s: %v", id, err)
+		}
+	}
+	return ids
+}
+
+// TestGetByIDsBatch_HappyPath verifies the bulk loader returns one entry per
+// supplied ID, missing IDs are silently dropped, and the back-compat default
+// (no opts) still hydrates the side-tables -- existing callers see no change.
+func TestGetByIDsBatch_HappyPath(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	svc := NewService(db)
+	ids := seedHydrateFixtures(t, svc)
+	ctx := context.Background()
+
+	// Include a non-existent ID -- must be silently dropped, not an error.
+	got, err := svc.GetByIDsBatch(ctx, append([]string{"no-such-id"}, ids...))
+	if err != nil {
+		t.Fatalf("GetByIDsBatch: %v", err)
+	}
+	if len(got) != len(ids) {
+		t.Errorf("expected %d artists, got %d", len(ids), len(got))
+	}
+	for _, id := range ids {
+		if _, ok := got[id]; !ok {
+			t.Errorf("missing artist %s in result", id)
+		}
+	}
+}
+
+// TestGetByIDsBatch_EmptyAndDuplicate covers the boundary paths: empty input
+// short-circuits with no DB hit; empty strings inside the slice are skipped;
+// duplicates collapse to a single lookup.
+func TestGetByIDsBatch_EmptyAndDuplicate(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	svc := NewService(db)
+	ids := seedHydrateFixtures(t, svc)
+	ctx := context.Background()
+
+	zero, err := svc.GetByIDsBatch(ctx, nil)
+	if err != nil {
+		t.Fatalf("GetByIDsBatch(nil): %v", err)
+	}
+	if len(zero) != 0 {
+		t.Errorf("expected empty map for nil input, got %v", zero)
+	}
+
+	// All-empty input also short-circuits (after the dedupe pass).
+	allEmpty, err := svc.GetByIDsBatch(ctx, []string{"", "", ""})
+	if err != nil {
+		t.Fatalf("GetByIDsBatch(empties): %v", err)
+	}
+	if len(allEmpty) != 0 {
+		t.Errorf("expected empty map for all-empty input, got %v", allEmpty)
+	}
+
+	// Duplicates plus an empty string collapse to a single lookup.
+	dup, err := svc.GetByIDsBatch(ctx, []string{ids[0], ids[0], "", ids[0]})
+	if err != nil {
+		t.Fatalf("GetByIDsBatch(dup): %v", err)
+	}
+	if len(dup) != 1 {
+		t.Errorf("expected 1 artist for duplicated input, got %d (%v)", len(dup), dup)
+	}
+}
+
+// TestGetByIDsBatch_NoHydration verifies that passing HydrateOpts{}
+// (the zero value -- nothing to hydrate) is honored: the result still
+// includes every requested artist, but the side-table fields stay
+// at their zero values for at least the provider-id side. This is the
+// opt-out path that lets the bulk-action handler skip unneeded work.
+func TestGetByIDsBatch_NoHydration(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	svc := NewService(db)
+	ids := seedHydrateFixtures(t, svc)
+	ctx := context.Background()
+
+	// Plant a provider-ID row so we can detect whether hydration ran.
+	if _, err := svc.artists.(*sqliteArtistRepo).db.ExecContext(ctx,
+		`INSERT INTO artist_provider_ids (artist_id, provider, provider_id, fetched_at)
+		 VALUES (?, 'musicbrainz', 'mb-12345', datetime('now'))`,
+		ids[0]); err != nil {
+		t.Fatalf("seeding provider id: %v", err)
+	}
+
+	// With HydrateAll (default), the MBID should hydrate onto the struct.
+	full, err := svc.GetByIDsBatch(ctx, []string{ids[0]})
+	if err != nil {
+		t.Fatalf("GetByIDsBatch(full): %v", err)
+	}
+	if full[ids[0]].MusicBrainzID != "mb-12345" {
+		t.Errorf("default hydration should populate MusicBrainzID; got %q", full[ids[0]].MusicBrainzID)
+	}
+
+	// With HydrateOpts{} (no hydration), MBID stays at the zero value.
+	bare, err := svc.GetByIDsBatch(ctx, []string{ids[0]}, HydrateOpts{})
+	if err != nil {
+		t.Fatalf("GetByIDsBatch(bare): %v", err)
+	}
+	if bare[ids[0]].MusicBrainzID != "" {
+		t.Errorf("HydrateOpts{} should skip provider hydration; got %q", bare[ids[0]].MusicBrainzID)
+	}
+}
+
+// TestPreloadArtistsByLibrary_HappyPath verifies the scanner's pre-load
+// helper returns a path-keyed map of the library's members, skipping any
+// artist whose path is empty (the scanner doesn't index those).
+func TestPreloadArtistsByLibrary_HappyPath(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	svc := NewService(db)
+	ids := seedHydrateFixtures(t, svc)
+	ctx := context.Background()
+
+	got, err := svc.PreloadArtistsByLibrary(ctx, "lib-h")
+	if err != nil {
+		t.Fatalf("PreloadArtistsByLibrary: %v", err)
+	}
+	if len(got) != len(ids) {
+		t.Errorf("expected %d preloaded, got %d", len(ids), len(got))
+	}
+	gotIDs := make([]string, 0, len(got))
+	for _, a := range got {
+		gotIDs = append(gotIDs, a.ID)
+	}
+	sort.Strings(gotIDs)
+	wantIDs := append([]string(nil), ids...)
+	sort.Strings(wantIDs)
+	for i := range wantIDs {
+		if gotIDs[i] != wantIDs[i] {
+			t.Errorf("preload set mismatch at index %d: want %s got %s", i, wantIDs[i], gotIDs[i])
+		}
+	}
+}
+
+// TestPreloadArtistsByLibrary_EmptyAndMissing covers the boundary paths:
+// empty libraryID short-circuits (no DB hit), a nonexistent library
+// yields an empty map, and an artist with no path (the scanner would
+// not key it anyway) is dropped from the result.
+func TestPreloadArtistsByLibrary_EmptyAndMissing(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	zero, err := svc.PreloadArtistsByLibrary(ctx, "")
+	if err != nil {
+		t.Fatalf("Preload(empty): %v", err)
+	}
+	if len(zero) != 0 {
+		t.Errorf("expected empty map for empty libraryID, got %v", zero)
+	}
+
+	missing, err := svc.PreloadArtistsByLibrary(ctx, "no-such-library")
+	if err != nil {
+		t.Fatalf("Preload(missing): %v", err)
+	}
+	if len(missing) != 0 {
+		t.Errorf("expected empty map for missing library, got %v", missing)
+	}
+
+	// Seed a library with one path-less artist; PreloadArtistsByLibrary
+	// must filter it out so the scanner's path-key invariant holds.
+	if _, err := svc.artists.(*sqliteArtistRepo).db.ExecContext(ctx,
+		`INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)
+		 VALUES ('lib-pl', 'lib-pl', '/music/pl', 'regular', 'filesystem', datetime('now'), datetime('now'))`); err != nil {
+		t.Fatalf("seeding library: %v", err)
+	}
+	a := &Artist{ID: "pl-1", Name: "PathLess", SortName: "PathLess", Path: ""}
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("creating pathless artist: %v", err)
+	}
+	if _, err := svc.artists.(*sqliteArtistRepo).db.ExecContext(ctx,
+		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+		 VALUES ('pl-1', 'lib-pl', 'filesystem', datetime('now'))`); err != nil {
+		t.Fatalf("membership: %v", err)
+	}
+
+	out, err := svc.PreloadArtistsByLibrary(ctx, "lib-pl")
+	if err != nil {
+		t.Fatalf("Preload(pl): %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("path-less artist must be excluded; got %v", out)
+	}
+}
+
+// TestServiceListRefsByLibrary verifies the service-level wrapper passes
+// through to the repository contract pinned by TestSqliteListRefsByLibrary.
+func TestServiceListRefsByLibrary(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	svc := NewService(db)
+	ids := seedHydrateFixtures(t, svc)
+	ctx := context.Background()
+
+	refs, err := svc.ListRefsByLibrary(ctx, "lib-h")
+	if err != nil {
+		t.Fatalf("ListRefsByLibrary: %v", err)
+	}
+	if len(refs) != len(ids) {
+		t.Errorf("expected %d refs, got %d", len(ids), len(refs))
+	}
+}
+
+// TestGetMethods_HydrateOptsVariadic exercises the variadic-opts shim on each
+// of the six Get* methods so the patch-coverage gate includes the opts-passed
+// branch alongside the no-opts back-compat branch. The functional contract
+// (no-hydration -> zero-valued side-table fields) is pinned by
+// TestGetByIDsBatch_NoHydration; this test just walks the shim.
+func TestGetMethods_HydrateOptsVariadic(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	svc := NewService(db)
+	ids := seedHydrateFixtures(t, svc)
+	ctx := context.Background()
+	first := ids[0]
+
+	if a, err := svc.GetByID(ctx, first, HydrateOpts{}); err != nil || a == nil {
+		t.Errorf("GetByID(opts): err=%v a=%v", err, a)
+	}
+	if a, err := svc.GetByMBID(ctx, "mb-none", HydrateOpts{}); err == nil && a != nil {
+		t.Errorf("GetByMBID(missing): expected nil/err; got %v", a)
+	}
+	if a, err := svc.GetByProviderID(ctx, "musicbrainz", "none", HydrateOpts{}); err == nil && a != nil {
+		t.Errorf("GetByProviderID(missing): expected nil/err; got %v", a)
+	}
+	if a, err := svc.GetByName(ctx, "Alpha", HydrateOpts{}); err != nil || a == nil {
+		t.Errorf("GetByName(opts): err=%v a=%v", err, a)
+	}
+	if _, err := svc.FindByMBIDOrNameUnscoped(ctx, "", "Alpha", HydrateOpts{}); err != nil {
+		t.Errorf("FindByMBIDOrNameUnscoped(opts): err=%v", err)
+	}
+	if a, err := svc.GetByPath(ctx, "/music/hyd/Alpha", HydrateOpts{}); err != nil || a == nil {
+		t.Errorf("GetByPath(opts): err=%v a=%v", err, a)
+	}
+}

--- a/internal/artist/sqlite_artist.go
+++ b/internal/artist/sqlite_artist.go
@@ -334,6 +334,108 @@ func (r *sqliteArtistRepo) Delete(ctx context.Context, id string) error {
 	return nil
 }
 
+// ListRefsByLibrary returns lightweight (id, name, path) records for every
+// artist whose membership includes libraryID and whose path is non-empty.
+// Single-query equivalent of paginating the full List output when callers
+// only need basic identifying fields (e.g. the scanner's per-library
+// removal sweep, #1409). The returned slice's order is the natural row
+// order from SQLite; callers MUST NOT rely on a particular sort.
+func (r *sqliteArtistRepo) ListRefsByLibrary(ctx context.Context, libraryID string) ([]ArtistRef, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT a.id, a.name, a.path FROM artists a
+		JOIN artist_libraries al ON al.artist_id = a.id
+		WHERE al.library_id = ? AND a.path != ''`,
+		libraryID)
+	if err != nil {
+		return nil, fmt.Errorf("listing artist refs for library %s: %w", libraryID, err)
+	}
+	defer rows.Close() //nolint:errcheck // Close error not actionable on cleanup
+
+	var result []ArtistRef
+	for rows.Next() {
+		var ref ArtistRef
+		if err := rows.Scan(&ref.ID, &ref.Name, &ref.Path); err != nil {
+			return nil, fmt.Errorf("scanning artist ref: %w", err)
+		}
+		result = append(result, ref)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating artist refs for library %s: %w", libraryID, err)
+	}
+	return result, nil
+}
+
+// ListByIDs returns the artist rows matching ids in a single query. Empty
+// input yields an empty slice with no DB hit. The IN-clause is built by
+// joining "?" literals so static-analysis tools can confirm no user input
+// flows into the SQL string; bound parameters carry every value. Order
+// of the returned rows is SQLite's natural order -- callers needing a
+// specific order should reconstruct it from a map keyed by ID.
+func (r *sqliteArtistRepo) ListByIDs(ctx context.Context, ids []string) ([]Artist, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	//nolint:gosec // G202: placeholders is a literal "?,?,..." string built by joining "?" literals; no user input.
+	query := `SELECT ` + artistColumns + ` FROM artists WHERE id IN (` + strings.Join(placeholders, ",") + `)`
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing artists by IDs: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // Close error not actionable on cleanup
+
+	result := make([]Artist, 0, len(ids))
+	for rows.Next() {
+		a, err := scanArtist(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning artist row: %w", err)
+		}
+		result = append(result, *a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating artist rows: %w", err)
+	}
+	return result, nil
+}
+
+// ListByLibrary returns the full artist rows whose membership includes
+// libraryID. Single query equivalent of paginating List with LibraryID set.
+// Used by the scanner's per-directory pre-load (#1411) so processDirectory
+// can read existing artists out of an in-memory map keyed by path instead
+// of issuing N GetByPath round-trips. Membership is resolved through
+// artist_libraries; rows with no membership are excluded.
+func (r *sqliteArtistRepo) ListByLibrary(ctx context.Context, libraryID string) ([]Artist, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+artistColumns+` FROM artists
+		WHERE EXISTS (
+			SELECT 1 FROM artist_libraries al
+			WHERE al.artist_id = artists.id AND al.library_id = ?
+		)`,
+		libraryID)
+	if err != nil {
+		return nil, fmt.Errorf("listing artists for library %s: %w", libraryID, err)
+	}
+	defer rows.Close() //nolint:errcheck // Close error not actionable on cleanup
+
+	var result []Artist
+	for rows.Next() {
+		a, err := scanArtist(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning artist row: %w", err)
+		}
+		result = append(result, *a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating artist rows for library %s: %w", libraryID, err)
+	}
+	return result, nil
+}
+
 // ListPathsByLibrary returns a map of artist ID to filesystem path for all
 // artists in the given library that have a non-empty path. Uses artist ID
 // as the key (not name) to avoid collisions when multiple artists share

--- a/internal/artist/sqlite_artist_list_test.go
+++ b/internal/artist/sqlite_artist_list_test.go
@@ -1,0 +1,169 @@
+package artist
+
+import (
+	"context"
+	"database/sql"
+	"sort"
+	"testing"
+)
+
+// seedListFixtures inserts two libraries and a small artist set with
+// per-library membership, so the ListRefsByLibrary / ListByIDs /
+// ListByLibrary tests below can verify the membership filter,
+// path-non-empty filter, and IN-list ordering semantics.
+func seedListFixtures(t *testing.T, db *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+
+	rows := []string{
+		`INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)
+		 VALUES ('lib-a', 'lib-a', '/music/a', 'regular', 'filesystem', datetime('now'), datetime('now'))`,
+		`INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)
+		 VALUES ('lib-b', 'lib-b', '/music/b', 'regular', 'filesystem', datetime('now'), datetime('now'))`,
+		// artist-1 in lib-a, with path
+		`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		 VALUES ('a-1', 'Alpha', 'Alpha', '/music/a/Alpha', datetime('now'), datetime('now'))`,
+		// artist-2 in lib-a, with path
+		`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		 VALUES ('a-2', 'Bravo', 'Bravo', '/music/a/Bravo', datetime('now'), datetime('now'))`,
+		// artist-3 in lib-a, empty path -- must be filtered out by ListRefsByLibrary
+		`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		 VALUES ('a-3', 'NoPath', 'NoPath', '', datetime('now'), datetime('now'))`,
+		// artist-4 in lib-b only
+		`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		 VALUES ('a-4', 'Charlie', 'Charlie', '/music/b/Charlie', datetime('now'), datetime('now'))`,
+		// artist-5 with no library membership at all
+		`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		 VALUES ('a-5', 'Orphan', 'Orphan', '/music/orphan/Orphan', datetime('now'), datetime('now'))`,
+		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+		 VALUES ('a-1', 'lib-a', 'filesystem', datetime('now'))`,
+		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+		 VALUES ('a-2', 'lib-a', 'filesystem', datetime('now'))`,
+		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+		 VALUES ('a-3', 'lib-a', 'filesystem', datetime('now'))`,
+		`INSERT INTO artist_libraries (artist_id, library_id, source, added_at)
+		 VALUES ('a-4', 'lib-b', 'filesystem', datetime('now'))`,
+	}
+	for _, q := range rows {
+		if _, err := db.ExecContext(ctx, q); err != nil {
+			t.Fatalf("seeding fixture %q: %v", q, err)
+		}
+	}
+}
+
+// TestSqliteListRefsByLibrary pins three contracts of the lightweight
+// ListRefsByLibrary helper added in #1409: membership scope, path filter,
+// and shape of the returned ArtistRef slice.
+func TestSqliteListRefsByLibrary(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	seedListFixtures(t, db)
+	repo := &sqliteArtistRepo{db: db}
+	ctx := context.Background()
+
+	refs, err := repo.ListRefsByLibrary(ctx, "lib-a")
+	if err != nil {
+		t.Fatalf("ListRefsByLibrary(lib-a): %v", err)
+	}
+	got := make(map[string]ArtistRef, len(refs))
+	for _, r := range refs {
+		got[r.ID] = r
+	}
+	// a-1 and a-2 must be returned. a-3 has an empty path so the helper
+	// must filter it out (the scanner's removal sweep relies on this).
+	// a-4 is in lib-b, a-5 has no membership; neither should appear.
+	if len(got) != 2 {
+		t.Fatalf("expected exactly 2 refs for lib-a; got %d (%v)", len(got), refs)
+	}
+	if _, ok := got["a-1"]; !ok {
+		t.Errorf("a-1 missing from lib-a refs")
+	}
+	if got["a-1"].Name != "Alpha" || got["a-1"].Path != "/music/a/Alpha" {
+		t.Errorf("a-1 ref shape wrong: %+v", got["a-1"])
+	}
+	if _, ok := got["a-2"]; !ok {
+		t.Errorf("a-2 missing from lib-a refs")
+	}
+	if _, ok := got["a-3"]; ok {
+		t.Errorf("a-3 has empty path; must be excluded but appeared in result")
+	}
+
+	empty, err := repo.ListRefsByLibrary(ctx, "lib-empty")
+	if err != nil {
+		t.Fatalf("ListRefsByLibrary(lib-empty): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("expected empty refs for nonexistent library; got %v", empty)
+	}
+}
+
+// TestSqliteListByIDs pins the IN-clause batch loader contract: empty input
+// is a no-op (no DB hit, nil slice), the returned rows match exactly the
+// requested IDs, and missing IDs are silently skipped (not an error).
+func TestSqliteListByIDs(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	seedListFixtures(t, db)
+	repo := &sqliteArtistRepo{db: db}
+	ctx := context.Background()
+
+	// Empty input: must short-circuit without touching the DB.
+	zero, err := repo.ListByIDs(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListByIDs(nil): %v", err)
+	}
+	if zero != nil {
+		t.Errorf("expected nil slice for empty input; got %v", zero)
+	}
+
+	// Mixed-existence input: a-1 + a-4 exist, no-such-id does not.
+	// The function must return the two that exist without erroring on
+	// the missing one.
+	rows, err := repo.ListByIDs(ctx, []string{"a-1", "a-4", "no-such-id"})
+	if err != nil {
+		t.Fatalf("ListByIDs(mixed): %v", err)
+	}
+	ids := make([]string, len(rows))
+	for i, a := range rows {
+		ids[i] = a.ID
+	}
+	sort.Strings(ids)
+	if len(ids) != 2 || ids[0] != "a-1" || ids[1] != "a-4" {
+		t.Errorf("expected [a-1 a-4]; got %v", ids)
+	}
+}
+
+// TestSqliteListByLibrary pins the bulk loader contract used by the scanner
+// pre-load (#1411): every artist whose membership includes the library is
+// returned, regardless of path-non-empty (the scanner needs the empty-path
+// entries too so it can decide whether to populate them on first scan).
+func TestSqliteListByLibrary(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	seedListFixtures(t, db)
+	repo := &sqliteArtistRepo{db: db}
+	ctx := context.Background()
+
+	rows, err := repo.ListByLibrary(ctx, "lib-a")
+	if err != nil {
+		t.Fatalf("ListByLibrary(lib-a): %v", err)
+	}
+	ids := make([]string, len(rows))
+	for i, a := range rows {
+		ids[i] = a.ID
+	}
+	sort.Strings(ids)
+	// All three lib-a artists must be returned, including a-3 (empty path).
+	// a-4 is in lib-b only; a-5 has no membership.
+	if len(ids) != 3 || ids[0] != "a-1" || ids[1] != "a-2" || ids[2] != "a-3" {
+		t.Errorf("expected [a-1 a-2 a-3]; got %v", ids)
+	}
+
+	empty, err := repo.ListByLibrary(ctx, "lib-empty")
+	if err != nil {
+		t.Fatalf("ListByLibrary(lib-empty): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("expected empty slice for nonexistent library; got %v", empty)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,6 +117,14 @@ type MusicConfig struct {
 type ScannerConfig struct {
 	Depth      int      `yaml:"depth" toml:"depth"`
 	Exclusions []string `yaml:"exclusions" toml:"exclusions" env:"SW_SCANNER_EXCLUSIONS" default:"Various Artists, Various, VA, Soundtrack, OST" desc:"Comma-separated artist directory names the scanner skips. Whitespace around each token is trimmed."`
+	// MtimeFastPath, when true, lets the scanner skip the per-file image
+	// stat + dimension probe loop for artist directories whose mtime has
+	// not advanced since the previous scan. Defaults to true; disable it
+	// (SW_SCANNER_MTIME_FAST_PATH=false) on filesystems that do not
+	// maintain stable directory mtimes -- some network shares, FUSE
+	// mounts, and any backup-restored tree where mtimes were not
+	// preserved fall into this category.
+	MtimeFastPath bool `yaml:"mtime_fast_path" toml:"mtime_fast_path" env:"SW_SCANNER_MTIME_FAST_PATH" default:"true" desc:"When true the scanner reuses cached image flags for artist directories whose mtime has not advanced since the previous scan, eliminating the per-file stat + dimension probe loop. Set to false on filesystems with unreliable mtimes (some network shares, FUSE mounts, backup-restored trees) so every scan re-probes."`
 }
 
 // BackupConfig holds database backup settings.
@@ -154,6 +162,12 @@ func Default() *Config {
 				"Various Artists", "Various", "VA",
 				"Soundtrack", "OST",
 			},
+			// Default-on; the fast-path is a no-op on the first scan
+			// (no prior LastScannedAt) and on directories that have
+			// been touched since the last scan, so the only behavioral
+			// difference is "second scan of an unchanged directory
+			// skips its inner ReadDir + image probe loop".
+			MtimeFastPath: true,
 		},
 		Backup: BackupConfig{
 			RetentionCount: 7,
@@ -232,6 +246,7 @@ const scaffoldTOML = `# Stillwater configuration
 [scanner]
 # depth = 1
 # exclusions = ["Various Artists", "Various", "VA", "Soundtrack", "OST"]
+# mtime_fast_path = true  # set to false on filesystems with unreliable mtimes
 
 [backup]
 # path = ""
@@ -476,6 +491,10 @@ func (c *Config) loadFromEnv() error {
 		// Music
 		{Key: "SW_MUSIC_PATH", Apply: setString(&c.Music.LibraryPath)},
 		{Key: "SW_SCANNER_EXCLUSIONS", Apply: setCSV(&c.Scanner.Exclusions)},
+		// SW_SCANNER_MTIME_FAST_PATH uses standard non-empty semantics so
+		// an unset variable leaves the default-on behavior intact; only
+		// an explicit "false" / "0" disables the fast path.
+		{Key: "SW_SCANNER_MTIME_FAST_PATH", Apply: setBool(&c.Scanner.MtimeFastPath)},
 		// Backup (lenient int; non-positive values are silently ignored)
 		{Key: "SW_BACKUP_PATH", Apply: setString(&c.Backup.Path)},
 		{Key: "SW_BACKUP_RETENTION", Apply: setIntPositive(&c.Backup.RetentionCount)},

--- a/internal/scanner/detect_existence_test.go
+++ b/internal/scanner/detect_existence_test.go
@@ -1,0 +1,133 @@
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+)
+
+// writeTestFile writes a small placeholder file at dir/name so the
+// detectFilesExistenceOnly cheap-existence path can find it without an
+// image-decode probe.
+func writeTestFile(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+}
+
+// TestDetectFilesExistenceOnly_AllPatterns drives detectFilesExistenceOnly --
+// the mtime fast-path's existence-only probe -- through every recognized
+// canonical filename pattern at once. It verifies that the cheap path sets
+// the right *Exists flags from disk reality (the contract pinned by issue
+// #1225's registry-vs-disk reconciliation) and reuses the supplied existing
+// Artist's dimensions / placeholders / low-res flags (which the expensive
+// probe would otherwise regenerate).
+func TestDetectFilesExistenceOnly_AllPatterns(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTestFile(t, dir, "artist.nfo")
+	writeTestFile(t, dir, "folder.jpg") // matches thumbPatterns
+	writeTestFile(t, dir, "fanart.jpg")
+	writeTestFile(t, dir, "logo.png")
+	writeTestFile(t, dir, "banner.jpg")
+
+	existing := &artist.Artist{
+		ThumbWidth: 1000, ThumbHeight: 1500, ThumbLowRes: false,
+		ThumbPlaceholder:  "thumb-placeholder",
+		FanartWidth:       1920,
+		FanartHeight:      1080,
+		FanartLowRes:      true,
+		FanartPlaceholder: "fanart-placeholder",
+		LogoWidth:         400, LogoHeight: 200, LogoPlaceholder: "logo-placeholder",
+		BannerWidth: 800, BannerHeight: 200, BannerPlaceholder: "banner-placeholder",
+	}
+	got, err := detectFilesExistenceOnly(dir, existing)
+	if err != nil {
+		t.Fatalf("detectFilesExistenceOnly: %v", err)
+	}
+
+	// Existence flags must come from disk reality.
+	if !got.NFOExists || !got.ThumbExists || !got.FanartExists ||
+		!got.LogoExists || !got.BannerExists {
+		t.Errorf("expected every *Exists=true; got %+v", got)
+	}
+	// FanartCount falls back to 1 when DiscoverFanart finds no variants.
+	if got.FanartCount < 1 {
+		t.Errorf("FanartCount=%d; expected >=1", got.FanartCount)
+	}
+	// Dimensions / placeholders / low-res must be reused from `existing`
+	// because the fast path skips the expensive probe.
+	if got.ThumbWidth != 1000 || got.ThumbHeight != 1500 || got.ThumbPlaceholder != "thumb-placeholder" {
+		t.Errorf("thumb fields not reused from existing; got %+v", got)
+	}
+	if got.FanartWidth != 1920 || got.FanartHeight != 1080 || !got.FanartLowRes ||
+		got.FanartPlaceholder != "fanart-placeholder" {
+		t.Errorf("fanart fields not reused from existing; got %+v", got)
+	}
+	if got.LogoWidth != 400 || got.LogoHeight != 200 || got.LogoPlaceholder != "logo-placeholder" {
+		t.Errorf("logo fields not reused from existing; got %+v", got)
+	}
+	if got.BannerWidth != 800 || got.BannerHeight != 200 || got.BannerPlaceholder != "banner-placeholder" {
+		t.Errorf("banner fields not reused from existing; got %+v", got)
+	}
+}
+
+// TestDetectFilesExistenceOnly_EmptyDir verifies the no-file branch: every
+// *Exists flag stays false and the function returns a zero detectedFiles
+// instead of an error. The scanner relies on this to surface file removals
+// (the inverse of the registry-vs-disk drift case): when a file disappears,
+// the fast-path must report Exists=false so processExistingArtist can clear
+// the stored flag.
+func TestDetectFilesExistenceOnly_EmptyDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	existing := &artist.Artist{
+		ThumbExists: true, FanartExists: true,
+		ThumbPlaceholder: "stale-placeholder",
+	}
+	got, err := detectFilesExistenceOnly(dir, existing)
+	if err != nil {
+		t.Fatalf("detectFilesExistenceOnly: %v", err)
+	}
+	if got.NFOExists || got.ThumbExists || got.FanartExists ||
+		got.LogoExists || got.BannerExists {
+		t.Errorf("empty dir should yield all-false flags; got %+v", got)
+	}
+}
+
+// TestDetectFilesExistenceOnly_ReadDirError surfaces a missing-directory
+// error -- the scanner uses this to short-circuit per-file work when the
+// underlying directory has been removed mid-scan.
+func TestDetectFilesExistenceOnly_ReadDirError(t *testing.T) {
+	t.Parallel()
+	got, err := detectFilesExistenceOnly("/this/path/does/not/exist/i/hope", &artist.Artist{})
+	if err == nil {
+		t.Fatalf("expected error for missing dir; got %+v", got)
+	}
+}
+
+// TestDetectFilesExistenceOnly_MultipleFanart pins the fanart-count branch:
+// when fanart-N.jpg variants exist alongside fanart.jpg, img.DiscoverFanart
+// counts them and FanartCount reflects the total -- otherwise the registry
+// would silently believe there is only one extraneous-images-eligible file.
+func TestDetectFilesExistenceOnly_MultipleFanart(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTestFile(t, dir, "fanart.jpg")
+	writeTestFile(t, dir, "fanart1.jpg") // DiscoverFanart format: {base}{N}, not {base}-{N}
+	writeTestFile(t, dir, "fanart2.jpg")
+
+	got, err := detectFilesExistenceOnly(dir, &artist.Artist{})
+	if err != nil {
+		t.Fatalf("detectFilesExistenceOnly: %v", err)
+	}
+	if !got.FanartExists {
+		t.Errorf("FanartExists should be true; got %+v", got)
+	}
+	if got.FanartCount < 3 {
+		t.Errorf("FanartCount=%d; expected >=3 (fanart + 2 variants)", got.FanartCount)
+	}
+}

--- a/internal/scanner/detect_existence_test.go
+++ b/internal/scanner/detect_existence_test.go
@@ -1,9 +1,11 @@
 package scanner
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/artist"
 )
@@ -34,8 +36,13 @@ func TestDetectFilesExistenceOnly_AllPatterns(t *testing.T) {
 	writeTestFile(t, dir, "logo.png")
 	writeTestFile(t, dir, "banner.jpg")
 
+	// LastScannedAt is set far in the future so the per-file mtime check
+	// passes; the in-place rewrite case is covered separately by
+	// TestDetectFilesExistenceOnly_InPlaceFileRewrite.
+	future := time.Now().Add(time.Hour)
 	existing := &artist.Artist{
-		ThumbWidth: 1000, ThumbHeight: 1500, ThumbLowRes: false,
+		LastScannedAt: &future,
+		ThumbWidth:    1000, ThumbHeight: 1500, ThumbLowRes: false,
 		ThumbPlaceholder:  "thumb-placeholder",
 		FanartWidth:       1920,
 		FanartHeight:      1080,
@@ -84,8 +91,10 @@ func TestDetectFilesExistenceOnly_AllPatterns(t *testing.T) {
 func TestDetectFilesExistenceOnly_EmptyDir(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+	future := time.Now().Add(time.Hour)
 	existing := &artist.Artist{
-		ThumbExists: true, FanartExists: true,
+		LastScannedAt: &future,
+		ThumbExists:   true, FanartExists: true,
 		ThumbPlaceholder: "stale-placeholder",
 	}
 	got, err := detectFilesExistenceOnly(dir, existing)
@@ -103,9 +112,60 @@ func TestDetectFilesExistenceOnly_EmptyDir(t *testing.T) {
 // underlying directory has been removed mid-scan.
 func TestDetectFilesExistenceOnly_ReadDirError(t *testing.T) {
 	t.Parallel()
-	got, err := detectFilesExistenceOnly("/this/path/does/not/exist/i/hope", &artist.Artist{})
+	future := time.Now().Add(time.Hour)
+	got, err := detectFilesExistenceOnly("/this/path/does/not/exist/i/hope", &artist.Artist{LastScannedAt: &future})
 	if err == nil {
 		t.Fatalf("expected error for missing dir; got %+v", got)
+	}
+}
+
+// TestDetectFilesExistenceOnly_InPlaceFileRewrite pins the POSIX-aware
+// per-file mtime check: when a canonical file (here, fanart.jpg) is
+// rewritten in place AFTER existing.LastScannedAt, the parent directory's
+// mtime does NOT advance on Linux/POSIX, so the directory-mtime gate
+// alone would miss the change. detectFilesExistenceOnly catches the
+// in-place rewrite by checking each canonical file's own mtime and
+// returns errFastPathFileTouched so the caller falls back to the full
+// detectFiles probe.
+func TestDetectFilesExistenceOnly_InPlaceFileRewrite(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTestFile(t, dir, "fanart.jpg")
+
+	// LastScannedAt is in the past; the file we just wrote has mtime
+	// "now", so it must be detected as a fresh in-place rewrite.
+	past := time.Now().Add(-time.Hour)
+	existing := &artist.Artist{LastScannedAt: &past}
+
+	_, err := detectFilesExistenceOnly(dir, existing)
+	if !errors.Is(err, errFastPathFileTouched) {
+		t.Fatalf("expected errFastPathFileTouched for file newer than LastScannedAt; got %v", err)
+	}
+}
+
+// TestDetectFilesExistenceOnly_FileMtimeBeforeLastScan covers the happy
+// path of the per-file mtime check: when every canonical file's mtime is
+// at or before LastScannedAt, the fast path proceeds with cached
+// dimensions and no error.
+func TestDetectFilesExistenceOnly_FileMtimeBeforeLastScan(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeTestFile(t, dir, "fanart.jpg")
+
+	// LastScannedAt is far in the future, so every file mtime is "before"
+	// the last scan and the fast path is applicable.
+	future := time.Now().Add(time.Hour)
+	existing := &artist.Artist{LastScannedAt: &future, FanartWidth: 1920, FanartHeight: 1080}
+
+	got, err := detectFilesExistenceOnly(dir, existing)
+	if err != nil {
+		t.Fatalf("detectFilesExistenceOnly: %v", err)
+	}
+	if !got.FanartExists {
+		t.Errorf("FanartExists should be true; got %+v", got)
+	}
+	if got.FanartWidth != 1920 || got.FanartHeight != 1080 {
+		t.Errorf("dimensions not reused from existing; got %+v", got)
 	}
 }
 
@@ -120,7 +180,8 @@ func TestDetectFilesExistenceOnly_MultipleFanart(t *testing.T) {
 	writeTestFile(t, dir, "fanart1.jpg") // DiscoverFanart format: {base}{N}, not {base}-{N}
 	writeTestFile(t, dir, "fanart2.jpg")
 
-	got, err := detectFilesExistenceOnly(dir, &artist.Artist{})
+	future := time.Now().Add(time.Hour)
+	got, err := detectFilesExistenceOnly(dir, &artist.Artist{LastScannedAt: &future})
 	if err != nil {
 		t.Fatalf("detectFilesExistenceOnly: %v", err)
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -909,11 +909,28 @@ func isCanonicalArtistFile(lower string) bool {
 		}
 		// Numbered fanart variants ({base}{N}.{ext}) -- DiscoverFanart's
 		// counting walks these on the full path, so their mtime matters
-		// for the cached-FanartCount invariant.
+		// for the cached-FanartCount invariant. Require the suffix to be
+		// purely numeric so unrelated files like fanart-old.jpg or
+		// fanart_backup.png don't needlessly drop the directory out of
+		// the fast path; DiscoverFanart only recognizes the numeric form.
 		base := strings.TrimSuffix(p, filepath.Ext(p))
 		if strings.HasPrefix(lower, base) && lower != p {
 			ext := filepath.Ext(lower)
-			if ext == filepath.Ext(p) {
+			if ext != filepath.Ext(p) {
+				continue
+			}
+			suffix := strings.TrimSuffix(strings.TrimPrefix(lower, base), ext)
+			if suffix == "" {
+				continue
+			}
+			numeric := true
+			for _, ch := range suffix {
+				if ch < '0' || ch > '9' {
+					numeric = false
+					break
+				}
+			}
+			if numeric {
 				return true
 			}
 		}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -312,6 +312,17 @@ func (s *Service) processDirectory(ctx context.Context, dirPath, name, libraryID
 	if preloaded != nil {
 		if hit, ok := preloaded[dirPath]; ok {
 			existing = hit
+		} else {
+			// Cache miss: the preload map can legitimately miss an
+			// existing artist (path-empty rows are excluded; a row
+			// added between preload and this iteration). Fall back to
+			// GetByPath so the lookup remains authoritative and we
+			// don't accidentally treat an existing artist as new.
+			got, err := s.artistService.GetByPath(ctx, dirPath)
+			if err != nil {
+				return fmt.Errorf("looking up artist by path: %w", err)
+			}
+			existing = got
 		}
 	} else {
 		got, err := s.artistService.GetByPath(ctx, dirPath)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -48,6 +48,13 @@ type Service struct {
 	defaultLibraryID string
 	libraryLister    LibraryLister
 
+	// mtimeFastPath toggles the per-directory mtime check that skips the
+	// inner ReadDir + image probe loop when an artist directory has not
+	// been touched since the previous scan. Set via SetMtimeFastPath
+	// (config-driven) so production gets the optimization by default and
+	// operators on filesystems with unreliable mtimes can disable it.
+	mtimeFastPath bool
+
 	mu          sync.Mutex
 	currentScan *ScanResult
 
@@ -74,7 +81,10 @@ func (s *Service) SetLibraryLister(ll LibraryLister) {
 	s.libraryLister = ll
 }
 
-// NewService creates a scanner service.
+// NewService creates a scanner service. The mtime fast-path is enabled by
+// default so production deployments get the optimization without an
+// explicit setter call; callers that need to disable it (FUSE mounts,
+// restored backups with broken mtimes) toggle SetMtimeFastPath(false).
 func NewService(artistService *artist.Service, ruleEngine *rule.Engine, ruleService *rule.Service, logger *slog.Logger, libraryPath string, exclusions []string) *Service {
 	excMap := make(map[string]bool, len(exclusions))
 	for _, e := range exclusions {
@@ -88,9 +98,17 @@ func NewService(artistService *artist.Service, ruleEngine *rule.Engine, ruleServ
 		logger:         logger,
 		libraryPath:    libraryPath,
 		exclusions:     excMap,
+		mtimeFastPath:  true, // matches ScannerConfig.MtimeFastPath default
 		shutdownCtx:    ctx,
 		shutdownCancel: cancel,
 	}
+}
+
+// SetMtimeFastPath toggles the per-directory mtime-based fast path. Pass
+// false from startup wiring on filesystems that do not maintain stable
+// directory mtimes; otherwise leave it on the default-true value.
+func (s *Service) SetMtimeFastPath(enabled bool) {
+	s.mtimeFastPath = enabled
 }
 
 // Shutdown cancels any in-progress background scans and waits for them to
@@ -197,12 +215,13 @@ func (s *Service) runScan(ctx context.Context, result *ScanResult) {
 		return
 	}
 
-	// Collect discovered paths for removal detection
-	discoveredPaths := make(map[string]bool)
-	var allLibraryPaths []string
+	// Collect discovered paths per library for removal detection. Keyed
+	// by libraryID so detectRemoved can query only the artists belonging
+	// to each scanned library (#1409) instead of paginating the entire
+	// catalog.
+	discoveredByLibrary := make(map[string]map[string]bool, len(targets))
 
 	for _, target := range targets {
-		allLibraryPaths = append(allLibraryPaths, target.path)
 		s.logger.Info("scanning library", "path", target.path, "library_id", target.libraryID)
 
 		entries, err := os.ReadDir(target.path)
@@ -211,6 +230,29 @@ func (s *Service) runScan(ctx context.Context, result *ScanResult) {
 			continue
 		}
 
+		// Pre-load every existing artist for this library in one query so
+		// processDirectory can look up the prior DB state from an in-
+		// memory map instead of issuing one GetByPath round-trip per
+		// directory entry (#1411). HydrateOpts{} (zero value) keeps the
+		// pre-load to a single artists-table query; processDirectory only
+		// reads core flag fields (NFOExists, Thumb*, Fanart*, Logo*,
+		// Banner*, IsExcluded, LastScannedAt, image placeholders /
+		// dimensions) which all live on the artists row.
+		var libraryArtists map[string]*artist.Artist
+		if target.libraryID != "" {
+			pre, preErr := s.artistService.PreloadArtistsByLibrary(ctx, target.libraryID, artist.HydrateOpts{Images: true})
+			if preErr != nil {
+				// Falling back to the legacy GetByPath path costs one
+				// round-trip per directory but is still correct, so we
+				// log and continue rather than failing the scan.
+				s.logger.Warn("preloading artists for library",
+					"library_id", target.libraryID, "error", preErr)
+			} else {
+				libraryArtists = pre
+			}
+		}
+
+		discoveredPaths := make(map[string]bool, len(entries))
 		for _, entry := range entries {
 			if ctx.Err() != nil {
 				s.mu.Lock()
@@ -234,31 +276,47 @@ func (s *Service) runScan(ctx context.Context, result *ScanResult) {
 			dirPath := filepath.Join(target.path, entry.Name())
 			discoveredPaths[dirPath] = true
 
-			if err := s.processDirectory(ctx, dirPath, entry.Name(), target.libraryID, result); err != nil {
+			if err := s.processDirectory(ctx, dirPath, entry.Name(), target.libraryID, libraryArtists, result); err != nil {
 				s.logger.Warn("error processing directory",
 					"path", dirPath, "error", err)
 			}
 		}
+		discoveredByLibrary[target.libraryID] = discoveredPaths
 	}
 
-	// Detect removed artists
-	s.detectRemoved(ctx, discoveredPaths, allLibraryPaths, result)
+	// Detect removed artists. Per-library sweep so we issue one
+	// ListRefsByLibrary query per scanned library instead of paginating
+	// every artist in the catalog (#1409).
+	s.detectRemoved(ctx, discoveredByLibrary, result)
 
 	// Record health snapshot at end of scan
 	s.recordHealthSnapshot(ctx)
 }
 
-func (s *Service) processDirectory(ctx context.Context, dirPath, name, libraryID string, result *ScanResult) error {
+func (s *Service) processDirectory(ctx context.Context, dirPath, name, libraryID string, preloaded map[string]*artist.Artist, result *ScanResult) error {
 	excluded := s.exclusions[strings.ToLower(name)]
 
 	// Look up existing artist before detectFiles so we can skip expensive
-	// placeholder regeneration when one already exists.
-	existing, err := s.artistService.GetByPath(ctx, dirPath)
-	if err != nil {
-		return fmt.Errorf("looking up artist by path: %w", err)
+	// placeholder regeneration when one already exists. Prefer the
+	// pre-loaded path-keyed map populated once per library above; fall
+	// back to a per-directory GetByPath only on miss (new artist, or the
+	// pre-load failed and we are running degraded). This bounds the
+	// "do we already know this artist?" cost to one query per library
+	// instead of one per directory entry (#1411).
+	var existing *artist.Artist
+	if preloaded != nil {
+		if hit, ok := preloaded[dirPath]; ok {
+			existing = hit
+		}
+	} else {
+		got, err := s.artistService.GetByPath(ctx, dirPath)
+		if err != nil {
+			return fmt.Errorf("looking up artist by path: %w", err)
+		}
+		existing = got
 	}
 
-	detected, detectErr := detectFiles(dirPath, existing)
+	detected, detectErr := s.detectFilesWithFastPath(dirPath, existing)
 	if detectErr != nil {
 		s.logger.Warn("reading artist directory", "path", dirPath, "error", detectErr)
 		return nil // skip this directory entirely -- preserve existing DB state
@@ -585,8 +643,58 @@ func (s *Service) recordHealthSnapshot(ctx context.Context) {
 	}
 }
 
-// detectRemoved finds artists in the database whose paths no longer exist on disk.
-func (s *Service) detectRemoved(ctx context.Context, discoveredPaths map[string]bool, libraryPaths []string, result *ScanResult) {
+// detectRemoved finds artists in the database whose paths no longer exist
+// on disk. Iterates the per-library map produced by the scan loop above
+// and queries each library's membership with ListRefsByLibrary -- a
+// single lightweight query per scanned library, instead of paginating
+// the full hydrated artist catalog (#1409). When discoveredByLibrary has
+// N entries this issues exactly N queries (plus the per-artist Delete
+// call when a removal is actually needed).
+//
+// Legacy single-path mode (no LibraryLister + empty defaultLibraryID)
+// falls back to the paginated full-catalog sweep that the M:N era
+// inherited; without a libraryID to scope against, ListRefsByLibrary
+// would return zero rows and the removal pass would be a silent no-op.
+// Tests still depend on this fallback (TestScan_RemovedArtist), and the
+// legacy code path is hit only when an operator runs Stillwater without
+// a configured LibraryService, which is itself unusual.
+func (s *Service) detectRemoved(ctx context.Context, discoveredByLibrary map[string]map[string]bool, result *ScanResult) {
+	for libraryID, discoveredPaths := range discoveredByLibrary {
+		if ctx.Err() != nil {
+			return
+		}
+		if libraryID == "" {
+			s.detectRemovedLegacyFallback(ctx, discoveredPaths, result)
+			continue
+		}
+		refs, err := s.artistService.ListRefsByLibrary(ctx, libraryID)
+		if err != nil {
+			s.logger.Warn("listing artist refs for removal check",
+				"library_id", libraryID, "error", err)
+			continue
+		}
+		for _, ref := range refs {
+			if discoveredPaths[ref.Path] {
+				continue
+			}
+			if err := s.artistService.Delete(ctx, ref.ID); err != nil {
+				s.logger.Warn("failed to remove artist", "id", ref.ID, "error", err)
+				continue
+			}
+			s.mu.Lock()
+			result.RemovedArtists++
+			s.mu.Unlock()
+			s.logger.Debug("artist removed (directory gone)", "name", ref.Name, "path", ref.Path)
+		}
+	}
+}
+
+// detectRemovedLegacyFallback is the paginated full-catalog sweep used by
+// the legacy single-path mode (no LibraryLister). It performs path-prefix
+// matching against s.libraryPath so artists outside the scanned tree are
+// left alone. Kept here as a back-compat shim; production deployments use
+// the per-library path above.
+func (s *Service) detectRemovedLegacyFallback(ctx context.Context, discoveredPaths map[string]bool, result *ScanResult) {
 	const pageSize = 200
 	params := artist.ListParams{Page: 1, PageSize: pageSize, Sort: "name"}
 
@@ -614,26 +722,20 @@ func (s *Service) detectRemoved(ctx context.Context, discoveredPaths map[string]
 		allArtists = append(allArtists, more...)
 	}
 
+	libraryPath := s.libraryPath
 	for _, a := range allArtists {
 		if discoveredPaths[a.Path] {
 			continue
 		}
-		// Only remove artists whose path falls under a scanned library.
-		// Use filepath.Rel to avoid false positives (e.g. /music matching /music2).
-		underScannedLib := false
-		aPath := filepath.Clean(a.Path)
-		for _, lp := range libraryPaths {
-			rel, err := filepath.Rel(filepath.Clean(lp), aPath)
+		if libraryPath != "" {
+			aPath := filepath.Clean(a.Path)
+			rel, err := filepath.Rel(filepath.Clean(libraryPath), aPath)
 			if err != nil {
 				continue
 			}
-			if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-				underScannedLib = true
-				break
+			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				continue
 			}
-		}
-		if !underScannedLib {
-			continue
 		}
 		if err := s.artistService.Delete(ctx, a.ID); err != nil {
 			s.logger.Warn("failed to remove artist", "id", a.ID, "error", err)
@@ -673,6 +775,168 @@ type detectedFiles struct {
 	BannerHeight      int
 }
 
+// detectFilesWithFastPath wraps detectFiles with a per-directory mtime
+// check (#1413). It is the scanner's entry point into file detection; the
+// behavior depends on whether the per-directory mtime indicates the
+// directory may have changed since the last scan:
+//
+//   - Fast path (mtime <= last scan, existing artist, fast-path enabled):
+//     calls detectFilesExistenceOnly. That helper still issues one
+//     os.ReadDir to learn which canonical filenames are on disk -- enough
+//     to set NFOExists, ThumbExists, FanartExists, FanartCount,
+//     LogoExists, BannerExists from disk reality. The expensive work is
+//     skipped: no os.Open, no image-header decode for dimensions, no full
+//     decode for perceptual-hash placeholder generation. Existing
+//     dimensions / low-res flags / placeholders are reused for image
+//     slots whose file is still present, and zeroed for slots whose file
+//     has disappeared (so persistNormalized removes the stale row).
+//
+//     Because existence is still probed from disk, the issue #1225
+//     contract -- "the registry must converge with disk on every visit"
+//     -- continues to hold: if hydrateImages reads an empty registry and
+//     sets existing.FanartExists=false but the file is still on disk,
+//     the fast path sees the file and sets detected.FanartExists=true,
+//     the mismatch lands in processExistingArtist's change branch, and
+//     Update -> persistNormalized rebuilds the row.
+//
+//   - Full path (any of: fast-path disabled, no existing artist, no
+//     prior LastScannedAt, mtime > last scan, future-dated mtime more
+//     than one minute ahead of "now", os.Stat failure): calls detectFiles
+//     which does the full per-image probe (dimensions + low-res +
+//     placeholder generation). The future-mtime guard absorbs ordinary
+//     clock drift while preventing a misbehaving filesystem from
+//     starving the per-image rescan indefinitely.
+//
+// The perf win is preserved: on a steady-state library where nothing
+// changes on disk, every recurring scan does one os.Stat + one
+// os.ReadDir per artist directory and zero image decodes. Image decodes
+// (dimension probe + placeholder generation) only run on first scan,
+// after a file mutation that bumps the directory mtime, or when the
+// fast path is disabled for an off-clock filesystem.
+func (s *Service) detectFilesWithFastPath(dirPath string, existing *artist.Artist) (detectedFiles, error) {
+	if !s.mtimeFastPath || existing == nil || existing.LastScannedAt == nil {
+		return detectFiles(dirPath, existing)
+	}
+	info, err := os.Stat(dirPath)
+	if err != nil {
+		// Stat failure: fall through so detectFiles surfaces the real
+		// error (or recovers via ReadDir behavior). Don't swallow it
+		// here -- preserves the legacy diagnostic.
+		return detectFiles(dirPath, existing)
+	}
+	mtime := info.ModTime()
+	lastScan := *existing.LastScannedAt
+	// Defensive against future-dated mtimes: a filesystem with a broken
+	// clock (or a manually-touched directory) can produce mtimes after
+	// "now". Re-probe in that case so a stuck future timestamp cannot
+	// indefinitely starve the per-file rescan. One minute of slack
+	// absorbs ordinary clock drift without disabling the fast path.
+	if mtime.After(time.Now().Add(time.Minute)) {
+		return detectFiles(dirPath, existing)
+	}
+	if mtime.After(lastScan) {
+		return detectFiles(dirPath, existing)
+	}
+	// Directory unchanged since last scan: do the cheap existence-only
+	// probe and reuse stored dimensions / placeholders / low-res flags
+	// for slots whose file is still on disk.
+	return detectFilesExistenceOnly(dirPath, existing)
+}
+
+// detectFilesExistenceOnly probes an artist directory for which canonical
+// image / NFO filenames are present, without running the expensive
+// per-file image probe (dimension decode + perceptual-hash placeholder
+// generation). It is the cheap half of detectFiles; the fast path in
+// detectFilesWithFastPath uses it to honor the issue #1225 disk-vs-
+// registry convergence contract while still skipping the work that
+// dominates scan time on slow / networked filesystems.
+//
+// Field policy:
+//
+//   - *Exists, FanartCount: computed from the live os.ReadDir result.
+//     These match what detectFiles would compute.
+//   - *Width, *Height, *LowRes, *Placeholder: reused from `existing` for
+//     image slots whose file is still on disk. Zeroed when the file has
+//     disappeared so persistNormalized clears the stale row.
+//
+// `existing` must be non-nil; callers already guard on that in
+// detectFilesWithFastPath.
+func detectFilesExistenceOnly(dirPath string, existing *artist.Artist) (detectedFiles, error) {
+	entries, err := os.ReadDir(dirPath)
+	if err != nil {
+		return detectedFiles{}, fmt.Errorf("reading directory: %w", err)
+	}
+
+	files := make(map[string]string, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			files[strings.ToLower(e.Name())] = e.Name()
+		}
+	}
+
+	var d detectedFiles
+	if _, ok := files["artist.nfo"]; ok {
+		d.NFOExists = true
+	}
+
+	for _, p := range thumbPatterns {
+		if _, ok := files[strings.ToLower(p)]; ok {
+			d.ThumbExists = true
+			d.ThumbWidth = existing.ThumbWidth
+			d.ThumbHeight = existing.ThumbHeight
+			d.ThumbLowRes = existing.ThumbLowRes
+			d.ThumbPlaceholder = existing.ThumbPlaceholder
+			break
+		}
+	}
+	for _, p := range fanartPatterns {
+		if actual, ok := files[strings.ToLower(p)]; ok {
+			d.FanartExists = true
+			d.FanartWidth = existing.FanartWidth
+			d.FanartHeight = existing.FanartHeight
+			d.FanartLowRes = existing.FanartLowRes
+			d.FanartPlaceholder = existing.FanartPlaceholder
+			// Count fanart variants from the same ReadDir result the
+			// full path uses via img.DiscoverFanart. Cheap: pure
+			// string-pattern matching against the already-built map.
+			fanartPaths, fanartErr := img.DiscoverFanart(dirPath, actual)
+			if fanartErr != nil {
+				slog.Warn("discovering fanart variants during scan",
+					slog.String("dir", dirPath),
+					slog.String("error", fanartErr.Error()))
+			}
+			if len(fanartPaths) > 0 {
+				d.FanartCount = len(fanartPaths)
+			} else {
+				d.FanartCount = 1
+			}
+			break
+		}
+	}
+	for _, p := range logoPatterns {
+		if _, ok := files[strings.ToLower(p)]; ok {
+			d.LogoExists = true
+			d.LogoWidth = existing.LogoWidth
+			d.LogoHeight = existing.LogoHeight
+			d.LogoLowRes = existing.LogoLowRes
+			d.LogoPlaceholder = existing.LogoPlaceholder
+			break
+		}
+	}
+	for _, p := range bannerPatterns {
+		if _, ok := files[strings.ToLower(p)]; ok {
+			d.BannerExists = true
+			d.BannerWidth = existing.BannerWidth
+			d.BannerHeight = existing.BannerHeight
+			d.BannerLowRes = existing.BannerLowRes
+			d.BannerPlaceholder = existing.BannerPlaceholder
+			break
+		}
+	}
+
+	return d, nil
+}
+
 // detectFiles checks for the presence of known image and NFO files in an artist
 // directory and probes each found image for low-resolution status.
 // When existing is non-nil, its placeholders are reused to skip expensive
@@ -710,7 +974,7 @@ func detectFiles(dirPath string, existing *artist.Artist) (detectedFiles, error)
 		if actual, ok := files[strings.ToLower(p)]; ok {
 			fp := filepath.Join(dirPath, actual)
 			d.ThumbExists = true
-			d.ThumbWidth, d.ThumbHeight, d.ThumbLowRes, d.ThumbPlaceholder = probeImageFile(fp, "thumb", existThumbPH)
+			d.ThumbWidth, d.ThumbHeight, d.ThumbLowRes, d.ThumbPlaceholder = probeImageFileFn(fp, "thumb", existThumbPH)
 			break
 		}
 	}
@@ -718,7 +982,7 @@ func detectFiles(dirPath string, existing *artist.Artist) (detectedFiles, error)
 		if actual, ok := files[strings.ToLower(p)]; ok {
 			fp := filepath.Join(dirPath, actual)
 			d.FanartExists = true
-			d.FanartWidth, d.FanartHeight, d.FanartLowRes, d.FanartPlaceholder = probeImageFile(fp, "fanart", existFanartPH)
+			d.FanartWidth, d.FanartHeight, d.FanartLowRes, d.FanartPlaceholder = probeImageFileFn(fp, "fanart", existFanartPH)
 			// Count all fanart files (primary + numbered variants).
 			fanartPaths, fanartErr := img.DiscoverFanart(dirPath, actual)
 			if fanartErr != nil {
@@ -738,7 +1002,7 @@ func detectFiles(dirPath string, existing *artist.Artist) (detectedFiles, error)
 		if actual, ok := files[strings.ToLower(p)]; ok {
 			fp := filepath.Join(dirPath, actual)
 			d.LogoExists = true
-			d.LogoWidth, d.LogoHeight, d.LogoLowRes, d.LogoPlaceholder = probeImageFile(fp, "logo", existLogoPH)
+			d.LogoWidth, d.LogoHeight, d.LogoLowRes, d.LogoPlaceholder = probeImageFileFn(fp, "logo", existLogoPH)
 			break
 		}
 	}
@@ -746,13 +1010,18 @@ func detectFiles(dirPath string, existing *artist.Artist) (detectedFiles, error)
 		if actual, ok := files[strings.ToLower(p)]; ok {
 			fp := filepath.Join(dirPath, actual)
 			d.BannerExists = true
-			d.BannerWidth, d.BannerHeight, d.BannerLowRes, d.BannerPlaceholder = probeImageFile(fp, "banner", existBannerPH)
+			d.BannerWidth, d.BannerHeight, d.BannerLowRes, d.BannerPlaceholder = probeImageFileFn(fp, "banner", existBannerPH)
 			break
 		}
 	}
 
 	return d, nil
 }
+
+// probeImageFileFn is the package-level seam through which detectFiles calls
+// probeImageFile. Tests swap it to count or short-circuit the expensive
+// image-probe work; production code never reassigns it.
+var probeImageFileFn = probeImageFile
 
 // probeImageFile opens a file once, probes dimensions for low-resolution
 // detection, and generates a placeholder. If existingPlaceholder is non-empty

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -238,18 +239,29 @@ func (s *Service) runScan(ctx context.Context, result *ScanResult) {
 		// Pre-load every existing artist for this library so
 		// processDirectory can look up the prior DB state from an in-
 		// memory map instead of issuing one GetByPath round-trip per
-		// directory entry (#1411). HydrateOpts{Images: true} is required
-		// because Thumb*/Fanart*/Logo*/Banner* existence flags, low-res
-		// flags, placeholders, and dimensions are stored in the
-		// artist_images side table -- not on the artists row -- and the
-		// scanner relies on those fields in detectFilesWithFastPath and
-		// processExistingArtist. Cost: 2 queries per scanned library
-		// (artists + artist_images) instead of N round-trips per
-		// directory entry. ProviderIDs and PrimaryLibrary are still
-		// skipped: neither is read on the scan hot path.
+		// directory entry (#1411).
+		//
+		// Hydration choice:
+		//   Images:      required -- Thumb*/Fanart*/Logo*/Banner* fields
+		//                live on artist_images and the scanner reads
+		//                them in detectFilesWithFastPath and
+		//                processExistingArtist.
+		//   ProviderIDs: required -- preloaded artists flow into
+		//                Update() (via processExistingArtist), which
+		//                calls persistNormalized that re-inserts
+		//                artist_provider_ids from the in-memory struct.
+		//                Without hydration the struct's MBID / AudioDB /
+		//                Discogs / etc. fields are zero, so Update would
+		//                silently wipe the existing rows. Documented in
+		//                TestRenameDirectory_PreservesProviderIDs.
+		//   PrimaryLibrary: skipped -- persistNormalized does not write
+		//                back artist_libraries on Update, so leaving
+		//                LibraryID unhydrated is safe.
+		// Cost: 3 queries per scanned library (artists + artist_images
+		// + artist_provider_ids) instead of N round-trips per directory.
 		var libraryArtists map[string]*artist.Artist
 		if target.libraryID != "" {
-			pre, preErr := s.artistService.PreloadArtistsByLibrary(ctx, target.libraryID, artist.HydrateOpts{Images: true})
+			pre, preErr := s.artistService.PreloadArtistsByLibrary(ctx, target.libraryID, artist.HydrateOpts{Images: true, ProviderIDs: true})
 			if preErr != nil {
 				// Falling back to the legacy GetByPath path costs one
 				// round-trip per directory but is still correct, so we
@@ -859,8 +871,64 @@ func (s *Service) detectFilesWithFastPath(dirPath string, existing *artist.Artis
 	}
 	// Directory unchanged since last scan: do the cheap existence-only
 	// probe and reuse stored dimensions / placeholders / low-res flags
-	// for slots whose file is still on disk.
-	return detectFilesExistenceOnly(dirPath, existing)
+	// for slots whose file is still on disk. detectFilesExistenceOnly
+	// returns errFastPathFileTouched when a canonical file's own mtime
+	// is newer than lastScan -- on POSIX, overwriting a file in place
+	// does NOT update the parent directory's mtime, so we have to check
+	// each canonical file's mtime individually before trusting cached
+	// dimensions / placeholders.
+	d, err := detectFilesExistenceOnly(dirPath, existing)
+	if errors.Is(err, errFastPathFileTouched) {
+		return detectFiles(dirPath, existing)
+	}
+	return d, err
+}
+
+// errFastPathFileTouched signals that detectFilesExistenceOnly detected an
+// in-place rewrite of a canonical image / NFO file (file mtime advanced
+// past existing.LastScannedAt). The directory mtime won't reflect this on
+// POSIX, so detectFilesWithFastPath must fall back to detectFiles to
+// re-probe dimensions and placeholders.
+var errFastPathFileTouched = fmt.Errorf("fast path: canonical file mtime advanced; falling back to full probe")
+
+// isCanonicalArtistFile reports whether lower (a lowercase filename) matches
+// any pattern the scanner reads on the artist hot path: NFO, thumb/folder,
+// fanart (including numbered variants), logo, banner.
+func isCanonicalArtistFile(lower string) bool {
+	if lower == "artist.nfo" {
+		return true
+	}
+	for _, p := range thumbPatterns {
+		if lower == p {
+			return true
+		}
+	}
+	for _, p := range fanartPatterns {
+		if lower == p {
+			return true
+		}
+		// Numbered fanart variants ({base}{N}.{ext}) -- DiscoverFanart's
+		// counting walks these on the full path, so their mtime matters
+		// for the cached-FanartCount invariant.
+		base := strings.TrimSuffix(p, filepath.Ext(p))
+		if strings.HasPrefix(lower, base) && lower != p {
+			ext := filepath.Ext(lower)
+			if ext == filepath.Ext(p) {
+				return true
+			}
+		}
+	}
+	for _, p := range logoPatterns {
+		if lower == p {
+			return true
+		}
+	}
+	for _, p := range bannerPatterns {
+		if lower == p {
+			return true
+		}
+	}
+	return false
 }
 
 // detectFilesExistenceOnly probes an artist directory for which canonical
@@ -888,9 +956,39 @@ func detectFilesExistenceOnly(dirPath string, existing *artist.Artist) (detected
 	}
 
 	files := make(map[string]string, len(entries))
+	// canonicalEntries indexes the DirEntry for each canonical filename we
+	// care about so we can stat each one's mtime without re-walking the
+	// directory. Required because POSIX does not update the parent
+	// directory's mtime when a file is overwritten in place, so the
+	// directory-mtime gate in detectFilesWithFastPath cannot detect an
+	// in-place rewrite of fanart.jpg / folder.jpg / etc. by itself.
+	canonicalEntries := make(map[string]os.DirEntry, 8)
 	for _, e := range entries {
-		if !e.IsDir() {
-			files[strings.ToLower(e.Name())] = e.Name()
+		if e.IsDir() {
+			continue
+		}
+		lower := strings.ToLower(e.Name())
+		files[lower] = e.Name()
+		if isCanonicalArtistFile(lower) {
+			canonicalEntries[lower] = e
+		}
+	}
+
+	// existing.LastScannedAt is guaranteed non-nil by the caller. Walk the
+	// canonical matches and verify each file's mtime has not advanced
+	// since the last scan. If any has, signal the caller to bail out and
+	// re-run the full detectFiles probe so dimensions and placeholders
+	// reflect the new content.
+	lastScan := *existing.LastScannedAt
+	for _, e := range canonicalEntries {
+		info, err := e.Info()
+		if err != nil {
+			// Stat racing with a delete is the common cause; treat it
+			// like an in-place change and re-probe.
+			return detectedFiles{}, errFastPathFileTouched
+		}
+		if info.ModTime().After(lastScan) {
+			return detectedFiles{}, errFastPathFileTouched
 		}
 	}
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -235,14 +235,18 @@ func (s *Service) runScan(ctx context.Context, result *ScanResult) {
 			continue
 		}
 
-		// Pre-load every existing artist for this library in one query so
+		// Pre-load every existing artist for this library so
 		// processDirectory can look up the prior DB state from an in-
 		// memory map instead of issuing one GetByPath round-trip per
-		// directory entry (#1411). HydrateOpts{} (zero value) keeps the
-		// pre-load to a single artists-table query; processDirectory only
-		// reads core flag fields (NFOExists, Thumb*, Fanart*, Logo*,
-		// Banner*, IsExcluded, LastScannedAt, image placeholders /
-		// dimensions) which all live on the artists row.
+		// directory entry (#1411). HydrateOpts{Images: true} is required
+		// because Thumb*/Fanart*/Logo*/Banner* existence flags, low-res
+		// flags, placeholders, and dimensions are stored in the
+		// artist_images side table -- not on the artists row -- and the
+		// scanner relies on those fields in detectFilesWithFastPath and
+		// processExistingArtist. Cost: 2 queries per scanned library
+		// (artists + artist_images) instead of N round-trips per
+		// directory entry. ProviderIDs and PrimaryLibrary are still
+		// skipped: neither is read on the scan hot path.
 		var libraryArtists map[string]*artist.Artist
 		if target.libraryID != "" {
 			pre, preErr := s.artistService.PreloadArtistsByLibrary(ctx, target.libraryID, artist.HydrateOpts{Images: true})

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -53,7 +54,10 @@ type Service struct {
 	// been touched since the previous scan. Set via SetMtimeFastPath
 	// (config-driven) so production gets the optimization by default and
 	// operators on filesystems with unreliable mtimes can disable it.
-	mtimeFastPath bool
+	// Stored as atomic.Bool because background scans read this flag from
+	// detectFilesWithFastPath while SetMtimeFastPath may be called from
+	// the config-reload path concurrently.
+	mtimeFastPath atomic.Bool
 
 	mu          sync.Mutex
 	currentScan *ScanResult
@@ -91,24 +95,25 @@ func NewService(artistService *artist.Service, ruleEngine *rule.Engine, ruleServ
 		excMap[strings.ToLower(e)] = true
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	return &Service{
+	s := &Service{
 		artistService:  artistService,
 		ruleEngine:     ruleEngine,
 		ruleService:    ruleService,
 		logger:         logger,
 		libraryPath:    libraryPath,
 		exclusions:     excMap,
-		mtimeFastPath:  true, // matches ScannerConfig.MtimeFastPath default
 		shutdownCtx:    ctx,
 		shutdownCancel: cancel,
 	}
+	s.mtimeFastPath.Store(true) // matches ScannerConfig.MtimeFastPath default
+	return s
 }
 
 // SetMtimeFastPath toggles the per-directory mtime-based fast path. Pass
 // false from startup wiring on filesystems that do not maintain stable
 // directory mtimes; otherwise leave it on the default-true value.
 func (s *Service) SetMtimeFastPath(enabled bool) {
-	s.mtimeFastPath = enabled
+	s.mtimeFastPath.Store(enabled)
 }
 
 // Shutdown cancels any in-progress background scans and waits for them to
@@ -814,7 +819,7 @@ type detectedFiles struct {
 // after a file mutation that bumps the directory mtime, or when the
 // fast path is disabled for an off-clock filesystem.
 func (s *Service) detectFilesWithFastPath(dirPath string, existing *artist.Artist) (detectedFiles, error) {
-	if !s.mtimeFastPath || existing == nil || existing.LastScannedAt == nil {
+	if !s.mtimeFastPath.Load() || existing == nil || existing.LastScannedAt == nil {
 		return detectFiles(dirPath, existing)
 	}
 	info, err := os.Stat(dirPath)

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1521,3 +1521,211 @@ func TestPreserveDimensions(t *testing.T) {
 		}
 	})
 }
+
+// withProbeImageFileFn swaps the package-level probeImageFileFn for the
+// duration of the test. Tests use it to count or short-circuit the
+// expensive per-file image probe (dimension decode + perceptual-hash
+// placeholder generation) that detectFiles runs.
+//
+// Not safe under t.Parallel since probeImageFileFn is a package-level
+// var; callers must run sequentially.
+func withProbeImageFileFn(t *testing.T, fn func(filePath, imageType, existingPlaceholder string) (int, int, bool, string)) {
+	t.Helper()
+	prev := probeImageFileFn
+	probeImageFileFn = fn
+	t.Cleanup(func() { probeImageFileFn = prev })
+}
+
+// forceLastScannedAtFuture pushes the artist's LastScannedAt forward by one
+// hour so the mtime fast-path is guaranteed to engage on the next scan
+// (mtime <= now < lastScannedAt). Without this, sub-second timing between
+// scan-1 finish and scan-2 stat would race the fast-path check, since the
+// DB stores last_scanned_at at second precision while filesystem mtime
+// carries nanoseconds.
+func forceLastScannedAtFuture(t *testing.T, db *sql.DB, artistID string) {
+	t.Helper()
+	future := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	if _, err := db.Exec(`UPDATE artists SET last_scanned_at = ? WHERE id = ?`, future, artistID); err != nil {
+		t.Fatalf("forcing last_scanned_at future: %v", err)
+	}
+}
+
+// TestScan_FastPath_ReconcilesArtistImagesRegistry pins the #1225 contract
+// against the D7 mtime fast-path (#1413): even when the fast path engages
+// (mtime <= lastScannedAt), the registry must still converge with disk on
+// every visit. Earlier D7 drafts synthesized detected.FanartExists from
+// existing.FanartExists, which hydrateImages had already corrupted to
+// match the broken registry -- so detected == existing, no change branch
+// fired, and the registry stayed broken forever.
+//
+// This test forces the fast path to engage by pushing LastScannedAt into
+// the future after scan 1, so the legacy timing race (sub-second mtime
+// vs. second-precision lastScannedAt) cannot mask the bug.
+func TestScan_FastPath_ReconcilesArtistImagesRegistry(t *testing.T) {
+	t.Parallel()
+	libDir := t.TempDir()
+	createArtistDir(t, libDir, "FastPath Reconcile", "fanart.jpg")
+	svc, artistSvc, db := setupScannerWithDB(t, libDir)
+	ctx := context.Background()
+
+	if _, err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run 1: %v", err)
+	}
+	waitForScan(t, svc, 5*time.Second)
+
+	a, _ := artistSvc.GetByPath(ctx, filepath.Join(libDir, "FastPath Reconcile"))
+	if a == nil {
+		t.Fatal("artist not found after first scan")
+	}
+	if !a.FanartExists {
+		t.Fatal("FanartExists should be true after first scan with fanart.jpg present")
+	}
+
+	// Delete the registry row (simulating #1225 drift) and push
+	// LastScannedAt into the future so the next scan is guaranteed to
+	// take the fast path.
+	if _, err := db.ExecContext(ctx,
+		`DELETE FROM artist_images WHERE artist_id = ? AND image_type = 'fanart'`, a.ID); err != nil {
+		t.Fatalf("deleting fanart row: %v", err)
+	}
+	forceLastScannedAtFuture(t, db, a.ID)
+
+	if _, err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run 2: %v", err)
+	}
+	waitForScan(t, svc, 5*time.Second)
+
+	imgs, err := artistSvc.GetImagesForArtist(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("getting images: %v", err)
+	}
+	hasFanart := false
+	for _, img := range imgs {
+		if img.ImageType == "fanart" && img.SlotIndex == 0 && img.Exists {
+			hasFanart = true
+			break
+		}
+	}
+	if !hasFanart {
+		t.Fatalf("expected artist_images fanart row to be reconciled by the fast-path scan; the registry must converge with disk on every visit even when the mtime fast path is taken (issue #1225 + #1413)")
+	}
+}
+
+// TestScan_FastPath_SkipsExpensiveProbe asserts that the D7 fast path does
+// NOT invoke probeImageFile (the expensive image-header decode +
+// perceptual-hash placeholder generation) on an unchanged-mtime rescan.
+// This is the perf win the fast path exists to deliver; if the count is
+// non-zero after the second scan, the fast path is silently doing the
+// expensive work and the optimization is broken.
+//
+// The companion contract -- existence checks DO still run -- is pinned by
+// TestScan_FastPath_ReconcilesArtistImagesRegistry above and by
+// TestScan_FastPath_DetectsFileRemoval below.
+func TestScan_FastPath_SkipsExpensiveProbe(t *testing.T) {
+	// No t.Parallel: probeImageFileFn is a package-level var.
+	var calls int
+	withProbeImageFileFn(t, func(filePath, imageType, existingPlaceholder string) (int, int, bool, string) {
+		calls++
+		// Delegate to real implementation so scan 1 still produces a
+		// fully populated artist record.
+		return probeImageFile(filePath, imageType, existingPlaceholder)
+	})
+
+	libDir := t.TempDir()
+	createArtistDir(t, libDir, "FastPath Skip", "fanart.jpg")
+	svc, artistSvc, db := setupScannerWithDB(t, libDir)
+	ctx := context.Background()
+
+	if _, err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run 1: %v", err)
+	}
+	waitForScan(t, svc, 5*time.Second)
+
+	a, _ := artistSvc.GetByPath(ctx, filepath.Join(libDir, "FastPath Skip"))
+	if a == nil {
+		t.Fatal("artist not found after first scan")
+	}
+	scan1Calls := calls
+	if scan1Calls == 0 {
+		t.Fatal("scan 1 should have called probeImageFile at least once (sanity check on the test seam)")
+	}
+
+	// Force the fast path to engage on scan 2.
+	forceLastScannedAtFuture(t, db, a.ID)
+
+	if _, err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run 2: %v", err)
+	}
+	waitForScan(t, svc, 5*time.Second)
+
+	if got := calls - scan1Calls; got != 0 {
+		t.Errorf("probeImageFile was called %d times during the fast-path rescan; want 0 (the perf win of D7 is that image decode + placeholder generation are skipped when mtime is unchanged)", got)
+	}
+}
+
+// TestScan_FastPath_DetectsFileRemoval pins that the fast path still
+// honors disk existence even when it skips the expensive probe. Removing
+// fanart.jpg between scans must flip FanartExists to false on the next
+// visit -- otherwise the fast path becomes a stale-data cache instead of
+// a perf optimization.
+//
+// Note: physically removing the file bumps the directory's mtime, so a
+// strict reading of "mtime fast path" would say this case is actually
+// served by the legacy detectFiles path. We explicitly push
+// LastScannedAt past the post-delete mtime so the fast path engages
+// nonetheless, which is the worst case for the contract.
+func TestScan_FastPath_DetectsFileRemoval(t *testing.T) {
+	t.Parallel()
+	libDir := t.TempDir()
+	dir := filepath.Join(libDir, "FastPath Remove")
+	createArtistDir(t, libDir, "FastPath Remove", "fanart.jpg")
+	svc, artistSvc, db := setupScannerWithDB(t, libDir)
+	ctx := context.Background()
+
+	if _, err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run 1: %v", err)
+	}
+	waitForScan(t, svc, 5*time.Second)
+
+	a, _ := artistSvc.GetByPath(ctx, filepath.Join(libDir, "FastPath Remove"))
+	if a == nil {
+		t.Fatal("artist not found after first scan")
+	}
+	if !a.FanartExists {
+		t.Fatal("FanartExists should be true after first scan")
+	}
+
+	// Physically remove the fanart file (this bumps the dir mtime).
+	if err := os.Remove(filepath.Join(dir, "fanart.jpg")); err != nil {
+		t.Fatalf("removing fanart.jpg: %v", err)
+	}
+	// Push LastScannedAt past the new mtime so the fast path still
+	// engages despite the disk change. This is the contract-strict
+	// test: even when the mtime check would let stale data slip
+	// through, the existence probe inside the fast path must catch
+	// the removal.
+	forceLastScannedAtFuture(t, db, a.ID)
+
+	if _, err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run 2: %v", err)
+	}
+	waitForScan(t, svc, 5*time.Second)
+
+	a2, _ := artistSvc.GetByPath(ctx, filepath.Join(libDir, "FastPath Remove"))
+	if a2 == nil {
+		t.Fatal("artist not found after second scan")
+	}
+	if a2.FanartExists {
+		t.Errorf("FanartExists = true after fanart.jpg removed; the fast path must still check disk existence, not just trust cached flags")
+	}
+
+	imgs, err := artistSvc.GetImagesForArtist(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("getting images: %v", err)
+	}
+	for _, img := range imgs {
+		if img.ImageType == "fanart" && img.SlotIndex == 0 && img.Exists {
+			t.Errorf("artist_images still reports fanart exists=true after the file was removed; the fast path must converge with disk")
+		}
+	}
+}

--- a/internal/scanner/setters_test.go
+++ b/internal/scanner/setters_test.go
@@ -1,0 +1,39 @@
+package scanner
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// TestSetters exercises the trivial setter accessors so the patch coverage
+// gate includes the back-compat wiring used by the application bootstrap
+// (cmd/stillwater) and the unit test harnesses. Each setter is one line of
+// production code; this test pins their semantics so a future refactor that
+// changes the field name fails here instead of failing in main.go startup
+// (where the broken wiring would not surface until runtime).
+func TestSetters(t *testing.T) {
+	t.Parallel()
+	logger := slog.Default()
+	s := NewService(nil, nil, nil, logger, "/music", nil)
+
+	// SetDefaultLibraryID
+	s.SetDefaultLibraryID("lib-default")
+	if s.defaultLibraryID != "lib-default" {
+		t.Errorf("SetDefaultLibraryID: want lib-default, got %q", s.defaultLibraryID)
+	}
+
+	// SetMtimeFastPath: NewService defaults the flag to true; the setter
+	// must let an operator disable the fast-path for known-broken
+	// filesystems (the documented SW_SCANNER_MTIME_FAST_PATH=false path).
+	if !s.mtimeFastPath {
+		t.Errorf("NewService should default mtimeFastPath=true; got false")
+	}
+	s.SetMtimeFastPath(false)
+	if s.mtimeFastPath {
+		t.Errorf("SetMtimeFastPath(false) should disable; still enabled")
+	}
+	s.SetMtimeFastPath(true)
+	if !s.mtimeFastPath {
+		t.Errorf("SetMtimeFastPath(true) should re-enable; still disabled")
+	}
+}

--- a/internal/scanner/setters_test.go
+++ b/internal/scanner/setters_test.go
@@ -25,15 +25,15 @@ func TestSetters(t *testing.T) {
 	// SetMtimeFastPath: NewService defaults the flag to true; the setter
 	// must let an operator disable the fast-path for known-broken
 	// filesystems (the documented SW_SCANNER_MTIME_FAST_PATH=false path).
-	if !s.mtimeFastPath {
+	if !s.mtimeFastPath.Load() {
 		t.Errorf("NewService should default mtimeFastPath=true; got false")
 	}
 	s.SetMtimeFastPath(false)
-	if s.mtimeFastPath {
+	if s.mtimeFastPath.Load() {
 		t.Errorf("SetMtimeFastPath(false) should disable; still enabled")
 	}
 	s.SetMtimeFastPath(true)
-	if !s.mtimeFastPath {
+	if !s.mtimeFastPath.Load() {
 		t.Errorf("SetMtimeFastPath(true) should re-enable; still disabled")
 	}
 }


### PR DESCRIPTION
## Summary

M49.6 W1 bundles five hot-path performance issues from the M49 audit into one PR. All ship with deterministic query-count regression tests against real SQLite.

- **#1409 (D1)** -- `scanner.detectRemoved` now uses the existing `ListPathsByLibrary` (1 query) instead of paginated `List` (~100 queries for a 5k-artist library).
- **#1410 (D2)** -- bulk-action loop uses new `Service.GetByIDsBatch`, dropping N+1 hydrate fan-out to a fixed ~4 queries regardless of selection size.
- **#1411 (D3)** -- `scanner.processDirectory` pre-loads the library via new `Service.PreloadArtistsByLibrary`; subsequent per-directory lookups read from a map instead of hitting the 3-table hydrate fan-out.
- **#1413 (D7)** -- new `SW_SCANNER_MTIME_FAST_PATH` config flag (default on) skips the expensive dimension/placeholder probe on directories whose mtime has not advanced since the previous scan. The fast path still disk-probes file existence so issue #1225's registry-vs-disk reconciliation contract holds.
- **#1414 (D9)** -- new `artist.HydrateOpts` lets callers opt out of unneeded `hydrateProviderIDs / hydrateImages / hydratePrimaryLibrary` queries. Default behavior (all-true) preserved for `/artists/{id}` JSON responses.

## Design note on D7 vs #1225

The first iteration of the mtime fast-path synthesized `detected.*` from the in-memory `existing.*` after `hydrateImages` had already overwritten those fields to match the registry. That broke #1225's "registry must converge with disk on every visit" contract: a missing registry row + present file produced no mismatch, no Update, no reconcile. The reworked fast path now disk-probes existence (cheap) while skipping dimension/placeholder probes (expensive), preserving the contract while keeping the perf win on slow filesystems. New tests force-engage the fast path under realistic conditions to pin the contract.

## Test plan

- [x] `go test -race ./...` (pre-push-gate, full deterministic suite)
- [x] `make lint` (0 issues)
- [x] `make check-openapi` (no drift)
- [x] Patch coverage at or above the per-package floor (M49.5 W6 ratchet)
- [x] Smoke boot: binary starts, `/api/v1/healthcheck` returns 200, graceful shutdown clean
- [x] Issue #1225 regression test `TestScan_ReconcilesArtistImagesRegistry` still passes
- [x] New tests: `TestScan_FastPath_ReconcilesArtistImagesRegistry`, `TestScan_FastPath_SkipsExpensiveProbe`, `TestScan_FastPath_DetectsFileRemoval`, plus query-count assertions for D1/D2/D3/D9

Closes #1409
Closes #1410
Closes #1411
Closes #1413
Closes #1414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggleable scanner mtime fast-path and bulk artist retrieval/preload to speed library-aware scans.

* **Performance**
  * Steady-state scans skip expensive per-file probes when directory mtimes are unchanged.
  * Batch artist loading reduces repeated lookups during bulk operations.

* **Reliability**
  * More accurate detection and reconciliation of added/removed artist images and per-library removal sweeps.

* **Documentation**
  * Env var reference updated with the new fast-path setting.

* **Tests**
  * Expanded tests for fast-path, batch/preload, and related behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->