### PR TITLE
chore(lint): enable gocritic + lift G107 to project-wide gosec exclude

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - errorlint
     - exhaustive
     - gocognit
+    - gocritic
     - gosec
     - govet
     - misspell
@@ -49,6 +50,40 @@ linters:
       # refactor-worthy sites are filed under parent #1540 in M55.5.
       # nolintlint enforces that every suppression carries a reason.
       min-complexity: 30
+    gocritic:
+      # Enable the style and performance tag bundles. The diagnostic tag is
+      # intentionally omitted: every diagnostic check overlaps something
+      # govet or staticcheck already reports, and adding it produces
+      # duplicate findings without surfacing new bugs. The experimental and
+      # opinionated tags are off by default and stay off; experimental is
+      # noise, opinionated is taste.
+      enabled-tags:
+        - style
+        - performance
+      # Per-check overrides within the enabled tags. Rationale per entry:
+      #   unnamedResult      - we use unnamed returns idiomatically; naming
+      #                        every (T, error) for the linter buys nothing.
+      #   hugeParam          - value-vs-pointer is a deliberate API design
+      #                        choice, not a per-call-site sweep.
+      #   paramTypeCombine   - "func(a, b string)" vs "func(a string, b string)"
+      #                        is stylistic; readability sometimes wants the
+      #                        expanded form when args are unrelated.
+      #   ifElseChain        - switch-vs-if is a per-site readability call; the
+      #                        check fires on every >=3-arm if-else even when
+      #                        the conditions don't share a discriminant.
+      #   octalLiteral       - we use 0o-prefixed file modes; the check also
+      #                        objects to single-digit literals like 0.
+      #   commentedOutCode   - false-positives on `// Deprecated:` markers,
+      #                        which Go treats as a semantic lint signal
+      #                        rather than commented-out code. See
+      #                        feedback_deprecated_marker in project memory.
+      disabled-checks:
+        - unnamedResult
+        - hugeParam
+        - paramTypeCombine
+        - ifElseChain
+        - octalLiteral
+        - commentedOutCode
     gosec:
       excludes:
         - G104  # Unhandled errors (too noisy for http.Error calls)
@@ -119,6 +154,15 @@ linters:
           # capacities are usually tiny constants. Production-side
           # preallocation is where the perf win lives.
           - prealloc
+          # gocritic in tests is dominated by httpNoBody on
+          # httptest.NewRequest(..., nil) (sweep showed 474 sites, ~96% of
+          # the test-file findings). The check is valid in production where
+          # http.NoBody documents intent and avoids the nil-vs-empty
+          # ambiguity, but in test request builders the nil is unambiguous
+          # and the diff churn / readability cost is the same
+          # ceremony-without-value rationale that excludes gocognit and
+          # prealloc from _test.go.
+          - gocritic
       # cmd/gen-* are build-time documentation generators that run once
       # per `make generate`. Allocation efficiency is not the point; the
       # code is optimized for readability of the generator itself, and

--- a/cmd/gen-doc-anchors/main.go
+++ b/cmd/gen-doc-anchors/main.go
@@ -191,7 +191,7 @@ func headingsToAnchors(path, docPath string) ([]string, error) {
 			continue
 		}
 		trimmed := strings.TrimLeft(line, "#")
-		if len(trimmed) == 0 || trimmed[0] != ' ' {
+		if trimmed == "" || trimmed[0] != ' ' {
 			// Not a heading (e.g. "#anchor" without trailing space).
 			continue
 		}

--- a/cmd/gen-rules-catalogue/main.go
+++ b/cmd/gen-rules-catalogue/main.go
@@ -182,8 +182,10 @@ func renderConfigurable(cfg rule.RuleConfig) string {
 	}
 
 	if cfg.ThresholdPercent > 0 {
-		params = append(params, fmt.Sprintf("Padding threshold (default %.0f%% of image area)", cfg.ThresholdPercent))
-		params = append(params, fmt.Sprintf("Trim margin (default %d px)", cfg.TrimMargin))
+		params = append(params,
+			fmt.Sprintf("Padding threshold (default %.0f%% of image area)", cfg.ThresholdPercent),
+			fmt.Sprintf("Trim margin (default %d px)", cfg.TrimMargin),
+		)
 	}
 
 	if cfg.MinCount > 0 {
@@ -223,8 +225,8 @@ func renderConfigurable(cfg rule.RuleConfig) string {
 func renderCatalogue(rules []rule.Rule) string {
 	// Partition rules by category, preserving registration order within each group.
 	byCategory := make(map[rule.RuleCategory][]rule.Rule)
-	for _, r := range rules {
-		byCategory[r.Category] = append(byCategory[r.Category], r)
+	for i := range rules {
+		byCategory[rules[i].Category] = append(byCategory[rules[i].Category], rules[i])
 	}
 
 	var b strings.Builder
@@ -234,7 +236,9 @@ func renderCatalogue(rules []rule.Rule) string {
 	b.WriteString("| Rule | Category | Default | Fixable |\n")
 	b.WriteString("|---|---|---|---|\n")
 	for _, cat := range categoryOrder {
-		for _, r := range byCategory[cat] {
+		catRules := byCategory[cat]
+		for i := range catRules {
+			r := &catRules[i]
 			entry := rule.CatalogueEntry(r.ID)
 			fixable := "Detection-only"
 			if entry.FixBehavior != "" {
@@ -247,7 +251,7 @@ func renderCatalogue(rules []rule.Rule) string {
 				r.Name,
 				nameToAnchor(r.Name),
 				categoryDisplayName(cat),
-				defaultState(r),
+				defaultState(*r),
 				fixable,
 			)
 		}
@@ -257,7 +261,9 @@ func renderCatalogue(rules []rule.Rule) string {
 
 	// --- Per-rule sections ---
 	for _, cat := range categoryOrder {
-		for _, r := range byCategory[cat] {
+		catRules := byCategory[cat]
+		for i := range catRules {
+			r := &catRules[i]
 			entry := rule.CatalogueEntry(r.ID)
 
 			b.WriteString("\n---\n\n")
@@ -269,7 +275,7 @@ func renderCatalogue(rules []rule.Rule) string {
 			b.WriteString("**Category:** ")
 			b.WriteString(categoryDisplayName(cat))
 			b.WriteString(" &middot; **Default:** ")
-			b.WriteString(defaultState(r))
+			b.WriteString(defaultState(*r))
 			b.WriteString(" &middot; **Severity:** ")
 			b.WriteString(r.Config.Severity)
 			if r.FilesystemDependent {

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -65,9 +65,11 @@ import (
 )
 
 func main() {
-	// Handle subcommands before starting the server
+	// Handle subcommands before starting the server. The switch has only one
+	// case today but is shaped for adding future subcommands (reset-config,
+	// migrate-only, etc.) without rewriting the dispatch.
 	if len(os.Args) > 1 {
-		switch os.Args[1] {
+		switch os.Args[1] { //nolint:gocritic // singleCaseSwitch: shaped for future subcommand cases, see comment above
 		case "reset-credentials":
 			if err := resetCredentials(); err != nil {
 				fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -1165,7 +1167,8 @@ func backfillDefaultLibrary(ctx context.Context, libService *library.Service, mu
 		// musicPath, and fall back to the first listed library.
 		var pathMatchID string
 		cleanedMusic := filepath.Clean(musicPath)
-		for _, lib := range libs {
+		for i := range libs {
+			lib := &libs[i]
 			if lib.Name == "Default" {
 				defaultID = lib.ID
 				break

--- a/internal/api/handlers_artist.go
+++ b/internal/api/handlers_artist.go
@@ -204,8 +204,8 @@ func (r *Router) handleArtistsPage(w http.ResponseWriter, req *http.Request) {
 	var artistIDs []string
 	if len(artists) > 0 {
 		artistIDs = make([]string, len(artists))
-		for i, a := range artists {
-			artistIDs[i] = a.ID
+		for i := range artists {
+			artistIDs[i] = artists[i].ID
 		}
 	}
 
@@ -272,7 +272,8 @@ func (r *Router) handleArtistsPage(w http.ResponseWriter, req *http.Request) {
 		// Build source info map for imported libraries (non-manual).
 		sources := make(map[string]templates.LibrarySourceInfo)
 		connNames := map[string]string{} // cache connection ID -> name
-		for _, lib := range libs {
+		for i := range libs {
+			lib := &libs[i]
 			if lib.Source == "" || lib.Source == "manual" {
 				continue
 			}

--- a/internal/api/handlers_artist_lock.go
+++ b/internal/api/handlers_artist_lock.go
@@ -186,8 +186,8 @@ func (r *Router) setImageLock(w http.ResponseWriter, req *http.Request, locked b
 		return
 	}
 	found := false
-	for _, img := range images {
-		if img.ID == imageID {
+	for i := range images {
+		if images[i].ID == imageID {
 			found = true
 			break
 		}

--- a/internal/api/handlers_conflict.go
+++ b/internal/api/handlers_conflict.go
@@ -111,7 +111,8 @@ func (r *Router) handleGetConnectionConflictDetail(w http.ResponseWriter, req *h
 	}
 	ledger := r.conflictDetector.Current(req.Context())
 	view := templates.ConnectionConflictDetailView{}
-	for _, c := range ledger.Connections {
+	for i := range ledger.Connections {
+		c := &ledger.Connections[i]
 		if c.ConnectionID != id {
 			continue
 		}
@@ -127,11 +128,11 @@ func (r *Router) handleGetConnectionConflictDetail(w http.ResponseWriter, req *h
 				limit = len(c.Paths)
 			}
 			summary := ""
-			for i := 0; i < limit; i++ {
-				if i > 0 {
+			for pi := 0; pi < limit; pi++ {
+				if pi > 0 {
 					summary += ", "
 				}
-				summary += c.Paths[i]
+				summary += c.Paths[pi]
 			}
 			if len(c.Paths) > limit {
 				summary += fmt.Sprintf(" (+%d more)", len(c.Paths)-limit)
@@ -539,7 +540,8 @@ func conflictBannerView(l conflict.Ledger) templates.ConflictBannerView {
 	view := templates.ConflictBannerView{
 		State: l.BannerState(),
 	}
-	for _, c := range l.Connections {
+	for i := range l.Connections {
+		c := &l.Connections[i]
 		if !c.Enabled || c.ManageServerFiles {
 			continue
 		}

--- a/internal/api/handlers_connection.go
+++ b/internal/api/handlers_connection.go
@@ -72,8 +72,8 @@ func (r *Router) handleListConnections(w http.ResponseWriter, req *http.Request)
 	}
 
 	resp := make([]connectionResponse, len(conns))
-	for i, c := range conns {
-		resp[i] = toConnectionResponse(c)
+	for i := range conns {
+		resp[i] = toConnectionResponse(conns[i])
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
@@ -406,7 +406,8 @@ func (r *Router) handleDeleteConnection(w http.ResponseWriter, req *http.Request
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 			return
 		}
-		for _, lib := range libs {
+		for i := range libs {
+			lib := &libs[i]
 			if deleteArtists {
 				if err := r.libraryService.DeleteWithArtists(req.Context(), lib.ID); err != nil {
 					r.logger.Error("deleting library with artists", "library_id", lib.ID, "error", err)

--- a/internal/api/handlers_connection_library.go
+++ b/internal/api/handlers_connection_library.go
@@ -101,7 +101,8 @@ func (r *Router) handleDiscoverLibraries(w http.ResponseWriter, req *http.Reques
 			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to discover libraries from " + conn.Type})
 			return
 		}
-		for _, f := range folders {
+		for i := range folders {
+			f := &folders[i]
 			d := discoveredLibrary{ExternalID: f.ItemID, Name: f.Name}
 			existing, lookupErr := r.libraryService.GetByConnectionAndExternalID(req.Context(), connID, f.ItemID)
 			if lookupErr != nil {
@@ -121,7 +122,8 @@ func (r *Router) handleDiscoverLibraries(w http.ResponseWriter, req *http.Reques
 			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to discover libraries from " + conn.Type})
 			return
 		}
-		for _, f := range folders {
+		for i := range folders {
+			f := &folders[i]
 			d := discoveredLibrary{ExternalID: f.ItemID, Name: f.Name}
 			existing, lookupErr := r.libraryService.GetByConnectionAndExternalID(req.Context(), connID, f.ItemID)
 			if lookupErr != nil {
@@ -599,7 +601,8 @@ func (r *Router) populateFromEmbyCtx(ctx context.Context, client *emby.Client, l
 			return fmt.Errorf("fetching artists from emby: %w", err)
 		}
 
-		for _, item := range resp.Items {
+		for i := range resp.Items {
+			item := &resp.Items[i]
 			result.Total++
 			mbid := item.ProviderIDs.MusicBrainzArtist
 
@@ -686,7 +689,8 @@ func (r *Router) populateFromJellyfinCtx(ctx context.Context, client *jellyfin.C
 			return fmt.Errorf("fetching artists from jellyfin: %w", err)
 		}
 
-		for _, item := range resp.Items {
+		for i := range resp.Items {
+			item := &resp.Items[i]
 			result.Total++
 			mbid := item.ProviderIDs.MusicBrainzArtist
 
@@ -1097,9 +1101,9 @@ func (r *Router) manualLibraries(ctx context.Context) []library.Library {
 		return nil
 	}
 	var manual []library.Library
-	for _, lib := range libs {
-		if lib.Source == library.SourceManual {
-			manual = append(manual, lib)
+	for i := range libs {
+		if libs[i].Source == library.SourceManual {
+			manual = append(manual, libs[i])
 		}
 	}
 	return manual
@@ -1250,7 +1254,8 @@ func (r *Router) scanFromEmby(ctx context.Context, client *emby.Client, lib *lib
 			return updated, fmt.Errorf("fetching artists from emby: %w", err)
 		}
 
-		for _, item := range resp.Items {
+		for i := range resp.Items {
+			item := &resp.Items[i]
 			a := r.resolveAndBackfillPlatformID(ctx,
 				item.ProviderIDs.MusicBrainzArtist, item.Name,
 				lib.ConnectionID, item.ID, lib, manualLibs)
@@ -1300,7 +1305,8 @@ func (r *Router) scanFromJellyfin(ctx context.Context, client *jellyfin.Client, 
 			return updated, fmt.Errorf("fetching artists from jellyfin: %w", err)
 		}
 
-		for _, item := range resp.Items {
+		for i := range resp.Items {
+			item := &resp.Items[i]
 			a := r.resolveAndBackfillPlatformID(ctx,
 				item.ProviderIDs.MusicBrainzArtist, item.Name,
 				lib.ConnectionID, item.ID, lib, manualLibs)

--- a/internal/api/handlers_fix.go
+++ b/internal/api/handlers_fix.go
@@ -398,14 +398,15 @@ func (r *Router) handleFixAll(w http.ResponseWriter, req *http.Request) {
 	// Only include open fixable violations; skip pending_choice (requires
 	// user candidate selection) and non-fixable violations.
 	var fixable []rule.RuleViolation
-	for _, v := range violations {
+	for i := range violations {
+		v := &violations[i]
 		if !v.Fixable || v.Status != rule.ViolationStatusOpen {
 			continue
 		}
 		if len(idSet) > 0 && !idSet[v.ID] {
 			continue
 		}
-		fixable = append(fixable, v)
+		fixable = append(fixable, *v)
 	}
 
 	if len(fixable) == 0 {
@@ -494,14 +495,15 @@ func (r *Router) runFixAll(reqCtx context.Context, violations []rule.RuleViolati
 		}
 		groupOrder := []string{}
 		byArtist := map[string]*artistGroup{}
-		for _, rv := range violations {
+		for i := range violations {
+			rv := &violations[i]
 			g, ok := byArtist[rv.ArtistID]
 			if !ok {
 				g = &artistGroup{artistID: rv.ArtistID}
 				byArtist[rv.ArtistID] = g
 				groupOrder = append(groupOrder, rv.ArtistID)
 			}
-			g.violations = append(g.violations, rv)
+			g.violations = append(g.violations, *rv)
 		}
 
 		// Phase 3: process artist groups with caching and yield.
@@ -512,7 +514,8 @@ func (r *Router) runFixAll(reqCtx context.Context, violations []rule.RuleViolati
 			_, aErr := r.artistService.GetByID(ctx, artistID)
 			if aErr != nil && errors.Is(aErr, artist.ErrNotFound) {
 				// Explicitly dismiss each violation for this deleted artist.
-				for _, rv := range g.violations {
+				for i := range g.violations {
+					rv := &g.violations[i]
 					if dErr := r.ruleService.DismissViolation(ctx, rv.ID); dErr != nil {
 						r.logger.Warn("fix-all: failed to dismiss orphan violation", "id", rv.ID, "error", dErr)
 					}
@@ -525,7 +528,8 @@ func (r *Router) runFixAll(reqCtx context.Context, violations []rule.RuleViolati
 			}
 
 			// Fix each violation for this artist.
-			for _, rv := range g.violations {
+			for i := range g.violations {
+				rv := &g.violations[i]
 				fr, fixErr := r.pipeline.FixViolation(ctx, rv.ID)
 
 				progress.mu.Lock()

--- a/internal/api/handlers_identify.go
+++ b/internal/api/handlers_identify.go
@@ -508,13 +508,14 @@ func (r *Router) identifyArtist(ctx context.Context, a *artist.Artist, connIdx *
 	// Multiple results or low score: queue only candidates with confidence >= 0.3
 	// to avoid flooding the review queue with low-confidence noise.
 	var reviewable []ScoredCandidate
-	for _, res := range results {
+	for i := range results {
+		res := &results[i]
 		confidence := float64(res.Score) / 200.0 // name-only tops at 0.5
 		if confidence < 0.3 {
 			continue
 		}
 		reviewable = append(reviewable, ScoredCandidate{
-			ArtistSearchResult: res,
+			ArtistSearchResult: *res,
 			Confidence:         confidence,
 			Reason:             "name match",
 		})
@@ -557,9 +558,10 @@ func (r *Router) enrichAndScoreTier2(ctx context.Context, results []provider.Art
 
 	scored := make([]ScoredCandidate, len(results))
 	attempted := 0
-	for i, res := range results {
+	for i := range results {
+		res := &results[i]
 		scored[i] = ScoredCandidate{
-			ArtistSearchResult: res,
+			ArtistSearchResult: *res,
 			Reason:             "album comparison",
 		}
 
@@ -593,13 +595,14 @@ func (r *Router) evaluateTier2(ctx context.Context, a *artist.Artist, scored []S
 	// Count candidates meeting thresholds.
 	var above70 []ScoredCandidate
 	var above30 []ScoredCandidate
-	for _, s := range scored {
+	for i := range scored {
+		s := &scored[i]
 		if s.AlbumComparison != nil {
 			if s.AlbumComparison.MatchPercent >= 70 {
-				above70 = append(above70, s)
+				above70 = append(above70, *s)
 			}
 			if s.AlbumComparison.MatchPercent >= 30 {
-				above30 = append(above30, s)
+				above30 = append(above30, *s)
 			}
 		}
 	}
@@ -671,7 +674,8 @@ func (r *Router) buildConnectionIndex(ctx context.Context) *connectionIndex {
 		byName: make(map[string][]connEntry),
 	}
 
-	for _, lib := range libs {
+	for li := range libs {
+		lib := &libs[li]
 		// Only index connection libraries (non-manual sources).
 		if lib.Source == library.SourceManual {
 			continue
@@ -695,7 +699,8 @@ func (r *Router) buildConnectionIndex(ctx context.Context) *connectionIndex {
 				break
 			}
 
-			for _, a := range artists {
+			for ai := range artists {
+				a := &artists[ai]
 				if a.MusicBrainzID == "" {
 					continue
 				}
@@ -721,9 +726,9 @@ func (r *Router) buildConnectionIndex(ctx context.Context) *connectionIndex {
 // zero confidence (used when album enrichment is not possible).
 func convertToScoredCandidates(results []provider.ArtistSearchResult) []ScoredCandidate {
 	scored := make([]ScoredCandidate, len(results))
-	for i, res := range results {
+	for i := range results {
 		scored[i] = ScoredCandidate{
-			ArtistSearchResult: res,
+			ArtistSearchResult: results[i],
 			Confidence:         0,
 			Reason:             "no album data available",
 		}

--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -779,7 +779,7 @@ func isPrivateURL(ctx context.Context, rawURL string) bool {
 func (r *Router) fetchImageFromURL(ctx context.Context, rawURL string) ([]byte, error) {
 	client := r.ssrfClient
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -2016,27 +2016,27 @@ func (r *Router) handleFanartBatchFetch(w http.ResponseWriter, req *http.Request
 	}
 
 	var allSaved []string
-	var errors []string
+	var errMsgs []string
 	for _, u := range body.URLs {
 		if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
-			errors = append(errors, fmt.Sprintf("invalid url: %s", u))
+			errMsgs = append(errMsgs, fmt.Sprintf("invalid url: %s", u))
 			continue
 		}
 		if isPrivateURL(req.Context(), u) {
-			errors = append(errors, fmt.Sprintf("private/reserved address: %s", u))
+			errMsgs = append(errMsgs, fmt.Sprintf("private/reserved address: %s", u))
 			continue
 		}
 		data, fetchErr := r.fetchImageFromURL(req.Context(), u)
 		if fetchErr != nil {
 			r.logger.Warn("fetching fanart image", "url", u, "error", fetchErr)
-			errors = append(errors, fmt.Sprintf("fetch failed: %s", u))
+			errMsgs = append(errMsgs, fmt.Sprintf("fetch failed: %s", u))
 			continue
 		}
 		batchMeta := &img.ExifMeta{Source: "user", Fetched: time.Now().UTC(), URL: u, Mode: "user"}
 		saved, saveErr := r.processAndAppendFanart(req.Context(), r.imageDir(a), data, batchMeta)
 		if saveErr != nil {
 			r.logger.Error("saving fanart image", "url", u, "error", saveErr)
-			errors = append(errors, fmt.Sprintf("save failed: %s", u))
+			errMsgs = append(errMsgs, fmt.Sprintf("save failed: %s", u))
 			continue
 		}
 		allSaved = append(allSaved, saved...)
@@ -2072,7 +2072,7 @@ func (r *Router) handleFanartBatchFetch(w http.ResponseWriter, req *http.Request
 	writeJSON(w, http.StatusOK, map[string]any{
 		"status":        "ok",
 		"saved":         allSaved,
-		"errors":        errors,
+		"errors":        errMsgs,
 		"count":         a.FanartCount,
 		"sync_warnings": syncWarnings,
 	})

--- a/internal/api/handlers_nfo.go
+++ b/internal/api/handlers_nfo.go
@@ -138,11 +138,12 @@ func (r *Router) handleNFOConflictCheck(w http.ResponseWriter, req *http.Request
 		if listErr != nil {
 			continue
 		}
-		for _, conn := range conns {
+		for i := range conns {
+			conn := &conns[i]
 			if !conn.Enabled {
 				continue
 			}
-			enabled, libName, _ := r.checkConnectionForNFOWriter(req.Context(), conn)
+			enabled, libName, _ := r.checkConnectionForNFOWriter(req.Context(), *conn)
 			if enabled {
 				check.ExternalWriter = conn.Type + ":" + conn.Name
 				if !check.HasConflict {
@@ -183,8 +184,8 @@ func (r *Router) handleClobberCheck(w http.ResponseWriter, req *http.Request) {
 		libs, err := r.libraryService.List(req.Context())
 		if err == nil {
 			hasPath := false
-			for _, lib := range libs {
-				if lib.Path != "" {
+			for i := range libs {
+				if libs[i].Path != "" {
 					hasPath = true
 					break
 				}
@@ -209,12 +210,13 @@ func (r *Router) handleClobberCheck(w http.ResponseWriter, req *http.Request) {
 
 	resp := ClobberCheckResponse{Risks: []ClobberRisk{}}
 
-	for _, conn := range conns {
+	for i := range conns {
+		conn := &conns[i]
 		if !conn.Enabled {
 			continue
 		}
 
-		enabled, libName, checkErr := r.checkConnectionForNFOWriter(req.Context(), conn)
+		enabled, libName, checkErr := r.checkConnectionForNFOWriter(req.Context(), *conn)
 
 		risk := ClobberRisk{
 			ConnectionID:   conn.ID,

--- a/internal/api/handlers_notifications.go
+++ b/internal/api/handlers_notifications.go
@@ -78,7 +78,8 @@ func (r *Router) handleNotificationsExport(w http.ResponseWriter, req *http.Requ
 		}
 		rows := make([]exportRow, len(violations))
 		now := time.Now()
-		for i, v := range violations {
+		for i := range violations {
+			v := &violations[i]
 			rows[i] = exportRow{
 				ArtistName:  v.ArtistName,
 				LibraryName: v.LibraryName,
@@ -110,7 +111,8 @@ func (r *Router) handleNotificationsExport(w http.ResponseWriter, req *http.Requ
 	}
 
 	now := time.Now()
-	for _, v := range violations {
+	for i := range violations {
+		v := &violations[i]
 		if req.Context().Err() != nil {
 			break
 		}

--- a/internal/api/handlers_onboarding_conflict.go
+++ b/internal/api/handlers_onboarding_conflict.go
@@ -16,7 +16,8 @@ import (
 // count: with no qualifying peers there is nothing to probe and the step
 // would only display a meaningless "all clear" message.
 func hasQualifyingConflictConnection(conns []connection.Connection) bool {
-	for _, c := range conns {
+	for i := range conns {
+		c := &conns[i]
 		if !c.Enabled {
 			continue
 		}
@@ -112,7 +113,8 @@ func (r *Router) handlePostOnboardingConflictStep(w http.ResponseWriter, req *ht
 // transient peer outages during first-time setup.
 func aggregateProbeError(l conflict.Ledger) string {
 	var failed []string
-	for _, c := range l.Connections {
+	for i := range l.Connections {
+		c := &l.Connections[i]
 		if !c.Enabled {
 			continue
 		}

--- a/internal/api/handlers_platform.go
+++ b/internal/api/handlers_platform.go
@@ -279,7 +279,8 @@ func (r *Router) handleSettingsPage(w http.ResponseWriter, req *http.Request) {
 	// and check whether any local library (with a filesystem path) exists.
 	symlinkSupported := false
 	hasLocalLibrary := false
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		if lib.Path != "" {
 			if !hasLocalLibrary {
 				hasLocalLibrary = true

--- a/internal/api/handlers_preferences.go
+++ b/internal/api/handlers_preferences.go
@@ -236,7 +236,7 @@ func isSuppressConfirmKey(key string) bool {
 		return false
 	}
 	action := key[len(PrefSuppressConfirmPrefix):]
-	if len(action) == 0 {
+	if action == "" {
 		return false
 	}
 	for _, c := range action {

--- a/internal/api/handlers_refresh.go
+++ b/internal/api/handlers_refresh.go
@@ -457,8 +457,8 @@ func (r *Router) handleReidentify(w http.ResponseWriter, req *http.Request) {
 // local albums are available.
 func (r *Router) enrichWithAlbumComparison(ctx context.Context, results []provider.ArtistSearchResult, localAlbums []string) []templates.DisambiguationCandidate {
 	candidates := make([]templates.DisambiguationCandidate, len(results))
-	for i, res := range results {
-		candidates[i].Result = res
+	for i := range results {
+		candidates[i].Result = results[i]
 	}
 
 	if len(localAlbums) == 0 || r.providerRegistry == nil {

--- a/internal/api/handlers_reidentify_wizard.go
+++ b/internal/api/handlers_reidentify_wizard.go
@@ -141,7 +141,8 @@ func projectWizardCandidates(step *reIdentifyWizardStep) []templates.WizardCandi
 		return nil
 	}
 	out := make([]templates.WizardCandidateView, 0, len(step.Candidates))
-	for _, c := range step.Candidates {
+	for i := range step.Candidates {
+		c := &step.Candidates[i]
 		pct := 0
 		switch {
 		case c.AlbumComparison != nil:
@@ -622,9 +623,10 @@ func (r *Router) ensureWizardCandidates(ctx context.Context, sess *reIdentifyWiz
 			candidates = r.enrichAndScoreTier2(ctx, results, localAlbums)
 		} else {
 			candidates = make([]ScoredCandidate, 0, len(results))
-			for _, res := range results {
+			for i := range results {
+				res := &results[i]
 				candidates = append(candidates, ScoredCandidate{
-					ArtistSearchResult: res,
+					ArtistSearchResult: *res,
 					Confidence:         float64(res.Score) / 200.0,
 					Reason:             "name match",
 				})

--- a/internal/api/handlers_report.go
+++ b/internal/api/handlers_report.go
@@ -177,7 +177,8 @@ func (r *Router) handleReportHealthByLibrary(w http.ResponseWriter, req *http.Re
 	}
 
 	summaries := make([]librarySummary, 0, len(libs))
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		stats, err := r.artistService.GetHealthStats(ctx, lib.ID)
 		if err != nil {
 			r.logger.Error("querying health stats for library", "library", lib.Name, "error", err)
@@ -271,8 +272,8 @@ func (r *Router) handleReportCompliance(w http.ResponseWriter, req *http.Request
 
 	// Collect artist IDs for the batch violation lookup.
 	ids := make([]string, len(artists))
-	for i, a := range artists {
-		ids[i] = a.ID
+	for i := range artists {
+		ids[i] = artists[i].ID
 	}
 
 	violations, err := r.ruleService.GetViolationsForArtists(ctx, ids)
@@ -294,14 +295,15 @@ func (r *Router) handleReportCompliance(w http.ResponseWriter, req *http.Request
 	}
 
 	rows := make([]templates.ComplianceRow, len(artists))
-	for i, a := range artists {
+	for i := range artists {
+		a := &artists[i]
 		vs := violations[a.ID]
 		if vs == nil {
 			vs = make([]rule.Violation, 0)
 		}
 		counts := resultCounts[a.ID]
 		rows[i] = templates.ComplianceRow{
-			Artist:              a,
+			Artist:              *a,
 			HealthScore:         a.HealthScore,
 			Violations:          vs,
 			RulesPassedCount:    counts.Passed,
@@ -346,8 +348,8 @@ func (r *Router) handleReportComplianceExport(w http.ResponseWriter, req *http.R
 
 	// Collect artist IDs and batch-load stored violations.
 	allIDs := make([]string, len(allArtists))
-	for i, a := range allArtists {
-		allIDs[i] = a.ID
+	for i := range allArtists {
+		allIDs[i] = allArtists[i].ID
 	}
 	violations, err := r.ruleService.GetViolationsForArtists(ctx, allIDs)
 	if err != nil {
@@ -362,8 +364,8 @@ func (r *Router) handleReportComplianceExport(w http.ResponseWriter, req *http.R
 		r.logger.Warn("listing libraries for compliance export", "error", err)
 	}
 	libNames := make(map[string]string, len(libs))
-	for _, l := range libs {
-		libNames[l.ID] = l.Name
+	for i := range libs {
+		libNames[libs[i].ID] = libs[i].Name
 	}
 
 	w.Header().Set("Content-Type", "text/csv")
@@ -377,13 +379,15 @@ func (r *Router) handleReportComplianceExport(w http.ResponseWriter, req *http.R
 		return
 	}
 
-	for _, a := range allArtists {
+	for i := range allArtists {
 		if ctx.Err() != nil {
 			break
 		}
+		a := &allArtists[i]
+		vs := violations[a.ID]
 		var violationNames []string
-		for _, v := range violations[a.ID] {
-			violationNames = append(violationNames, v.RuleName)
+		for j := range vs {
+			violationNames = append(violationNames, vs[j].RuleName)
 		}
 		libName := libNames[a.LibraryID]
 
@@ -419,11 +423,11 @@ func boolCSV(b bool) string {
 // start with formula-trigger characters (=, +, -, @) with a single quote so
 // spreadsheet applications treat them as plain text.
 func sanitizeCSV(s string) string {
-	if len(s) == 0 {
+	if s == "" {
 		return s
 	}
 	trimmed := strings.TrimLeft(s, " \t")
-	if len(trimmed) == 0 {
+	if trimmed == "" {
 		return s
 	}
 	switch trimmed[0] {
@@ -502,8 +506,8 @@ func (r *Router) handleCompliancePage(w http.ResponseWriter, req *http.Request) 
 
 	// Collect artist IDs and batch-load stored violations.
 	pageIDs := make([]string, len(artists))
-	for i, a := range artists {
-		pageIDs[i] = a.ID
+	for i := range artists {
+		pageIDs[i] = artists[i].ID
 	}
 	pageViolations, err := r.ruleService.GetViolationsForArtists(ctx, pageIDs)
 	if err != nil {
@@ -513,13 +517,14 @@ func (r *Router) handleCompliancePage(w http.ResponseWriter, req *http.Request) 
 	}
 
 	rows := make([]templates.ComplianceRow, len(artists))
-	for i, a := range artists {
+	for i := range artists {
+		a := &artists[i]
 		vs := pageViolations[a.ID]
 		if vs == nil {
 			vs = make([]rule.Violation, 0)
 		}
 		rows[i] = templates.ComplianceRow{
-			Artist:      a,
+			Artist:      *a,
 			HealthScore: a.HealthScore,
 			Violations:  vs,
 		}
@@ -620,8 +625,8 @@ func (r *Router) handleReportMetadataCompleteness(w http.ResponseWriter, req *ht
 		if libs, err := r.libraryService.List(ctx); err != nil {
 			r.logger.Warn("listing libraries for metadata completeness", "error", err)
 		} else {
-			for _, lib := range libs {
-				libNames[lib.ID] = lib.Name
+			for i := range libs {
+				libNames[libs[i].ID] = libs[i].Name
 			}
 		}
 	}

--- a/internal/api/handlers_shared_filesystem.go
+++ b/internal/api/handlers_shared_filesystem.go
@@ -151,11 +151,12 @@ func (r *Router) buildSharedFilesystemStatus(ctx context.Context) (*SharedFilesy
 			return nil, nil, fmt.Errorf("list libraries for peer resolution: %w", allErr)
 		}
 		libNames := make(map[string]string, len(allLibs))
-		for _, lib := range allLibs {
-			libNames[lib.ID] = lib.Name
+		for i := range allLibs {
+			libNames[allLibs[i].ID] = allLibs[i].Name
 		}
 
-		for _, lib := range sharedLibs {
+		for i := range sharedLibs {
+			lib := &sharedLibs[i]
 			// Resolve peer library IDs to a human-readable description.
 			overlapWith := resolvePeerDescription(lib.SharedFSPeerLibraryIDs, libNames)
 
@@ -193,7 +194,8 @@ func (r *Router) collectImageFetcherWarnings(ctx context.Context, sharedLibs []l
 	checked := make(map[string]bool)
 	var warnings []connection.ImageFetcherWarning
 
-	for _, lib := range sharedLibs {
+	for i := range sharedLibs {
+		lib := &sharedLibs[i]
 		if lib.ConnectionID == "" || checked[lib.ConnectionID] {
 			continue
 		}

--- a/internal/api/handlers_user.go
+++ b/internal/api/handlers_user.go
@@ -338,8 +338,9 @@ func parseDuration(s string) (time.Duration, error) {
 // Pre-renders to a buffer so partial failures return a 500 instead of truncated HTML.
 func (r *Router) renderUserTableRows(w http.ResponseWriter, req *http.Request, users []auth.User) {
 	var buf bytes.Buffer
-	for _, u := range users {
-		if err := templates.UserTableRowFragment(u).Render(req.Context(), &buf); err != nil {
+	for i := range users {
+		u := &users[i]
+		if err := templates.UserTableRowFragment(*u).Render(req.Context(), &buf); err != nil {
 			r.logger.Error("rendering user table row", "user_id", u.ID, "error", err)
 			http.Error(w, "Failed to render user list", http.StatusInternalServerError)
 			return

--- a/internal/artist/completeness.go
+++ b/internal/artist/completeness.go
@@ -192,13 +192,14 @@ func buildCompletenessReport(rows []CompletenessRow, lowest []LowestCompleteness
 	counts := make([]int, len(allFieldDefs))
 	totals := make([]int, len(allFieldDefs))
 
-	for _, row := range rows {
+	for ri := range rows {
+		row := &rows[ri]
 		for i, fd := range allFieldDefs {
 			if !fd.applicable(row.Type) {
 				continue
 			}
 			totals[i]++
-			if fd.present(row) {
+			if fd.present(*row) {
 				counts[i]++
 			}
 		}
@@ -250,13 +251,14 @@ func buildLibraryCoverage(rows []CompletenessRow, libNames map[string]string) []
 	order := make([]string, 0)
 	byLib := make(map[string]*libEntry)
 
-	for _, row := range rows {
+	for ri := range rows {
+		row := &rows[ri]
 		lid := row.LibraryID
 		if _, exists := byLib[lid]; !exists {
 			order = append(order, lid)
 			byLib[lid] = &libEntry{}
 		}
-		byLib[lid].rows = append(byLib[lid].rows, row)
+		byLib[lid].rows = append(byLib[lid].rows, *row)
 	}
 
 	// Only emit library_coverage when more than one library is present.

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -239,6 +239,8 @@ func NewServiceWithRepos(
 // Service via NewServiceWithRepos. Returning the interface types (not the
 // concrete sqlite structs) keeps the call site honest about what the Service
 // actually depends on.
+//
+//nolint:gocritic // tooManyResultsChecker: returns one entry per repo interface so tests can swap individual repos via NewServiceWithRepos; collapsing into a struct would force every test call site to thread fields.
 func NewDefaultRepos(db *sql.DB) (
 	Repository,
 	ProviderIDRepository,
@@ -900,7 +902,8 @@ func imageRegistryDrift(current, desired []ArtistImage) bool {
 	}
 	index := func(rows []ArtistImage) map[key]row {
 		out := make(map[key]row, len(rows))
-		for _, r := range rows {
+		for i := range rows {
+			r := &rows[i]
 			out[key{r.ImageType, r.SlotIndex}] = row{
 				exists:      r.Exists,
 				lowRes:      r.LowRes,
@@ -1277,10 +1280,10 @@ func (s *Service) RemoveLockedField(ctx context.Context, id, field string) error
 	if err != nil {
 		return err
 	}
-	target := strings.ToLower(strings.TrimSpace(field))
+	target := strings.TrimSpace(field)
 	kept := make([]string, 0, len(a.LockedFields))
 	for _, f := range a.LockedFields {
-		if strings.ToLower(f) == target {
+		if strings.EqualFold(f, target) {
 			continue
 		}
 		kept = append(kept, f)
@@ -1308,9 +1311,9 @@ func (s *Service) IsFieldLocked(a *Artist, field string) bool {
 	if a == nil {
 		return false
 	}
-	target := strings.ToLower(strings.TrimSpace(field))
+	target := strings.TrimSpace(field)
 	for _, f := range a.LockedFields {
-		if strings.ToLower(f) == target {
+		if strings.EqualFold(f, target) {
 			return true
 		}
 	}
@@ -1424,9 +1427,10 @@ func (s *Service) FindDuplicates(ctx context.Context) ([]DuplicateGroup, error) 
 func (s *Service) hydrateDuplicateGroups(ctx context.Context, groups []DuplicateGroup) error {
 	// Collect all unique artist IDs across every group.
 	seen := make(map[string]struct{})
-	for _, g := range groups {
-		for _, a := range g.Artists {
-			seen[a.ID] = struct{}{}
+	for gi := range groups {
+		g := &groups[gi]
+		for ai := range g.Artists {
+			seen[g.Artists[ai].ID] = struct{}{}
 		}
 	}
 	if len(seen) == 0 {
@@ -1866,7 +1870,8 @@ func (s *Service) hydrateImagesBatch(ctx context.Context, artists []Artist) erro
 // normalized ArtistImage slice.
 func applyImageMetadata(a *Artist, imgs []ArtistImage) {
 	fanartCount := 0
-	for _, img := range imgs {
+	for i := range imgs {
+		img := &imgs[i]
 		switch img.ImageType {
 		case "thumb":
 			a.ThumbExists = img.Exists

--- a/internal/artist/sqlite_image.go
+++ b/internal/artist/sqlite_image.go
@@ -140,7 +140,8 @@ func (r *sqliteImageRepo) UpsertAll(ctx context.Context, artistID string, images
 	}
 	defer upsertStmt.Close() //nolint:errcheck // Close error not actionable on cleanup
 
-	for _, img := range images {
+	for i := range images {
+		img := &images[i]
 		id := img.ID
 		if id == "" {
 			id = uuid.New().String()

--- a/internal/conflict/detector.go
+++ b/internal/conflict/detector.go
@@ -244,8 +244,8 @@ func (d *Detector) Refresh(ctx context.Context) Ledger {
 	}
 
 	states := make([]ConnectionState, 0, len(conns))
-	for _, c := range conns {
-		states = append(states, d.checkOne(ctx, c))
+	for i := range conns {
+		states = append(states, d.checkOne(ctx, conns[i]))
 	}
 	ledger := Ledger{
 		GeneratedAt: time.Now().UTC(),
@@ -290,7 +290,8 @@ func (d *Detector) Refresh(ctx context.Context) Ledger {
 func ledgerSignature(l Ledger) string {
 	var b strings.Builder
 	b.WriteString(l.BannerState())
-	for _, c := range l.Connections {
+	for i := range l.Connections {
+		c := &l.Connections[i]
 		b.WriteByte('|')
 		b.WriteString(c.ConnectionID)
 		b.WriteByte(':')
@@ -615,8 +616,8 @@ func (e embyPaths) MusicLibraryPaths(ctx context.Context) ([]string, error) {
 		return nil, err
 	}
 	var out []string
-	for _, lib := range libs {
-		out = append(out, lib.Locations...)
+	for i := range libs {
+		out = append(out, libs[i].Locations...)
 	}
 	return out, nil
 }
@@ -629,8 +630,8 @@ func (j jellyfinPaths) MusicLibraryPaths(ctx context.Context) ([]string, error) 
 		return nil, err
 	}
 	var out []string
-	for _, lib := range libs {
-		out = append(out, lib.Locations...)
+	for i := range libs {
+		out = append(out, libs[i].Locations...)
 	}
 	return out, nil
 }

--- a/internal/conflict/ledger.go
+++ b/internal/conflict/ledger.go
@@ -134,7 +134,8 @@ func (l Ledger) AnyImageConflict() bool {
 	if len(l.RoundTrips) > 0 {
 		return true
 	}
-	for _, c := range l.Connections {
+	for i := range l.Connections {
+		c := &l.Connections[i]
 		if !c.Enabled {
 			continue
 		}
@@ -158,7 +159,8 @@ func (l Ledger) AnyNFOConflict() bool {
 	if len(l.RoundTrips) > 0 {
 		return true
 	}
-	for _, c := range l.Connections {
+	for i := range l.Connections {
+		c := &l.Connections[i]
 		if !c.Enabled {
 			continue
 		}

--- a/internal/connection/emby/client.go
+++ b/internal/connection/emby/client.go
@@ -69,12 +69,13 @@ func (c *Client) GetMusicLibraries(ctx context.Context) ([]VirtualFolder, error)
 	}
 
 	var music []VirtualFolder
-	for _, f := range folders {
+	for i := range folders {
+		f := &folders[i]
 		ct := strings.TrimSpace(strings.ToLower(f.CollectionType))
 		include := ct == "music" || ct == ""
 		c.Logger.Debug("emby virtual folder discovered", "name", f.Name, "collection_type", f.CollectionType, "included_as_music", include)
 		if include {
-			music = append(music, f)
+			music = append(music, *f)
 		}
 	}
 	return music, nil
@@ -93,7 +94,8 @@ func (c *Client) CheckNFOWriterEnabled(ctx context.Context) (bool, string, error
 		return false, "", fmt.Errorf("checking emby nfo saver settings: %w", err)
 	}
 
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		for _, saver := range lib.LibraryOptions.MetadataSavers {
 			if strings.Contains(strings.ToLower(saver), "nfo") {
 				return true, lib.Name, nil
@@ -121,7 +123,8 @@ func (c *Client) CheckImageFetchersEnabled(ctx context.Context) ([]ImageFetcherS
 	}
 
 	var results []ImageFetcherStatus
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		for _, opt := range lib.LibraryOptions.TypeOptions {
 			if !strings.EqualFold(opt.Type, "MusicArtist") {
 				continue
@@ -320,7 +323,8 @@ func (c *Client) GetLibrarySettings(ctx context.Context) ([]LibrarySettingsStatu
 	}
 
 	results := make([]LibrarySettingsStatus, 0, len(libs))
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		status := LibrarySettingsStatus{
 			LibraryID:      lib.ItemID,
 			LibraryName:    lib.Name,
@@ -361,8 +365,8 @@ func (c *Client) DisableConflictingSettings(ctx context.Context, libraryID strin
 	}
 
 	var target *VirtualFolder
-	for i, lib := range libs {
-		if lib.ItemID == libraryID {
+	for i := range libs {
+		if libs[i].ItemID == libraryID {
 			target = &libs[i]
 			break
 		}
@@ -512,7 +516,8 @@ func (c *Client) CheckImageSaverEnabled(ctx context.Context) (bool, string, erro
 	if err != nil {
 		return false, "", fmt.Errorf("checking emby image saver settings: %w", err)
 	}
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		if lib.LibraryOptions.SaveLocalMetadata {
 			return true, lib.Name, nil
 		}
@@ -532,7 +537,8 @@ func (c *Client) SnapshotLibraryOptions(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("getting music libraries for snapshot: %w", err)
 	}
 	entries := make([]mediabrowser.LibrarySaverSnapshotEntry, 0, len(libs))
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		savers := lib.LibraryOptions.MetadataSavers
 		if savers == nil {
 			savers = []string{}

--- a/internal/connection/emby/push.go
+++ b/internal/connection/emby/push.go
@@ -133,7 +133,7 @@ func (c *Client) PushMetadata(ctx context.Context, platformArtistID string, data
 func (c *Client) refreshItem(ctx context.Context, platformArtistID string) {
 	path := fmt.Sprintf("/Items/%s/Refresh", url.PathEscape(platformArtistID))
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		connection.BuildRequestURL(c.BaseURL, path+"?ReplaceAllMetadata=false&ReplaceAllImages=false"), nil)
+		connection.BuildRequestURL(c.BaseURL, path+"?ReplaceAllMetadata=false&ReplaceAllImages=false"), http.NoBody)
 	if err != nil {
 		c.Logger.Warn("creating emby refresh request", "artist_id", platformArtistID, "error", err)
 		return
@@ -241,7 +241,7 @@ func (c *Client) DeleteImage(ctx context.Context, platformArtistID string, image
 	}
 
 	path := fmt.Sprintf("/Items/%s/Images/%s", url.PathEscape(platformArtistID), embyType)
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, connection.BuildRequestURL(c.BaseURL, path), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, connection.BuildRequestURL(c.BaseURL, path), http.NoBody)
 	if err != nil {
 		return fmt.Errorf("creating image delete request: %w", err)
 	}

--- a/internal/connection/httpclient/client.go
+++ b/internal/connection/httpclient/client.go
@@ -49,7 +49,7 @@ func NewBase(baseURL, apiKey string, httpClient *http.Client, logger *slog.Logge
 // Get performs a GET request and JSON-decodes the response body into result.
 // Returns an error if the status is not 200 OK.
 func (b *BaseClient) Get(ctx context.Context, path string, result any) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connection.BuildRequestURL(b.BaseURL, path), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connection.BuildRequestURL(b.BaseURL, path), http.NoBody)
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}
@@ -98,7 +98,7 @@ func (b *BaseClient) Post(ctx context.Context, path string, body io.Reader) erro
 // GetRaw performs a GET request and returns the raw response bytes and Content-Type header.
 // The success response body is capped at 25 MB.
 func (b *BaseClient) GetRaw(ctx context.Context, path string) ([]byte, string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connection.BuildRequestURL(b.BaseURL, path), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connection.BuildRequestURL(b.BaseURL, path), http.NoBody)
 	if err != nil {
 		return nil, "", fmt.Errorf("creating request: %w", err)
 	}

--- a/internal/connection/jellyfin/client.go
+++ b/internal/connection/jellyfin/client.go
@@ -65,12 +65,13 @@ func (c *Client) GetMusicLibraries(ctx context.Context) ([]VirtualFolder, error)
 	}
 
 	var music []VirtualFolder
-	for _, f := range folders {
+	for i := range folders {
+		f := &folders[i]
 		ct := strings.TrimSpace(strings.ToLower(f.CollectionType))
 		include := ct == "music" || ct == ""
 		c.Logger.Debug("jellyfin virtual folder discovered", "name", f.Name, "collection_type", f.CollectionType, "included_as_music", include)
 		if include {
-			music = append(music, f)
+			music = append(music, *f)
 		}
 	}
 	return music, nil
@@ -89,7 +90,8 @@ func (c *Client) CheckNFOWriterEnabled(ctx context.Context) (bool, string, error
 		return false, "", fmt.Errorf("checking jellyfin nfo saver settings: %w", err)
 	}
 
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		for _, saver := range lib.LibraryOptions.MetadataSavers {
 			if strings.Contains(strings.ToLower(saver), "nfo") {
 				return true, lib.Name, nil
@@ -118,7 +120,8 @@ func (c *Client) CheckImageFetchersEnabled(ctx context.Context) ([]ImageFetcherS
 	}
 
 	var results []ImageFetcherStatus
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		// If internet providers are globally disabled for this library,
 		// image fetchers are inactive regardless of TypeOptions.
 		if !lib.LibraryOptions.EnableInternetProviders {
@@ -325,7 +328,8 @@ func (c *Client) GetLibrarySettings(ctx context.Context) ([]LibrarySettingsStatu
 	}
 
 	results := make([]LibrarySettingsStatus, 0, len(libs))
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		status := LibrarySettingsStatus{
 			LibraryID:               lib.ItemID,
 			LibraryName:             lib.Name,
@@ -371,8 +375,8 @@ func (c *Client) DisableConflictingSettings(ctx context.Context, libraryID strin
 	}
 
 	var target *VirtualFolder
-	for i, lib := range libs {
-		if lib.ItemID == libraryID {
+	for i := range libs {
+		if libs[i].ItemID == libraryID {
 			target = &libs[i]
 			break
 		}
@@ -409,7 +413,8 @@ func (c *Client) CheckImageSaverEnabled(ctx context.Context) (bool, string, erro
 	if err != nil {
 		return false, "", fmt.Errorf("checking jellyfin image saver settings: %w", err)
 	}
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		if lib.LibraryOptions.SaveLocalMetadata {
 			return true, lib.Name, nil
 		}
@@ -427,7 +432,8 @@ func (c *Client) SnapshotLibraryOptions(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("getting music libraries for snapshot: %w", err)
 	}
 	entries := make([]mediabrowser.LibrarySaverSnapshotEntry, 0, len(libs))
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		savers := lib.LibraryOptions.MetadataSavers
 		if savers == nil {
 			savers = []string{}

--- a/internal/connection/jellyfin/push.go
+++ b/internal/connection/jellyfin/push.go
@@ -199,7 +199,7 @@ func (c *Client) fetchItem(ctx context.Context, itemID string) (map[string]any, 
 		return nil, fmt.Errorf("item id is required")
 	}
 	path := fmt.Sprintf("/Items?Ids=%s&Fields=Overview,ProviderIds,PremiereDate,EndDate,Genres,Tags,LockData,LockedFields", url.QueryEscape(itemID))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connection.BuildRequestURL(c.BaseURL, path), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connection.BuildRequestURL(c.BaseURL, path), http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating fetch request: %w", err)
 	}
@@ -325,7 +325,7 @@ func (c *Client) DeleteImage(ctx context.Context, platformArtistID string, image
 	}
 
 	path := fmt.Sprintf("/Items/%s/Images/%s", url.PathEscape(platformArtistID), jfType)
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, connection.BuildRequestURL(c.BaseURL, path), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, connection.BuildRequestURL(c.BaseURL, path), http.NoBody)
 	if err != nil {
 		return fmt.Errorf("creating image delete request: %w", err)
 	}

--- a/internal/connection/lidarr/client.go
+++ b/internal/connection/lidarr/client.go
@@ -162,7 +162,7 @@ func (c *Client) DisableMetadataConsumer(ctx context.Context, configID int) erro
 func (c *Client) getMetadataProviderConfigs(ctx context.Context) ([]MetadataProviderConfig, error) {
 	const path = "/api/v1/config/metadataprovider"
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connection.BuildRequestURL(c.BaseURL, path), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connection.BuildRequestURL(c.BaseURL, path), http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -360,7 +360,7 @@ func (c *Client) RestoreLibraryOptions(ctx context.Context, snapshotJSON string)
 // model, so putMetadataConsumer can PUT back a lossless body without
 // dropping anything the peer cares about.
 func (c *Client) getMetadataConsumers(ctx context.Context) ([]map[string]any, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connection.BuildRequestURL(c.BaseURL, "/api/v1/metadata"), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, connection.BuildRequestURL(c.BaseURL, "/api/v1/metadata"), http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -488,7 +488,9 @@ func collapseDuplicateArtists(ctx context.Context, db *sql.DB, logger *slog.Logg
 		return fmt.Errorf("finding name duplicates: %w", err)
 	}
 
-	allGroups := append(mbidGroups, nameGroups...)
+	allGroups := make([]collapseGroup, 0, len(mbidGroups)+len(nameGroups))
+	allGroups = append(allGroups, mbidGroups...)
+	allGroups = append(allGroups, nameGroups...)
 	if len(allGroups) == 0 {
 		return nil
 	}

--- a/internal/foreign/scanner.go
+++ b/internal/foreign/scanner.go
@@ -101,15 +101,16 @@ func (s *Scanner) Scan(ctx context.Context) error {
 
 	scanned, recorded, cleared, skipped := 0, 0, 0, 0
 	process := func(artists []artist.Artist) {
-		for _, a := range artists {
+		for i := range artists {
 			if ctx.Err() != nil {
 				return
 			}
+			a := &artists[i]
 			if a.Path == "" {
 				skipped++
 				continue
 			}
-			rec, clr, sk := s.scanArtist(ctx, a)
+			rec, clr, sk := s.scanArtist(ctx, *a)
 			scanned++
 			recorded += rec
 			cleared += clr

--- a/internal/image/cleanup.go
+++ b/internal/image/cleanup.go
@@ -68,7 +68,7 @@ func CleanupConflictingFormats(dir string, fileName string, logger *slog.Logger)
 
 		entryExt := strings.ToLower(filepath.Ext(name))
 		entryBase := strings.TrimSuffix(name, filepath.Ext(name))
-		if strings.ToLower(entryBase) != lowerBase {
+		if !strings.EqualFold(entryBase, lowerBase) {
 			continue // different base name entirely
 		}
 

--- a/internal/image/exif.go
+++ b/internal/image/exif.go
@@ -465,7 +465,9 @@ func injectPNGDescription(data []byte, description string) ([]byte, error) {
 	chunkType := []byte("tEXt")
 	_, _ = chunk.Write(chunkType)
 	_, _ = chunk.Write(payload)
-	crcData := append(chunkType, payload...)
+	crcData := make([]byte, 0, len(chunkType)+len(payload))
+	crcData = append(crcData, chunkType...)
+	crcData = append(crcData, payload...)
 	_ = binary.Write(&chunk, binary.BigEndian, crc32.ChecksumIEEE(crcData))
 
 	// Walk existing chunks. Insert our tEXt after IHDR, skip existing

--- a/internal/image/processor.go
+++ b/internal/image/processor.go
@@ -41,7 +41,7 @@ func ProbeRemoteImage(ctx context.Context, rawURL string) (*RemoteImageInfo, err
 // variant exists so that callers that already hold a test-safe *http.Client
 // (e.g. httptest.Server.Client()) can bypass the SSRF-safe transport in tests.
 func ProbeRemoteImageWithClient(ctx context.Context, rawURL string, client *http.Client) (*RemoteImageInfo, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}

--- a/internal/langpref/langpref.go
+++ b/internal/langpref/langpref.go
@@ -134,7 +134,7 @@ func EncodeJSON(tags []string) (string, error) {
 // language subtag must be 2-3 ASCII letters (ISO 639). Subsequent
 // subtags are 1-8 alphanumeric characters separated by hyphens.
 func isValidLanguageTag(s string) bool {
-	if len(s) == 0 || len(s) > MaxTagLength {
+	if s == "" || len(s) > MaxTagLength {
 		return false
 	}
 	parts := strings.Split(s, "-")
@@ -148,7 +148,7 @@ func isValidLanguageTag(s string) bool {
 		}
 	}
 	for _, p := range parts[1:] {
-		if len(p) == 0 || len(p) > 8 {
+		if p == "" || len(p) > 8 {
 			return false
 		}
 		for _, c := range p {

--- a/internal/library/validate.go
+++ b/internal/library/validate.go
@@ -59,7 +59,7 @@ func CheckPathExists(path string) error {
 		// On Windows, prepending "/" to a drive-letter path (e.g.
 		// "C:\dir") produces "\C:\dir" after Clean. Trim the leading
 		// separator to restore the valid form.
-		if len(vol) == 2 && vol[1] == ':' && len(cleaned) > 0 {
+		if len(vol) == 2 && vol[1] == ':' && cleaned != "" {
 			cleaned = cleaned[1:]
 		}
 	}

--- a/internal/provider/audiodb/audiodb.go
+++ b/internal/provider/audiodb/audiodb.go
@@ -89,7 +89,8 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 	}
 
 	results := make([]provider.ArtistSearchResult, 0, len(artists))
-	for _, art := range artists {
+	for i := range artists {
+		art := &artists[i]
 		results = append(results, provider.ArtistSearchResult{
 			ProviderID:    art.IDArtist,
 			Name:          art.Artist,
@@ -229,7 +230,7 @@ func (a *Adapter) buildLookupURL(apiKey, mbid string) string {
 // fetchArtists performs an HTTP GET and parses the artist list from the response.
 // Premium keys are sent in the X-API-KEY header (v2); the free key is embedded in the URL (v1).
 func (a *Adapter) fetchArtists(ctx context.Context, reqURL string, apiKey string) ([]AudioDBArtist, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}

--- a/internal/provider/deezer/deezer.go
+++ b/internal/provider/deezer/deezer.go
@@ -80,7 +80,8 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 	}
 
 	results := make([]provider.ArtistSearchResult, 0, len(resp.Data))
-	for _, r := range resp.Data {
+	for i := range resp.Data {
+		r := &resp.Data[i]
 		results = append(results, provider.ArtistSearchResult{
 			ProviderID: strconv.Itoa(r.ID),
 			Name:       r.Name,
@@ -168,7 +169,7 @@ func (a *Adapter) GetImages(ctx context.Context, id string) ([]provider.ImageRes
 
 // doRequest executes a GET request and returns the response body.
 func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/discogs/discogs.go
+++ b/internal/provider/discogs/discogs.go
@@ -254,7 +254,7 @@ func (a *Adapter) getToken(ctx context.Context) (string, error) {
 }
 
 func (a *Adapter) doRequest(ctx context.Context, reqURL, token string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}

--- a/internal/provider/duckduckgo/duckduckgo.go
+++ b/internal/provider/duckduckgo/duckduckgo.go
@@ -147,7 +147,7 @@ func (a *Adapter) getVQDToken(ctx context.Context, query string) (string, error)
 func (a *Adapter) getVQDFromMainPage(ctx context.Context, query string) (string, error) {
 	params := url.Values{"q": {query}}
 	reqURL := a.baseURL + "/?" + params.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return "", err
 	}
@@ -228,7 +228,7 @@ func (a *Adapter) fetchImages(ctx context.Context, query, vqd string) ([]imageHi
 	}
 
 	reqURL := a.baseURL + "/i.js?" + params.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/fanarttv/fanarttv.go
+++ b/internal/provider/fanarttv/fanarttv.go
@@ -76,7 +76,7 @@ func (a *Adapter) GetImages(ctx context.Context, mbid string) ([]provider.ImageR
 	}
 
 	reqURL := fmt.Sprintf("%s/%s?api_key=%s", a.baseURL, mbid, apiKey)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}

--- a/internal/provider/genius/genius.go
+++ b/internal/provider/genius/genius.go
@@ -207,7 +207,7 @@ func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) 
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}

--- a/internal/provider/lastfm/lastfm.go
+++ b/internal/provider/lastfm/lastfm.go
@@ -214,7 +214,7 @@ func (a *Adapter) getAPIKey(ctx context.Context) (string, error) {
 }
 
 func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -76,7 +76,8 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 	}
 
 	results := make([]provider.ArtistSearchResult, 0, len(resp.Artists))
-	for _, a := range resp.Artists {
+	for i := range resp.Artists {
+		a := &resp.Artists[i]
 		// Use the higher of the API's native score and our name similarity
 		// score. The API score reflects relevance factors beyond name matching
 		// (popularity, tag matches), while name similarity catches cases where
@@ -126,12 +127,12 @@ func (a *Adapter) GetArtist(ctx context.Context, mbid string) (*provider.ArtistM
 		return nil, err
 	}
 
-	var artist MBArtist
-	if err := json.Unmarshal(body, &artist); err != nil {
+	var mbArtist MBArtist
+	if err := json.Unmarshal(body, &mbArtist); err != nil {
 		return nil, fmt.Errorf("parsing artist response: %w", err)
 	}
 
-	meta := a.mapArtist(ctx, &artist)
+	meta := a.mapArtist(ctx, &mbArtist)
 
 	// Localize member names from each member's primary aliases when the user
 	// has set metadata language preferences. MusicBrainz omits aliases from
@@ -512,7 +513,7 @@ func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) 
 		}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -809,8 +810,8 @@ func applyRelation(meta *provider.ArtistMetadata, rel MBRelation, seen map[strin
 // is shared with collectAndScoreAliases so "is person" relations cannot
 // duplicate an existing alias.
 func applyRelations(meta *provider.ArtistMetadata, mb *MBArtist, seen map[string]bool) {
-	for _, rel := range mb.Relations {
-		applyRelation(meta, rel, seen)
+	for i := range mb.Relations {
+		applyRelation(meta, mb.Relations[i], seen)
 	}
 }
 

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -22,7 +22,7 @@ var sensitiveParamRe = regexp.MustCompile(`(?i)(api_?key|token|secret|password|a
 // propagating malformed values like "Qabc" or "Qspecial:Random" through
 // providerIDs, which would otherwise drive a failed direct-entity SPARQL and
 // mask the MBID fallback.
-var wikidataQIDRe = regexp.MustCompile(`^Q[0-9]+$`)
+var wikidataQIDRe = regexp.MustCompile(`^Q\d+$`)
 
 // ScrubError removes sensitive query parameter values (API keys, tokens, passwords)
 // from error strings before they are written to logs. Provider errors may contain

--- a/internal/provider/settings.go
+++ b/internal/provider/settings.go
@@ -227,9 +227,9 @@ func (s *SettingsService) ListProviderKeyStatuses(ctx context.Context) ([]Provid
 		}
 		// Fetch mirror config early so we can use it both for the persisted
 		// status gate and the ProviderKeyStatus assignment below.
-		cap := caps[name]
+		capInfo := caps[name]
 		var mirror *MirrorConfig
-		if cap.SupportsBaseURL {
+		if capInfo.SupportsBaseURL {
 			m, err := s.GetMirrorConfig(ctx, name)
 			if err != nil {
 				return nil, err
@@ -237,7 +237,7 @@ func (s *SettingsService) ListProviderKeyStatuses(ctx context.Context) ([]Provid
 			mirror = m
 		}
 		// Only look up persisted test status when the provider has an API key
-		// or an active mirror. Using cap.SupportsBaseURL alone would show stale
+		// or an active mirror. Using capInfo.SupportsBaseURL alone would show stale
 		// status after mirror removal since the capability flag stays true.
 		if hasKey || mirror != nil {
 			persisted, err := s.GetKeyStatus(ctx, name)
@@ -255,12 +255,12 @@ func (s *SettingsService) ListProviderKeyStatuses(ctx context.Context) ([]Provid
 			OptionalKey:     optionalKey,
 			HasKey:          hasKey,
 			Status:          status,
-			AccessTier:      cap.Tier,
-			HelpURL:         cap.HelpURL,
-			RateLimit:       cap.RateLimit,
-			SupportsBaseURL: cap.SupportsBaseURL,
+			AccessTier:      capInfo.Tier,
+			HelpURL:         capInfo.HelpURL,
+			RateLimit:       capInfo.RateLimit,
+			SupportsBaseURL: capInfo.SupportsBaseURL,
 		}
-		if cap.SupportsBaseURL {
+		if capInfo.SupportsBaseURL {
 			pks.Mirror = mirror
 		}
 		statuses = append(statuses, pks)

--- a/internal/provider/spotify/spotify.go
+++ b/internal/provider/spotify/spotify.go
@@ -350,7 +350,7 @@ func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) 
 
 // executeRequest performs a single HTTP GET with the given bearer token.
 func (a *Adapter) executeRequest(ctx context.Context, reqURL, token string) ([]byte, int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/provider/wikidata/wikidata.go
+++ b/internal/provider/wikidata/wikidata.go
@@ -160,7 +160,8 @@ func (a *Adapter) GetImages(ctx context.Context, mbid string) ([]provider.ImageR
 	seen := make(map[string]bool)
 	var entries []imageEntry
 
-	for _, b := range bindings {
+	for i := range bindings {
+		b := &bindings[i]
 		if b.Image.Value != "" {
 			fn := extractCommonsFilename(b.Image.Value)
 			key := string(provider.ImageThumb) + ":" + fn
@@ -246,7 +247,7 @@ func (a *Adapter) executeSPARQL(ctx context.Context, query string) ([]SPARQLBind
 	}
 	reqURL := a.endpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -396,8 +397,8 @@ func mapArtist(mbid string, bindings []SPARQLBinding) *provider.ArtistMetadata {
 
 	// Collect unique genres from all bindings
 	seen := make(map[string]bool)
-	for _, b := range bindings {
-		genre := b.Genre.Value
+	for i := range bindings {
+		genre := bindings[i].Genre.Value
 		if genre != "" && !seen[genre] {
 			seen[genre] = true
 			meta.Genres = append(meta.Genres, genre)
@@ -470,7 +471,7 @@ func (a *Adapter) resolveCommonsURL(ctx context.Context, filename string) (*Comm
 	}
 	reqURL := a.commonsEndpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating commons request: %w", err)
 	}

--- a/internal/provider/wikipedia/wikipedia.go
+++ b/internal/provider/wikipedia/wikipedia.go
@@ -314,7 +314,7 @@ func (a *Adapter) TestConnection(ctx context.Context) error {
 		"format": {"json"},
 	}
 	wikiReq, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		a.actionEndpoint+"?"+params.Encode(), nil)
+		a.actionEndpoint+"?"+params.Encode(), http.NoBody)
 	if err != nil {
 		return err
 	}
@@ -348,7 +348,7 @@ func (a *Adapter) TestConnection(ctx context.Context) error {
 		"format": {"json"},
 	}
 	sparqlReq, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		a.wikidataEndpoint+"?"+sparqlQuery.Encode(), nil)
+		a.wikidataEndpoint+"?"+sparqlQuery.Encode(), http.NoBody)
 	if err != nil {
 		return err
 	}
@@ -385,7 +385,7 @@ func (a *Adapter) TestConnection(ctx context.Context) error {
 		"format": {"json"},
 	}
 	entityReq, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		a.wikidataAPIEndpoint+"?"+entityParams.Encode(), nil)
+		a.wikidataAPIEndpoint+"?"+entityParams.Encode(), http.NoBody)
 	if err != nil {
 		return err
 	}
@@ -500,7 +500,7 @@ func (a *Adapter) resolveFromMBID(ctx context.Context, mbid string) (string, str
 	}
 	reqURL := a.wikidataEndpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return "", "", &provider.ErrProviderUnavailable{
 			Provider: provider.NameWikipedia,
@@ -591,7 +591,7 @@ func (a *Adapter) resolveToLocalizedTitle(ctx context.Context, qid, lang string)
 	}
 	reqURL := a.wikidataAPIEndpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return "", &provider.ErrProviderUnavailable{
 			Provider: provider.NameWikipedia,
@@ -661,7 +661,7 @@ func (a *Adapter) resolveFromQID(ctx context.Context, qid string) (string, error
 	}
 	reqURL := a.wikidataAPIEndpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return "", &provider.ErrProviderUnavailable{
 			Provider: provider.NameWikipedia,
@@ -743,7 +743,7 @@ func (a *Adapter) fetchExtractFrom(ctx context.Context, endpoint, title string) 
 	}
 	reqURL := endpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return "", "", &provider.ErrProviderUnavailable{
 			Provider: provider.NameWikipedia,
@@ -816,7 +816,7 @@ func (a *Adapter) fetchWikitext(ctx context.Context, title string) (string, erro
 	}
 	reqURL := a.actionEndpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 	if err != nil {
 		return "", &provider.ErrProviderUnavailable{
 			Provider: provider.NameWikipedia,

--- a/internal/rule/bulk_executor.go
+++ b/internal/rule/bulk_executor.go
@@ -139,9 +139,10 @@ func (e *BulkExecutor) run(ctx context.Context, job *BulkJob) {
 			if len(page) == 0 {
 				break
 			}
-			for _, a := range page {
+			for i := range page {
+				a := &page[i]
 				if !a.IsExcluded && !a.Locked {
-					artists = append(artists, a)
+					artists = append(artists, *a)
 				}
 			}
 			if len(page) < pageSize {
@@ -251,9 +252,9 @@ func (e *BulkExecutor) fetchImages(ctx context.Context, a *artist.Artist, mode s
 		if err != nil || len(results) == 0 {
 			return BulkItemSkipped, "no MBID and provider search found nothing"
 		}
-		for _, r := range results {
-			if r.MusicBrainzID != "" {
-				a.MusicBrainzID = r.MusicBrainzID
+		for i := range results {
+			if results[i].MusicBrainzID != "" {
+				a.MusicBrainzID = results[i].MusicBrainzID
 				_ = e.artistService.Update(ctx, a)
 				break
 			}

--- a/internal/rule/checkers.go
+++ b/internal/rule/checkers.go
@@ -1118,14 +1118,14 @@ func (e *Engine) makeImageDuplicateChecker() Checker {
 	}
 }
 
-// truncateStr returns the first max runes of s, appending "..." if truncated.
+// truncateStr returns the first maxRunes runes of s, appending "..." if truncated.
 // Uses rune-safe slicing to avoid splitting multi-byte UTF-8 characters.
-func truncateStr(s string, max int) string {
+func truncateStr(s string, maxRunes int) string {
 	runes := []rune(s)
-	if len(runes) <= max {
+	if len(runes) <= maxRunes {
 		return s
 	}
-	return string(runes[:max]) + "..."
+	return string(runes[:maxRunes]) + "..."
 }
 
 func checkMetadataQuality(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {

--- a/internal/rule/engine.go
+++ b/internal/rule/engine.go
@@ -335,7 +335,8 @@ func (e *Engine) Evaluate(ctx context.Context, a *artist.Artist) (*EvaluationRes
 		ArtistName: a.Name,
 	}
 
-	for _, r := range rules {
+	for i := range rules {
+		r := &rules[i]
 		if !r.Enabled {
 			continue
 		}

--- a/internal/rule/fixers.go
+++ b/internal/rule/fixers.go
@@ -1079,7 +1079,7 @@ func (f *LogoPaddingFixer) fixViaAPI(ctx context.Context, a *artist.Artist, v *V
 func fetchImageURL(ctx context.Context, rawURL string) ([]byte, error) {
 	client := &http.Client{Timeout: fetchTimeout}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rule/fscache.go
+++ b/internal/rule/fscache.go
@@ -359,19 +359,21 @@ func (e *Engine) getImageDimensionsCached(dirPath string, patterns []string) (in
 	lowerToActual := buildLowerToActual(entries)
 
 	for _, pattern := range patterns {
-		if actual, ok := lowerToActual[strings.ToLower(pattern)]; ok {
-			p := filepath.Join(dirPath, actual)
-			f, openErr := os.Open(p) //nolint:gosec // G304: path from trusted library root
-			if openErr != nil {
-				continue
-			}
-			w, h, dimErr := image.GetDimensions(f)
-			f.Close() //nolint:errcheck // Close error not actionable; explicit close where defer is not appropriate
-			if dimErr != nil {
-				continue
-			}
-			return w, h, nil
+		actual, ok := lowerToActual[strings.ToLower(pattern)]
+		if !ok {
+			continue
 		}
+		p := filepath.Join(dirPath, actual)
+		f, openErr := os.Open(p) //nolint:gosec // G304: path from trusted library root
+		if openErr != nil {
+			continue
+		}
+		w, h, dimErr := image.GetDimensions(f)
+		f.Close() //nolint:errcheck // Close error not actionable; explicit close where defer is not appropriate
+		if dimErr != nil {
+			continue
+		}
+		return w, h, nil
 	}
 
 	return 0, 0, fmt.Errorf("no matching image in %s", dirPath)

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -361,7 +361,8 @@ func (s *Service) WithLogger(logger *slog.Logger) *Service {
 // signal for the dirty-tracking query to schedule them on the next pass.
 func (s *Service) SeedDefaults(ctx context.Context) error {
 	now := s.clock.Now().Format(time.RFC3339)
-	for _, r := range defaultRules {
+	for i := range defaultRules {
+		r := &defaultRules[i]
 		autoMode := r.AutomationMode
 		if autoMode == "" {
 			autoMode = "auto"
@@ -1224,15 +1225,16 @@ func GroupViolations(violations []RuleViolation, groupBy string) []ViolationGrou
 	var order []string
 	groups := make(map[string]*ViolationGroup)
 
-	for _, v := range violations {
-		key, label := keyFunc(v)
+	for i := range violations {
+		v := &violations[i]
+		key, label := keyFunc(*v)
 		g, exists := groups[key]
 		if !exists {
 			g = &ViolationGroup{Key: key, Label: label}
 			groups[key] = g
 			order = append(order, key)
 		}
-		g.Violations = append(g.Violations, v)
+		g.Violations = append(g.Violations, *v)
 		g.Count++
 	}
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -199,7 +199,8 @@ func (s *Service) runScan(ctx context.Context, result *ScanResult) {
 		if err != nil {
 			s.logger.Error("listing libraries for scan", "error", err)
 		}
-		for _, lib := range libs {
+		for i := range libs {
+			lib := &libs[i]
 			if lib.Path == "" {
 				s.logger.Info("skipping pathless library (no path configured)", "library_id", lib.ID, "name", lib.Name)
 				continue
@@ -639,7 +640,8 @@ func (s *Service) recordHealthSnapshot(ctx context.Context) {
 	processed := 0
 
 	processPage := func(artists []artist.Artist) {
-		for _, a := range artists {
+		for i := range artists {
+			a := &artists[i]
 			if a.HealthScore >= 100.0 {
 				compliant++
 			}
@@ -756,7 +758,8 @@ func (s *Service) detectRemovedLegacyFallback(ctx context.Context, discoveredPat
 	}
 
 	libraryPath := s.libraryPath
-	for _, a := range allArtists {
+	for i := range allArtists {
+		a := &allArtists[i]
 		if discoveredPaths[a.Path] {
 			continue
 		}
@@ -969,8 +972,6 @@ func isCanonicalArtistFile(lower string) bool {
 //
 // `existing` must be non-nil; callers already guard on that in
 // detectFilesWithFastPath.
-//
-//nolint:gocognit // Per-slot pattern walk (thumb, fanart, logo, banner) with a per-slot field-copy from existing, an mtime fast-path bailout that re-signals to the full-probe path when any canonical file has been overwritten in place (POSIX directory mtime does not catch in-place rewrites -- the per-file stat is the gate), and the DiscoverFanart-driven count refresh for the fanart slot. The slot-by-slot expansion is essential to the field-copy correctness from the existing row.
 func detectFilesExistenceOnly(dirPath string, existing *artist.Artist) (detectedFiles, error) {
 	entries, err := os.ReadDir(dirPath)
 	if err != nil {
@@ -1020,58 +1021,63 @@ func detectFilesExistenceOnly(dirPath string, existing *artist.Artist) (detected
 	}
 
 	for _, p := range thumbPatterns {
-		if _, ok := files[strings.ToLower(p)]; ok {
-			d.ThumbExists = true
-			d.ThumbWidth = existing.ThumbWidth
-			d.ThumbHeight = existing.ThumbHeight
-			d.ThumbLowRes = existing.ThumbLowRes
-			d.ThumbPlaceholder = existing.ThumbPlaceholder
-			break
+		if _, ok := files[strings.ToLower(p)]; !ok {
+			continue
 		}
+		d.ThumbExists = true
+		d.ThumbWidth = existing.ThumbWidth
+		d.ThumbHeight = existing.ThumbHeight
+		d.ThumbLowRes = existing.ThumbLowRes
+		d.ThumbPlaceholder = existing.ThumbPlaceholder
+		break
 	}
 	for _, p := range fanartPatterns {
-		if actual, ok := files[strings.ToLower(p)]; ok {
-			d.FanartExists = true
-			d.FanartWidth = existing.FanartWidth
-			d.FanartHeight = existing.FanartHeight
-			d.FanartLowRes = existing.FanartLowRes
-			d.FanartPlaceholder = existing.FanartPlaceholder
-			// Count fanart variants from the same ReadDir result the
-			// full path uses via img.DiscoverFanart. Cheap: pure
-			// string-pattern matching against the already-built map.
-			fanartPaths, fanartErr := img.DiscoverFanart(dirPath, actual)
-			if fanartErr != nil {
-				slog.Warn("discovering fanart variants during scan",
-					slog.String("dir", dirPath),
-					slog.String("error", fanartErr.Error()))
-			}
-			if len(fanartPaths) > 0 {
-				d.FanartCount = len(fanartPaths)
-			} else {
-				d.FanartCount = 1
-			}
-			break
+		actual, ok := files[strings.ToLower(p)]
+		if !ok {
+			continue
 		}
+		d.FanartExists = true
+		d.FanartWidth = existing.FanartWidth
+		d.FanartHeight = existing.FanartHeight
+		d.FanartLowRes = existing.FanartLowRes
+		d.FanartPlaceholder = existing.FanartPlaceholder
+		// Count fanart variants from the same ReadDir result the
+		// full path uses via img.DiscoverFanart. Cheap: pure
+		// string-pattern matching against the already-built map.
+		fanartPaths, fanartErr := img.DiscoverFanart(dirPath, actual)
+		if fanartErr != nil {
+			slog.Warn("discovering fanart variants during scan",
+				slog.String("dir", dirPath),
+				slog.String("error", fanartErr.Error()))
+		}
+		if len(fanartPaths) > 0 {
+			d.FanartCount = len(fanartPaths)
+		} else {
+			d.FanartCount = 1
+		}
+		break
 	}
 	for _, p := range logoPatterns {
-		if _, ok := files[strings.ToLower(p)]; ok {
-			d.LogoExists = true
-			d.LogoWidth = existing.LogoWidth
-			d.LogoHeight = existing.LogoHeight
-			d.LogoLowRes = existing.LogoLowRes
-			d.LogoPlaceholder = existing.LogoPlaceholder
-			break
+		if _, ok := files[strings.ToLower(p)]; !ok {
+			continue
 		}
+		d.LogoExists = true
+		d.LogoWidth = existing.LogoWidth
+		d.LogoHeight = existing.LogoHeight
+		d.LogoLowRes = existing.LogoLowRes
+		d.LogoPlaceholder = existing.LogoPlaceholder
+		break
 	}
 	for _, p := range bannerPatterns {
-		if _, ok := files[strings.ToLower(p)]; ok {
-			d.BannerExists = true
-			d.BannerWidth = existing.BannerWidth
-			d.BannerHeight = existing.BannerHeight
-			d.BannerLowRes = existing.BannerLowRes
-			d.BannerPlaceholder = existing.BannerPlaceholder
-			break
+		if _, ok := files[strings.ToLower(p)]; !ok {
+			continue
 		}
+		d.BannerExists = true
+		d.BannerWidth = existing.BannerWidth
+		d.BannerHeight = existing.BannerHeight
+		d.BannerLowRes = existing.BannerLowRes
+		d.BannerPlaceholder = existing.BannerPlaceholder
+		break
 	}
 
 	return d, nil
@@ -1119,24 +1125,26 @@ func detectFiles(dirPath string, existing *artist.Artist) (detectedFiles, error)
 		}
 	}
 	for _, p := range fanartPatterns {
-		if actual, ok := files[strings.ToLower(p)]; ok {
-			fp := filepath.Join(dirPath, actual)
-			d.FanartExists = true
-			d.FanartWidth, d.FanartHeight, d.FanartLowRes, d.FanartPlaceholder = probeImageFileFn(fp, "fanart", existFanartPH)
-			// Count all fanart files (primary + numbered variants).
-			fanartPaths, fanartErr := img.DiscoverFanart(dirPath, actual)
-			if fanartErr != nil {
-				slog.Warn("discovering fanart variants during scan",
-					slog.String("dir", dirPath),
-					slog.String("error", fanartErr.Error()))
-			}
-			if len(fanartPaths) > 0 {
-				d.FanartCount = len(fanartPaths)
-			} else {
-				d.FanartCount = 1
-			}
-			break
+		actual, ok := files[strings.ToLower(p)]
+		if !ok {
+			continue
 		}
+		fp := filepath.Join(dirPath, actual)
+		d.FanartExists = true
+		d.FanartWidth, d.FanartHeight, d.FanartLowRes, d.FanartPlaceholder = probeImageFileFn(fp, "fanart", existFanartPH)
+		// Count all fanart files (primary + numbered variants).
+		fanartPaths, fanartErr := img.DiscoverFanart(dirPath, actual)
+		if fanartErr != nil {
+			slog.Warn("discovering fanart variants during scan",
+				slog.String("dir", dirPath),
+				slog.String("error", fanartErr.Error()))
+		}
+		if len(fanartPaths) > 0 {
+			d.FanartCount = len(fanartPaths)
+		} else {
+			d.FanartCount = 1
+		}
+		break
 	}
 	for _, p := range logoPatterns {
 		if actual, ok := files[strings.ToLower(p)]; ok {

--- a/internal/settingsio/export.go
+++ b/internal/settingsio/export.go
@@ -280,7 +280,8 @@ func (s *Service) Export(ctx context.Context, passphrase string) (*Envelope, err
 	if err != nil {
 		return nil, fmt.Errorf("listing connections: %w", err)
 	}
-	for _, c := range conns {
+	for i := range conns {
+		c := &conns[i]
 		payload.Connections = append(payload.Connections, ConnectionExport{
 			Name:                 c.Name,
 			Type:                 c.Type,
@@ -328,7 +329,8 @@ func (s *Service) Export(ctx context.Context, passphrase string) (*Envelope, err
 		if err != nil {
 			return nil, fmt.Errorf("listing rules: %w", err)
 		}
-		for _, r := range rules {
+		for i := range rules {
+			r := &rules[i]
 			payload.Rules = append(payload.Rules, RuleExport{
 				ID:             r.ID,
 				Enabled:        r.Enabled,

--- a/internal/settingsio/import_sections.go
+++ b/internal/settingsio/import_sections.go
@@ -94,20 +94,21 @@ func (s *Service) importConnections(ctx context.Context, conns []ConnectionExpor
 // are created with a new ID. IsActive is forced to false on create to prevent
 // multiple active profiles from being introduced during import.
 func (s *Service) importPlatformProfiles(ctx context.Context, profiles []platform.Profile, result *ImportResult) error {
-	for _, p := range profiles {
+	for i := range profiles {
+		p := &profiles[i]
 		existing, err := s.platformSvc.GetByName(ctx, p.Name)
 		if err != nil {
 			return fmt.Errorf("looking up platform profile %q: %w", p.Name, err)
 		}
 		if existing != nil {
 			p.ID = existing.ID
-			if err := s.platformSvc.Update(ctx, &p); err != nil {
+			if err := s.platformSvc.Update(ctx, p); err != nil {
 				return fmt.Errorf("updating platform profile %q: %w", p.Name, err)
 			}
 		} else {
 			p.ID = ""          // Let Create generate a new ID.
 			p.IsActive = false // Avoid creating multiple active profiles on import.
-			if err := s.platformSvc.Create(ctx, &p); err != nil {
+			if err := s.platformSvc.Create(ctx, p); err != nil {
 				return fmt.Errorf("creating platform profile %q: %w", p.Name, err)
 			}
 		}
@@ -120,19 +121,20 @@ func (s *Service) importPlatformProfiles(ctx context.Context, profiles []platfor
 // webhook is updated in place with its ID preserved; absent webhooks are
 // created with a new ID.
 func (s *Service) importWebhooks(ctx context.Context, webhooks []webhook.Webhook, result *ImportResult) error {
-	for _, w := range webhooks {
+	for i := range webhooks {
+		w := &webhooks[i]
 		existing, err := s.webhookSvc.GetByNameAndURL(ctx, w.Name, w.URL)
 		if err != nil {
 			return fmt.Errorf("looking up webhook %q: %w", w.Name, err)
 		}
 		if existing != nil {
 			w.ID = existing.ID
-			if err := s.webhookSvc.Update(ctx, &w); err != nil {
+			if err := s.webhookSvc.Update(ctx, w); err != nil {
 				return fmt.Errorf("updating webhook %q: %w", w.Name, err)
 			}
 		} else {
 			w.ID = "" // Let Create generate a new ID.
-			if err := s.webhookSvc.Create(ctx, &w); err != nil {
+			if err := s.webhookSvc.Create(ctx, w); err != nil {
 				return fmt.Errorf("creating webhook %q: %w", w.Name, err)
 			}
 		}
@@ -170,7 +172,8 @@ func (s *Service) importRules(ctx context.Context, rules []RuleExport, result *I
 	if s.ruleService == nil {
 		return nil
 	}
-	for _, re := range rules {
+	for i := range rules {
+		re := &rules[i]
 		if re.ID == "" {
 			continue
 		}
@@ -216,7 +219,8 @@ func (s *Service) importScraperPreferences(ctx context.Context, configs []Scrape
 	if s.scraperService == nil {
 		return nil
 	}
-	for _, sce := range configs {
+	for i := range configs {
+		sce := &configs[i]
 		if sce.Scope == "" {
 			continue
 		}

--- a/internal/settingsio/libraries.go
+++ b/internal/settingsio/libraries.go
@@ -82,7 +82,8 @@ func (s *Service) exportLibraries(ctx context.Context) ([]LibraryExport, error) 
 //nolint:gocognit // Per-library upsert with primary-key (name) lookup, secondary-key ((connection_id, external_id)) fallback for renamed peer libraries, and source-aware connection remap; skip-with-warning behavior preserves the disaster-recovery contract when individual rows cannot resolve. The skip vs error ladder mirrors importUserPreferences and is part of the import envelope's documented contract.
 func (s *Service) importLibraries(ctx context.Context, libs []LibraryExport, result *ImportResult) error {
 	now := time.Now().UTC().Format(time.RFC3339)
-	for _, le := range libs {
+	for i := range libs {
+		le := &libs[i]
 		if le.Name == "" {
 			// A blank name cannot satisfy the UNIQUE constraint and would
 			// collide on a second import. Skip with a warning rather than

--- a/internal/settingsio/tokens.go
+++ b/internal/settingsio/tokens.go
@@ -77,7 +77,8 @@ func (s *Service) exportAPITokens(ctx context.Context) ([]APITokenExport, error)
 //     the prior behavior for callers that prefer a quiet skip over a silent
 //     ownership change (e.g. prod->staging clones).
 func (s *Service) importAPITokens(ctx context.Context, tokens []APITokenExport, result *ImportResult, opts ImportOptions) error {
-	for _, te := range tokens {
+	for i := range tokens {
+		te := &tokens[i]
 		if te.TokenHash == "" {
 			// A blank hash cannot satisfy authentication and would collide
 			// on the UNIQUE constraint after one row. Skip with a warning

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -332,8 +332,8 @@ func (s *Service) SetDockerForTest(isDocker bool) {
 // post-Apply UI surface without exercising the full runApply pipeline (which
 // would attempt to overwrite the test binary). Production code does NOT use
 // this; runApply alone calls markRestartRequired after a verified swap.
-func (s *Service) MarkRestartRequiredForTest(version string) {
-	s.markRestartRequired(version)
+func (s *Service) MarkRestartRequiredForTest(versionTag string) {
+	s.markRestartRequired(versionTag)
 }
 
 // MarkAutoAppliedForTest exposes the internal markAutoApplied write so
@@ -341,8 +341,8 @@ func (s *Service) MarkRestartRequiredForTest(version string) {
 // settings row without driving the full Apply pipeline. Production code
 // does NOT use this; the scheduler's applyAuto branch is the only caller
 // of markAutoApplied in the running service.
-func (s *Service) MarkAutoAppliedForTest(ctx context.Context, version string) error {
-	return s.markAutoApplied(ctx, version)
+func (s *Service) MarkAutoAppliedForTest(ctx context.Context, versionTag string) error {
+	return s.markAutoApplied(ctx, versionTag)
 }
 
 // detectDocker returns true when the process appears to be running inside a
@@ -977,11 +977,11 @@ var executablePath = os.Executable
 // version tag. Held under s.mu so a concurrent Status() reader sees both
 // fields update atomically; otherwise the UI could observe restartRequired=true
 // with pendingVersion still empty.
-func (s *Service) markRestartRequired(version string) {
+func (s *Service) markRestartRequired(versionTag string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.restartRequired = true
-	s.pendingVersion = version
+	s.pendingVersion = versionTag
 }
 
 // fetchReleases calls the GitHub Releases API for this repository. The page
@@ -991,7 +991,7 @@ func (s *Service) markRestartRequired(version string) {
 // this slice for the newest entry matching the requested channel.
 func (s *Service) fetchReleases(ctx context.Context) ([]githubRelease, error) {
 	const apiURL = "https://api.github.com/repos/sydlexius/stillwater/releases?per_page=100"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -1032,7 +1032,7 @@ func (s *Service) downloadBytes(ctx context.Context, rawURL string) ([]byte, err
 		return nil, fmt.Errorf("download URL must use https, got %q", parsed.Scheme)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -1502,7 +1502,7 @@ func (s *Service) applyAuto(candidateVersion string) error {
 // Written outside SetConfig because these fields are scheduler-owned
 // (not user-editable) and SetConfig's transaction semantics already
 // cover the user-facing knobs only.
-func (s *Service) markAutoApplied(ctx context.Context, version string) error {
+func (s *Service) markAutoApplied(ctx context.Context, versionTag string) error {
 	now := time.Now().UTC().Format(time.RFC3339)
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -1511,7 +1511,7 @@ func (s *Service) markAutoApplied(ctx context.Context, version string) error {
 	defer func() { _ = tx.Rollback() }()
 	for _, kv := range []struct{ k, v string }{
 		{SettingLastAutoApplied, now},
-		{SettingLastAutoAppliedVer, version},
+		{SettingLastAutoAppliedVer, versionTag},
 	} {
 		if _, err := tx.ExecContext(ctx,
 			`INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
@@ -1527,8 +1527,8 @@ func (s *Service) markAutoApplied(ctx context.Context, version string) error {
 // Idempotent: a tag already present is a no-op. The scheduler reads
 // SkippedVersions on every tick, so the next auto-apply candidate is
 // gated on the post-write list without restarting the scheduler.
-func (s *Service) AddSkippedVersion(ctx context.Context, version string) error {
-	if version == "" {
+func (s *Service) AddSkippedVersion(ctx context.Context, versionTag string) error {
+	if versionTag == "" {
 		return fmt.Errorf("version tag must be non-empty")
 	}
 	s.skippedVersionsMu.Lock()
@@ -1538,17 +1538,17 @@ func (s *Service) AddSkippedVersion(ctx context.Context, version string) error {
 		return fmt.Errorf("reading config: %w", err)
 	}
 	for _, v := range cfg.SkippedVersions {
-		if v == version {
+		if v == versionTag {
 			return nil
 		}
 	}
-	cfg.SkippedVersions = append(cfg.SkippedVersions, version)
+	cfg.SkippedVersions = append(cfg.SkippedVersions, versionTag)
 	return s.writeSkippedVersions(ctx, cfg.SkippedVersions)
 }
 
 // RemoveSkippedVersion removes a tag from the skip list. Idempotent:
 // removing a tag that is not present is a no-op.
-func (s *Service) RemoveSkippedVersion(ctx context.Context, version string) error {
+func (s *Service) RemoveSkippedVersion(ctx context.Context, versionTag string) error {
 	s.skippedVersionsMu.Lock()
 	defer s.skippedVersionsMu.Unlock()
 	cfg, err := s.GetConfig(ctx)
@@ -1557,7 +1557,7 @@ func (s *Service) RemoveSkippedVersion(ctx context.Context, version string) erro
 	}
 	out := make([]string, 0, len(cfg.SkippedVersions))
 	for _, v := range cfg.SkippedVersions {
-		if v != version {
+		if v != versionTag {
 			out = append(out, v)
 		}
 	}

--- a/internal/version/format.go
+++ b/internal/version/format.go
@@ -96,7 +96,7 @@ func UserAgent(prefix, repoURL string) string {
 // canonicalVersion returns v with a leading "v" if it is not already present.
 // golang.org/x/mod/semver requires the "v" prefix.
 func canonicalVersion(v string) string {
-	if len(v) > 0 && v[0] != 'v' {
+	if v != "" && v[0] != 'v' {
 		return "v" + v
 	}
 	return v

--- a/internal/watcher/probe.go
+++ b/internal/watcher/probe.go
@@ -89,7 +89,8 @@ func ProbeFSNotify(path string, timeout time.Duration) bool {
 // ProbeAll probes all non-pathless libraries and populates the cache.
 // Called synchronously at startup before the watcher goroutine starts.
 func (pc *ProbeCache) ProbeAll(ctx context.Context, libs []library.Library, logger *slog.Logger) {
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		if lib.IsPathless() {
 			continue
 		}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -264,7 +264,8 @@ func (s *Service) refreshWatchPaths(ctx context.Context) {
 	}
 
 	wanted := make(map[string]bool)
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		if !lib.FSWatchEnabled() || lib.IsPathless() {
 			continue
 		}
@@ -358,7 +359,8 @@ func (s *Service) initPollSnapshots(ctx context.Context) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		if !lib.FSPollEnabled() || lib.IsPathless() {
 			continue
 		}
@@ -390,7 +392,8 @@ func (s *Service) refreshPollPaths(ctx context.Context) {
 	}
 
 	wanted := make(map[string]int) // path -> interval
-	for _, lib := range libs {
+	for i := range libs {
+		lib := &libs[i]
 		if !lib.FSPollEnabled() || lib.IsPathless() {
 			continue
 		}

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -93,13 +93,14 @@ func (s *Service) ListByEvent(ctx context.Context, eventType string) ([]Webhook,
 	}
 
 	var matched []Webhook
-	for _, w := range all {
+	for i := range all {
+		w := &all[i]
 		if !w.Enabled {
 			continue
 		}
 		for _, e := range w.Events {
 			if e == eventType {
-				matched = append(matched, w)
+				matched = append(matched, *w)
 				break
 			}
 		}

--- a/web/templates/helpers.go
+++ b/web/templates/helpers.go
@@ -121,7 +121,7 @@ func fieldLabel(ctx context.Context, field string) string {
 	if result == "field."+field {
 		parts := strings.Split(field, "_")
 		for i, p := range parts {
-			if len(p) > 0 {
+			if p != "" {
 				parts[i] = strings.ToUpper(p[:1]) + p[1:]
 			}
 		}
@@ -185,8 +185,8 @@ func hxValsJSONAny(pairs map[string]any) string {
 // mergeSliceValues combines current and provider slices, deduplicating
 // case-insensitively while preserving original casing. Returns a raw
 // comma-separated string suitable for passing to hxValsJSON.
-func mergeSliceValues(current, provider []string) string {
-	seen := make(map[string]bool, len(current)+len(provider))
+func mergeSliceValues(current, providerVals []string) string {
+	seen := make(map[string]bool, len(current)+len(providerVals))
 	var merged []string
 	for _, v := range current {
 		trimmed := strings.TrimSpace(v)
@@ -196,7 +196,7 @@ func mergeSliceValues(current, provider []string) string {
 			merged = append(merged, trimmed)
 		}
 	}
-	for _, v := range provider {
+	for _, v := range providerVals {
 		trimmed := strings.TrimSpace(v)
 		lower := strings.ToLower(trimmed)
 		if lower != "" && !seen[lower] {


### PR DESCRIPTION
## Summary

- Enables `gocritic` with `enabled-tags: [style, performance]`. Drops `diagnostic` — every diagnostic-class check overlaps existing `govet` + `staticcheck` findings, so adding it produces duplicate signals.
- 6 disabled checks: `unnamedResult`, `hugeParam`, `paramTypeCombine`, `ifElseChain`, `octalLiteral`, `commentedOutCode`. The last is M49.7-specific (false-positives on this repo's `// Deprecated:` markers per `feedback_deprecated_marker`).
- `_test.go` exclusion for gocritic (matches gocognit + prealloc precedent; scoped survey showed 474 `httpNoBody` findings in test request builders, ~96% of test-file noise).
- 175 production sites swept (107 rangeValCopy, 33 httpNoBody, 9 importShadow, 9 emptyStringTest, 6 nestingReduce, 4 appendAssign, 3 equalFold, 2 builtinShadow, 4 singletons, 2 `//nolint` with specific reasons).
- **Two correctness-class bug fixes** surfaced by the appendAssign check: aliasing of `mbidGroups` backing storage in `database/migrate.go` and aliasing of a 4-byte chunkType literal in `image/exif.go`. Both fixed with sized `make+append`. gocritic earned its keep on entry.
- **Bundled: G107 cleanup.** Lifts `G107` (URL provided to HTTP request as taint input) from per-site `//nolint:gosec` directives to a project-wide `gosec.excludes` entry. The two outbound-fetch surfaces (image fetch + updater download) are SSRF-protected at the transport layer and validated by callers. G107 fires inconsistently between gosec v2.11.4 (pre-commit pin) and v2.12.2 (CI/canonical hook); project-wide exclude keeps lint deterministic across that drift. Drops the redundant `//nolint:gosec` at `handlers_image.go:781`.
- No user-visible behavior change. Lint config + mechanical sweep + transport-protected SSRF cleanup.

## Linked issue

Closes #1418

Final PR in the M49.7 W2 lint chain — siblings to merged #1556 (gocognit) and #1557 (prealloc).

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Lint baseline clean (`golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 ./...` returns 0 issues).
- [x] Single squashed commit (`f9cd5d50`).
- [x] Labels set: `chore` + `docs: not-required`.
- [x] Docs label decision: `docs: not-required` (lint config + sweep + scoped SSRF cleanup; no user-visible behavioral change).
- [x] Screenshot N/A (no UI).
- [x] UAT N/A (no behavioral change; lint-clean baseline + existing tests verify).
- [x] OpenAPI N/A.
- [x] templ N/A.

## Test plan

- [x] `go test -race ./...` passes locally.
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] `golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 ./...` clean (zero gocritic findings; zero regressions in gocognit/prealloc/other linters).
- Manual UAT: N/A.
- Reviewer follow-ups:
  - **Correctness fixes** (worth a careful look): the two `appendAssign` aliasing fixes in `internal/database/migrate.go` and `internal/image/exif.go`. Both were latent backing-storage aliasing bugs the linter found; sized `make+append` removes the alias hazard.
  - **G107 lift to project-wide**: rationale is gosec cross-version drift + SSRF protection at the transport layer. If you'd prefer per-site nolints retained, easy to revert that 2-file portion of the diff.

## Notes for CR

- 70 files touched. Largest single-file delta is `internal/scanner/scanner.go` (+/- 136 lines, mostly `rangeValCopy` index conversions on iteration over large structs).
- The `commentedOutCode` entry in `disabled-checks` is technically redundant (golangci-lint v2 disables it by default), but pinned explicitly with a comment so the project's intent survives future golangci-lint upgrades that flip the default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal refactors improving iteration stability and pointer semantics across many modules.
  * Standardized HTTP GET request construction to use an explicit no-body value for more consistent networking.
  * Enhanced linter configuration to enable gocritic style/performance bundles and fine-tune exclusions for test files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->