### PR TITLE
chore(security): ignore CVE-2026-5773 + CVE-2026-6276 (Alpine 3.23 curl)

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -24,3 +24,26 @@ ignore:
       type: apk
     review-by: "2026-06-09"
     reason: "Alpine 3.23 still on 1.68.0-r0; fix 1.68.1 not yet backported"
+
+  # curl 8.19.0-r0 -- no fix in Alpine 3.23-main as of 2026-05-19.
+  # v3.23 still carries 8.19.0-r0; fix is 8.20.0-r0 in edge-main only.
+  # Practical reachability is nil: curl ships in the runtime image only to
+  # back the Docker HEALTHCHECK, which probes a fixed localhost URL with
+  # no attacker-controllable input. Stillwater itself does not invoke curl.
+  # Upstream: https://security.alpinelinux.org/vuln/CVE-2026-5773
+  - vulnerability: CVE-2026-5773
+    package:
+      name: curl
+      type: apk
+    review-by: "2026-06-19"
+    reason: "Alpine 3.23 still on 8.19.0-r0; fix 8.20.0-r0 in edge-main only. Used only by Docker healthcheck."
+
+  # curl 8.19.0-r0 -- no fix in Alpine 3.23-main as of 2026-05-19.
+  # Same upstream-lag situation and reachability assessment as CVE-2026-5773.
+  # Upstream: https://security.alpinelinux.org/vuln/CVE-2026-6276
+  - vulnerability: CVE-2026-6276
+    package:
+      name: curl
+      type: apk
+    review-by: "2026-06-19"
+    reason: "Alpine 3.23 still on 8.19.0-r0; fix 8.20.0-r0 in edge-main only. Used only by Docker healthcheck."


### PR DESCRIPTION
## Summary

- Two new High-severity advisories on \`curl 8.19.0-r0\` (CVE-2026-5773 SMB connection reuse flaw, CVE-2026-6276) block the local Grype gate on the v1.1.0 release-prep workflow.
- Alpine 3.23-main still ships \`8.19.0-r0\`; the fix (\`8.20.0-r0\`) exists only in edge-main and has not been backported to the 3.23 stable branch (confirmed via https://security.alpinelinux.org/vuln/CVE-2026-5773 and the Alpine v3.23 package tracker as of 2026-05-19).
- This PR adds both CVEs to \`.grype.yaml\` with \`review-by: "2026-06-19"\` (one month out, matching the cadence of the existing CVE-2026-3805 / CVE-2026-27135 entries).
- **Reachability:** curl ships in the runtime image only to back the Docker HEALTHCHECK at \`build/docker/Dockerfile:84\`, which probes a fixed localhost URL with no attacker-controllable input. Stillwater itself never shells out to curl. Practical exploit surface in the container is effectively nil.

## Linked issue

No tracking issue (chore PR unblocking the v1.1.0 release tag; filing one would be ceremony).

## Pre-flight checklist

- [x] Pre-push gate green locally (pre-push hook ran it on push).
- [x] Single focused commit.
- [x] Labels set (\`security\`, \`chore\`, \`docs: not-required\`).
- [x] No user-visible behavior change (\`docs: not-required\` applies).
- [x] No code change beyond \`.grype.yaml\`.

## Test plan

- [x] \`grype ghcr.io/sydlexius/stillwater:scan --fail-on high -c .grype.yaml\` against the freshly built image: both Highs now suppressed, only sub-threshold Mediums remain, scan exits 0.
- [x] \`bash scripts/pre-push-gate.sh\` green.
- [ ] After merge, retry \`make scan\` on \`main\` to confirm the v1.1.0 tag path is unblocked.

## Follow-up after merge

This is the final blocker before tagging v1.1.0. Once merged: rebuild the scan image, re-run grype to confirm, then tag \`v1.1.0\` (signed annotated) on the resulting main HEAD to trigger the \`release.yml\` goreleaser run.

The v1.1.0 release notes draft (in the conversation thread) will incorporate a **Known limitation** paragraph noting the upstream Alpine lag and the reachability assessment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vulnerability scanning configuration for curl packages on Alpine 3.23 with improved backport and edge-only fix handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->