### PR TITLE
feat(ci): pilot scheduled mutation testing on internal/nfo

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -26,10 +26,13 @@
 #     --disable flag. They flip integer/float literals (e.g. 100 -> 101)
 #     which fires constantly inside constant blocks, default values, and
 #     buffer-size hints without indicating real test gaps.
-#   - exclude_dirs in mutation.config.yml drops generated mock packages
-#     (any internal/*/mocks/ directory and any *_mock.go file) so they
-#     do not skew the score. internal/nfo/ currently has none, but the
-#     filter is in place defensively for when the pilot scope widens.
+#   - exclude_dirs in mutation.config.yml drops mock packages by path
+#     prefix `mocks` (e.g. internal/*/mocks/) so they do not skew the
+#     score. go-mutesting only does prefix matching here -- it does NOT
+#     support globs or filename suffixes -- so generated `*_mock.go`
+#     files outside a `mocks` directory would still be mutated. The
+#     filter is defensive for when the pilot widens to packages that
+#     emit a `mocks/` subdir; internal/nfo currently has none.
 #   - Known unkillable mutants: the two time.Now() call sites in
 #     snapshot.go (Save) and writeback.go (WriteBackArtistNFOWithFieldMap)
 #     will always survive because a deterministic test suite cannot

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,184 @@
+# Scheduled mutation-testing workflow (pilot)
+#
+# Triggers: weekly cron on Monday 05:00 UTC + manual workflow_dispatch.
+#
+# Schedule choice (Monday 05:00 UTC):
+#   - Sits in the 40-minute gap between codeql.yml (04:17 UTC) and
+#     fuzz.yml (06:00 UTC) so the three weekly heavy jobs do not
+#     compete for ubuntu-latest capacity.
+#   - Morning UTC means failures appear early in the European/US workday.
+#
+# Scope -- pilot:
+#   internal/nfo/ ONLY (9 non-test files, ~1.5k LoC). Extending coverage
+#   to additional packages (notably internal/rule/) is intentionally
+#   deferred to a follow-up issue to be filed at milestone close so we
+#   can size runtime against real data first.
+#
+# Tool choice: github.com/avito-tech/go-mutesting (maintained fork of
+# zimmski/go-mutesting). The fork adds annotation-driven exclusions
+# (// mutator-disable-next-line, // mutator-disable-func,
+# // mutator-disable-regexp) and a YAML config file. We lean on the
+# CLI flags + config for pilot-scale noise tuning and leave source
+# annotations as a future option if specific call sites prove noisy.
+#
+# Noise tuning:
+#   - numbers/incrementer and numbers/decrementer are disabled via the
+#     --disable flag. They flip integer/float literals (e.g. 100 -> 101)
+#     which fires constantly inside constant blocks, default values, and
+#     buffer-size hints without indicating real test gaps.
+#   - exclude_dirs in mutation.config.yml drops generated mock packages
+#     (any internal/*/mocks/ directory and any *_mock.go file) so they
+#     do not skew the score. internal/nfo/ currently has none, but the
+#     filter is in place defensively for when the pilot scope widens.
+#   - Known unkillable mutants: the two time.Now() call sites in
+#     snapshot.go (Save) and writeback.go (WriteBackArtistNFOWithFieldMap)
+#     will always survive because a deterministic test suite cannot
+#     detect a mutated timestamp. They form the baseline noise floor
+#     for the pilot; if surviving mutants grow beyond that handful,
+#     the report is signaling a real test gap. Source annotations to
+#     formally exclude them were considered and deferred to the
+#     follow-up that expands scope beyond the pilot.
+#
+# Output:
+#   Surviving mutants are surfaced two ways and ONLY two ways:
+#     1. A markdown table in $GITHUB_STEP_SUMMARY (file, surviving count,
+#        score) for quick triage from the run page.
+#     2. The full go-mutesting log uploaded as an artifact for diff
+#        inspection (each FAIL entry prints the unified diff).
+#   No PR comments. This is a noisy signal by nature; comment spam would
+#   dilute reviewer attention. Surviving mutants are advisory, not a
+#   gate -- the workflow exits 0 regardless of mutation score so that
+#   the schedule keeps running and the trend stays visible.
+
+name: Mutation Testing
+
+on:
+  schedule:
+    - cron: '0 5 * * 1' # weekly, Monday 05:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutate:
+    name: Mutate internal/nfo
+    runs-on: ubuntu-latest
+    # 60-minute ceiling: ~1.5k LoC across 9 files times the avito-tech
+    # fork's per-mutation `go test ./internal/nfo` budget. The pilot
+    # currently finishes well under this on a warm cache; the ceiling
+    # exists so a regression that explodes mutation count gets killed
+    # rather than burning runner minutes.
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install go-mutesting
+        # Pinned to @latest deliberately. The avito-tech fork is the
+        # active maintenance fork (the upstream zimmski/go-mutesting is
+        # archived); there are no semver tags to pin to. Dependabot's
+        # action-version automation does not cover `go install` lines,
+        # so we accept upstream drift here in exchange for picking up
+        # mutator fixes without manual SHA bumps.
+        run: go install github.com/avito-tech/go-mutesting/cmd/go-mutesting@latest
+
+      - name: Write go-mutesting config
+        # exclude_dirs is a path-prefix filter on the binary's
+        # target-walk. We list the two patterns we never want mutated:
+        # mock packages (internal/<x>/mocks/) and generated *_mock.go
+        # files. The list is defensive -- internal/nfo currently has
+        # neither -- so the pilot's noise floor stays stable if the
+        # scope later widens to packages that do generate mocks.
+        run: |
+          cat > mutation.config.yml <<'YAML'
+          skip_without_test: true
+          skip_with_build_tags: true
+          silent_mode: false
+          exclude_dirs:
+            - mocks
+            - _mock.go
+          YAML
+
+      - name: Run mutation testing
+        # --disable numbers/* drops the incrementer/decrementer
+        # mutators (see the noise-tuning notes in the workflow header).
+        # Output is captured to mutation.log so the parse-summary step
+        # below can extract surviving-mutant counts without re-running
+        # the (expensive) mutation pass. `|| true` is intentional --
+        # the binary exits 0 in normal operation even when mutants
+        # survive, but we belt-and-brace against a future exit-code
+        # change so the parse step always sees the log.
+        run: |
+          set -o pipefail
+          go-mutesting \
+            --config mutation.config.yml \
+            --disable 'numbers/*' \
+            ./internal/nfo/... \
+            2>&1 | tee mutation.log || true
+
+      - name: Build workflow summary
+        # Parse the captured log into a markdown table on the run page.
+        # go-mutesting writes one line per mutant with the shape:
+        #   PASS|FAIL "<tmpdir>/<path>/<file>.go.<N>" with checksum ...
+        # and a trailer:
+        #   The mutation score is X.YZ (P passed, F failed, S skipped, total is T)
+        #
+        # We collapse FAIL entries (= surviving mutants) by source file
+        # and append the overall score line verbatim. awk handles the
+        # accumulation; jq is unnecessary for line-oriented text.
+        if: always()
+        run: |
+          {
+            echo "# Mutation testing report"
+            echo
+            echo "Target: \`./internal/nfo/...\`"
+            echo
+            if [ ! -s mutation.log ]; then
+              echo "_No mutation.log produced -- check the previous step._"
+              exit 0
+            fi
+            score_line=$(grep -E '^The mutation score is' mutation.log | tail -n1 || true)
+            if [ -n "$score_line" ]; then
+              echo "**Score:** ${score_line}"
+              echo
+            fi
+            surviving=$(grep -c '^FAIL ' mutation.log || true)
+            echo "**Surviving mutants:** ${surviving:-0}"
+            echo
+            if [ "${surviving:-0}" -gt 0 ]; then
+              echo "## Surviving mutants by file"
+              echo
+              echo "| File | Surviving mutants |"
+              echo "| ---- | ----------------- |"
+              grep '^FAIL ' mutation.log \
+                | sed -E 's|^FAIL "[^"]*/(internal/nfo/[^"]+)\.go\.[0-9]+".*|\1.go|' \
+                | sort \
+                | uniq -c \
+                | awk '{printf "| %s | %d |\n", $2, $1}'
+              echo
+              echo "Full diffs for each surviving mutant are in the \`mutation-report\` artifact."
+            else
+              echo "_No surviving mutants -- the test suite killed every mutation._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload mutation report
+        # Always upload so a clean run still produces a downloadable
+        # baseline -- useful for diffing trend lines week over week.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutation-report
+          path: mutation.log
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -93,12 +93,12 @@ jobs:
         run: go install github.com/avito-tech/go-mutesting/cmd/go-mutesting@latest
 
       - name: Write go-mutesting config
-        # exclude_dirs is a path-prefix filter on the binary's
-        # target-walk. We list the two patterns we never want mutated:
-        # mock packages (internal/<x>/mocks/) and generated *_mock.go
-        # files. The list is defensive -- internal/nfo currently has
-        # neither -- so the pilot's noise floor stays stable if the
-        # scope later widens to packages that do generate mocks.
+        # exclude_dirs is a path-prefix filter on the binary's target-walk.
+        # We only list `mocks` here because go-mutesting matches by path
+        # prefix, not by glob or suffix -- a `_mock.go` entry would never
+        # actually exclude any generated mock files. internal/nfo has no
+        # mocks today; the `mocks` entry is defensive for when the pilot
+        # widens to packages that do generate mocks.
         run: |
           cat > mutation.config.yml <<'YAML'
           skip_without_test: true
@@ -106,25 +106,29 @@ jobs:
           silent_mode: false
           exclude_dirs:
             - mocks
-            - _mock.go
           YAML
 
       - name: Run mutation testing
-        # --disable numbers/* drops the incrementer/decrementer
-        # mutators (see the noise-tuning notes in the workflow header).
-        # Output is captured to mutation.log so the parse-summary step
-        # below can extract surviving-mutant counts without re-running
-        # the (expensive) mutation pass. `|| true` is intentional --
-        # the binary exits 0 in normal operation even when mutants
-        # survive, but we belt-and-brace against a future exit-code
-        # change so the parse step always sees the log.
+        # --disable numbers/* drops the incrementer/decrementer mutators
+        # (see the noise-tuning notes in the workflow header). Output is
+        # captured to mutation.log so the parse-summary step below can
+        # extract surviving-mutant counts without re-running the
+        # (expensive) mutation pass.
+        #
+        # `continue-on-error: true` keeps the workflow non-gating: a real
+        # failure (tool crash, test infra error) marks the step red and
+        # the rest of the workflow still runs (summary + artifact upload).
+        # Using `continue-on-error` instead of a shell-level `|| true`
+        # preserves failure VISIBILITY -- a crash is loudly red in the UI
+        # rather than silently green.
+        continue-on-error: true
         run: |
           set -o pipefail
           go-mutesting \
             --config mutation.config.yml \
             --disable 'numbers/*' \
             ./internal/nfo/... \
-            2>&1 | tee mutation.log || true
+            2>&1 | tee mutation.log
 
       - name: Build workflow summary
         # Parse the captured log into a markdown table on the run page.


### PR DESCRIPTION
> Reopened after CodeRabbit went silent on #1537 and again on #1538 (two close/reopen attempts each unable to engage the bot). Same branch, fresh PR number, branch rebased onto latest main so CR sees a clean diff in its open-PR pipeline.

## Summary

- Adds a weekly scheduled (Monday 05:00 UTC, plus `workflow_dispatch`) mutation-testing workflow that runs `go-mutesting` (avito-tech maintained fork) against `internal/nfo/`. Surviving mutants surface in the workflow summary; the full report uploads as an artifact. No PR comments to avoid review noise.
- Scope intentionally narrowed to `internal/nfo` only as a pilot bounded in runtime (9 non-test files, ~1.5k LoC). Extending coverage to `internal/rule/` tracked as a follow-up to be filed at milestone close.
- Schedule slot (Monday 05:00 UTC) sits between codeql (04:17) and fuzz (06:00) so the three weekly heavy jobs do not compete for `ubuntu-latest` capacity.

## Trade-offs documented inline

- **`go install ...@latest`** for `go-mutesting`: the upstream fork has no semver tags and Dependabot does not cover `go install` lines. Documented in the workflow header.
- **`--disable 'numbers/*'`**: silences `numbers/incrementer` + `numbers/decrementer` mutators. They flip integer/float literals on every line and produce mostly noise (constant blocks, buffer hints) without indicating real test gaps. Remove the flag if a future round wants the noise to surface signal.
- **Two known-unkillable `time.Now()` sites** in `snapshot.go` and `writeback.go` form the expected baseline noise floor. Source annotations to formally exclude them are deferred to the scope-expansion follow-up.

## Action SHAs

`actions/checkout`, `actions/setup-go`, and `actions/upload-artifact` pin to the exact SHAs used by `.github/workflows/fuzz.yml` so Dependabot's consolidated bump path is preserved.

Closes #1420

## Test plan

- [x] `actionlint` clean on the workflow file
- [x] Local review-toolkit pass (code-reviewer; CLI flag spelling verified against go-mutesting upstream source)
- [x] Action SHA pins exactly match `fuzz.yml`
- [ ] Post-merge: trigger via `workflow_dispatch` to confirm the workflow runs end-to-end, populates `GITHUB_STEP_SUMMARY`, and uploads the artifact

Part of [M49.7](https://github.com/sydlexius/stillwater/milestone/60).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated "Mutation Testing" workflow that runs weekly and can be triggered manually.
  * Executes mutation runs non-blocking, appends a summarized markdown report to the workflow summary, and uploads a mutation log as a retained artifact (90 days) for review.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->