### PR TITLE
test(api): regression test for fetchImageFromURL ctx cancellation

### DIFF
--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
 	"image/jpeg"
 	"io"
+	"log/slog"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -2489,5 +2491,60 @@ func TestHandleImageUpload_FanartAppend_RerunsRules(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Error("RunForArtist was not invoked after successful fanart append")
+	}
+}
+
+// blockingRoundTripper blocks indefinitely unless its request's context is
+// canceled, in which case it returns the context error. It is the inverse of
+// stubRoundTripper: where stubRoundTripper proves the happy path, this one
+// proves that a caller-supplied context governs request lifetime. Without
+// http.NewRequestWithContext, a canceled caller ctx would have no effect on
+// the in-flight request and this transport would block until t.Fatal hit the
+// outer 1-second deadline.
+type blockingRoundTripper struct{}
+
+func (blockingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+// TestFetchImageFromURL_CancelledContext is the regression test for issue
+// #1412 D6: fetchImageFromURL must honor its ctx so that a disconnected
+// client releases the ssrfClient connection pool slot instead of leaving
+// the request in flight until the underlying timeout fires. Before the fix
+// the function used http.NewRequest with no ctx and the call site carried a
+// suppress-noctx lint exemption; after the fix it uses
+// http.NewRequestWithContext and propagates the caller's ctx into client.Do.
+//
+// The test calls fetchImageFromURL with an already-canceled ctx and asserts
+// that the call returns promptly (well under any production fetch timeout)
+// with an error chain that includes context.Canceled.
+func TestFetchImageFromURL_CancelledContext(t *testing.T) {
+	t.Parallel()
+
+	r := &Router{
+		ssrfClient: &http.Client{Transport: blockingRoundTripper{}},
+		logger:     slog.New(slog.DiscardHandler),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so client.Do sees a dead ctx immediately
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := r.fetchImageFromURL(ctx, "https://8.8.8.8/test.jpg")
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("fetchImageFromURL returned nil error for canceled ctx; want context.Canceled")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v; want chain to include context.Canceled", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("fetchImageFromURL did not return within 1s after ctx cancellation; ctx is not being honored")
 	}
 }


### PR DESCRIPTION
## Summary

M49.6 W2 closes #1412 by adding the regression test that was the issue's outstanding acceptance criterion. The production-side fix (threading \`ctx\` through \`fetchImageFromURL\` + dropping the \`noctx\` nolint) already landed in 7bba4eda as part of PR #1514 (M49.5 W3.3A SSRF transport hoist).

This PR adds \`TestFetchImageFromURL_CancelledContext\`, which calls the function with an already-cancelled context and asserts:
- The call returns within 1 second (well under any production fetch timeout).
- The returned error chain contains \`context.Canceled\`.

This pins the ctx-propagation contract so a future refactor can't silently regress to the pre-#1514 \`http.NewRequest\` (no ctx) form without failing CI.

## Test plan

- [x] `go test -race ./internal/api/...` (TestFetchImageFromURL_CancelledContext passes)
- [x] `bash scripts/pre-push-gate.sh` (full deterministic suite clean)
- [x] `grep -n "noctx" internal/api/handlers_image.go` returns empty (re-verifies the prior fix held)

Closes #1412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to verify image fetching operations correctly handle request context cancellation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->