### PR TITLE
chore(lint): align golangci-lint to v2.12.2 across pre-commit, copilot setup, and CI

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -36,8 +36,8 @@ steps:
 
   - name: Install golangci-lint
     run: |
-      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.11.4/install.sh \
-        | sh -s -- -b "$(go env GOPATH)/bin" v2.11.4
+      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh \
+        | sh -s -- -b "$(go env GOPATH)/bin" v2.12.2
 
   - name: Verify build
     run: make build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # wired via `core.hooksPath = .githooks` is `.githooks/pre-commit`,
 # which mirrors these checks in plain bash and is what CI expects.
 # Tool version pins below should stay in sync with the canonical hook
-# (notably: markdownlint-cli2 v0.22.1, golangci-lint v2.11.4, typos v1.44.0).
+# (notably: markdownlint-cli2 v0.22.1, golangci-lint v2.12.2, typos v1.44.0).
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -26,7 +26,8 @@ repos:
       - id: gitleaks
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.11.4
+    # rev must match the version pinned in .github/workflows/ci.yml's golangci-lint-action step to prevent cross-version //nolint drift; see #1560
+    rev: v2.12.2
     hooks:
       - id: golangci-lint
 


### PR DESCRIPTION
## Summary

- Bumps `.pre-commit-config.yaml` golangci-lint hook `rev:` from v2.11.4 to v2.12.2.
- Bumps `.github/copilot-setup-steps.yml` curl install URL + install arg from v2.11.4 to v2.12.2.
- Confirms `.github/workflows/ci.yml:78` already at v2.12.2 (canonical source of truth — unchanged).
- Adds an inline comment in `.pre-commit-config.yaml` noting the rev must match CI's pinned version to prevent the cross-version //nolint drift that bit PR #1558.
- No user-visible behavior change. Lint hygiene.

## Linked issue

Closes #1560

Filed from PR #1558 review where v2.11.4 (pre-commit framework) and v2.12.2 (CI) disagreed about whether gosec G107 fires on \`(*Router).fetchImageFromURL\`, causing a sub-agent's per-site \`//nolint\` to be flagged as unused by nolintlint in CI.

## Pre-flight checklist

- [x] Pre-push gate green locally.
- [x] `golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 ./...` clean at v2.12.2.
- [x] Single commit `71ae509b`.
- [x] Labels: `chore` + `docs: not-required`.
- [x] Docs label decision: `docs: not-required` (tooling version bump; no user-visible behavior).
- [x] Screenshot N/A.
- [x] UAT N/A (tooling config; verified by lint-clean baseline).
- [x] OpenAPI N/A.
- [x] templ N/A.

## Test plan

- [x] `go test -race ./...` passes.
- [x] `bash scripts/pre-push-gate.sh` passes.
- [x] `golangci-lint run` clean at v2.12.2 (the new shared pin).
- Manual UAT: N/A.
- Reviewer follow-ups:
  - Optional: investigate whether the pre-commit framework hook is even needed, given the project's `.githooks/pre-commit` already runs `golangci-lint` directly using the system-installed binary. Filed as the "Optional follow-up" section in #1560 body.

## Notes for CR

- Tiny diff: 2 files, +5/-4 lines.
- The added inline comment near the pre-commit hook is the load-bearing change for future contributors: it explicitly says this rev must match CI's pin and cites #1560.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Synchronized development tool versions across project configuration files to improve consistency and alignment. Updated tool versions in GitHub Actions workflow installation configuration and pre-commit hooks to ensure uniform versions across automated processes, local development environments, and build pipelines. This maintains consistent tooling for all team members and continuous integration systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->