### PR TITLE
chore(lint): enable gocognit at threshold 30 with two-axis triage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - errcheck
     - errorlint
     - exhaustive
+    - gocognit
     - gosec
     - govet
     - misspell
@@ -34,6 +35,19 @@ linters:
       comparison: true
     exhaustive:
       default-signifies-exhaustive: true
+    gocognit:
+      # Threshold 30 is the gocognit default and the standard floor for
+      # cognitive complexity in Go projects. Raising it would bury
+      # findings the linter is meant to surface. Production functions
+      # over 30 are individually triaged: each has a function-specific
+      # //nolint:gocognit reason explaining why the complexity is
+      # essential at that site, or a reason ending with "refactor
+      # tracked under parent #1540 (sub-issue TBD)" when the function
+      # warrants a follow-up refactor. The two-axis triage (cog x path
+      # criticality) is documented in #1468; sub-issues for the
+      # refactor-worthy sites are filed under parent #1540 in M55.5.
+      # nolintlint enforces that every suppression carries a reason.
+      min-complexity: 30
     gosec:
       excludes:
         - G104  # Unhandled errors (too noisy for http.Error calls)
@@ -90,6 +104,15 @@ linters:
           - errcheck
           - noctx
           - contextcheck
+          # gocognit on tests would force rewriting table-driven cases,
+          # fixture builders, and integration scenarios into helper-heavy
+          # forms that obscure what the test is actually exercising. The
+          # same "ceremony without value" rationale that exempts gosec
+          # and errcheck from test files applies here. A substantial
+          # share of threshold-30 violations live in _test.go /
+          # _fuzz_test.go; excluding them categorically keeps the
+          # production sweep the signal-bearing part of the lint surface.
+          - gocognit
       - text: "catalogue.*is a misspelling"
         linters:
           - misspell

--- a/cmd/gen-rules-catalogue/main.go
+++ b/cmd/gen-rules-catalogue/main.go
@@ -218,6 +218,8 @@ func renderConfigurable(cfg rule.RuleConfig) string {
 // renderCatalogue returns the full Markdown body to place between the
 // BEGIN/END markers. Rules are grouped in categoryOrder and within each
 // group ordered by their position in rules (registration order).
+//
+//nolint:gocognit // Markdown generator: emits per-category section headers and per-rule subsections with field-conditional rendering (description, severity, automation, frontmatter); splitting the conditionals would scatter the Markdown structure across helpers and obscure the rendered output's shape.
 func renderCatalogue(rules []rule.Rule) string {
 	// Partition rules by category, preserving registration order within each group.
 	byCategory := make(map[rule.RuleCategory][]rule.Rule)

--- a/cmd/gen-settings-reference/main.go
+++ b/cmd/gen-settings-reference/main.go
@@ -747,6 +747,8 @@ func buildTab(p panel, keys map[string]string) (docTab, error) {
 // buildSections groups the panel's keys by tier-2 namespace (the section ID)
 // and returns one docSection per group, preserving panel-source order for both
 // sections and their controls.
+//
+//nolint:gocognit // Two-level grouping with first-appearance ordering at both section and control granularity; the i18n key segmenter has to handle title/desc-only keys, control composite IDs, and orphaned keys in a single pass to preserve panel-source order, and splitting the segmentation rules would multiply map lookups.
 func buildSections(panelKeys []string, allKeys map[string]string) ([]docSection, error) {
 	type sectionAccum struct {
 		id          string

--- a/internal/api/handlers_artist.go
+++ b/internal/api/handlers_artist.go
@@ -150,6 +150,8 @@ func parseIDsParam(raw string) []string {
 
 // handleArtistsPage renders the artist list HTML page.
 // GET /artists
+//
+//nolint:gocognit // Artists page handler (cog 50): resolves auth, parses paging/sort/filter params, validates "show selected" IDs, queries the page slice + total counts + facet counts, then renders both full-page and HTMX-partial responses. The parse/query/render stages could move into named helpers reading from a shared request-context struct without reshuffling render-time fields. Refactor tracked in #1550.
 func (r *Router) handleArtistsPage(w http.ResponseWriter, req *http.Request) {
 	userID := middleware.UserIDFromContext(req.Context())
 	if userID == "" {

--- a/internal/api/handlers_backdrop.go
+++ b/internal/api/handlers_backdrop.go
@@ -505,6 +505,8 @@ func (r *Router) handleFanartSlotDelete(w http.ResponseWriter, req *http.Request
 
 // handleFanartReorder reorders local fanart files according to a given permutation.
 // POST /api/v1/artists/{id}/images/fanart/reorder
+//
+//nolint:gocognit // Permutation validation (range-check, dup-check, length-match) interleaved with two-phase rename (stage to .tmp, then commit) and rollback-on-partial-failure; the rollback ordering only makes sense in the linear form.
 func (r *Router) handleFanartReorder(w http.ResponseWriter, req *http.Request) {
 	artistID, ok := RequirePathParam(w, req, "id")
 	if !ok {

--- a/internal/api/handlers_bulk_actions.go
+++ b/internal/api/handlers_bulk_actions.go
@@ -302,6 +302,8 @@ func (r *Router) handleBulkActionCancel(w http.ResponseWriter, _ *http.Request) 
 
 // runBulkAction executes the action for each artist ID in a detached goroutine.
 // Uses a mutex-protected progress struct so status polls see consistent state.
+//
+//nolint:gocognit // Action-dispatch worker: per-action branches (lock/unlock/delete/refresh) each have distinct prerequisites and outcome accounting, all wrapped in the same cancel-aware loop with mutex-protected progress; the dispatch must stay in one function for the cancel observer to see consistent state transitions.
 func (r *Router) runBulkAction(reqCtx context.Context, action string, ids []string, progress *BulkActionProgress) {
 	// Detach from the request lifecycle but keep request-scoped values
 	// (user, logger, etc.). fix-all uses the same pattern. Wrap with a

--- a/internal/api/handlers_conflict.go
+++ b/internal/api/handlers_conflict.go
@@ -163,6 +163,8 @@ func (r *Router) handleGetConnectionConflictDetail(w http.ResponseWriter, req *h
 //
 // POST /api/v1/connections/{id}/stillwater-managed
 // Body: {"enabled": true|false}
+//
+//nolint:gocognit // Multi-source body decoder (JSON, form, query) feeding a strict-validation gate, followed by a per-connection serialization mutex, idempotency snapshot-shape consistency check, and apply/clear dispatch with a refresh that MUST run on every error path (the #1190 data-loss reproduction depends on the refresh ordering). The decoder ladder is the boundary the strict-validation policy guards.
 func (r *Router) handleSetStillwaterManaged(w http.ResponseWriter, req *http.Request) {
 	id := req.PathValue("id")
 	if id == "" {

--- a/internal/api/handlers_connection.go
+++ b/internal/api/handlers_connection.go
@@ -449,6 +449,8 @@ func (r *Router) handleDeleteConnection(w http.ResponseWriter, req *http.Request
 
 // handleTestConnection tests connectivity to a platform and updates its status.
 // POST /api/v1/connections/{id}/test
+//
+//nolint:gocognit // Per-connection-type test dispatch (cog 71): Emby/Jellyfin/Lidarr each with TLS, auth, capability, library-listing probes and a unified status-update + SSE-emit tail. The size warrants extracting per-type probe helpers behind a small interface while preserving per-failure error-message specificity for troubleshooting. Refactor tracked in #1544.
 func (r *Router) handleTestConnection(w http.ResponseWriter, req *http.Request) {
 	id, ok := RequirePathParam(w, req, "id")
 	if !ok {

--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -588,6 +588,7 @@ func (r *Router) dedupeForImport(
 	return a, false
 }
 
+//nolint:gocognit // Paginated Emby fetch with per-artist upsert, conflict-with-manual-libraries detection, image-presence cache updates, and disambiguation when external MBID differs from local; the paginate loop's continuation conditions and per-artist outcome accounting must remain in sequence.
 func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, lib *library.Library, result *populateResult) error {
 	manualLibs := r.manualLibraries(ctx)
 	startIndex := 0
@@ -674,6 +675,7 @@ func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, l
 	return nil
 }
 
+//nolint:gocognit // Paginated Jellyfin fetch with the same multi-state per-artist accounting as the Emby variant (upsert, conflict-with-manual, image cache, disambiguation); the Jellyfin response schema differs from Emby's so the two cannot share a code path without an adapter abstraction that would itself raise complexity.
 func (r *Router) populateFromJellyfinCtx(ctx context.Context, client *jellyfin.Client, lib *library.Library, result *populateResult) error {
 	manualLibs := r.manualLibraries(ctx)
 	startIndex := 0
@@ -868,6 +870,8 @@ var platformToStillwaterType = map[string]string{
 // downloadPlatformImages downloads available images from a media platform for a single artist.
 // connType identifies the platform source (e.g. "emby", "jellyfin") for provenance metadata.
 // Errors are non-fatal: logged as warnings and skipped.
+//
+//nolint:gocognit // Platform image downloader (cog 60): walks the imageTag -> Stillwater image-type map, downloads each present tag with per-type cache-miss handling, saves with platform-naming patterns, records provenance, and finally walks the backdropTags slice with a parallel pipeline; a per-tag pipeline struct with a download-save-provenance method would preserve provenance attribution while flattening the cog score. Refactor tracked in #1546.
 func (r *Router) downloadPlatformImages(ctx context.Context, dl imageDownloader, platformArtistID string, imageTags map[string]string, backdropTags []string, a *artist.Artist, connType string, result *populateResult) {
 	dir := r.imageDir(a)
 	if dir == "" {

--- a/internal/api/handlers_fix.go
+++ b/internal/api/handlers_fix.go
@@ -468,6 +468,8 @@ func (r *Router) handleFixAllStatus(w http.ResponseWriter, _ *http.Request) {
 //  2. Artist grouping: check each artist once, skip orphaned groups
 //  3. Rule caching: Pipeline caches rule lookups across the entire run
 //  4. Yield: sleep between artist groups to release the SQLite write lock
+//
+//nolint:gocognit // Three-phase fix-all worker: bulk-dismiss orphans, group violations by artist, then per-group existence check + per-violation FixViolation with mutex-protected progress updates and a yield between groups so HTTP handlers can take the SQLite write lock. The phases share progress state and refactoring would force a progress-aware iterator type just to satisfy gocognit.
 func (r *Router) runFixAll(reqCtx context.Context, violations []rule.RuleViolation, scoped bool, progress *FixAllProgress) {
 	go func() {
 		// Detach from request lifecycle but preserve request-scoped values.

--- a/internal/api/handlers_identify.go
+++ b/internal/api/handlers_identify.go
@@ -421,6 +421,8 @@ func (r *Router) runBulkIdentify(ctx context.Context, artists []artist.Artist, p
 }
 
 // identifyArtist runs the 3-tier identification pipeline for a single artist.
+//
+//nolint:gocognit // 3-tier identification (connection match, exact MB query, search with disambiguation) requires that each tier's outcome decision -- match, ambiguous, skip, fall through -- be evaluated in order with tier-specific guards; the tier ordering is the function's purpose and cannot be flattened.
 func (r *Router) identifyArtist(ctx context.Context, a *artist.Artist, connIdx *connectionIndex) identifyResult {
 	// Skip locked artists -- they should not be auto-modified.
 	if a.Locked {

--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -94,6 +94,8 @@ var validContentTypes = map[string]bool{
 
 // handleImageUpload handles multipart file uploads for artist images.
 // POST /api/v1/artists/{id}/images/upload
+//
+//nolint:gocognit // Linear guard chain (auth, artist exists, image dir, multipart parse, type allowlist, file slot, content-type allowlist, size cap, pre-save geometry check) then either the fanart-append or primary-save branch with per-branch provenance, event emission, rule re-eval, and platform sync; the guard ordering is the API contract. The companion handleImageFetch (sub-issue) covers the duplicated branch shape; refactor tracked in #1552.
 func (r *Router) handleImageUpload(w http.ResponseWriter, req *http.Request) {
 	artistID, ok := RequirePathParam(w, req, "id")
 	if !ok {
@@ -259,6 +261,8 @@ func (r *Router) handleImageUpload(w http.ResponseWriter, req *http.Request) {
 
 // handleImageFetch fetches an image from a URL and saves it for the artist.
 // POST /api/v1/artists/{id}/images/fetch
+//
+//nolint:gocognit // URL-fetch image handler (cog 35): mirrors handleImageUpload's guard chain (auth, artist, image dir, validation, pre-save geometry, fanart-vs-primary save) with a URL fetch substituted for the multipart parse and an extra private-URL block; the cross-handler duplication is the structural smell driving cog and a shared image-receive helper would flatten both. Refactor tracked in #1552.
 func (r *Router) handleImageFetch(w http.ResponseWriter, req *http.Request) {
 	artistID, ok := RequirePathParam(w, req, "id")
 	if !ok {
@@ -902,6 +906,8 @@ func sortImageResults(images []provider.ImageResult, sortBy string) {
 // After persisting, provenance metadata (phash, source, file format, mtime) is read from the
 // image file and recorded in the artist_images table.
 // When exists is false all flags and the placeholder are cleared.
+//
+//nolint:gocognit // Probes file existence then conditionally derives dimensions, low-res flag, placeholder, phash, source format, and mtime; each step's error handling is local to its concern and splitting would just shuffle the conditionals across helpers.
 func (r *Router) setArtistImageFlag(ctx context.Context, a *artist.Artist, imageType string, exists bool) {
 	var lowRes bool
 	var placeholder string
@@ -1206,6 +1212,8 @@ func (r *Router) handleImageInfo(w http.ResponseWriter, req *http.Request) {
 
 // handleDeleteImage deletes a local artist image file.
 // DELETE /api/v1/artists/{id}/images/{type}
+//
+//nolint:gocognit // Fanart delete is a distinct branch that walks every numbered variant before invoking platform-side delete; the regular-image branch uses #1161 strict-stat semantics so a transient stat error preserves the exists_flag. Each branch's response shape (HTMX preview-card vs JSON) is API contract.
 func (r *Router) handleDeleteImage(w http.ResponseWriter, req *http.Request) {
 	artistID, ok := RequirePathParam(w, req, "id")
 	if !ok {

--- a/internal/api/handlers_nfo.go
+++ b/internal/api/handlers_nfo.go
@@ -174,6 +174,8 @@ type ClobberCheckResponse struct {
 
 // handleClobberCheck checks all enabled connections for NFO/image writing configuration.
 // GET /api/v1/connections/clobber-check
+//
+//nolint:gocognit // Fast-path library-path gate (clobber risk is impossible when no library has a filesystem path), then per-connection NFO-writer probe with per-result risk aggregation; the HTMX-vs-JSON response shaping rebuilds the risk list into a template-friendly slice and that adapter has to live with the aggregation to share the filtered subset.
 func (r *Router) handleClobberCheck(w http.ResponseWriter, req *http.Request) {
 	// If no library has a filesystem path, Stillwater cannot write NFO files,
 	// so there is no clobber risk regardless of server configuration.

--- a/internal/api/handlers_platform.go
+++ b/internal/api/handlers_platform.go
@@ -203,6 +203,8 @@ func normalizeSettingsSection(section string) string {
 
 // handleSettingsPage renders the settings HTML page.
 // GET /settings
+//
+//nolint:gocognit // Top-level settings page aggregator: auth gate, platforms list, providers list, integrations, language prefs, update config, log config; each subsection has its own error branch with a degrade-or-bail decision and merging them would require shared error sentinels that obscure the per-section policy.
 func (r *Router) handleSettingsPage(w http.ResponseWriter, req *http.Request) {
 	userID := middleware.UserIDFromContext(req.Context())
 	if userID == "" {

--- a/internal/api/handlers_preferences.go
+++ b/internal/api/handlers_preferences.go
@@ -355,6 +355,8 @@ func (r *Router) handleGetPreference(w http.ResponseWriter, req *http.Request) {
 // handleGetPreferences returns all preferences for the authenticated user,
 // merged with defaults so every known key is always present.
 // GET /api/v1/preferences
+//
+//nolint:gocognit // Defaults merge then per-row overlay with per-key normalization (boolean coercion with app-level fallback for auto_fetch_images, page_size clamp, bg_opacity clamp, metadata_languages re-validation); each normalizer is keyed on a different preference family so the if-ladder is the dispatch and a generic normalizer would have to thread per-family parameters through.
 func (r *Router) handleGetPreferences(w http.ResponseWriter, req *http.Request) {
 	userID := middleware.UserIDFromContext(req.Context())
 	if userID == "" {

--- a/internal/api/handlers_provider.go
+++ b/internal/api/handlers_provider.go
@@ -30,6 +30,8 @@ func (r *Router) handleListProviders(w http.ResponseWriter, req *http.Request) {
 // By default, the key is tested before saving. If the test fails, an error is
 // returned with a "Save anyway" option (skip_test=true). Supports both JSON
 // body and form-encoded data (for HTMX forms).
+//
+//nolint:gocognit // Set-provider-key handler (cog 58): content-type-dependent input parsing (JSON vs form), provider-by-name dispatch for the test call, encrypted persistence with "save anyway" fallback, and HTMX-aware response shaping (full JSON vs partial render); the parse/test/persist/respond pipeline could be sliced into named stages while keeping the single-flight semantics. Refactor tracked in #1547.
 func (r *Router) handleSetProviderKey(w http.ResponseWriter, req *http.Request) {
 	name := provider.ProviderName(req.PathValue("name"))
 	if !isValidProviderName(name) {
@@ -505,6 +507,8 @@ func (r *Router) handleGetWebSearchProviders(w http.ResponseWriter, req *http.Re
 // When enabled, the provider is added to image field priority lists at lowest position.
 // When disabled, it is removed from all priority lists.
 // PUT /api/v1/providers/websearch/{name}/toggle
+//
+//nolint:gocognit // Web-search toggle (cog 61): walks every image-field priority list to insert-or-remove the provider, persists each modified list, and emits per-field SSE events; the per-field add/remove decision could move into a typed list-mutator while keeping the single-pass write semantics. Refactor tracked in #1545.
 func (r *Router) handleSetWebSearchEnabled(w http.ResponseWriter, req *http.Request) {
 	name := provider.ProviderName(req.PathValue("name"))
 

--- a/internal/api/handlers_push.go
+++ b/internal/api/handlers_push.go
@@ -85,6 +85,8 @@ func (r *Router) handlePushMetadata(w http.ResponseWriter, req *http.Request) {
 
 // handlePushImages uploads artist images to an Emby/Jellyfin connection.
 // POST /api/v1/artists/{id}/push/images
+//
+//nolint:gocognit // Per-image-type upload: enumerate poster/banner/clearart/disc/fanart with per-type file-presence check, MIME detection, connection-dispatch (Emby vs Jellyfin client), and outcome accounting; the per-type branches share enough state that helpers would have 8+ parameters.
 func (r *Router) handlePushImages(w http.ResponseWriter, req *http.Request) {
 	artistID, ok := RequirePathParam(w, req, "id")
 	if !ok {

--- a/internal/api/handlers_rule.go
+++ b/internal/api/handlers_rule.go
@@ -223,6 +223,8 @@ func (r *Router) handleEvaluateArtist(w http.ResponseWriter, req *http.Request) 
 // Returns 202 Accepted immediately. Poll GET /api/v1/rules/run-all/status for progress
 // (shared status slot with run-all; 409 if either is already running).
 // POST /api/v1/rules/{id}/run
+//
+//nolint:gocognit // Rule existence + pipeline-configured + scope-parse guards, shared-slot conflict check, async goroutine with panic recovery, post-run violation-count computation gated by per-severity badge settings, and final mutex-protected status flip; the violation-count branch mirrors handleRunAllRules because both share the rule-run status slot, and refactoring requires the run-all variant to land at the same time; refactor tracked in #1555.
 func (r *Router) handleRunRule(w http.ResponseWriter, req *http.Request) {
 	ruleID, ok := RequirePathParam(w, req, "id")
 	if !ok {
@@ -360,6 +362,8 @@ func (r *Router) handleRunRule(w http.ResponseWriter, req *http.Request) {
 
 // handleRunArtistRules runs all enabled rules scoped to a single artist.
 // POST /api/v1/artists/{id}/run-rules
+//
+//nolint:gocognit // Each error path has both an HTMX inline-error fragment and a JSON response (artist-not-found, pipeline-nil, pipeline-failure); pulling the per-shape rendering into a helper would lose the per-error styling tokens and the contextual log messages, which is the bulk of the cog score.
 func (r *Router) handleRunArtistRules(w http.ResponseWriter, req *http.Request) {
 	artistID, ok := RequirePathParam(w, req, "id")
 	if !ok {

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -29,6 +29,8 @@ type AuthProvider interface {
 // OptionalAuth returns middleware that populates the user context if a valid
 // session exists but does not reject unauthenticated requests. Use this for
 // public pages that change behavior based on auth state.
+//
+//nolint:gocognit // Auth resolution descends three credential sources in order (API token by prefix, session cookie, no-credential pass-through) and each branch must capture user/role/scopes onto the request context only when the credential validates; flattening would force redundant validation calls.
 func OptionalAuth(authService AuthProvider) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -28,6 +28,8 @@ var quietExactSuffixes = []string{
 // basePath is prepended to quiet path patterns so sub-path deployments are
 // handled correctly. Successful requests on quiet paths are not logged;
 // error responses (>= 400) are still logged.
+//
+//nolint:gocognit // Quiet-path matching, status-class decision, scrubbed-param emission, and SSE/long-poll handling are all per-request branches the middleware must apply in order; splitting them into helpers would force re-passing the captured ResponseWriter/Request through wrapper structs without simplifying the control flow.
 func Logging(logger *slog.Logger, basePath string) func(http.Handler) http.Handler {
 	// Build the resolved quiet-path lists once at init.
 	quietPrefixes := make([]string, len(quietPrefixSuffixes))

--- a/internal/artist/scan.go
+++ b/internal/artist/scan.go
@@ -316,6 +316,8 @@ var legacyFilterSQL = map[string]string{
 }
 
 // buildWhereClause constructs WHERE conditions from list parameters.
+//
+//nolint:gocognit // SQL WHERE assembler: each filter field (IDs, search, locked, missing-image flags, status enum, library scope, source list) has bespoke placeholder shape and argument count; the if-ladder enforces the column-to-args correspondence the SQL parameter binding depends on.
 func buildWhereClause(params ListParams) (string, []any) {
 	var conditions []string
 	var args []any

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -129,6 +129,8 @@ func (s *Service) ListUsers(ctx context.Context) ([]User, error) {
 // administrator, and ErrLastAdmin if downgrading the last active administrator.
 // The checks and role update run inside a BEGIN IMMEDIATE transaction
 // to prevent concurrent downgrades from racing past the safeguards.
+//
+//nolint:gocognit // Txn-bound precondition chain: role enum gate, current-role query, no-op short-circuit, protected-user guard on downgrade, last-admin guard, then a constrained UPDATE that also recognizes the SQL trigger's "cannot change role of a protected user" error so the API returns ErrProtectedUser instead of a generic error. The guards are the security invariant; splitting them into helpers would only obscure ordering.
 func (s *Service) UpdateUserRole(ctx context.Context, userID, newRole string) error {
 	if newRole != "administrator" && newRole != "operator" {
 		return fmt.Errorf("invalid role %q: must be administrator or operator", newRole)

--- a/internal/conflict/detector.go
+++ b/internal/conflict/detector.go
@@ -334,6 +334,7 @@ func (d *Detector) Invalidate() {
 	d.mu.Unlock()
 }
 
+//nolint:gocognit // Per-connection probe: TLS reachability, auth verification, library listing, capability flags, and conflict status (disabled, manage-files-off, server-unreachable) each map to a distinct ConnectionState transition; sequencing matters because later probes assume earlier ones succeeded.
 func (d *Detector) checkOne(ctx context.Context, c connection.Connection) ConnectionState {
 	state := ConnectionState{
 		ConnectionID:      c.ID,

--- a/internal/foreign/scanner.go
+++ b/internal/foreign/scanner.go
@@ -171,6 +171,8 @@ func (s *Scanner) Scan(ctx context.Context) error {
 // scanArtist examines a single artist directory and reconciles the ledger
 // with on-disk reality. Returns (recorded, cleared, skipped) counts so the
 // caller can roll up Scan-level metrics.
+//
+//nolint:gocognit // Foreign-file reconciler (cog 50): reconciles on-disk files against the ledger with skip-don't-clear semantics (ambiguous reads -> skipped, not recorded/cleared, per the proactive-cron blast-radius safeguard). The bucket-selection ladder is essential to the safety policy but the per-file classification could split into a typed classifier helper to ease readability. Refactor tracked in #1549.
 func (s *Scanner) scanArtist(ctx context.Context, a artist.Artist) (int, int, int) {
 	entries, err := os.ReadDir(a.Path)
 	if err != nil {

--- a/internal/image/cleanup.go
+++ b/internal/image/cleanup.go
@@ -35,6 +35,8 @@ var conflictingExtensions = map[string][]string{
 //
 // The file being written (exact match on fileName) is skipped, since
 // WriteFileAtomic handles overwriting it.
+//
+//nolint:gocognit // Three-way per-entry classification (exact match, same-format-different-case, conflicting format) with case-sensitive-FS detection via os.SameFile; the matrix is the function's purpose and the rename-vs-delete decision per cell carries the case-mismatch-survives-write-failure guarantee documented in the function's contract.
 func CleanupConflictingFormats(dir string, fileName string, logger *slog.Logger) error {
 	ext := strings.ToLower(filepath.Ext(fileName))
 	base := strings.TrimSuffix(fileName, filepath.Ext(fileName))

--- a/internal/image/fanart.go
+++ b/internal/image/fanart.go
@@ -196,6 +196,8 @@ func NextFanartIndex(maxSuffix int, kodi bool) int {
 // 0-based indices. Each file keeps its original extension. primaryName is the
 // base name for index 0 (e.g. "backdrop.jpg"). dir is the parent directory.
 // kodi controls the numbering convention (see FanartFilename).
+//
+//nolint:gocognit // Two-phase rename (stage to .tmp then commit to final name) with best-effort rollback in both phases; the rollback walks the already-mutated subset of files so the partial-failure recovery has to remain inline alongside the forward path.
 func RenumberFanart(dir, primaryName string, survivors []string, kodi bool) error {
 	if len(survivors) == 0 {
 		return nil

--- a/internal/image/save.go
+++ b/internal/image/save.go
@@ -19,6 +19,8 @@ import (
 // filename is written as a real file. Subsequent filenames are created as
 // relative symlinks pointing to the primary file. If symlink creation fails,
 // it falls back to a regular atomic write.
+//
+//nolint:gocognit // Format detection, logo PNG conversion, conflicting-format cleanup, primary write, and symlink-vs-copy fallback for the remaining names share state (dir, format, primary path) that would need to be threaded through 3+ helpers to split; the linear form here matches the file-on-disk semantics.
 func Save(dir string, imageType string, data []byte, fileNames []string, useSymlinks bool, meta *ExifMeta, logger *slog.Logger) ([]string, error) {
 	if len(fileNames) == 0 {
 		return nil, fmt.Errorf("no filenames configured for image type %q", imageType)

--- a/internal/library/service.go
+++ b/internal/library/service.go
@@ -285,6 +285,8 @@ func collectUnlinkCandidates(ctx context.Context, tx *sql.Tx, libraryID string) 
 //
 // Order matters: the membership snapshot is taken BEFORE the library
 // delete fires the cascade.
+//
+//nolint:gocognit // Txn-bound multi-stage prune: snapshot membership pre-cascade, drop library, conditionally allow connection-orphan sweep based on sibling count, then per-candidate keep-or-prune decision driven by remaining memberships AND cross-connection mappings, plus the #1072 stale-mapping cleanup that the FK CASCADE never fires for. Each condition gates the next stage so the txn body cannot factor without sharing tx + sql.NullString state through helpers.
 func (s *Service) DeleteWithArtists(ctx context.Context, id string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/logging/ringhandler.go
+++ b/internal/logging/ringhandler.go
@@ -34,6 +34,8 @@ func (h *RingHandler) Enabled(_ context.Context, level slog.Level) bool {
 }
 
 // Handle converts a slog.Record to a LogEntry and writes it to the buffer.
+//
+//nolint:gocognit // slog.Record attribute walk requires a type switch over every supported slog.Kind (string, int64, uint64, float64, bool, duration, time, group, any) so each kind can be encoded to LogEntry's typed field; this is the slog contract, not application logic, and cannot be flattened.
 func (h *RingHandler) Handle(_ context.Context, r slog.Record) error {
 	entry := LogEntry{
 		Time:    r.Time,

--- a/internal/nfo/parser.go
+++ b/internal/nfo/parser.go
@@ -78,6 +78,8 @@ func Parse(r io.Reader) (*ArtistNFO, error) {
 
 // parseTokens walks the XML token stream, populating known fields and
 // capturing unknown elements as raw bytes.
+//
+//nolint:gocognit // xml.Decoder token-stream consumer: <artist> entry guard, per-token type switch over StartElement/EndElement, known-vs-unknown element dispatch, and invalid-XML-name skip path for elements the lenient decoder accepted but a strict re-serializer would reject. The token-loop shape is xml.Decoder's contract.
 func parseTokens(decoder *xml.Decoder, nfo *ArtistNFO) error {
 	var inArtist bool
 

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -116,6 +116,8 @@ func (o *Orchestrator) SetExecutor(e ScraperExecutor) {
 // MusicBrainz URL) can be used when calling later providers.
 // When a ScraperExecutor is configured, delegates to it for scraper-config-driven
 // per-field fetching with fallback chains.
+//
+//nolint:gocognit // Per-field provider iteration in priority order with provider-ID enrichment carry-forward between fields; this is the legacy non-scraper path retained for callers that have no scraper config, and its semantics must match ScrapeAll's outcome on a parallel diagram.
 func (o *Orchestrator) FetchMetadata(ctx context.Context, mbid, name string, providerIDs map[ProviderName]string) (*FetchResult, error) {
 	if o.executor != nil {
 		return o.executor.ScrapeAll(ctx, mbid, name, "global", providerIDs)
@@ -383,6 +385,7 @@ type providerResult struct {
 	imagesAttempted bool  // true whenever GetImages was actually invoked, regardless of outcome
 }
 
+//nolint:gocognit // Per-provider cached fetch with lookup-precedence ladder (provider ID > MBID > name), name-based retry only when MBID-not-found AND the provider implements NameLookupProvider, plus ErrNotFound-vs-transient distinction for both GetArtist and GetImages so stale data is cleared on a definitive miss but preserved on a transient failure. Near-identical to scraper.Executor.getProviderResult (cog 34 each); the consolidation is a peripheral concern but worth tracking; refactor tracked in #1554.
 func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName, mbid string, artistName string, providerIDs map[ProviderName]string, cache map[ProviderName]*providerResult, mu *sync.Mutex) *providerResult {
 	mu.Lock()
 	if pr, ok := cache[name]; ok {

--- a/internal/provider/wikipedia/infobox.go
+++ b/internal/provider/wikipedia/infobox.go
@@ -203,6 +203,8 @@ func fieldValue(fields map[string]string, aliases ...string) string {
 // parseListField extracts a list of items from a wikitext field value.
 // Handles: {{flatlist|...}}, {{hlist|...}}, {{plainlist|...}}, bullet lists,
 // <br /> separators, and comma-separated values.
+//
+//nolint:gocognit // Wikitext list parser: each separator format ({{flatlist}}, bullets, <br />, commas) has its own probing branch, and the cleanup pass (link unwrap, ref strip, html-entity decode, whitespace normalization) applies after detection; the format-detection ladder is the function's purpose.
 func parseListField(value string) []string {
 	// Strip ref tags and their content first.
 	value = stripRefs(value)
@@ -386,6 +388,8 @@ func resolveWikilinks(s string) string {
 
 // stripSimpleTemplates removes common inline templates like {{nowrap|text}},
 // {{small|text}}, {{lang|xx|text}}, keeping only the last pipe-delimited argument.
+//
+//nolint:gocognit // Template stripper walks the input per known template type, balancing nested {{...}} braces and respecting pipe-argument boundaries; the brace-balance + pipe-tracking state machine cannot be expressed without nested conditionals over the byte-level scan.
 func stripSimpleTemplates(s string) string {
 	simpleTemplates := []string{"nowrap", "small", "lang", "native name", "nihongo", "transl"}
 

--- a/internal/provider/wikipedia/wikipedia.go
+++ b/internal/provider/wikipedia/wikipedia.go
@@ -101,6 +101,8 @@ func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSe
 // English is appended as a fallback when not already present in the
 // preference list; if the user has explicitly placed "en" earlier, it
 // is tried in that position rather than last.
+//
+//nolint:gocognit // Resolves an ID to (title, QID), iterates user language preferences with English fallback, and at each language probes extracts, sitelinks, infobox, image, and disambiguation handling; the per-language fallthrough on empty content keeps the policy in one place rather than scattered helpers.
 func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
 	id = strings.TrimSpace(id)
 	if id == "" {

--- a/internal/rule/bulk_executor.go
+++ b/internal/rule/bulk_executor.go
@@ -85,6 +85,7 @@ func (e *BulkExecutor) Cancel() error {
 	return nil
 }
 
+//nolint:gocognit // Bulk worker drives per-artist progress through evaluate -> fix -> persist while watching context cancellation and accumulating counts; the loop body's status transitions and cancellation checkpoints share state (job pointer, counters, mu) that cannot be split without leaking the mutex into helpers.
 func (e *BulkExecutor) run(ctx context.Context, job *BulkJob) {
 	defer func() {
 		e.mu.Lock()

--- a/internal/rule/checkers.go
+++ b/internal/rule/checkers.go
@@ -481,6 +481,8 @@ func (e *Engine) getLogoBoundsFromBytes(data []byte) (content, original goimage.
 // every evaluation. For API-only artists (no local path), the checker fetches
 // the logo through the platform image fetcher and caches the raw bytes only
 // when a violation is found, so the fixer can consume them.
+//
+//nolint:gocognit // Returned closure dispatches across three logo sources (local disk with mtime cache, API fetch when no local path, in-memory cached API bytes) and handoff to the fixer via cache; the source-selection ladder is the checker's purpose and cannot be flattened.
 func (e *Engine) makeLogoPaddingChecker() Checker {
 	return func(ctx context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
 		if !a.LogoExists {

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -247,6 +247,8 @@ func (p *Pipeline) RunRule(ctx context.Context, ruleID string) (*RunResult, erro
 // RunRuleScoped evaluates a single rule against artists determined by scope.
 // Returns ArtistsTotal/ArtistsSkipped on the result so the UI can report
 // "evaluating 12 of 800 (788 unchanged)" for the incremental path.
+//
+//nolint:gocognit // Single-rule pipeline run (cog 74): progress reporting against ArtistsTotal, scope-aware artist walk, per-artist evaluate-fix-persist with deferred resolved-status writes (#983 ordering), automation-mode dispatch (manual vs auto), and result aggregation; identical control-flow structure to RunAllScoped but pinned to one rule for surgical user runs from the UI -- the duplication itself is the structural smell. Refactor tracked in #1543.
 func (p *Pipeline) RunRuleScoped(ctx context.Context, ruleID string, scope RunScope) (*RunResult, error) {
 	result := &RunResult{Scope: scope.String()}
 
@@ -504,6 +506,8 @@ func (p *Pipeline) RunImageRulesForArtist(ctx context.Context, a *artist.Artist)
 // runForArtistFiltered is the shared body of RunForArtist and
 // RunImageRulesForArtist. An empty categoryFilter runs every violation;
 // a non-empty value runs only violations whose Category matches exactly.
+//
+//nolint:gocognit // Per-artist pipeline orchestrator (cog 79): iterates rules, evaluates each, batches resolved-status writes per #983, dispatches fix-or-discover by automation mode, persists artist mutations, recomputes health score, and emits SSE; the load-bearing #983 persist ordering is the main complexity driver and a refactor must preserve it. Refactor tracked in #1541.
 func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, categoryFilter string) (*RunResult, error) {
 	result := &RunResult{}
 
@@ -767,6 +771,8 @@ func (p *Pipeline) RunAll(ctx context.Context) (*RunResult, error) {
 // by scope (incremental or all). The result reports both the number of
 // artists processed and the total eligible count so progress UIs can show
 // "evaluating 12 of 800 (788 unchanged)".
+//
+//nolint:gocognit // Full-sweep pipeline (cog 77): rule registry walk, per-rule artist iteration with scope-aware source, evaluate-fix-persist + #983 deferred resolved-status writes, automation-mode dispatch, per-rule and global counters; the rule-major iteration order is required so that all violations of a given rule see a coherent before/after view of the artist within a single pipeline pass. Refactor tracked in #1542.
 func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult, error) {
 	result := &RunResult{Scope: scope.String()}
 
@@ -1023,6 +1029,8 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 //
 // processed counts artists fn was actually invoked on (regardless of return
 // value), since both successes and failures consumed pipeline work.
+//
+//nolint:gocognit // Scope walker (cog 45): dirty/all/single-artist scopes with per-scope source enumeration (ListDirtyIDs vs ListEligible vs single ID) and per-artist evaluated-mark policy gated on fn outcome; the markEvaluated bool flips meaning per scope, which is the structural smell driving the cog score. Refactor tracked in #1551.
 func (p *Pipeline) walkScopedArtists(ctx context.Context, scope RunScope, markEvaluated bool, fn func(a *artist.Artist) bool) (int, error) {
 	if scope == RunScopeIncremental {
 		ids, err := p.artistService.ListDirtyIDs(ctx)

--- a/internal/rule/fixers.go
+++ b/internal/rule/fixers.go
@@ -320,6 +320,8 @@ func (f *ImageFixer) CanFix(v *Violation) bool {
 func (f *ImageFixer) SupportsCandidateDiscovery() bool { return true }
 
 // Fix fetches the best available image from providers and saves it.
+//
+//nolint:gocognit // ImageFixer.Fix (cog 51): dispatches across manual discovery, auto-select-best, and auto-with-candidates modes; each mode has its own provider walk, candidate-list construction, and persistence path (FixResult vs Candidates field). Refactoring to per-mode method dispatch on a strategy type would clear the cog hot spot while keeping the per-mode persistence shape. Refactor tracked in #1548.
 func (f *ImageFixer) Fix(ctx context.Context, a *artist.Artist, v *Violation) (*FixResult, error) {
 	if a.MusicBrainzID == "" {
 		return &FixResult{
@@ -886,6 +888,8 @@ func (f *LogoPaddingFixer) Fix(ctx context.Context, a *artist.Artist, v *Violati
 }
 
 // fixViaDisk handles the filesystem-based logo trim (original behavior).
+//
+//nolint:gocognit // Linear filesystem pipeline: case-insensitive logo discovery, trim with margin, dimension-unchanged short-circuit (avoid fix/reappear cycle), provenance preservation across the trimmed bytes, atomic save, then case-mismatched-duplicate cleanup. Each step depends on the previous output (path -> bytes -> trimmed -> dimensions -> save -> dedup) and the linearity is essential to the on-disk semantics.
 func (f *LogoPaddingFixer) fixViaDisk(ctx context.Context, a *artist.Artist, v *Violation) (*FixResult, error) {
 	entries, readErr := os.ReadDir(a.Path)
 	if readErr != nil {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -162,6 +162,7 @@ func (s *Service) Status() *ScanResult {
 	return &snapshot
 }
 
+//nolint:gocognit // Scan worker: lock-protected status transitions, per-library file walk, cancellation checkpoints, error aggregation, progress publication, and completion sync; the lifecycle ordering (acquire -> walk -> publish -> release) and cancellation-aware control flow do not factor cleanly into helpers without sharing the result mutex across them.
 func (s *Service) runScan(ctx context.Context, result *ScanResult) {
 	defer s.scanWg.Done()
 	defer func() {
@@ -894,6 +895,8 @@ var errFastPathFileTouched = fmt.Errorf("fast path: canonical file mtime advance
 // isCanonicalArtistFile reports whether lower (a lowercase filename) matches
 // any pattern the scanner reads on the artist hot path: NFO, thumb/folder,
 // fanart (including numbered variants), logo, banner.
+//
+//nolint:gocognit // Pattern-family fan-out across NFO + thumb/fanart/logo/banner pattern slices plus the numbered-fanart variant check that requires the suffix to be purely numeric (DiscoverFanart only recognizes the numeric form so unrelated files like fanart-old.jpg must stay off the fast path). The hot-path predicate is called per directory entry during scans, so an allocation-free implementation matters more than a few cog points; refactor tracked in #1553.
 func isCanonicalArtistFile(lower string) bool {
 	if lower == "artist.nfo" {
 		return true
@@ -966,6 +969,8 @@ func isCanonicalArtistFile(lower string) bool {
 //
 // `existing` must be non-nil; callers already guard on that in
 // detectFilesWithFastPath.
+//
+//nolint:gocognit // Per-slot pattern walk (thumb, fanart, logo, banner) with a per-slot field-copy from existing, an mtime fast-path bailout that re-signals to the full-probe path when any canonical file has been overwritten in place (POSIX directory mtime does not catch in-place rewrites -- the per-file stat is the gate), and the DiscoverFanart-driven count refresh for the fanart slot. The slot-by-slot expansion is essential to the field-copy correctness from the existing row.
 func detectFilesExistenceOnly(dirPath string, existing *artist.Artist) (detectedFiles, error) {
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {

--- a/internal/scraper/executor.go
+++ b/internal/scraper/executor.go
@@ -50,6 +50,8 @@ func NewExecutor(service *Service, registry *provider.Registry, settings *provid
 // Settings > Providers (#1030). The scraper config still controls which fields
 // are enabled and supplies a backup fallback list for any provider absent from
 // the priority settings.
+//
+//nolint:gocognit // Top-level orchestrator: priority resolution, per-field scrape, provider-ID enrichment carry-forward between iterations, and per-field error aggregation; the carry-forward semantics across the per-field loop require sequential flow rather than parallel helpers.
 func (e *Executor) ScrapeAll(ctx context.Context, mbid, name, scope string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error) {
 	// Ensure providerIDs is writable so EnrichProviderIDs can populate it
 	// with IDs extracted from earlier providers' URL results.
@@ -224,6 +226,8 @@ func (e *Executor) ScrapeAll(ctx context.Context, mbid, name, scope string, prov
 // For image fields, all providers in the chain are queried and their results are
 // aggregated so users can choose from multiple candidates. For text fields, the
 // first provider that returns data wins (priority order determines preference).
+//
+//nolint:gocognit // Image-field aggregation and text-field first-wins are two distinct provider-loop policies sharing setup (primary, fallback chain, cache, mu); the branching inside the loop expresses that policy split and refactoring would duplicate the chain-walk logic.
 func (e *Executor) scrapeField(
 	ctx context.Context,
 	mbid, name string,
@@ -324,6 +328,8 @@ type providerResult struct {
 }
 
 // getProviderResult fetches and caches results from a single provider.
+//
+//nolint:gocognit // Same per-provider lookup-precedence ladder and ErrNotFound-vs-transient distinction as provider.Orchestrator.getProviderResult (cog 34 each); kept as a near-duplicate so the scraper-aware path stays decoupled from the legacy orchestrator path during the executor migration. The consolidation belongs with the orchestrator twin; refactor tracked in #1554.
 func (e *Executor) getProviderResult(
 	ctx context.Context,
 	name provider.ProviderName,

--- a/internal/settingsio/export.go
+++ b/internal/settingsio/export.go
@@ -234,6 +234,8 @@ func (s *Service) WithScraperService(ss *scraper.Service) *Service {
 // Export collects all settings data, encrypts it with the given passphrase,
 // and returns an Envelope. The passphrase is used with PBKDF2 to derive an
 // AES-256-GCM key, making exports portable across instances.
+//
+//nolint:gocognit // Export aggregates 11 distinct surface-area sections (KV settings, provider keys, naming, custom rules, scraper config, libraries with platform tokens, identify session, language prefs, watcher, update channel, webhooks) and each section has bespoke decryption and skip-if-empty handling; the linear sectioned form mirrors the envelope schema and is the version-history anchor for the export format.
 func (s *Service) Export(ctx context.Context, passphrase string) (*Envelope, error) {
 	payload := Payload{
 		Settings:     make(map[string]string),

--- a/internal/settingsio/libraries.go
+++ b/internal/settingsio/libraries.go
@@ -78,6 +78,8 @@ func (s *Service) exportLibraries(ctx context.Context) ([]LibraryExport, error) 
 // importUserPreferences). Path validation is intentionally bypassed: the
 // target filesystem may not yet contain the directory at restore time, and
 // rejecting absent paths would defeat the disaster-recovery use case.
+//
+//nolint:gocognit // Per-library upsert with primary-key (name) lookup, secondary-key ((connection_id, external_id)) fallback for renamed peer libraries, and source-aware connection remap; skip-with-warning behavior preserves the disaster-recovery contract when individual rows cannot resolve. The skip vs error ladder mirrors importUserPreferences and is part of the import envelope's documented contract.
 func (s *Service) importLibraries(ctx context.Context, libs []LibraryExport, result *ImportResult) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, le := range libs {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -420,6 +420,8 @@ func detectDocker() bool {
 //     still individually opt-in)
 //   - AutoCheck:          false
 //   - CheckIntervalHours: DefaultCheckIntervalHours (24h)
+//
+//nolint:gocognit // Loads ~10 distinct config keys with per-key parse, default-fallback, and validation policy (channel enum, interval clamp, bool coercion, skipped-versions JSON parse, optional fields); each key's recovery logic is independent and merging them under a generic loader would suppress meaningful defaults.
 func (s *Service) GetConfig(ctx context.Context) (Config, error) {
 	cfg := Config{
 		Channel:            ChannelStable,
@@ -1079,6 +1081,8 @@ func (s *Service) setState(st State, progress int, errMsg string) {
 // are not semver and would be rejected by semverRE/parseSemver. That path
 // filters to nightlyRE matches and picks the lexicographic max; the
 // fixed-width date suffix makes lex order agree with chronological order.
+//
+//nolint:gocognit // Channel-aware max selector: nightly is its own non-semver path (lex max on fixed-width date suffix), stable filters out both GitHub-flagged prereleases and tags with prerelease suffixes ("-rc.1"), prerelease accepts both. The full-scan-then-max strategy is required because GitHub returns releases in reverse-chronological order while backported releases (v1.9.9 after v2.0.0) would defeat a first-match strategy.
 func pickLatest(releases []githubRelease, ch Channel) *githubRelease {
 	if ch == ChannelNightly {
 		var best *githubRelease
@@ -1291,6 +1295,8 @@ func atomicReplaceFile(target string, newContent []byte) error {
 // selects on it alongside the timer, so a cadence change (24h to 1h) or
 // Enabled/AutoCheck/AutoUpdate toggle takes effect on the very next
 // scheduler iteration rather than waiting out the previous interval.
+//
+//nolint:gocognit // Select-loop multiplexer over ctx.Done, configChange pulse, and timer.C with a shared resetTimer closure that handles the Go time.Timer Stop-then-drain pattern. The configChange wakeup intentionally does NOT run a Check (the user may have just toggled AutoCheck off); the timer branch re-reads config after the network Check so an in-flight AutoUpdate toggle or SkippedVersions edit is honored before maybeAutoApply launches.
 func (s *Service) StartScheduler(ctx context.Context) {
 	// Initial read picks up the persisted interval. Fall back to the
 	// default on read error so a transient DB hiccup at startup does

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -69,6 +69,8 @@ func (s *Service) SetDebounce(d time.Duration) {
 // Start blocks until ctx is canceled. It creates an fsnotify watcher,
 // watches library root directories, and dispatches events. If fsnotify
 // is unavailable, the service still runs with poll-only support.
+//
+//nolint:gocognit // Main event loop multiplexes fsnotify events, poll ticker, library config reload, and ctx.Done across a single select; each case has its own debounce, dedup, and dispatch logic and lifting cases into methods would still leave the select skeleton intact.
 func (s *Service) Start(ctx context.Context) {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Enables `gocognit` in `.golangci.yml` with `min-complexity: 30` (the standard floor). 61 production sites exceed the threshold and carry `//nolint:gocognit` directives with function-specific reasons.
- 17 of those directives reference 15 refactor sub-issues filed under parent #1540 (M55.5 -- Dead Code Hunt). The triage rule combines cognitive complexity score with code-path criticality (critical / standard / peripheral); sites where the complexity is essential (envelope schemas, provider ladders, hot-path predicates) carry standalone reasons, sites where refactor is warranted track to sub-issues.
- Adds `gocognit` to the existing `_test.go` exclusion rule alongside gosec/errcheck/noctx. Same precedent as the existing exclusion: rewriting table-driven tests to satisfy gocognit is the ceremony-without-value pattern the rule was added to deflect.
- No user-visible behavior change. Pure lint config + annotation.

## Linked issue

Closes #1468

Surfaces 15 follow-up refactor issues #1541-#1555 under parent #1540 (M55.5).

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Code review pass complete (`pr-review-toolkit:code-reviewer` returned zero findings across all 5 severity levels).
- [x] Single squashed commit (`fe38eedf`).
- [x] Labels set: `chore` + `docs: not-required`.
- [x] Docs label decision: `docs: not-required` (lint config + annotation; no user-visible behavioral change).
- [x] Screenshot N/A (no UI change).
- [x] UAT N/A (no behavioral change to exercise; lint config is verified by `golangci-lint run --max-issues-per-linter 0 ./...` being clean).
- [x] OpenAPI N/A (no API surface change).
- [x] templ N/A (no `.templ` change).

## Test plan

- [x] `go test -race ./...` passes locally.
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] `golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 ./...` clean (zero gocognit findings; no regressions in other linters).
- Manual UAT steps:
  - N/A -- no behavioral change. Verification is lint-config integrity (already covered).
- Reviewer follow-ups:
  - Threshold choice: locked at 30 per the M49.7 dispatch plan's tuning protocol (>10 violations at 30 -> raise to 35; the parent decided to stay at 30 because 35 was burying findings).
  - The 5 sites at exactly cog 30 are NOT flagged (golangci-lint uses strict `>30`); accepted gap per parent decision.
  - All 12 sites flagged for sub-issue (cog >= 50 critical/standard, plus critical-with-smell at 30-49) plus 3 additional sites surfaced during review (isCanonicalArtistFile, getProviderResult duplication, handleRunRule consolidation) are tracked.

## Notes for CR

- 12 files touched purely for nolint additions (zero logic changes; verified by code-reviewer).
- Reasons follow the format documented in `.github/instructions/lint-config.instructions.md`: `//nolint:gocognit // <function-specific reason>` for essential complexity, or `<reason>; refactor tracked in #NNNN` for sites with refactor follow-ups under parent #1540.
- The test-file exclusion expansion is intentional and matches the existing gosec/errcheck/noctx precedent codified in the same instructions file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality tooling by implementing new linting standards across the codebase to improve maintainability and consistency. These infrastructure improvements maintain code reliability and support ongoing development practices without affecting user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->