### PR TITLE
chore(ci): pin go-mutesting install by commit SHA (Scorecard #88)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -87,13 +87,12 @@ jobs:
           go-version-file: go.mod
 
       - name: Install go-mutesting
-        # Pinned to @latest deliberately. The avito-tech fork is the
-        # active maintenance fork (the upstream zimmski/go-mutesting is
-        # archived); there are no semver tags to pin to. Dependabot's
-        # action-version automation does not cover `go install` lines,
-        # so we accept upstream drift here in exchange for picking up
-        # mutator fixes without manual SHA bumps.
-        run: go install github.com/avito-tech/go-mutesting/cmd/go-mutesting@latest
+        # Pinned by commit SHA (Scorecard Pinned-Dependencies). The SHA
+        # below is v2.3.1 on the avito-tech fork, which is the active
+        # maintenance fork (upstream zimmski/go-mutesting is archived).
+        # Bump manually when picking up new mutator fixes -- Dependabot's
+        # action-version automation does not cover `go install` lines.
+        run: go install github.com/avito-tech/go-mutesting/cmd/go-mutesting@48d0401f00fbfb9502adc2c5138497ad8ccfafb9 # v2.3.1
 
       - name: Write go-mutesting config
         # exclude_dirs is a path-prefix filter on the binary's target-walk.


### PR DESCRIPTION
## Summary

- Resolves OSSF Scorecard Pinned-Dependencies alert #88 (severity 9, `goCommand not pinned by hash`) at `.github/workflows/mutation.yml:97`.
- Replaces `go install github.com/avito-tech/go-mutesting/cmd/go-mutesting@latest` with the same path pinned to commit `48d0401f00fbfb9502adc2c5138497ad8ccfafb9` (avito-tech/go-mutesting **v2.3.1**, released 2025-12-26).
- The existing comment claimed "there are no semver tags to pin to" on the avito-tech fork. That premise was incorrect: the fork has tagged seven releases since v1.0, and current HEAD already resolves to `v2.3.1`, so the pin is **behavior-preserving today** and only changes future behavior (now manual bump, not auto-drift).
- Comment rewritten to reflect the new manual-bump policy.

## Linked issue

Closes #88 (code scanning alert, not a tracked issue).

## Pre-flight checklist

- [x] Pre-push gate green locally (pre-push hook ran the gate; YAML-only diff, all Go/templ/openapi/migration steps short-circuited).
- [x] Code review pass complete (single-line YAML pin, no review-toolkit pass needed for a security-driven workflow patch).
- [x] Commits squashed into a clean single logical commit before first push.
- [x] At least one label set on `gh pr create --label ...` (`ci`, `security`, `docs: not-required`).
- [x] Docs label decision made: `docs: not-required` -- CI/workflow change, no user-visible behavioral change.
- [ ] Screenshot attached for any UI change. (n/a)
- [ ] UAT performed for user-visible changes. (n/a -- workflow only fires on Monday 05:00 UTC cron or manual dispatch; install command exercised by the workflow itself on next run)
- [x] OpenAPI spec updated if any request or response shape changed. (n/a)
- [x] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed. (n/a)

## Test plan

- [x] `go test -race ./...` passes locally. (no Go changed)
- [x] `bash scripts/pre-push-gate.sh` passes locally. (ran via pre-push hook)
- [x] Verified avito-tech/go-mutesting current HEAD == tag `v2.3.1` == commit `48d0401f`, confirming the pin is behavior-preserving on this PR.
- [ ] Manual UAT steps (list the specific flows exercised):
  - [x] Confirmed pin format matches repo convention (`@<sha> # <tag>`) used by other workflow entries.
  - [x] actionlint pre-commit hook passes on the modified workflow file.
- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
  - [ ] Decision to keep manual-bump policy (vs. setting up Dependabot via a `tools.go` pattern) -- deliberate for the mutation-testing pilot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mutation testing workflow configuration to use a pinned dependency version for improved stability in continuous integration processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->