### PR TITLE
ci: align Docker tag publishing with template channel design

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,5 +242,4 @@ jobs:
           file: build/docker/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           ref: main
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
@@ -44,15 +47,19 @@ jobs:
             type=raw,value=nightly
             type=raw,value=nightly-{{date 'YYYYMMDD'}}
 
-      # Nightly builds are amd64-only. Multi-arch releases are handled by
-      # GoReleaser in the release workflow using per-arch Dockerfiles.
+      # Nightly builds the same multi-arch matrix as stable (amd64 + arm64) so
+      # the :nightly tag is usable on the same hosts as :latest. arm64 is built
+      # under QEMU emulation, which is slower (~10min vs ~3min native) but keeps
+      # the workflow single-job. The release workflow uses GoReleaser with
+      # per-arch Dockerfiles instead, trading workflow setup for native speed
+      # where wall-clock matters.
       - name: Build and push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
           file: build/docker/Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
## Summary

Two related CI tag-publishing fixes so the registry's named tags match what the Unraid template (and updater channels, by extension) advertise.

- **`ci.yml`**: stop pushing `:latest` on every push to `main`. The per-merge build was racing `release.yml`/GoReleaser for `:latest`, so the tag only reliably meant "newest stable release" for the brief window between a release tag and the next merge to main. After this change `:latest` is owned exclusively by `release.yml`; the per-merge build pushes `:<sha>` only, which remains useful for forensic rollback.
- **`nightly.yml`**: build `:nightly` multi-arch (`linux/amd64` + `linux/arm64`) so the nightly channel works on the same hosts as `:latest` (already multi-arch via GoReleaser). Adds `docker/setup-qemu-action` to enable arm64 emulation; build time goes from ~3 min to ~10 min, acceptable for a once-a-day cron. The release workflow continues to use GoReleaser's per-arch Dockerfile pattern for native-speed multi-arch on user-facing release builds.

## Why QEMU rather than a matrix on native ARM runners

Matrix-on-`ubuntu-24.04-arm` (two parallel build jobs + a manifest-merge job) is faster wall-clock but adds three independent failure surfaces, two intermediate per-arch tags that would need their own retention story, and ~60 extra lines of workflow YAML to maintain. For a midnight cron job nobody is waiting on, single-job/single-failure-mode is the right trade.

## Companion change

The `unraid-templates` repo will get a follow-up commit adding a `nightly` `<Branch>` entry to `templates/stillwater.xml` so Unraid users can opt into the nightly channel from the CA UI.

## Test plan

- [ ] CI passes on this branch (actionlint will validate the workflow YAML).
- [ ] After merge, watch the next push to `main`: confirm `:latest` is no longer republished by the per-merge job. The current `:latest` digest will stay pinned to whatever the last release set it to.
- [ ] After merge, manually trigger `nightly.yml` via `workflow_dispatch` and confirm `:nightly` is multi-arch in GHCR (`docker buildx imagetools inspect ghcr.io/sydlexius/stillwater:nightly` should show two manifests, one per arch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker images now support both amd64 and arm64 architectures
  * CI/CD workflows updated with improved Docker image tagging strategy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->