### PR TITLE
feat(httpsafe): extend isBlocked to cover CGNAT and RFC 2544 prefixes

### DIFF
--- a/internal/httpsafe/httpsafe.go
+++ b/internal/httpsafe/httpsafe.go
@@ -11,8 +11,29 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/netip"
 	"time"
 )
+
+// extraBlockedPrefixes covers reserved IPv4 ranges that Go's stdlib helpers
+// (net.IP.IsPrivate, IsLoopback, IsLinkLocalUnicast, IsLinkLocalMulticast,
+// IsUnspecified) do not flag but which should never be reachable from
+// outbound HTTP:
+//
+//   - 100.64.0.0/10  CGNAT shared address space (RFC 6598). Often used as a
+//     transit range inside ISP networks and on tunnel/VPN interfaces. Reaching
+//     it from an SSRF context is almost always unintended.
+//   - 198.18.0.0/15  RFC 2544 benchmark / interconnect range. Reserved for
+//     device-to-device testing and sometimes routed internally; treat as
+//     non-public.
+//
+// IPv6 ULA (fc00::/7) and link-local (fe80::/10) are already caught by
+// net.IP.IsPrivate and net.IP.IsLinkLocalUnicast respectively, so they do not
+// appear here -- they are exercised by the test suite for lock-in.
+var extraBlockedPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+}
 
 // ErrPrivateAddress is returned by SafeTransport's DialContext when a target
 // host resolves to a loopback, link-local, or RFC 1918 address. Exposed as a
@@ -108,11 +129,39 @@ func SafeClient(timeout time.Duration) *http.Client {
 
 // isBlocked returns true for IP addresses that must never be contacted from
 // outbound HTTP requests: loopback, link-local unicast, link-local multicast,
-// RFC 1918 private ranges, and the unspecified address.
+// RFC 1918 private ranges, the unspecified address, and the extra reserved
+// ranges in extraBlockedPrefixes (CGNAT, RFC 2544).
 func isBlocked(ip net.IP) bool {
-	return ip.IsLoopback() ||
+	if ip.IsLoopback() ||
 		ip.IsPrivate() ||
 		ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() ||
-		ip.IsUnspecified()
+		ip.IsUnspecified() {
+		return true
+	}
+	// Convert the net.IP to a netip.Addr for prefix matching. AddrFromSlice
+	// accepts both 4-byte and 16-byte representations; we normalise to a 4-byte
+	// IPv4 form (via To4) when applicable so the IPv4 prefixes in
+	// extraBlockedPrefixes match correctly even when ip is a 4-in-6 mapped
+	// address.
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		// Fail closed. The only documented callers pass net.IP values from
+		// the Go resolver, which always produces 4-byte or 16-byte slices.
+		// Reaching this branch means the input has a non-standard length
+		// (zero, 5-15, 17+) -- either a bug in the caller or a future
+		// non-resolver code path. We refuse to dial an address we cannot
+		// classify; safer to reject than to silently allow.
+		return true
+	}
+	addr = addr.Unmap()
+	for _, prefix := range extraBlockedPrefixes {
+		if prefix.Contains(addr) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/httpsafe/httpsafe_test.go
+++ b/internal/httpsafe/httpsafe_test.go
@@ -22,11 +22,16 @@ import (
 // removed and the URL simply happens to be unreachable in CI.
 func assertBlocked(t *testing.T, addr, label string) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// 500ms is generous: SafeTransport.DialContext runs the SSRF guard
+	// before any I/O, so a healthy implementation completes in microseconds.
+	// A wider budget masks regressions where the guard is bypassed and the
+	// dial actually attempts I/O against an unroutable address.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 	conn, err := httpsafe.SafeTransport().DialContext(ctx, "tcp", addr)
 	if conn != nil {
 		conn.Close()
+		t.Fatalf("DialContext(%q): returned non-nil conn for %s; SSRF block must not open a socket", addr, label)
 	}
 	if !errors.Is(err, httpsafe.ErrPrivateAddress) {
 		t.Fatalf("DialContext(%q): err = %v; want errors.Is(err, ErrPrivateAddress) for %s", addr, err, label)
@@ -69,6 +74,39 @@ func TestSafeTransport_BlocksRFC1918_172(t *testing.T) {
 func TestSafeTransport_BlocksRFC1918_192(t *testing.T) {
 	t.Parallel()
 	assertBlocked(t, "192.168.0.1:80", "RFC 1918 (192.168.0.0/16)")
+}
+
+// TestSafeTransport_BlocksCGNAT verifies the 100.64.0.0/10 CGNAT range
+// (RFC 6598). CGNAT space is widely deployed inside ISP networks and on
+// tunnel/VPN interfaces, and is not covered by Go's net.IP.IsPrivate helper,
+// so it requires an explicit prefix check in isBlocked.
+func TestSafeTransport_BlocksCGNAT(t *testing.T) {
+	t.Parallel()
+	assertBlocked(t, "100.64.0.1:80", "CGNAT (RFC 6598, 100.64.0.0/10)")
+}
+
+// TestSafeTransport_Blocks_RFC2544 verifies the 198.18.0.0/15 benchmark /
+// interconnect range (RFC 2544). Not covered by net.IP.IsPrivate; relies on
+// the explicit prefix check in isBlocked.
+func TestSafeTransport_Blocks_RFC2544(t *testing.T) {
+	t.Parallel()
+	assertBlocked(t, "198.18.0.1:80", "RFC 2544 benchmark (198.18.0.0/15)")
+}
+
+// TestSafeTransport_BlocksIPv6ULA verifies that an IPv6 unique local address
+// (fc00::/7) is rejected. ULA is already caught via net.IP.IsPrivate (Go 1.17+);
+// this test locks that behavior in so a future refactor cannot drop it.
+func TestSafeTransport_BlocksIPv6ULA(t *testing.T) {
+	t.Parallel()
+	assertBlocked(t, "[fc00::1]:80", "IPv6 ULA (fc00::/7)")
+}
+
+// TestSafeTransport_BlocksIPv6LinkLocal verifies that an IPv6 link-local
+// address (fe80::/10) is rejected. Caught via net.IP.IsLinkLocalUnicast; this
+// test locks that behavior in.
+func TestSafeTransport_BlocksIPv6LinkLocal(t *testing.T) {
+	t.Parallel()
+	assertBlocked(t, "[fe80::1]:80", "IPv6 link-local (fe80::/10)")
 }
 
 // TestSafeTransport_AllowsPublicIP verifies that a genuine public IP is allowed

--- a/internal/httpsafe/internal_test.go
+++ b/internal/httpsafe/internal_test.go
@@ -1,0 +1,23 @@
+package httpsafe
+
+import (
+	"net"
+	"testing"
+)
+
+// TestIsBlockedFailClosedMalformedIP locks in the fail-closed branch of
+// isBlocked at the point where netip.AddrFromSlice rejects an input slice
+// whose length is neither 4 nor 16. The external SafeTransport tests cannot
+// reach this branch because callers feed it net.IP values produced by the Go
+// resolver, which always returns 4- or 16-byte representations. A future
+// refactor that silently changes that branch to return false (fail-open)
+// would reopen an SSRF vector for any non-resolver call site -- this test
+// is the guard.
+func TestIsBlockedFailClosedMalformedIP(t *testing.T) {
+	t.Parallel()
+	// Length 5: not a valid IPv4 or IPv6 byte representation.
+	malformed := net.IP{1, 2, 3, 4, 5}
+	if !isBlocked(malformed) {
+		t.Fatalf("isBlocked(%v) = false; want true (fail-closed on malformed slice)", malformed)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `100.64.0.0/10` (CGNAT, RFC 6598) and `198.18.0.0/15` (RFC 2544 benchmark/interconnect) to the SSRF transport's blocked-prefix list. Both ranges are non-public but not flagged by Go's `net.IP.IsPrivate` helper, so they need an explicit prefix check.
- Adds lock-in tests for IPv6 ULA (`fc00::/7`) and IPv6 link-local (`fe80::/10`) on top of CGNAT and RFC 2544 -- the IPv6 ranges are already caught via `net.IP.IsPrivate` / `IsLinkLocalUnicast`, but had no explicit assertions to catch a future regression.

## Hardenings from local review-toolkit pass

- `isBlocked`'s `netip.AddrFromSlice` failure path was originally `return false` (fail-open). Changed to `return true` (fail-closed) with explanatory comment. Defense-in-depth against a future caller that passes a non-resolver byte slice.
- `assertBlocked` test helper now asserts `conn == nil` and uses a 500ms timeout (was 5s). Tightens what a regression has to do to slip past the test.

Closes #1521 (follow-up from PR #1514 CR review round 4).

## Test plan

- [x] `go test -race -count=1 ./internal/httpsafe/...` passes
- [x] Pre-push gate green
- [x] Local review-toolkit pass (code-reviewer + silent-failure-hunter)
- [ ] CI green on the PR

Part of [M49.7](https://github.com/sydlexius/stillwater/milestone/60).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked additional reserved network ranges (Carrier-Grade NAT 100.64.0.0/10 and RFC‑2544 198.18.0.0/15).
  * Extended IPv6 protections to cover Unique Local Addresses and link-local ranges.
  * Strengthened IP validation to fail-closed on malformed or non-standard addresses, improving SSRF protection.

* **Tests**
  * Added unit tests covering the new ranges and malformed-IP fail-closed behavior; tightened test timeouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->