### PR TITLE
chore(release): prep v1.1.0 (version bump, doc currency, source-of-truth)

### DIFF
--- a/docs/site/src/how-to/acme-letsencrypt.md
+++ b/docs/site/src/how-to/acme-letsencrypt.md
@@ -19,7 +19,7 @@ ACME is the right answer when:
 ACME is the wrong answer when:
 
 - You want HTTPS on a private LAN host with no public DNS or open inbound ports. Use a self-signed certificate via [Direct TLS setup](direct-tls-setup.md) instead.
-- You want a certificate for an IP address rather than a DNS name. That requires ZeroSSL with EAB credentials and is tracked separately ([#931](https://github.com/sydlexius/stillwater/issues/931)).
+- You want a certificate for an IP address rather than a DNS name. That requires ZeroSSL with EAB credentials, tracked in [#1564](https://github.com/sydlexius/stillwater/issues/1564) but not yet active.
 - You already run Caddy, Traefik, or similar in front of Stillwater. Let it handle TLS termination; do not double up.
 
 ## Prerequisites { #acme-overview }

--- a/docs/site/src/how-to/direct-tls-setup.md
+++ b/docs/site/src/how-to/direct-tls-setup.md
@@ -1,5 +1,5 @@
 ---
-description: Serve Stillwater over HTTPS without a reverse proxy by supplying your own TLS certificate, with notes on cert generation, Docker healthcheck behavior, and ACME / HTTP/3 support arriving in v1.1.0.
+description: Serve Stillwater over HTTPS without a reverse proxy by supplying your own TLS certificate or letting Stillwater obtain one via ACME, with notes on cert generation, Docker healthcheck behavior, and HTTP/3 support.
 ---
 
 # Direct TLS setup
@@ -9,7 +9,7 @@ Stillwater can terminate TLS itself instead of relying on a fronting reverse pro
 When direct TLS is the wrong answer:
 
 - You already run a proxy (Caddy, SWAG, Traefik, Nginx) for the rest of your stack. Adding Stillwater to it is usually less work than maintaining a separate cert lifecycle for one app. See [Run Stillwater behind a reverse proxy](reverse-proxy.md).
-- You want automatic certificate management. v1.0 only supports bring-your-own (BYO) certificates; ACME-managed certs land in v1.1.
+- You want a production-validated automatic certificate path today. Stillwater's native ACME (Let's Encrypt) integration is currently marked **Experimental** in the TLS Status card pending end-to-end validation against a real public deployment. For production right now, prefer bring-your-own certificates -- or a reverse proxy with its own ACME client -- until the Experimental marker is removed.
 
 When direct TLS is the right answer:
 
@@ -67,7 +67,7 @@ Open Settings, scroll to the General tab. The TLS Status card shows one of three
 
 - **Inactive** -- plain HTTP, no cert configured.
 - **Active (BYO certificate)** -- direct TLS using the cert and key supplied via env vars or config file.
-- **Active (ACME, &lt;domain&gt;)** -- ACME-managed cert (arrives in v1.1).
+- **Active (ACME, &lt;domain&gt;)** -- ACME-managed cert. An amber **Experimental** chip and a short caveat appear next to this state until the ACME path has been validated end-to-end against a real public deployment.
 
 The card also lists the bound port so you can confirm whether you're in collapse mode (HTTPS on the original `SW_PORT`) or split-port mode (HTTPS on `SW_TLS_PORT`). When HTTP/3 is enabled, an additional `HTTP/3 on :<port>/UDP` row appears. The card is read-only; configure TLS via env vars or the config file.
 
@@ -79,21 +79,39 @@ Once Stillwater detects a TLS connection, it automatically sets a strict `Strict
 
 The container's healthcheck targets `localhost` over the configured protocol. When `SW_TLS_CERT_FILE` is set, the entrypoint exports `SW_HEALTH_URL` so the probe uses HTTPS on the right port. The probe runs with `curl -k` to skip cert verification -- this is intentional, because a localhost healthcheck against a self-signed cert would otherwise fail for the wrong reason. You do not need to set `SW_HEALTH_URL` yourself; setting `SW_TLS_CERT_FILE` is enough.
 
-## What's next in v1.1
+## ACME and HTTP redirect
 
-The TLS surface is built so the following land without further configuration churn:
+Beyond bring-your-own certificates, the TLS surface supports two related features that share the same listener stack. All three of these are configured via environment variables or `config.toml` / `config.yaml`; **there is no UI for TLS configuration** today, and the TLS Status card in Settings is read-only by design.
 
-### ACME (Let's Encrypt / Buypass)
+### ACME (Let's Encrypt) -- Experimental
 
-Added in v1.1.0; see issue [#930](https://github.com/sydlexius/stillwater/issues/930). Configure via `SW_ACME_DOMAIN`, `SW_ACME_EMAIL`, and `SW_ACME_CA`.
+Configure via `SW_ACME_DOMAIN`, `SW_ACME_EMAIL`, and `SW_ACME_CA`:
 
-### ACME (ZeroSSL, IP-SAN)
+```sh
+SW_ACME_DOMAIN=stillwater.example.com
+SW_ACME_EMAIL=admin@example.com
+# SW_ACME_CA=https://acme-staging-v02.api.letsencrypt.org/directory   # optional: use the LE staging directory for testing
+```
 
-Added in v1.1.0; see issue [#931](https://github.com/sydlexius/stillwater/issues/931). Lets you obtain certificates for a public IP address rather than a DNS name.
+Or in `config.toml`:
+
+```toml
+[acme]
+domain    = "stillwater.example.com"
+email     = "admin@example.com"
+# ca      = "https://acme-staging-v02.api.letsencrypt.org/directory"
+# cache_dir = "/config/acme-cache"
+```
+
+The domain must resolve to this server and port 80 must be reachable from the public internet so the ACME challenge succeeds. The TLS Status card flags this path as **Experimental** with an amber chip and caveat until it has been validated end-to-end against a real public deployment -- prefer BYO certificates for production until that marker is removed.
+
+### ACME (ZeroSSL, IP-SAN) -- reserved
+
+The struct fields (`SW_ACME_EAB_KEY_ID`, `SW_ACME_EAB_MAC_KEY`, `SW_ACME_IP`) are stubbed for forward compatibility but the lego-based ZeroSSL / IP-SAN code path is not yet active. Setting these env vars has no effect today. Tracked in issue [#1564](https://github.com/sydlexius/stillwater/issues/1564).
 
 ### HTTP-to-HTTPS redirect listener
 
-Added in v1.1.0. Setting `SW_HTTP_REDIRECT_PORT=80` makes Stillwater bind a second plain-HTTP listener that 301-redirects every request to the HTTPS port. See the [HTTP-to-HTTPS redirect](http-redirect.md) how-to for setup details and reverse-proxy interactions.
+Setting `SW_HTTP_REDIRECT_PORT=80` makes Stillwater bind a second plain-HTTP listener that 301-redirects every request to the HTTPS port. See the [HTTP-to-HTTPS redirect](http-redirect.md) how-to for setup details and reverse-proxy interactions.
 
 ## HTTP/3 (QUIC) { #http3-quic-firewall }
 

--- a/docs/site/src/reference/_doc-anchors.txt
+++ b/docs/site/src/reference/_doc-anchors.txt
@@ -163,8 +163,9 @@ how-to/configure-provider-priorities#set-the-global-priority
 how-to/configure-provider-priorities#two-related-knobs
 how-to/configure-provider-priorities#what-changes-after-a-priority-edit
 how-to/configure-provider-priorities#what-to-put-where
-how-to/direct-tls-setup#acme-lets-encrypt-buypass
-how-to/direct-tls-setup#acme-zerossl-ip-san
+how-to/direct-tls-setup#acme-and-http-redirect
+how-to/direct-tls-setup#acme-lets-encrypt-experimental
+how-to/direct-tls-setup#acme-zerossl-ip-san-reserved
 how-to/direct-tls-setup#configure-stillwater
 how-to/direct-tls-setup#confirm
 how-to/direct-tls-setup#confirm-it-took-effect-settings-general-tls-status
@@ -177,7 +178,6 @@ how-to/direct-tls-setup#generate-a-self-signed-cert-local-testing
 how-to/direct-tls-setup#hsts
 how-to/direct-tls-setup#http-to-https-redirect-listener
 how-to/direct-tls-setup#http3-quic-http3-quic-firewall
-how-to/direct-tls-setup#whats-next-in-v11
 how-to/edit-artist#add-or-change-a-provider-id
 how-to/edit-artist#discard-accidental-edits
 how-to/edit-artist#edit-a-single-field

--- a/internal/auth/provider_emby.go
+++ b/internal/auth/provider_emby.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/connection"
+	"github.com/sydlexius/stillwater/internal/version"
 )
 
 // EmbyProvider authenticates users against an Emby server.
@@ -57,7 +58,7 @@ func (p *EmbyProvider) Authenticate(ctx context.Context, creds Credentials) (*Id
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Emby-Authorization",
-		`MediaBrowser Client="Stillwater", Device="Server", DeviceId="stillwater", Version="1.0.0"`)
+		fmt.Sprintf(`MediaBrowser Client="Stillwater", Device="Server", DeviceId="stillwater", Version=%q`, version.Version))
 
 	resp, err := p.client.Do(req)
 	if err != nil {

--- a/internal/auth/provider_jellyfin.go
+++ b/internal/auth/provider_jellyfin.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/connection"
+	"github.com/sydlexius/stillwater/internal/version"
 )
 
 // JellyfinProvider authenticates users against a Jellyfin server.
@@ -57,7 +58,7 @@ func (p *JellyfinProvider) Authenticate(ctx context.Context, creds Credentials) 
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization",
-		`MediaBrowser Client="Stillwater", Device="Server", DeviceId="stillwater", Version="1.0.0"`)
+		fmt.Sprintf(`MediaBrowser Client="Stillwater", Device="Server", DeviceId="stillwater", Version=%q`, version.Version))
 
 	resp, err := p.client.Do(req)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,7 +80,7 @@ type HTTP3Config struct {
 // ACMEConfig holds Automatic Certificate Management Environment settings.
 // Domain/Email/CA/CacheDir drive the autocert (Let's Encrypt / Buypass via
 // golang.org/x/crypto/acme/autocert) path today. EabKeyID/EabMacKey/IP are
-// reserved for the ZeroSSL IP-SAN wiring (#931, lego); leaving them
+// reserved for the ZeroSSL IP-SAN wiring (#1564, lego); leaving them
 // populated but unread keeps the env-var loader and reference docs stable
 // across the milestone.
 type ACMEConfig struct {
@@ -220,14 +220,22 @@ const scaffoldTOML = `# Stillwater configuration
 # enabled = false
 # port = 0  # 0 reuses the effective HTTPS port (SW_TLS_PORT or SW_PORT).
 
-# Automatic Certificate Management Environment (ACME). Reserved for future
-# use; not yet active. Until the ACME path lands, configure direct TLS via
-# [server.tls] above (BYO certificate) or terminate at a fronting proxy.
+# Automatic Certificate Management Environment (ACME). Currently marked
+# Experimental in the Settings -> General TLS Status card pending end-to-end
+# validation against a real public deployment; prefer [server.tls] (BYO
+# certificate) above for production until that marker is removed. The
+# domain MUST resolve to this server and port 80 MUST be reachable from
+# the public internet for the ACME challenge to succeed. ACME and BYO TLS
+# are mutually exclusive -- set one or the other, not both.
+# See: https://sydlexius.github.io/stillwater/how-to/direct-tls-setup/
 # [acme]
 # domain = "stillwater.example.com"
 # email = "admin@example.com"
-# ca = "letsencrypt"
+# ca = "https://acme-v02.api.letsencrypt.org/directory"  # Let's Encrypt production (default). Use the staging URL while testing to avoid rate limits.
 # cache_dir = "/config/acme-cache"
+# eab_key_id  = ""  # Reserved for future use (ZeroSSL / IP-SAN); not yet active.
+# eab_mac_key = ""  # Reserved for future use (ZeroSSL / IP-SAN); not yet active.
+# ip          = ""  # Reserved for future use (IP-SAN certificate orders); not yet active.
 
 [database]
 # path = "/config/stillwater.db"

--- a/internal/server/cert_manager.go
+++ b/internal/server/cert_manager.go
@@ -1,7 +1,7 @@
 // CertManager abstracts the source of TLS certificates so the listener
 // startup code does not branch on which ACME flavor (or BYO) is configured.
 // The autocert (Let's Encrypt / Buypass) implementation lives in this file;
-// a future ZeroSSL/lego implementation (#931) will satisfy the same
+// a future ZeroSSL/lego implementation (#1564) will satisfy the same
 // interface without touching listeners.go.
 //
 // The split is a textbook strategy pattern: the config layer picks an

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // These variables are set at build time via -ldflags.
 var (
-	Version = "1.0.6"
+	Version = "1.1.0"
 	Commit  = "unknown"
 	Date    = "unknown"
 )

--- a/web/components/_doc-anchors.txt
+++ b/web/components/_doc-anchors.txt
@@ -163,8 +163,9 @@ how-to/configure-provider-priorities#set-the-global-priority
 how-to/configure-provider-priorities#two-related-knobs
 how-to/configure-provider-priorities#what-changes-after-a-priority-edit
 how-to/configure-provider-priorities#what-to-put-where
-how-to/direct-tls-setup#acme-lets-encrypt-buypass
-how-to/direct-tls-setup#acme-zerossl-ip-san
+how-to/direct-tls-setup#acme-and-http-redirect
+how-to/direct-tls-setup#acme-lets-encrypt-experimental
+how-to/direct-tls-setup#acme-zerossl-ip-san-reserved
 how-to/direct-tls-setup#configure-stillwater
 how-to/direct-tls-setup#confirm
 how-to/direct-tls-setup#confirm-it-took-effect-settings-general-tls-status
@@ -177,7 +178,6 @@ how-to/direct-tls-setup#generate-a-self-signed-cert-local-testing
 how-to/direct-tls-setup#hsts
 how-to/direct-tls-setup#http-to-https-redirect-listener
 how-to/direct-tls-setup#http3-quic-http3-quic-firewall
-how-to/direct-tls-setup#whats-next-in-v11
 how-to/edit-artist#add-or-change-a-provider-id
 how-to/edit-artist#discard-accidental-edits
 how-to/edit-artist#edit-a-single-field


### PR DESCRIPTION
## Summary

- Bump `internal/version/version.go` fallback from `1.0.6` to `1.1.0` ahead of tagging v1.1.0.
- Refresh `direct-tls-setup.md` and `acme-letsencrypt.md` to describe v1.1.0 features (BYO TLS, ACME, HTTP/3, HTTP-to-HTTPS redirect) as current state rather than "arriving in v1.1.0"; drop "Added in vX.Y.Z" markers; add explicit Experimental framing for ACME and "configured via env vars / config files, no UI" callouts. Rename the "What's next in v1.1" section to "ACME and HTTP redirect".
- Source-of-truth sweep: `provider_emby.go` and `provider_jellyfin.go` no longer hardcode `Version="1.0.0"` in their `MediaBrowser` auth header; both now read from `version.Version` so the value tracks the binary. (No known consumer gates on this string, but the previous behavior advertised the wrong client version.)
- Update stale `#931` tracking references in `cert_manager.go` and `config.go` to point at newly filed #1564 (the deferred ZeroSSL/lego ACME provider, which #931 closed via rescope in #1520 without filing a follow-up).
- Refresh `scaffoldTOML`'s ACME block in `config.go` from outdated "Reserved for future use" framing.

## Linked issue

No closing issue (release-prep bundle). Side effect: filed #1564 to track the deferred ZeroSSL work.

## Pre-flight checklist

- [x] Pre-push gate green locally (pre-push hook ran it on push).
- [x] Code review pass complete (targeted, no /prep-pr for a chore PR).
- [x] One clean commit.
- [x] Labels set (`chore`, `documentation`).
- [x] Docs label decision: this PR IS the doc work; neither `needs-docs-review` nor `docs: not-required` applies.
- [x] No UI change (no screenshot needed).
- [x] OpenAPI unchanged.
- [x] No `.templ` changes (no `templ generate` needed).

## Test plan

- [x] `go test -race ./...` via pre-push gate.
- [x] `bash scripts/pre-push-gate.sh` green.
- [ ] Manual: build and verify `stillwater -v` outputs `v1.1.0` once merged.
- [ ] Reviewer follow-ups:
  - Confirm the Emby/Jellyfin auth header version-string change is acceptable (no known consumers gate on it; if any do, they'd see `Stillwater/1.1.0` instead of `Stillwater/1.0.0`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTTP-to-HTTPS redirect configuration support via environment variable.

* **Documentation**
  * Expanded TLS and ACME setup guidance with experimental status notation and production deployment recommendations.
  * Updated IP-certificate limitations and ZeroSSL configuration documentation.

* **Chores**
  * Version bumped to 1.1.0.
  * Authentication providers now use dynamic version strings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->