### PR TITLE
test(server): bump pollUntilServing deadline to 5s for parallel-load stability

### DIFF
--- a/internal/server/listeners_test.go
+++ b/internal/server/listeners_test.go
@@ -104,7 +104,7 @@ func generateSelfSignedCert(t *testing.T, writeDir string) (certPath, keyPath st
 // is ready immediately after RunListeners returns.
 func pollUntilServing(t *testing.T, addr string) {
 	t.Helper()
-	deadline := 2 * time.Second
+	deadline := 5 * time.Second
 	stop := time.Now().Add(deadline)
 	for time.Now().Before(stop) {
 		c, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)


### PR DESCRIPTION
## Summary

- Lifts the hardcoded `pollUntilServing` deadline in `internal/server/listeners_test.go` from 2s to 5s.
- Under heavy parallel suite load, ECDSA cert generation plus TLS listener startup can exceed 2s, producing spurious `TestRunListeners_TLSSplitPort` failures (observed 2026-05-13 during the M49.5 W1 parallel refactor). The new 5s budget aligns with the canonical "give-up" bound the rest of this file already uses for analogous wait paths.

Closes #1496

## Test plan

- [x] `go test -race -count=1 ./internal/server/...` passes locally
- [x] Pre-push gate green (full test suite + lint + OpenAPI + coverage)
- [ ] CI green on the PR

Part of [M49.7](https://github.com/sydlexius/stillwater/milestone/60).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of server connection initialization verification by adjusting timeout parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->