### PR TITLE
chore(lint): enable prealloc and sweep production slice allocations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     - nilerr
     - noctx
     - nolintlint
+    - prealloc
     - revive
     - sqlclosecheck
     - staticcheck
@@ -113,6 +114,18 @@ linters:
           # _fuzz_test.go; excluding them categorically keeps the
           # production sweep the signal-bearing part of the lint surface.
           - gocognit
+          # prealloc in tests is noise: fixture builders and table setups
+          # are written for readability, not allocator throughput, and the
+          # capacities are usually tiny constants. Production-side
+          # preallocation is where the perf win lives.
+          - prealloc
+      # cmd/gen-* are build-time documentation generators that run once
+      # per `make generate`. Allocation efficiency is not the point; the
+      # code is optimized for readability of the generator itself, and
+      # adding capacity hints to small build-step slices buys nothing.
+      - path: cmd/gen-.*/
+        linters:
+          - prealloc
       - text: "catalogue.*is a misspelling"
         linters:
           - misspell

--- a/internal/api/handlers_apitoken.go
+++ b/internal/api/handlers_apitoken.go
@@ -36,7 +36,9 @@ func (r *Router) handleCreateAPIToken(w http.ResponseWriter, req *http.Request) 
 		body.Scopes = "read"
 	}
 	callerRole := middleware.RoleFromContext(req.Context())
-	var normalizedScopes []string
+	// Cap at the comma count + 1 (max possible split entries); empty
+	// segments and invalid scopes shrink the final slice.
+	normalizedScopes := make([]string, 0, strings.Count(body.Scopes, ",")+1)
 	for _, s := range strings.Split(body.Scopes, ",") {
 		trimmed := strings.TrimSpace(s)
 		if trimmed == "" {

--- a/internal/api/handlers_artist.go
+++ b/internal/api/handlers_artist.go
@@ -410,6 +410,8 @@ func (r *Router) handleArtistDetailPage(w http.ResponseWriter, req *http.Request
 	}
 
 	// Build platform connection list for "View on Platform" links.
+	// Cap at len(pids); per-row connection fetches may error and skip,
+	// so final length can be smaller but never larger.
 	var connections []templates.ArtistDetailConnection
 	hasDebugConnection := false
 	if r.connectionService != nil {
@@ -417,6 +419,7 @@ func (r *Router) handleArtistDetailPage(w http.ResponseWriter, req *http.Request
 		if pidErr != nil {
 			r.logger.Warn("listing platform IDs for detail page", "artist_id", id, "error", pidErr)
 		}
+		connections = make([]templates.ArtistDetailConnection, 0, len(pids))
 		for _, pid := range pids {
 			conn, connErr := r.connectionService.GetByID(req.Context(), pid.ConnectionID)
 			if connErr != nil {

--- a/internal/api/handlers_backdrop.go
+++ b/internal/api/handlers_backdrop.go
@@ -859,7 +859,7 @@ func (r *Router) handleFanartSyncState(w http.ResponseWriter, req *http.Request)
 
 // buildSyncTooltip builds a human-readable tooltip for a fanart sync slot.
 func buildSyncTooltip(s fanartSyncSlot) string {
-	var parts []string
+	parts := make([]string, 0, len(s.Connections))
 	for _, c := range s.Connections {
 		status := "not synced"
 		if c.Synced {

--- a/internal/artist/sqlite_history.go
+++ b/internal/artist/sqlite_history.go
@@ -184,8 +184,8 @@ func (r *sqliteHistoryRepo) ListGlobal(ctx context.Context, filter GlobalHistory
 		ORDER BY mc.created_at DESC, mc.id DESC
 		LIMIT ? OFFSET ?`
 
-	queryArgs := make([]any, len(args))
-	copy(queryArgs, args)
+	queryArgs := make([]any, 0, len(args)+2)
+	queryArgs = append(queryArgs, args...)
 	queryArgs = append(queryArgs, filter.Limit, filter.Offset)
 
 	rows, err := r.db.QueryContext(ctx, selectQ, queryArgs...)

--- a/internal/connection/emby/push.go
+++ b/internal/connection/emby/push.go
@@ -38,7 +38,7 @@ func (c *Client) PushMetadata(ctx context.Context, platformArtistID string, data
 	// Styles and Moods map to TagItems (Emby uses {Name} objects, not flat
 	// strings). Disambiguation and YearsActive have no corresponding Emby
 	// fields and are omitted.
-	var items []tagItem
+	items := make([]tagItem, 0, len(data.Styles)+len(data.Moods))
 	for _, s := range data.Styles {
 		items = append(items, tagItem{Name: s})
 	}

--- a/internal/nfo/diff.go
+++ b/internal/nfo/diff.go
@@ -28,21 +28,23 @@ func Diff(old, newNFO *ArtistNFO) *DiffResult {
 		newVal string
 	}
 
-	comparisons := []comparison{
-		{"Name", getStr(old, func(n *ArtistNFO) string { return n.Name }), getStr(newNFO, func(n *ArtistNFO) string { return n.Name })},
-		{"Sort Name", getStr(old, func(n *ArtistNFO) string { return n.SortName }), getStr(newNFO, func(n *ArtistNFO) string { return n.SortName })},
-		{"Type", getStr(old, func(n *ArtistNFO) string { return n.Type }), getStr(newNFO, func(n *ArtistNFO) string { return n.Type })},
-		{"Gender", getStr(old, func(n *ArtistNFO) string { return n.Gender }), getStr(newNFO, func(n *ArtistNFO) string { return n.Gender })},
-		{"Disambiguation", getStr(old, func(n *ArtistNFO) string { return n.Disambiguation }), getStr(newNFO, func(n *ArtistNFO) string { return n.Disambiguation })},
-		{"MusicBrainz ID", getStr(old, func(n *ArtistNFO) string { return n.MusicBrainzArtistID }), getStr(newNFO, func(n *ArtistNFO) string { return n.MusicBrainzArtistID })},
-		{"AudioDB ID", getStr(old, func(n *ArtistNFO) string { return n.AudioDBArtistID }), getStr(newNFO, func(n *ArtistNFO) string { return n.AudioDBArtistID })},
-		{"Years Active", getStr(old, func(n *ArtistNFO) string { return n.YearsActive }), getStr(newNFO, func(n *ArtistNFO) string { return n.YearsActive })},
-		{"Born", getStr(old, func(n *ArtistNFO) string { return n.Born }), getStr(newNFO, func(n *ArtistNFO) string { return n.Born })},
-		{"Formed", getStr(old, func(n *ArtistNFO) string { return n.Formed }), getStr(newNFO, func(n *ArtistNFO) string { return n.Formed })},
-		{"Died", getStr(old, func(n *ArtistNFO) string { return n.Died }), getStr(newNFO, func(n *ArtistNFO) string { return n.Died })},
-		{"Disbanded", getStr(old, func(n *ArtistNFO) string { return n.Disbanded }), getStr(newNFO, func(n *ArtistNFO) string { return n.Disbanded })},
-		{"Biography", getStr(old, func(n *ArtistNFO) string { return n.Biography }), getStr(newNFO, func(n *ArtistNFO) string { return n.Biography })},
-	}
+	// Capacity 16 = 13 scalar fields + 3 slice-joined fields appended
+	// below (keep in sync if fields are added).
+	comparisons := append(make([]comparison, 0, 16),
+		comparison{"Name", getStr(old, func(n *ArtistNFO) string { return n.Name }), getStr(newNFO, func(n *ArtistNFO) string { return n.Name })},
+		comparison{"Sort Name", getStr(old, func(n *ArtistNFO) string { return n.SortName }), getStr(newNFO, func(n *ArtistNFO) string { return n.SortName })},
+		comparison{"Type", getStr(old, func(n *ArtistNFO) string { return n.Type }), getStr(newNFO, func(n *ArtistNFO) string { return n.Type })},
+		comparison{"Gender", getStr(old, func(n *ArtistNFO) string { return n.Gender }), getStr(newNFO, func(n *ArtistNFO) string { return n.Gender })},
+		comparison{"Disambiguation", getStr(old, func(n *ArtistNFO) string { return n.Disambiguation }), getStr(newNFO, func(n *ArtistNFO) string { return n.Disambiguation })},
+		comparison{"MusicBrainz ID", getStr(old, func(n *ArtistNFO) string { return n.MusicBrainzArtistID }), getStr(newNFO, func(n *ArtistNFO) string { return n.MusicBrainzArtistID })},
+		comparison{"AudioDB ID", getStr(old, func(n *ArtistNFO) string { return n.AudioDBArtistID }), getStr(newNFO, func(n *ArtistNFO) string { return n.AudioDBArtistID })},
+		comparison{"Years Active", getStr(old, func(n *ArtistNFO) string { return n.YearsActive }), getStr(newNFO, func(n *ArtistNFO) string { return n.YearsActive })},
+		comparison{"Born", getStr(old, func(n *ArtistNFO) string { return n.Born }), getStr(newNFO, func(n *ArtistNFO) string { return n.Born })},
+		comparison{"Formed", getStr(old, func(n *ArtistNFO) string { return n.Formed }), getStr(newNFO, func(n *ArtistNFO) string { return n.Formed })},
+		comparison{"Died", getStr(old, func(n *ArtistNFO) string { return n.Died }), getStr(newNFO, func(n *ArtistNFO) string { return n.Died })},
+		comparison{"Disbanded", getStr(old, func(n *ArtistNFO) string { return n.Disbanded }), getStr(newNFO, func(n *ArtistNFO) string { return n.Disbanded })},
+		comparison{"Biography", getStr(old, func(n *ArtistNFO) string { return n.Biography }), getStr(newNFO, func(n *ArtistNFO) string { return n.Biography })},
+	)
 
 	// Slice fields joined for display
 	comparisons = append(comparisons,

--- a/internal/provider/fanarttv/fanarttv.go
+++ b/internal/provider/fanarttv/fanarttv.go
@@ -147,7 +147,9 @@ func isNotFound(err error) bool {
 }
 
 func mapImages(resp *Response) []provider.ImageResult {
-	var results []provider.ImageResult
+	results := make([]provider.ImageResult, 0,
+		len(resp.ArtistThumb)+len(resp.ArtistBackground)+
+			len(resp.HDMusicLogo)+len(resp.MusicLogo)+len(resp.MusicBanner))
 	source := string(provider.NameFanartTV)
 
 	for _, img := range resp.ArtistThumb {

--- a/internal/rule/bulk_executor.go
+++ b/internal/rule/bulk_executor.go
@@ -102,9 +102,12 @@ func (e *BulkExecutor) run(ctx context.Context, job *BulkJob) {
 		return
 	}
 
-	// Collect target artists: specific IDs if provided, otherwise all non-excluded
+	// Collect target artists: specific IDs if provided, otherwise all non-excluded.
+	// When ArtistIDs is set, cap at that length; per-row Get/exclusion may skip
+	// entries but never adds beyond it.
 	var artists []artist.Artist
 	if len(job.ArtistIDs) > 0 {
+		artists = make([]artist.Artist, 0, len(job.ArtistIDs))
 		for _, id := range job.ArtistIDs {
 			if ctx.Err() != nil {
 				e.finishJob(ctx, job, BulkStatusCanceled, "")


### PR DESCRIPTION
## Summary

- Enables `prealloc` in `.golangci.yml` with v2 defaults (`range-loops: true`, `for-loops: false`, `simple: true`).
- Adds prealloc to the existing `_test\.go` exclusion rule (alongside gosec/errcheck/noctx/contextcheck/gocognit), and adds a new `cmd/gen-.*/` exclusion rule per the M49.7 dispatch-plan decision.
- Sweeps 8 production sites with bounded-capacity `make()` preallocation: 5 linter-flagged + 3 plan-mandated sites (the three plan-mandated targets weren't linter-flagged because their loops contain `continue`, which prealloc's heuristic skips; applied the upper-bound cap anyway for the optimization win).
- Zero `//nolint:prealloc` directives needed — every flagged or plan-mandated site had a tractable capacity expression.
- No user-visible behavior change. Pure lint config + mechanical slice-preallocation sweep.

## Linked issue

Closes #1469

Sibling to merged PR #1556 (#1468 gocognit, M49.7 W2.2A). Next in chain: #1418 (gocritic, W2.2C).

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Code review pass complete (`pr-review-toolkit:code-reviewer` returned no CRITICAL/HIGH/MEDIUM findings; two LOW informational + one NIT, all non-blocking).
- [x] Single squashed commit (`4754bcb`).
- [x] Labels set: `chore` + `docs: not-required`.
- [x] Docs label decision: `docs: not-required` (lint config + mechanical preallocation; no user-visible behavioral change).
- [x] Screenshot N/A (no UI).
- [x] UAT N/A (no behavioral change; lint-clean run verifies).
- [x] OpenAPI N/A.
- [x] templ N/A.

## Test plan

- [x] `go test -race ./...` passes locally.
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] `golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 ./...` clean (zero prealloc findings, no regressions in other linters incl. the just-merged gocognit set).
- Manual UAT steps:
  - N/A -- preallocation is a pure optimization; lint-clean baseline is the verification.
- Reviewer follow-ups:
  - Two structural refactors needed to satisfy prealloc: `internal/nfo/diff.go` (slice-literal -> `append(make([]T, 0, 16), entries...)`) and `internal/artist/sqlite_history.go` (the original `make([]any, N)+copy+append` actually allocated N zero values then grew past them; refactored to the standard `make(0, cap)+append-spread+appends` form). Both refactors are linter-compelled; behavior preserved.
  - Three plan-mandated sites (`handlers_artist.go:413`, `bulk_executor.go:106`, `handlers_apitoken.go:39`) preallocate with upper-bound caps despite not being linter-flagged. The loops contain `continue` paths that mean actual size may be < cap; that's intentional (cap is a ceiling, not exact).

## Notes for CR

- 9 files touched: 1 config + 8 source.
- Capacity expressions: 6 sites use `len(input)`; 1 site (`handlers_apitoken.go`) uses `strings.Count(s, ",")+1` (correct upper bound for `strings.Split` results); 1 site (`fanarttv.go`) uses sum-of-5-source-slice-lengths; 1 site (`nfo/diff.go`) uses literal 16 with in-line sync comment.
- `cmd/gen-*` exclusion rule is pre-emptive (zero findings today; future gen output likely to trigger).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration to enforce stricter code quality standards
  * Optimized internal memory allocation patterns across multiple components for improved runtime performance and resource efficiency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->