### PR TITLE
fix(security): switch fetchImageURL to httpsafe.SafeClient for SSRF protection

### DIFF
--- a/internal/api/handlers_notifications.go
+++ b/internal/api/handlers_notifications.go
@@ -355,7 +355,7 @@ func (r *Router) handleApplyViolationCandidate(w http.ResponseWriter, req *http.
 		Mode:    "manual",
 	}
 	naming, useSymlinks := r.getActiveNamingAndSymlinks(req.Context(), body.ImageType)
-	saved, err := rule.SaveImageFromURL(req.Context(), a, body.ImageType, body.URL, naming, useSymlinks, candidateMeta, r.platformService, r.logger)
+	saved, err := rule.SaveImageFromURL(req.Context(), r.ssrfClient, a, body.ImageType, body.URL, naming, useSymlinks, candidateMeta, r.platformService, r.logger)
 	if err != nil {
 		r.logger.Error("applying image candidate", "artist_id", a.ID, "image_type", body.ImageType, "error", err)
 		writeError(w, req, http.StatusInternalServerError, "failed to apply image candidate")

--- a/internal/rule/bulk_executor.go
+++ b/internal/rule/bulk_executor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/event"
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	img "github.com/sydlexius/stillwater/internal/image"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/platform"
@@ -31,6 +33,13 @@ type BulkExecutor struct {
 	publisher       *publish.Publisher
 	logger          *slog.Logger
 	eventBus        *event.Bus
+	// httpClient is the HTTP client used by saveBestImage to download image
+	// bytes from provider-supplied URLs. It defaults to an SSRF-safe client
+	// backed by httpsafe.SafeTransport so the bulk-fix pipeline cannot be
+	// coerced into fetching internal-network resources via a malicious or
+	// compromised provider response. Tests override this field with a plain
+	// *http.Client when exercising the loopback-bound httptest path.
+	httpClient *http.Client
 
 	mu        sync.Mutex
 	cancelFn  context.CancelFunc
@@ -54,6 +63,7 @@ func NewBulkExecutor(bulkService *BulkService, artistService *artist.Service, or
 		expectedWrites:  expectedWrites,
 		publisher:       publisher,
 		logger:          logger.With(slog.String("component", "bulk-executor")),
+		httpClient:      httpsafe.SafeClient(fetchTimeout),
 	}
 }
 
@@ -351,7 +361,7 @@ func (e *BulkExecutor) saveBestImage(ctx context.Context, a *artist.Artist, imag
 			Rule:    "",
 			Mode:    "auto",
 		}
-		saved, err := SaveImageFromURL(ctx, a, imageType, c.URL, naming, useSymlinks, meta, e.platformService, e.logger)
+		saved, err := SaveImageFromURL(ctx, e.httpClient, a, imageType, c.URL, naming, useSymlinks, meta, e.platformService, e.logger)
 		if err != nil {
 			e.logger.Debug("image candidate failed", "url", c.URL, "error", err)
 			continue

--- a/internal/rule/bulk_executor_test.go
+++ b/internal/rule/bulk_executor_test.go
@@ -92,10 +92,13 @@ func TestBulkExecutor_SaveBestImage_PlatformNaming(t *testing.T) {
 
 	// Construct a BulkExecutor with only the dependencies saveBestImage needs.
 	// bulkService, artistService, orchestrator, pipeline, and snapshotService
-	// are all nil because saveBestImage does not call them directly.
+	// are all nil because saveBestImage does not call them directly. The
+	// httpClient is a plain client because the httptest server binds to
+	// 127.0.0.1, which the default SSRF-safe transport blocks.
 	executor := &BulkExecutor{
 		platformService: platformSvc,
 		logger:          testLogger(),
+		httpClient:      &http.Client{Timeout: fetchTimeout},
 	}
 
 	saved := executor.saveBestImage(ctx, a, "fanart", fetchResult)

--- a/internal/rule/bulk_executor_test.go
+++ b/internal/rule/bulk_executor_test.go
@@ -2,6 +2,7 @@ package rule
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/platform"
 	"github.com/sydlexius/stillwater/internal/provider"
 )
@@ -128,5 +130,41 @@ func TestBulkExecutor_SaveBestImage_PlatformNaming(t *testing.T) {
 	// Confirm the artist's in-memory FanartExists flag was set.
 	if !a.FanartExists {
 		t.Error("a.FanartExists should be true after saveBestImage succeeds")
+	}
+}
+
+// TestNewBulkExecutor_HTTPClient_RejectsLoopback pins the SSRF-hardening
+// contract of the production BulkExecutor constructor. The other BulkExecutor
+// tests override e.httpClient with a plain client so httptest's 127.0.0.1
+// fixtures keep working; this test exercises the DEFAULT NewBulkExecutor
+// wiring against a loopback httptest server and asserts the request is
+// rejected by httpsafe.SafeTransport before the dial completes.
+//
+// If a future change to NewBulkExecutor drops the
+// httpsafe.SafeClient(fetchTimeout) initialiser, this test fails -- guarding
+// against the exact regression class that surfaced fixers.go:fetchImageURL
+// during PR #1558 review (split into PR #1563 / #1559).
+func TestNewBulkExecutor_HTTPClient_RejectsLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Construct via the production constructor. Most params are nil because
+	// we only exercise the httpClient field; NewBulkExecutor only dereferences
+	// the logger (via logger.With) during construction.
+	e := NewBulkExecutor(nil, nil, nil, nil, nil, nil, nil, nil, testLogger())
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, http.NoBody)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+	resp, err := e.httpClient.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatalf("expected SafeTransport to reject loopback URL %s, but request succeeded with status %d", srv.URL, resp.StatusCode)
+	}
+	if !errors.Is(err, httpsafe.ErrPrivateAddress) {
+		t.Fatalf("expected ErrPrivateAddress from SafeTransport, got: %v", err)
 	}
 }

--- a/internal/rule/coverage_targets_test.go
+++ b/internal/rule/coverage_targets_test.go
@@ -414,6 +414,9 @@ func TestImageFixer_Fix_SuccessfulDownloadAndSave(t *testing.T) {
 
 	dir := t.TempDir()
 	f := NewImageFixer(mock, nil, nonSharedFSCheck(), testLogger())
+	// httptest.NewServer binds to 127.0.0.1, which the default SSRF-safe
+	// transport blocks. Swap in a plain client so the loopback fetch succeeds.
+	f.httpClient = &http.Client{Timeout: fetchTimeout}
 	a := &artist.Artist{
 		Name:          "Save Success",
 		MusicBrainzID: "mbid-save",
@@ -466,6 +469,8 @@ func TestImageFixer_Fix_AllDownloadsFail(t *testing.T) {
 	}
 
 	f := NewImageFixer(mock, nil, nonSharedFSCheck(), testLogger())
+	// httptest server is on 127.0.0.1 -- bypass SafeTransport for this test.
+	f.httpClient = &http.Client{Timeout: fetchTimeout}
 	a := &artist.Artist{
 		Name:          "All Fail",
 		MusicBrainzID: "mbid-allfail",

--- a/internal/rule/fixer_test.go
+++ b/internal/rule/fixer_test.go
@@ -622,6 +622,8 @@ func TestImageFixer_Fix_PostDownloadDimensionGate(t *testing.T) {
 	}
 
 	f := NewImageFixer(mock, nil, nonSharedFSCheck(), testLogger())
+	// httptest server is on 127.0.0.1 -- override SafeTransport for loopback.
+	f.httpClient = &http.Client{Timeout: fetchTimeout}
 	a := &artist.Artist{
 		Name:          "Adie",
 		MusicBrainzID: "mbid-adie",
@@ -677,6 +679,8 @@ func TestImageFixer_Fix_ThumbSquare_ResolutionGate(t *testing.T) {
 	}
 
 	f := NewImageFixer(mock, nil, nonSharedFSCheck(), testLogger())
+	// httptest server is on 127.0.0.1 -- override SafeTransport for loopback.
+	f.httpClient = &http.Client{Timeout: fetchTimeout}
 	a := &artist.Artist{
 		Name:          "Adie",
 		MusicBrainzID: "mbid-adie-sq",

--- a/internal/rule/fixer_test.go
+++ b/internal/rule/fixer_test.go
@@ -3,6 +3,7 @@ package rule
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"image"
 	"image/color"
@@ -15,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/library"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/provider"
@@ -2532,5 +2534,35 @@ func TestPipeline_RunRule_RecordsAutoFixHistory(t *testing.T) {
 	}
 	if len(changes) == 0 {
 		t.Fatal("expected at least one rule_fix entry after RunRule, got none")
+	}
+}
+
+// TestNewImageFixer_HTTPClient_RejectsLoopback pins the SSRF-hardening
+// contract of the production ImageFixer constructor. Sibling regression test
+// to TestNewBulkExecutor_HTTPClient_RejectsLoopback (bulk_executor_test.go);
+// both guard against future changes that drop httpsafe.SafeClient from the
+// constructor and silently re-introduce the SSRF surface the rule engine
+// shipped with before PR #1563.
+func TestNewImageFixer_HTTPClient_RejectsLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Construct via the production constructor; nil params are safe here
+	// because NewImageFixer does not dereference them at construction time.
+	f := NewImageFixer(nil, nil, nil, testLogger())
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, http.NoBody)
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
+	resp, err := f.httpClient.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatalf("expected SafeTransport to reject loopback URL %s, but request succeeded with status %d", srv.URL, resp.StatusCode)
+	}
+	if !errors.Is(err, httpsafe.ErrPrivateAddress) {
+		t.Fatalf("expected ErrPrivateAddress from SafeTransport, got: %v", err)
 	}
 }

--- a/internal/rule/fixers.go
+++ b/internal/rule/fixers.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/filesystem"
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	img "github.com/sydlexius/stillwater/internal/image"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/platform"
@@ -270,7 +271,15 @@ type ImageFixer struct {
 	platformService *platform.Service
 	fsCheck         *SharedFSCheck
 	logger          *slog.Logger
-	imageCache      sync.Map // keyed by MBID; value: *imageCacheEntry
+	// httpClient is the HTTP client used to download image bytes from
+	// provider-supplied URLs. It defaults to an SSRF-safe client backed by
+	// httpsafe.SafeTransport, which blocks loopback/private/link-local
+	// destinations so a malicious or compromised provider cannot coerce the
+	// rule engine into fetching internal-network resources. Tests that exercise
+	// the download path against httptest.NewServer (which binds to 127.0.0.1)
+	// must override this field with a plain *http.Client after construction.
+	httpClient *http.Client
+	imageCache sync.Map // keyed by MBID; value: *imageCacheEntry
 }
 
 // NewImageFixer creates an ImageFixer.
@@ -280,6 +289,7 @@ func NewImageFixer(orchestrator imageProvider, platformService *platform.Service
 		platformService: platformService,
 		fsCheck:         fsCheck,
 		logger:          logger,
+		httpClient:      httpsafe.SafeClient(fetchTimeout),
 	}
 }
 
@@ -449,7 +459,7 @@ func (f *ImageFixer) Fix(ctx context.Context, a *artist.Artist, v *Violation) (*
 	// Try downloading candidates until one succeeds
 	useSymlinks := activeUseSymlinks(ctx, f.platformService)
 	for _, c := range candidates {
-		data, err := fetchImageURL(ctx, c.URL)
+		data, err := fetchImageURL(ctx, f.httpClient, c.URL)
 		if err != nil {
 			f.logger.Debug("image download failed", "url", c.URL, "error", err)
 			continue
@@ -579,8 +589,15 @@ func setImageFlag(a *artist.Artist, imageType string) {
 // When naming is non-nil, it overrides the platform-aware resolution (used by
 // the apply-candidate API handler which resolves naming at the call site).
 // Returns the list of saved filenames on success.
-func SaveImageFromURL(ctx context.Context, a *artist.Artist, imageType, rawURL string, naming []string, useSymlinks bool, meta *img.ExifMeta, platformService *platform.Service, logger *slog.Logger) ([]string, error) {
-	data, err := fetchImageURL(ctx, rawURL)
+//
+// The client parameter must be an SSRF-safe HTTP client (e.g.
+// httpsafe.SafeClient) in production paths. The rule engine threads its
+// BulkExecutor.httpClient through here, and the apply-candidate API handler
+// threads its Router.ssrfClient. Tests that exercise the download path against
+// an httptest server can pass a plain *http.Client because SafeTransport
+// blocks loopback destinations.
+func SaveImageFromURL(ctx context.Context, client *http.Client, a *artist.Artist, imageType, rawURL string, naming []string, useSymlinks bool, meta *img.ExifMeta, platformService *platform.Service, logger *slog.Logger) ([]string, error) {
+	data, err := fetchImageURL(ctx, client, rawURL)
 	if err != nil {
 		return nil, fmt.Errorf("downloading image: %w", err)
 	}
@@ -1076,9 +1093,13 @@ func (f *LogoPaddingFixer) fixViaAPI(ctx context.Context, a *artist.Artist, v *V
 }
 
 // fetchImageURL downloads image data from a URL with timeout and size limits.
-func fetchImageURL(ctx context.Context, rawURL string) ([]byte, error) {
-	client := &http.Client{Timeout: fetchTimeout}
-
+//
+// The client parameter is required and must be an SSRF-safe HTTP client (e.g.
+// httpsafe.SafeClient) for production callers; the function does not construct
+// its own client so that all outbound rule-engine fetches share the same
+// SSRF-protected transport. Tests may inject a plain *http.Client when
+// targeting httptest servers on the loopback interface.
+func fetchImageURL(ctx context.Context, client *http.Client, rawURL string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Threads `httpsafe.SafeClient` (SafeTransport-backed) through `internal/rule/fixers.go:fetchImageURL` so all three production call sites use the SSRF-safe dialer that blocks loopback, link-local, and RFC 1918 addresses.
- `fetchImageURL` signature: takes a `*http.Client` parameter (no internal client construction).
- `ImageFixer` struct: adds `httpClient` field, initialized to `httpsafe.SafeClient(fetchTimeout)` in `NewImageFixer`.
- `BulkExecutor` struct: adds `httpClient` field, initialized in its constructor; threads through to `SaveImageFromURL`.
- `SaveImageFromURL` signature: takes a `*http.Client` parameter; `internal/api/handlers_notifications.go:358` passes `r.ssrfClient`.
- 5 test sites updated to inject a plain `*http.Client` after construction (httptest servers bind to 127.0.0.1, which SafeTransport blocks).
- No `//nolint:gosec` directives or `.golangci.yml` changes. The previous PR (#1558) already removed the G107 nolint; this fix means none need to be re-added because all callsites are now SafeTransport-protected.

## Linked issue

Closes #1559

Filed from CodeRabbit's review of #1558 — CR correctly identified a third unprotected outbound-fetch callsite (`fixers.go:fetchImageURL`) that a project-wide G107 exclude would have masked. This PR is the proper, reviewable fix.

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] `golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 ./...` clean.
- [x] `go test -race ./internal/rule/...` passes (47s).
- [x] Single commit `104fc9d3`.
- [x] Labels: `bug` + `security` + `priority: high` + `rules` + `docs: not-required`.
- [x] Docs label decision: `docs: not-required` (security hardening at the transport layer; no user-visible behavior change).
- [x] Screenshot N/A.
- [x] UAT: covered by the 5 test-site updates that exercise the new injection pattern (httptest servers + plain-client override).
- [x] OpenAPI N/A.
- [x] templ N/A.

## Test plan

- [x] `go test -race ./internal/rule/...` passes — the 5 updated test sites (httptest-server-based) confirm the injection pattern works correctly.
- [x] `bash scripts/pre-push-gate.sh` passes (all hard checks, including patch coverage).
- [x] `golangci-lint run` clean.
- Manual UAT: N/A — the SSRF guard is enforced at the transport DialContext layer; verification is the test suite + lint baseline.
- Reviewer follow-ups:
  - The test-injection pattern (`f.httpClient = &http.Client{Timeout: fetchTimeout}` after construction) mirrors the existing pattern in `internal/api/handlers_image_test.go` for `r.ssrfClient`. Same precedent.
  - Two of the five test-site overrides (in `fixer_test.go` and `bulk_executor_test.go`) were missed by an earlier WIP pass; this PR ships the complete set.

## Notes for CR

- 6 files / +53/-10. Production: 3 files (`fixers.go`, `bulk_executor.go`, `handlers_notifications.go`). Tests: 3 files (`fixer_test.go`, `bulk_executor_test.go`, `coverage_targets_test.go`).
- The `fetchImageURL` function is now a pure free function with a `client *http.Client` parameter — no method receiver, no internal client. Caller-injected client makes the SafeTransport vs plain-client choice explicit at each call site.
- Diagnostic-class lint backstop: `.golangci.yml` is deliberately unchanged (no project-wide G107 exclude). If a future contributor adds a new outbound HTTP path with a raw client, gosec G107 will fire and act as a regression guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened safety of image downloads: image retrieval used across candidate application, bulk processing, and image-fixing now uses an SSRF-hardened HTTP client to block unsafe local/loopback requests without changing visible behavior.

* **Tests**
  * Added/updated regression tests to verify the hardened client blocks loopback/private addresses and to ensure image naming and save behavior remain correct.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->