### PR TITLE
chore(security): enforce SafeTransport via AST regression guard

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,6 +37,12 @@ linters:
       comparison: true
     exhaustive:
       default-signifies-exhaustive: true
+    # Raw &http.Client{...} construction in production code is forbidden by
+    # an AST-based regression test at
+    # internal/httpsafe/no_raw_client_construction_test.go. Forbidigo's
+    # regex matcher cannot reliably distinguish composite-literal
+    # construction from legitimate *http.Client type references, so the
+    # enforcement lives in the test suite rather than in golangci-lint.
     gocognit:
       # Threshold 30 is the gocognit default and the standard floor for
       # cognitive complexity in Go projects. Raising it would bury

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
 	golang.org/x/time v0.15.0
+	golang.org/x/tools v0.44.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/internal/api/handlers_provider_test.go
+++ b/internal/api/handlers_provider_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/provider"
@@ -30,7 +31,14 @@ func testRouterWithMirror(t *testing.T) *Router {
 	rateLimiters := provider.NewRateLimiterMap()
 	providerSettings := provider.NewSettingsService(db, enc)
 	registry := provider.NewRegistry()
-	registry.Register(musicbrainz.New(rateLimiters, logger))
+	// The musicbrainz adapter's default HTTP client is httpsafe.SafeClient,
+	// which blocks loopback addresses (127.0.0.1) -- exactly what
+	// httptest.NewServer binds to. Tests inject a plain *http.Client so the
+	// mirror auto-test path can reach the loopback fixture. Production
+	// wiring is unaffected.
+	mbAdapter := musicbrainz.New(rateLimiters, logger)
+	mbAdapter.SetHTTPClient(&http.Client{Timeout: 10 * time.Second})
+	registry.Register(mbAdapter)
 
 	return NewRouter(RouterDeps{
 		ProviderSettings: providerSettings,

--- a/internal/auth/provider_emby.go
+++ b/internal/auth/provider_emby.go
@@ -34,7 +34,13 @@ func NewEmbyProvider(serverURL string, autoProvision bool, guardRail, defaultRol
 		autoProvision: autoProvision,
 		guardRail:     guardRail,
 		defaultRole:   defaultRole,
-		client:        &http.Client{Timeout: 10 * time.Second},
+		// Uses a raw http.Client (not httpsafe.SafeClient) because Emby is a
+		// user-configured login backend that typically lives on loopback or an
+		// RFC 1918 LAN address for self-hosted deployments. The httpsafe SSRF
+		// guard would reject those destinations and break authentication for
+		// legitimate setups. The destination URL is operator-supplied (and
+		// validated via connection.ValidateBaseURL), not user-controlled input.
+		client: &http.Client{Timeout: 10 * time.Second},
 	}, nil
 }
 

--- a/internal/auth/provider_jellyfin.go
+++ b/internal/auth/provider_jellyfin.go
@@ -34,7 +34,13 @@ func NewJellyfinProvider(serverURL string, autoProvision bool, guardRail, defaul
 		autoProvision: autoProvision,
 		guardRail:     guardRail,
 		defaultRole:   defaultRole,
-		client:        &http.Client{Timeout: 10 * time.Second},
+		// Uses a raw http.Client (not httpsafe.SafeClient) because Jellyfin is a
+		// user-configured login backend that typically lives on loopback or an
+		// RFC 1918 LAN address for self-hosted deployments. The httpsafe SSRF
+		// guard would reject those destinations and break authentication for
+		// legitimate setups. The destination URL is operator-supplied (and
+		// validated via connection.ValidateBaseURL), not user-controlled input.
+		client: &http.Client{Timeout: 10 * time.Second},
 	}, nil
 }
 

--- a/internal/connection/emby/client.go
+++ b/internal/connection/emby/client.go
@@ -29,6 +29,14 @@ type Client struct {
 }
 
 // New creates an Emby client with default HTTP settings.
+//
+// Uses a raw http.Client (not httpsafe.SafeClient) because Emby is a
+// user-configured media server that almost always lives on loopback
+// (127.0.0.1) or an RFC 1918 LAN address (192.168.x.x, 10.x.x.x) for
+// self-hosted deployments. The httpsafe.SafeTransport SSRF guard would
+// reject precisely those destinations, breaking the integration for
+// legitimate setups. The destination URL is supplied by the operator
+// via Settings, not by user-controlled provider input.
 func New(baseURL, apiKey, userID string, logger *slog.Logger) *Client {
 	return NewWithHTTPClient(baseURL, apiKey, userID, &http.Client{Timeout: 10 * time.Second}, logger)
 }
@@ -285,6 +293,9 @@ func AuthenticateByName(ctx context.Context, baseURL, username, password string,
 		deviceID, version.Version,
 	))
 
+	// Auth flow targets the same operator-supplied Emby server as the rest of
+	// the package (see New() for the LAN/loopback rationale). httpsafe would
+	// block these legitimate destinations.
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/connection/jellyfin/client.go
+++ b/internal/connection/jellyfin/client.go
@@ -29,6 +29,14 @@ type Client struct {
 }
 
 // New creates a Jellyfin client with default HTTP settings.
+//
+// Uses a raw http.Client (not httpsafe.SafeClient) because Jellyfin is a
+// user-configured media server that almost always runs on loopback
+// (127.0.0.1) or an RFC 1918 LAN address (192.168.x.x, 10.x.x.x) for
+// self-hosted deployments. The httpsafe.SafeTransport SSRF guard would
+// reject those destinations, breaking the integration for legitimate
+// setups. The destination URL is operator-supplied via Settings, not
+// user-controlled input.
 func New(baseURL, apiKey, userID string, logger *slog.Logger) *Client {
 	return NewWithHTTPClient(baseURL, apiKey, userID, &http.Client{Timeout: 10 * time.Second}, logger)
 }
@@ -289,6 +297,9 @@ func AuthenticateByName(ctx context.Context, baseURL, username, password string,
 		deviceID, version.Version,
 	))
 
+	// Auth flow targets the same operator-supplied Jellyfin server as the rest
+	// of the package (see New() for the LAN/loopback rationale). httpsafe would
+	// block these legitimate destinations.
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/connection/lidarr/client.go
+++ b/internal/connection/lidarr/client.go
@@ -21,6 +21,13 @@ type Client struct {
 }
 
 // New creates a Lidarr client with default HTTP settings.
+//
+// Uses a raw http.Client (not httpsafe.SafeClient) because Lidarr is a
+// user-configured *arr-stack service that typically runs alongside Stillwater
+// on loopback (127.0.0.1:8686) or an RFC 1918 LAN address. The
+// httpsafe.SafeTransport SSRF guard would reject those destinations,
+// breaking the integration for legitimate self-hosted setups. The destination
+// URL is operator-supplied via Settings, not user-controlled input.
 func New(baseURL, apiKey string, logger *slog.Logger) *Client {
 	return NewWithHTTPClient(baseURL, apiKey, &http.Client{Timeout: 10 * time.Second}, logger)
 }

--- a/internal/httpsafe/no_raw_client_construction_test.go
+++ b/internal/httpsafe/no_raw_client_construction_test.go
@@ -1,0 +1,370 @@
+package httpsafe_test
+
+// Functional regression guard for raw *http.Client construction in
+// production code. Every outbound HTTP path must go through
+// httpsafe.SafeClient to enforce the SafeTransport SSRF guard.
+//
+// Two tests live here:
+//
+//   1. TestNoRawHTTPClientConstruction walks every production package
+//      (Tests=false, so _test.go is skipped) and asserts that no
+//      *ast.CompositeLit whose type resolves to net/http.Client appears
+//      outside the allowlist below. New construction sites fail the
+//      test until they are migrated to httpsafe.SafeClient or
+//      explicitly allowlisted; the latter requires a
+//      security-review-grade rationale comment in the production code
+//      naming the LAN/loopback service.
+//
+//   2. TestDetectorFiresOnContrivedFixture writes a synthetic Go file
+//      containing a raw &http.Client{...} composite literal to a temp
+//      directory, runs the same detector against it, and asserts it
+//      produces a finding. If the production scan ever stops detecting
+//      raw constructions (AST visitor change, types-resolution
+//      regression), this test fails alongside the production scan.
+//
+// The detector matches *ast.CompositeLit nodes only. Alternative
+// idioms that bypass the AST visitor (var c http.Client zero-value
+// declarations, new(http.Client), dereferenced copies of
+// http.DefaultClient) are out of scope: they are not the regression
+// class observed in PR #1558 and are vanishingly rare in real Go code.
+// If a future regression uses one of those idioms, extend the visitor
+// to cover *ast.ValueSpec and *ast.CallExpr(new).
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// allowedRawClientSites lists production file:line pairs where a raw
+// http.Client composite literal is intentional. Each entry corresponds
+// to a per-site rationale comment in the production file explaining why
+// httpsafe.SafeClient is the wrong tool here. The line number is the
+// line that contains the `http.Client{` token, not the surrounding
+// declaration.
+//
+// Adding an entry here is a deliberate security decision. Reviewers
+// should confirm:
+//   - The destination is a user-configured local service (loopback or
+//     RFC1918 LAN), not an outbound-to-internet endpoint.
+//   - SafeTransport's SSRF guard would reject that destination by
+//     design (loopback/private addresses are exactly what it blocks).
+//   - The corresponding rationale comment in production code names the
+//     service and the LAN/loopback reasoning.
+//
+// The keys are repo-rooted slash-delimited paths (filepath.ToSlash so
+// the test runs identically on Windows-style separators, even though the
+// project is Linux/macOS-only today).
+var allowedRawClientSites = map[string]bool{
+	// Emby connection client: operator-supplied media-server URL,
+	// validated via connection.ValidateBaseURL.
+	"internal/connection/emby/client.go:41":  true,
+	"internal/connection/emby/client.go:299": true,
+	// Jellyfin connection client: same pattern as Emby.
+	"internal/connection/jellyfin/client.go:41":  true,
+	"internal/connection/jellyfin/client.go:303": true,
+	// Lidarr connection client: operator-supplied *arr-stack URL.
+	"internal/connection/lidarr/client.go:32": true,
+	// Auth providers (login backends): operator-supplied media-server
+	// URLs, validated via connection.ValidateBaseURL.
+	"internal/auth/provider_emby.go:43":     true,
+	"internal/auth/provider_jellyfin.go:43": true,
+}
+
+// rootDirs is the production-code surface this test walks. The
+// production code surface is the four top-level directories that
+// contain hand-written Go: cmd/, internal/, tools/, and scripts/. New
+// top-level production directories must be added here so a missing
+// directory cannot silently hide a regression.
+var rootDirs = []string{"cmd", "internal", "tools", "scripts"}
+
+// TestNoRawHTTPClientConstruction walks every production package and
+// fails if any *ast.CompositeLit whose type is net/http.Client appears
+// outside the allowlist.
+func TestNoRawHTTPClientConstruction(t *testing.T) {
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("locate repo root: %v", err)
+	}
+
+	// packages.Load with full type info is what lets us resolve a
+	// composite-literal's type to the canonical net/http.Client even
+	// when the import is aliased. Tests=false omits _test.go files
+	// (which are explicitly allowed to construct raw clients for
+	// fixture wiring per the issue's class-(b) classification).
+	patterns := make([]string, 0, len(rootDirs))
+	for _, d := range rootDirs {
+		patterns = append(patterns, "./"+d+"/...")
+	}
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedDeps |
+			packages.NeedImports,
+		Dir:   repoRoot,
+		Tests: false,
+	}
+	pkgs, err := packages.Load(cfg, patterns...)
+	if err != nil {
+		t.Fatalf("load packages: %v", err)
+	}
+	// Per-package compile/type-check failures land in pkg.Errors, not in
+	// the top-level err returned above. If TypesInfo fails to populate
+	// for a package, scanFileForRawClient silently skips its files (no
+	// types to resolve against) and any &http.Client{} in those files
+	// goes undetected. A security guard whose failure mode is "silently
+	// stop guarding" is worse than no guard; fail loud instead.
+	if loadErrs := collectLoadErrors(pkgs); len(loadErrs) > 0 {
+		t.Fatalf("packages.Load reported %d per-package error(s); the scan cannot prove the absence of raw constructions:\n  %s",
+			len(loadErrs), strings.Join(loadErrs, "\n  "))
+	}
+	// A complete load failure would silently report zero findings,
+	// masking a real regression. Refuse to pass in that state.
+	if countWithSyntax(pkgs) == 0 {
+		t.Fatalf("packages.Load returned no packages with syntax; check repo state")
+	}
+
+	var findings []string
+	for _, pkg := range pkgs {
+		// httpsafe defines SafeClient and must be allowed to construct
+		// a raw *http.Client.
+		if strings.HasSuffix(pkg.PkgPath, "/internal/httpsafe") {
+			continue
+		}
+		for i, file := range pkg.Syntax {
+			// pkg.GoFiles is parallel to pkg.Syntax. CompiledGoFiles
+			// may include generated files we do not care about; GoFiles
+			// is the source-of-truth source list.
+			if i >= len(pkg.GoFiles) {
+				continue
+			}
+			path := pkg.GoFiles[i]
+			rel, relErr := filepath.Rel(repoRoot, path)
+			if relErr != nil {
+				rel = path
+			}
+			rel = filepath.ToSlash(rel)
+			findings = append(findings, scanFileForRawClient(pkg.Fset, pkg.TypesInfo, file, rel)...)
+		}
+	}
+
+	// Filter findings through the allowlist. A finding inside the
+	// allowlist is the expected/documented state; everything else is a
+	// regression. Each finding is "file:line  <message>"; the allowlist
+	// keys are just "file:line", so we split on the first space.
+	var regressions []string
+	for _, f := range findings {
+		key := f
+		if idx := strings.IndexByte(f, ' '); idx > 0 {
+			key = f[:idx]
+		}
+		if allowedRawClientSites[key] {
+			continue
+		}
+		regressions = append(regressions, f)
+	}
+	if len(regressions) > 0 {
+		sort.Strings(regressions)
+		t.Fatalf("found %d raw http.Client construction site(s) outside the allowlist:\n  %s\n"+
+			"If this site is a user-configured LAN/loopback service that SafeTransport would reject by design, "+
+			"add the file:line to allowedRawClientSites in this test AND add a rationale comment in the "+
+			"production code naming the service.",
+			len(regressions), strings.Join(regressions, "\n  "))
+	}
+}
+
+// TestDetectorFiresOnContrivedFixture writes a synthetic Go file
+// containing a raw &http.Client{...} composite literal and asserts the
+// detector produces a finding. If the production scan ever stops
+// detecting raw constructions (AST visitor change, types-resolution
+// regression), this test fails alongside the production scan.
+func TestDetectorFiresOnContrivedFixture(t *testing.T) {
+	const src = `package fixture
+
+import (
+	"net/http"
+	"time"
+)
+
+func makeRawClient() *http.Client {
+	return &http.Client{Timeout: 5 * time.Second}
+}
+`
+
+	// Write the fixture to a temp directory with its own minimal go.mod.
+	// packages.Load then parses it in a real types-info context (net/http
+	// resolves to the real stdlib type, not a stub). A temp module avoids
+	// any cross-talk with the host repo's go.mod.
+	dir := t.TempDir()
+	fixturePath := filepath.Join(dir, "fixture.go")
+	goMod := "module fixture\n\ngo 1.26\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o600); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(fixturePath, []byte(src), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedDeps |
+			packages.NeedImports,
+		Dir:   dir,
+		Tests: false,
+	}
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	if loadErrs := collectLoadErrors(pkgs); len(loadErrs) > 0 {
+		t.Fatalf("fixture packages.Load reported %d per-package error(s):\n  %s",
+			len(loadErrs), strings.Join(loadErrs, "\n  "))
+	}
+	if countWithSyntax(pkgs) == 0 {
+		t.Fatalf("fixture failed to load with syntax")
+	}
+
+	var findings []string
+	for _, pkg := range pkgs {
+		for i, file := range pkg.Syntax {
+			if i >= len(pkg.GoFiles) {
+				continue
+			}
+			rel := filepath.ToSlash(filepath.Base(pkg.GoFiles[i]))
+			findings = append(findings, scanFileForRawClient(pkg.Fset, pkg.TypesInfo, file, rel)...)
+		}
+	}
+
+	if len(findings) == 0 {
+		t.Fatalf("detector did not fire on contrived fixture; the production scan may be broken")
+	}
+	// The construction is on line 9 of the fixture source above.
+	// Asserting the exact line catches off-by-one regressions in
+	// fset.Position(cl.Pos()).
+	wantPrefix := "fixture.go:9 "
+	if !strings.HasPrefix(findings[0], wantPrefix) {
+		t.Fatalf("finding does not start with %q: %v", wantPrefix, findings)
+	}
+}
+
+// scanFileForRawClient is the shared detector. Given a parsed AST file
+// and its types info, it returns a slice of "file:line ..." findings
+// for every *ast.CompositeLit whose type resolves to net/http.Client.
+// Both production and contrived-fixture tests call this function, so
+// the contrived fixture genuinely exercises the production detector.
+//
+// info should never be nil under normal operation; collectLoadErrors
+// fails the test before we reach this function if a package's types
+// info failed to populate. The nil guard remains defensive: if it ever
+// triggers, that is a test setup bug to investigate, not a silent
+// no-op.
+func scanFileForRawClient(fset *token.FileSet, info *types.Info, file *ast.File, rel string) []string {
+	if info == nil {
+		return nil
+	}
+	var out []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		cl, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		typ := info.TypeOf(cl)
+		if typ == nil {
+			return true
+		}
+		if !isNetHTTPClient(typ) {
+			return true
+		}
+		pos := fset.Position(cl.Pos())
+		out = append(out, rel+":"+strconv.Itoa(pos.Line)+" raw &http.Client{} construction; use httpsafe.SafeClient(timeout) instead")
+		return true
+	})
+	return out
+}
+
+// isNetHTTPClient reports whether t is the named type net/http.Client.
+// Composite literals always carry the named (non-pointer) type, so we
+// match on the named type directly. A defensive Unalias keeps the check
+// stable if a future Go version introduces aliases at this boundary.
+func isNetHTTPClient(t types.Type) bool {
+	named, ok := types.Unalias(t).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	return obj.Pkg().Path() == "net/http" && obj.Name() == "Client"
+}
+
+// findRepoRoot walks up from the test's working directory until it
+// finds the repo's go.mod. `go test` starts us inside
+// internal/httpsafe, so the walk is short.
+func findRepoRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir := wd
+	for {
+		// We must not confuse a sub-module's go.mod with the repo root.
+		// Stillwater is a single-module repo, so the first go.mod we
+		// hit walking up IS the root; if Stillwater ever adopts
+		// sub-modules, this loop should also check for a sentinel file
+		// (e.g. ".git").
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", &noGoModError{start: wd}
+		}
+		dir = parent
+	}
+}
+
+type noGoModError struct{ start string }
+
+func (e *noGoModError) Error() string {
+	return "go.mod not found walking up from " + e.start
+}
+
+// countWithSyntax returns the number of packages that loaded enough
+// syntax to inspect. A complete failure to load any package would
+// silently report zero findings, so we treat a zero count as a fatal
+// test setup error rather than a clean run.
+func countWithSyntax(pkgs []*packages.Package) int {
+	count := 0
+	for _, p := range pkgs {
+		if len(p.Syntax) > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+// collectLoadErrors returns "<pkg>: <err>" entries for every per-package
+// error in pkgs, plus an entry for any package that loaded syntax but
+// failed to populate TypesInfo (which would silently skip the file in
+// scanFileForRawClient). Callers should fail the test loudly when this
+// returns a non-empty slice.
+func collectLoadErrors(pkgs []*packages.Package) []string {
+	var out []string
+	for _, p := range pkgs {
+		for _, e := range p.Errors {
+			out = append(out, p.PkgPath+": "+e.Error())
+		}
+		if p.TypesInfo == nil && len(p.Syntax) > 0 {
+			out = append(out, p.PkgPath+": syntax loaded but TypesInfo is nil")
+		}
+	}
+	return out
+}

--- a/internal/httpsafe/no_raw_client_construction_test.go
+++ b/internal/httpsafe/no_raw_client_construction_test.go
@@ -139,13 +139,14 @@ func TestNoRawHTTPClientConstruction(t *testing.T) {
 			continue
 		}
 		for i, file := range pkg.Syntax {
-			// pkg.GoFiles is parallel to pkg.Syntax. CompiledGoFiles
-			// may include generated files we do not care about; GoFiles
-			// is the source-of-truth source list.
-			if i >= len(pkg.GoFiles) {
+			// pkg.Syntax is parallel to pkg.CompiledGoFiles in
+			// golang.org/x/tools/go/packages -- using pkg.GoFiles here
+			// would silently misalign indices for packages with
+			// generated/cgo files.
+			if i >= len(pkg.CompiledGoFiles) {
 				continue
 			}
-			path := pkg.GoFiles[i]
+			path := pkg.CompiledGoFiles[i]
 			rel, relErr := filepath.Rel(repoRoot, path)
 			if relErr != nil {
 				rel = path

--- a/internal/provider/audiodb/audiodb.go
+++ b/internal/provider/audiodb/audiodb.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
@@ -38,7 +39,7 @@ type Adapter struct {
 // New creates a TheAudioDB adapter with the default base URLs.
 func New(limiter *provider.RateLimiterMap, settings *provider.SettingsService, logger *slog.Logger) *Adapter {
 	return &Adapter{
-		client:    &http.Client{Timeout: 10 * time.Second},
+		client:    httpsafe.SafeClient(10 * time.Second),
 		limiter:   limiter,
 		settings:  settings,
 		logger:    logger.With(slog.String("provider", "audiodb")),
@@ -52,7 +53,7 @@ func New(limiter *provider.RateLimiterMap, settings *provider.SettingsService, l
 func NewWithBaseURL(limiter *provider.RateLimiterMap, settings *provider.SettingsService, logger *slog.Logger, baseURL string) *Adapter {
 	base := strings.TrimRight(baseURL, "/")
 	return &Adapter{
-		client:    &http.Client{Timeout: 10 * time.Second},
+		client:    httpsafe.SafeClient(10 * time.Second),
 		limiter:   limiter,
 		settings:  settings,
 		logger:    logger.With(slog.String("provider", "audiodb")),

--- a/internal/provider/audiodb/audiodb_test.go
+++ b/internal/provider/audiodb/audiodb_test.go
@@ -17,6 +17,13 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// useLoopbackTestClient swaps the SafeClient-backed default for a plain
+// http.Client when tests need to reach an httptest.Server on 127.0.0.1.
+// SafeTransport blocks loopback by design.
+func useLoopbackTestClient(a *Adapter) {
+	a.client = &http.Client{Timeout: 10 * time.Second}
+}
+
 func setupTest(t *testing.T) (*provider.RateLimiterMap, *provider.SettingsService) {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
@@ -121,7 +128,7 @@ func TestSearchArtist(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	results, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -150,7 +157,7 @@ func TestGetArtist(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	meta, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
 	if err != nil {
@@ -518,7 +525,7 @@ func TestGetArtistNotFound(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.GetArtist(context.Background(), "not-found")
 	if err == nil {
@@ -537,7 +544,7 @@ func TestGetImages(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	images, err := a.GetImages(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
 	if err != nil {
@@ -556,7 +563,7 @@ func TestPremiumKeyUsesV2Header(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -578,7 +585,7 @@ func TestFreeKeyUsesV1URL(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -597,7 +604,7 @@ func TestRequiresAuth(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, "http://unused")
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	if a.RequiresAuth() {
 		t.Error("expected RequiresAuth to return false (free tier available)")
@@ -612,7 +619,7 @@ func TestNumericIDRoutesToDirectEndpoint(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	// Numeric ID should route to the direct lookup endpoint (artist.php / lookup/artist/)
 	_, err := a.GetArtist(context.Background(), "111239")
@@ -632,7 +639,7 @@ func TestUUIDRoutesToMBIDEndpoint(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	// UUID should route to the MBID lookup endpoint (artist-mb.php / lookup/artist_mb/)
 	_, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
@@ -652,7 +659,7 @@ func TestNumericIDRoutesImages(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.GetImages(context.Background(), "111239")
 	if err != nil {
@@ -671,7 +678,7 @@ func TestFreeKeyNumericIDRoutesToV1Direct(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.GetArtist(context.Background(), "111239")
 	if err != nil {

--- a/internal/provider/audiodb/audiodb_test.go
+++ b/internal/provider/audiodb/audiodb_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/provider"
@@ -119,6 +120,8 @@ func TestSearchArtist(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	results, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -146,6 +149,8 @@ func TestGetArtist(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	meta, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
 	if err != nil {
@@ -512,6 +517,8 @@ func TestGetArtistNotFound(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetArtist(context.Background(), "not-found")
 	if err == nil {
@@ -529,6 +536,8 @@ func TestGetImages(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	images, err := a.GetImages(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
 	if err != nil {
@@ -546,6 +555,8 @@ func TestPremiumKeyUsesV2Header(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -566,6 +577,8 @@ func TestFreeKeyUsesV1URL(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -583,6 +596,8 @@ func TestRequiresAuth(t *testing.T) {
 	limiter, settings := setupTest(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, "http://unused")
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	if a.RequiresAuth() {
 		t.Error("expected RequiresAuth to return false (free tier available)")
@@ -596,6 +611,8 @@ func TestNumericIDRoutesToDirectEndpoint(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	// Numeric ID should route to the direct lookup endpoint (artist.php / lookup/artist/)
 	_, err := a.GetArtist(context.Background(), "111239")
@@ -614,6 +631,8 @@ func TestUUIDRoutesToMBIDEndpoint(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	// UUID should route to the MBID lookup endpoint (artist-mb.php / lookup/artist_mb/)
 	_, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
@@ -632,6 +651,8 @@ func TestNumericIDRoutesImages(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetImages(context.Background(), "111239")
 	if err != nil {
@@ -649,6 +670,8 @@ func TestFreeKeyNumericIDRoutesToV1Direct(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetArtist(context.Background(), "111239")
 	if err != nil {

--- a/internal/provider/deezer/deezer.go
+++ b/internal/provider/deezer/deezer.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
@@ -37,7 +38,7 @@ func New(limiter *provider.RateLimiterMap, logger *slog.Logger) *Adapter {
 // NewWithBaseURL creates a Deezer adapter with a custom base URL (for testing).
 func NewWithBaseURL(limiter *provider.RateLimiterMap, logger *slog.Logger, baseURL string) *Adapter {
 	return &Adapter{
-		client:  &http.Client{Timeout: 10 * time.Second},
+		client:  httpsafe.SafeClient(10 * time.Second),
 		limiter: limiter,
 		logger:  logger.With(slog.String("provider", "deezer")),
 		baseURL: strings.TrimRight(baseURL, "/"),

--- a/internal/provider/deezer/deezer_test.go
+++ b/internal/provider/deezer/deezer_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/provider"
 )
@@ -57,7 +58,10 @@ func newTestAdapter(t *testing.T, baseURL string) *Adapter {
 	t.Helper()
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	return NewWithBaseURL(limiter, logger, baseURL)
+	a := NewWithBaseURL(limiter, logger, baseURL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
+	return a
 }
 
 func TestName(t *testing.T) {

--- a/internal/provider/discogs/discogs.go
+++ b/internal/provider/discogs/discogs.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/internal/version"
 )
@@ -36,7 +37,7 @@ func New(limiter *provider.RateLimiterMap, settings *provider.SettingsService, l
 // NewWithBaseURL creates a Discogs adapter with a custom base URL (for testing).
 func NewWithBaseURL(limiter *provider.RateLimiterMap, settings *provider.SettingsService, logger *slog.Logger, baseURL string) *Adapter {
 	return &Adapter{
-		client:   &http.Client{Timeout: 10 * time.Second},
+		client:   httpsafe.SafeClient(10 * time.Second),
 		limiter:  limiter,
 		settings: settings,
 		logger:   logger.With(slog.String("provider", "discogs")),

--- a/internal/provider/discogs/discogs_test.go
+++ b/internal/provider/discogs/discogs_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/provider"
@@ -79,6 +80,8 @@ func TestSearchArtist(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	results, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -106,6 +109,8 @@ func TestSearchArtistFuzzyMatch(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	// Search for a misspelled name to prove scores are computed via
 	// NameSimilarity rather than hard-coded to 100.
@@ -130,6 +135,8 @@ func TestGetArtist(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	meta, err := a.GetArtist(context.Background(), "3840")
 	if err != nil {
@@ -155,6 +162,8 @@ func TestGetImages(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	images, err := a.GetImages(context.Background(), "3840")
 	if err != nil {
@@ -223,6 +232,8 @@ func TestGetArtistByNameFallback(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	// Passing an artist name (non-numeric, non-UUID) should trigger name search.
 	meta, err := a.GetArtist(context.Background(), "Adele")
@@ -249,6 +260,8 @@ func TestGetArtistByNameNoResults(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetArtist(context.Background(), "NonexistentArtist")
 	if err == nil {
@@ -276,6 +289,8 @@ func TestGetArtistWithStyles(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	meta, err := a.GetArtist(context.Background(), "3840")
 	if err != nil {

--- a/internal/provider/discogs/discogs_test.go
+++ b/internal/provider/discogs/discogs_test.go
@@ -17,6 +17,13 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// useLoopbackTestClient swaps the SafeClient-backed default for a plain
+// http.Client when tests need to reach an httptest.Server on 127.0.0.1.
+// SafeTransport blocks loopback by design.
+func useLoopbackTestClient(a *Adapter) {
+	a.client = &http.Client{Timeout: 10 * time.Second}
+}
+
 func setupTest(t *testing.T) (*provider.RateLimiterMap, *provider.SettingsService) {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
@@ -81,7 +88,7 @@ func TestSearchArtist(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	results, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -110,7 +117,7 @@ func TestSearchArtistFuzzyMatch(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	// Search for a misspelled name to prove scores are computed via
 	// NameSimilarity rather than hard-coded to 100.
@@ -136,7 +143,7 @@ func TestGetArtist(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	meta, err := a.GetArtist(context.Background(), "3840")
 	if err != nil {
@@ -163,7 +170,7 @@ func TestGetImages(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	images, err := a.GetImages(context.Background(), "3840")
 	if err != nil {
@@ -233,7 +240,7 @@ func TestGetArtistByNameFallback(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	// Passing an artist name (non-numeric, non-UUID) should trigger name search.
 	meta, err := a.GetArtist(context.Background(), "Adele")
@@ -261,7 +268,7 @@ func TestGetArtistByNameNoResults(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.GetArtist(context.Background(), "NonexistentArtist")
 	if err == nil {
@@ -290,7 +297,7 @@ func TestGetArtistWithStyles(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	meta, err := a.GetArtist(context.Background(), "3840")
 	if err != nil {

--- a/internal/provider/duckduckgo/duckduckgo.go
+++ b/internal/provider/duckduckgo/duckduckgo.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
@@ -55,7 +56,7 @@ func New(limiter *provider.RateLimiterMap, logger *slog.Logger) *Adapter {
 // NewWithBaseURL creates a DuckDuckGo adapter with custom base URLs (for testing).
 func NewWithBaseURL(limiter *provider.RateLimiterMap, logger *slog.Logger, baseURL, htmlURL string) *Adapter {
 	return &Adapter{
-		client:  &http.Client{Timeout: 15 * time.Second},
+		client:  httpsafe.SafeClient(15 * time.Second),
 		limiter: limiter,
 		logger:  logger.With(slog.String("provider", "duckduckgo")),
 		baseURL: strings.TrimRight(baseURL, "/"),

--- a/internal/provider/duckduckgo/duckduckgo_test.go
+++ b/internal/provider/duckduckgo/duckduckgo_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/provider"
 )
@@ -43,6 +44,8 @@ func TestSearchImages(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	images, err := a.SearchImages(context.Background(), "Radiohead", provider.ImageThumb)
 	if err != nil {
@@ -91,6 +94,8 @@ func TestSearchImagesEmpty(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	images, err := a.SearchImages(context.Background(), "Unknown Artist", provider.ImageThumb)
 	if err != nil {
@@ -118,6 +123,8 @@ func TestSearchImagesServerError(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.SearchImages(context.Background(), "Radiohead", provider.ImageThumb)
 	if err == nil {
@@ -136,6 +143,8 @@ func TestSearchImagesVQDFailure(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.SearchImages(context.Background(), "Radiohead", provider.ImageThumb)
 	if err == nil {
@@ -147,6 +156,8 @@ func TestSearchImagesUnsupportedType(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, "http://localhost", "http://localhost")
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	images, err := a.SearchImages(context.Background(), "Radiohead", provider.ImageType("unknown"))
 	if err != nil {
@@ -193,6 +204,8 @@ func TestVQDFallbackToHTML(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	images, err := a.SearchImages(context.Background(), "Radiohead", provider.ImageThumb)
 	if err != nil {
@@ -240,6 +253,8 @@ func TestSearchImagesContextCanceled(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/provider/duckduckgo/duckduckgo_test.go
+++ b/internal/provider/duckduckgo/duckduckgo_test.go
@@ -12,6 +12,14 @@ import (
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
+// useLoopbackTestClient swaps the SafeClient-backed default for a plain
+// http.Client when tests need to reach an httptest.Server on 127.0.0.1.
+// SafeTransport blocks loopback by design. Timeout matches the adapter
+// default so timeout-sensitive behavior is exercised consistently.
+func useLoopbackTestClient(a *Adapter) {
+	a.client = &http.Client{Timeout: 15 * time.Second}
+}
+
 func loadFixture(t *testing.T, name string) []byte {
 	t.Helper()
 	data, err := os.ReadFile("testdata/" + name)
@@ -45,7 +53,7 @@ func TestSearchImages(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	images, err := a.SearchImages(context.Background(), "Radiohead", provider.ImageThumb)
 	if err != nil {
@@ -95,7 +103,7 @@ func TestSearchImagesEmpty(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	images, err := a.SearchImages(context.Background(), "Unknown Artist", provider.ImageThumb)
 	if err != nil {
@@ -124,7 +132,7 @@ func TestSearchImagesServerError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.SearchImages(context.Background(), "Radiohead", provider.ImageThumb)
 	if err == nil {
@@ -144,7 +152,7 @@ func TestSearchImagesVQDFailure(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.SearchImages(context.Background(), "Radiohead", provider.ImageThumb)
 	if err == nil {
@@ -157,7 +165,7 @@ func TestSearchImagesUnsupportedType(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, "http://localhost", "http://localhost")
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	images, err := a.SearchImages(context.Background(), "Radiohead", provider.ImageType("unknown"))
 	if err != nil {
@@ -205,7 +213,7 @@ func TestVQDFallbackToHTML(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	images, err := a.SearchImages(context.Background(), "Radiohead", provider.ImageThumb)
 	if err != nil {
@@ -254,7 +262,7 @@ func TestSearchImagesContextCanceled(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/provider/fanarttv/fanarttv.go
+++ b/internal/provider/fanarttv/fanarttv.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
@@ -34,7 +35,7 @@ func New(limiter *provider.RateLimiterMap, settings *provider.SettingsService, l
 // NewWithBaseURL creates a Fanart.tv adapter with a custom base URL (for testing).
 func NewWithBaseURL(limiter *provider.RateLimiterMap, settings *provider.SettingsService, logger *slog.Logger, baseURL string) *Adapter {
 	return &Adapter{
-		client:   &http.Client{Timeout: 10 * time.Second},
+		client:   httpsafe.SafeClient(10 * time.Second),
 		limiter:  limiter,
 		settings: settings,
 		logger:   logger.With(slog.String("provider", "fanarttv")),

--- a/internal/provider/fanarttv/fanarttv_test.go
+++ b/internal/provider/fanarttv/fanarttv_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/provider"
@@ -62,6 +63,8 @@ func TestGetImages(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	images, err := a.GetImages(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
 	if err != nil {
@@ -106,6 +109,8 @@ func TestGetImagesNotFound(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetImages(context.Background(), "nonexistent")
 	if err == nil {
@@ -133,6 +138,8 @@ func TestGetImagesNoKey(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, "http://localhost")
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err = a.GetImages(context.Background(), "any-id")
 	if err == nil {
@@ -148,6 +155,8 @@ func TestSearchReturnsNil(t *testing.T) {
 	limiter, settings := setupTest(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, "http://localhost")
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	results, err := a.SearchArtist(context.Background(), "anything")
 	if err != nil {
@@ -162,6 +171,8 @@ func TestGetArtistReturnsNil(t *testing.T) {
 	limiter, settings := setupTest(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, "http://localhost")
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	meta, err := a.GetArtist(context.Background(), "anything")
 	if err != nil {

--- a/internal/provider/genius/genius.go
+++ b/internal/provider/genius/genius.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/internal/version"
 )
@@ -36,7 +37,7 @@ func New(limiter *provider.RateLimiterMap, settings *provider.SettingsService, l
 // NewWithBaseURL creates a Genius adapter with a custom base URL (for testing).
 func NewWithBaseURL(limiter *provider.RateLimiterMap, settings *provider.SettingsService, logger *slog.Logger, baseURL string) *Adapter {
 	return &Adapter{
-		client:   &http.Client{Timeout: 10 * time.Second},
+		client:   httpsafe.SafeClient(10 * time.Second),
 		limiter:  limiter,
 		settings: settings,
 		logger:   logger.With(slog.String("provider", "genius")),

--- a/internal/provider/genius/genius_test.go
+++ b/internal/provider/genius/genius_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/provider"
@@ -83,6 +84,8 @@ func TestSearchArtist(t *testing.T) {
 	srv := newTestServer(t)
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	results, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -111,6 +114,8 @@ func TestSearchArtistDeduplicates(t *testing.T) {
 	srv := newTestServer(t)
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	results, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -128,6 +133,8 @@ func TestGetArtistByID(t *testing.T) {
 	srv := newTestServer(t)
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	meta, err := a.GetArtist(context.Background(), "604")
 	if err != nil {
@@ -155,6 +162,8 @@ func TestGetArtistByName(t *testing.T) {
 	srv := newTestServer(t)
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	meta, err := a.GetArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -178,6 +187,8 @@ func TestGetArtistNotFound(t *testing.T) {
 	}))
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetArtist(context.Background(), "nonexistent")
 	if err == nil {
@@ -192,6 +203,8 @@ func TestGetArtistNotFound(t *testing.T) {
 func TestGetImagesReturnsNil(t *testing.T) {
 	limiter, settings := setupTest(t)
 	a := NewWithBaseURL(limiter, settings, testLogger(), "http://localhost")
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	images, err := a.GetImages(context.Background(), "any")
 	if err != nil {
@@ -207,6 +220,8 @@ func TestTestConnection(t *testing.T) {
 	srv := newTestServer(t)
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	if err := a.TestConnection(context.Background()); err != nil {
 		t.Fatalf("TestConnection: %v", err)
@@ -216,6 +231,8 @@ func TestTestConnection(t *testing.T) {
 func TestRequiresAuth(t *testing.T) {
 	limiter, settings := setupTest(t)
 	a := NewWithBaseURL(limiter, settings, testLogger(), "http://localhost")
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	if !a.RequiresAuth() {
 		t.Error("expected RequiresAuth to return true")
@@ -247,6 +264,8 @@ func TestGetArtistUUIDReturnsNotFound(t *testing.T) {
 	srv := newTestServer(t)
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	// A MusicBrainz UUID should be rejected immediately without making an API call.
 	_, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
@@ -296,6 +315,8 @@ func TestGetArtistByNameRejectsMismatch(t *testing.T) {
 	}))
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	// Searching "Adele" should not return Kim Kardashian's data.
 	_, err := a.GetArtist(context.Background(), "Adele")
@@ -329,6 +350,8 @@ func TestGetArtistByNameAcceptsCorrectMatch(t *testing.T) {
 	}))
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	meta, err := a.GetArtist(context.Background(), "Adele")
 	if err != nil {
@@ -352,6 +375,8 @@ func TestSearchArtistScoresReflectSimilarity(t *testing.T) {
 	}))
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	results, err := a.SearchArtist(context.Background(), "Adele")
 	if err != nil {
@@ -475,6 +500,8 @@ func TestAuthRequired(t *testing.T) {
 	settings := provider.NewSettingsService(db, enc)
 	// Do not set an API key -- should trigger ErrAuthRequired.
 	a := NewWithBaseURL(limiter, settings, testLogger(), "http://localhost")
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err = a.SearchArtist(context.Background(), "test")
 	if err == nil {

--- a/internal/provider/genius/genius_test.go
+++ b/internal/provider/genius/genius_test.go
@@ -17,6 +17,13 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// useLoopbackTestClient swaps the SafeClient-backed default for a plain
+// http.Client when tests need to reach an httptest.Server on 127.0.0.1.
+// SafeTransport blocks loopback by design.
+func useLoopbackTestClient(a *Adapter) {
+	a.client = &http.Client{Timeout: 10 * time.Second}
+}
+
 func setupTest(t *testing.T) (*provider.RateLimiterMap, *provider.SettingsService) {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
@@ -85,7 +92,7 @@ func TestSearchArtist(t *testing.T) {
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	results, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -115,7 +122,7 @@ func TestSearchArtistDeduplicates(t *testing.T) {
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	results, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -134,7 +141,7 @@ func TestGetArtistByID(t *testing.T) {
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	meta, err := a.GetArtist(context.Background(), "604")
 	if err != nil {
@@ -163,7 +170,7 @@ func TestGetArtistByName(t *testing.T) {
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	meta, err := a.GetArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -188,7 +195,7 @@ func TestGetArtistNotFound(t *testing.T) {
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.GetArtist(context.Background(), "nonexistent")
 	if err == nil {
@@ -204,7 +211,7 @@ func TestGetImagesReturnsNil(t *testing.T) {
 	limiter, settings := setupTest(t)
 	a := NewWithBaseURL(limiter, settings, testLogger(), "http://localhost")
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	images, err := a.GetImages(context.Background(), "any")
 	if err != nil {
@@ -221,7 +228,7 @@ func TestTestConnection(t *testing.T) {
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	if err := a.TestConnection(context.Background()); err != nil {
 		t.Fatalf("TestConnection: %v", err)
@@ -232,7 +239,7 @@ func TestRequiresAuth(t *testing.T) {
 	limiter, settings := setupTest(t)
 	a := NewWithBaseURL(limiter, settings, testLogger(), "http://localhost")
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	if !a.RequiresAuth() {
 		t.Error("expected RequiresAuth to return true")
@@ -265,7 +272,7 @@ func TestGetArtistUUIDReturnsNotFound(t *testing.T) {
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	// A MusicBrainz UUID should be rejected immediately without making an API call.
 	_, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
@@ -316,7 +323,7 @@ func TestGetArtistByNameRejectsMismatch(t *testing.T) {
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	// Searching "Adele" should not return Kim Kardashian's data.
 	_, err := a.GetArtist(context.Background(), "Adele")
@@ -351,7 +358,7 @@ func TestGetArtistByNameAcceptsCorrectMatch(t *testing.T) {
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	meta, err := a.GetArtist(context.Background(), "Adele")
 	if err != nil {
@@ -376,7 +383,7 @@ func TestSearchArtistScoresReflectSimilarity(t *testing.T) {
 	defer srv.Close()
 	a := NewWithBaseURL(limiter, settings, testLogger(), srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	results, err := a.SearchArtist(context.Background(), "Adele")
 	if err != nil {
@@ -501,7 +508,7 @@ func TestAuthRequired(t *testing.T) {
 	// Do not set an API key -- should trigger ErrAuthRequired.
 	a := NewWithBaseURL(limiter, settings, testLogger(), "http://localhost")
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err = a.SearchArtist(context.Background(), "test")
 	if err == nil {

--- a/internal/provider/lastfm/lastfm.go
+++ b/internal/provider/lastfm/lastfm.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/internal/provider/tagclass"
 	"github.com/sydlexius/stillwater/internal/version"
@@ -36,7 +37,7 @@ func New(limiter *provider.RateLimiterMap, settings *provider.SettingsService, l
 // NewWithBaseURL creates a Last.fm adapter with a custom base URL (for testing).
 func NewWithBaseURL(limiter *provider.RateLimiterMap, settings *provider.SettingsService, logger *slog.Logger, baseURL string) *Adapter {
 	return &Adapter{
-		client:   &http.Client{Timeout: 10 * time.Second},
+		client:   httpsafe.SafeClient(10 * time.Second),
 		limiter:  limiter,
 		settings: settings,
 		logger:   logger.With(slog.String("provider", "lastfm")),

--- a/internal/provider/lastfm/lastfm_test.go
+++ b/internal/provider/lastfm/lastfm_test.go
@@ -17,6 +17,13 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// useLoopbackTestClient swaps the SafeClient-backed default for a plain
+// http.Client when tests need to reach an httptest.Server on 127.0.0.1.
+// SafeTransport blocks loopback by design.
+func useLoopbackTestClient(a *Adapter) {
+	a.client = &http.Client{Timeout: 10 * time.Second}
+}
+
 func setupTest(t *testing.T) (*provider.RateLimiterMap, *provider.SettingsService) {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
@@ -78,7 +85,7 @@ func TestSearchArtist(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	results, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -102,7 +109,7 @@ func TestGetArtistByMBID(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	meta, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
 	if err != nil {
@@ -129,7 +136,7 @@ func TestGetArtistByName(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	meta, err := a.GetArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -147,7 +154,7 @@ func TestGetArtistNotFound(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.GetArtist(context.Background(), "nonexistent")
 	if err == nil {
@@ -164,7 +171,7 @@ func TestGetImagesReturnsNil(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, "http://localhost")
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	images, err := a.GetImages(context.Background(), "any")
 	if err != nil {
@@ -214,7 +221,7 @@ func TestGetArtistByNameRejectsMismatch(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	// Searching "Adele" should reject "Kim Kardashian" due to low similarity.
 	_, err := a.GetArtist(context.Background(), "Adele")
@@ -249,7 +256,7 @@ func TestGetArtistByNameThresholdZeroDisablesValidation(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	// With threshold=0, even a completely mismatched name should be accepted.
 	meta, err := a.GetArtist(context.Background(), "Adele")
@@ -278,7 +285,7 @@ func TestGetArtistByMBIDSkipsValidation(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	// MBID-based lookup should skip name validation entirely.
 	meta, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
@@ -300,7 +307,7 @@ func TestSearchArtistScoresReflectSimilarity(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	results, err := a.SearchArtist(context.Background(), "Adele")
 	if err != nil {
@@ -337,7 +344,7 @@ func TestGetArtistTagClassification(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	meta, err := a.GetArtist(context.Background(), "87c5dedd-371d-4571-9e1f-e8de0ef7f5d0")
 	if err != nil {
@@ -378,7 +385,7 @@ func TestSearchArtistExactMatchScore(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	results, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {

--- a/internal/provider/lastfm/lastfm_test.go
+++ b/internal/provider/lastfm/lastfm_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/provider"
@@ -76,6 +77,8 @@ func TestSearchArtist(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	results, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -98,6 +101,8 @@ func TestGetArtistByMBID(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	meta, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
 	if err != nil {
@@ -123,6 +128,8 @@ func TestGetArtistByName(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	meta, err := a.GetArtist(context.Background(), "Radiohead")
 	if err != nil {
@@ -139,6 +146,8 @@ func TestGetArtistNotFound(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetArtist(context.Background(), "nonexistent")
 	if err == nil {
@@ -154,6 +163,8 @@ func TestGetImagesReturnsNil(t *testing.T) {
 	limiter, settings := setupTest(t)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, "http://localhost")
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	images, err := a.GetImages(context.Background(), "any")
 	if err != nil {
@@ -202,6 +213,8 @@ func TestGetArtistByNameRejectsMismatch(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	// Searching "Adele" should reject "Kim Kardashian" due to low similarity.
 	_, err := a.GetArtist(context.Background(), "Adele")
@@ -235,6 +248,8 @@ func TestGetArtistByNameThresholdZeroDisablesValidation(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	// With threshold=0, even a completely mismatched name should be accepted.
 	meta, err := a.GetArtist(context.Background(), "Adele")
@@ -262,6 +277,8 @@ func TestGetArtistByMBIDSkipsValidation(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	// MBID-based lookup should skip name validation entirely.
 	meta, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
@@ -282,6 +299,8 @@ func TestSearchArtistScoresReflectSimilarity(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	results, err := a.SearchArtist(context.Background(), "Adele")
 	if err != nil {
@@ -317,6 +336,8 @@ func TestGetArtistTagClassification(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	meta, err := a.GetArtist(context.Background(), "87c5dedd-371d-4571-9e1f-e8de0ef7f5d0")
 	if err != nil {
@@ -356,6 +377,8 @@ func TestSearchArtistExactMatchScore(t *testing.T) {
 	defer srv.Close()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	results, err := a.SearchArtist(context.Background(), "Radiohead")
 	if err != nil {

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/internal/provider/tagclass"
 	"github.com/sydlexius/stillwater/internal/version"
@@ -38,9 +39,7 @@ func New(limiter *provider.RateLimiterMap, logger *slog.Logger) *Adapter {
 // NewWithBaseURL creates a MusicBrainz adapter with a custom base URL (for testing).
 func NewWithBaseURL(limiter *provider.RateLimiterMap, logger *slog.Logger, baseURL string) *Adapter {
 	return &Adapter{
-		client: &http.Client{
-			Timeout: 10 * time.Second,
-		},
+		client:  httpsafe.SafeClient(10 * time.Second),
 		limiter: limiter,
 		logger:  logger.With(slog.String("provider", "musicbrainz")),
 		baseURL: strings.TrimRight(baseURL, "/"),
@@ -502,6 +501,25 @@ func (a *Adapter) BaseURL() string {
 // DefaultBaseURL returns the default MusicBrainz API base URL.
 func (a *Adapter) DefaultBaseURL() string {
 	return defaultBaseURL
+}
+
+// SetHTTPClient replaces the adapter's HTTP client. Intended for tests
+// that run against an httptest.NewServer loopback fixture, which
+// httpsafe.SafeClient (the production default) rejects by design.
+// Production callers should not need this; the constructor wires the
+// SafeClient automatically.
+//
+// Callers must call this before initiating requests, not concurrently
+// with them. doRequest reads a.client without a lock; matching that
+// here would add ceremony without benefit because the only legitimate
+// caller is single-threaded test setup. Panics on nil to surface the
+// misconfiguration at the wiring site rather than as a confusing nil
+// dereference deep inside doRequest.
+func (a *Adapter) SetHTTPClient(c *http.Client) {
+	if c == nil {
+		panic("musicbrainz.SetHTTPClient: client must not be nil")
+	}
+	a.client = c
 }
 
 // doRequest executes an HTTP GET with rate limiting and standard headers.

--- a/internal/provider/musicbrainz/musicbrainz_test.go
+++ b/internal/provider/musicbrainz/musicbrainz_test.go
@@ -87,7 +87,16 @@ func newTestAdapter(t *testing.T, baseURL string) *Adapter {
 	// Production uses the default limiter; see internal/provider/ratelimit.go.
 	limiter.SetLimit(provider.NameMusicBrainz, 1000)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	return NewWithBaseURL(limiter, logger, baseURL)
+	a := NewWithBaseURL(limiter, logger, baseURL)
+	// Production wires a.client to httpsafe.SafeClient, which rejects the
+	// loopback (127.0.0.1) addresses that httptest.NewServer binds to by
+	// design. Tests override the client with a plain *http.Client so the
+	// httptest fixture is reachable; the production SSRF guard is exercised
+	// by internal/httpsafe's own test suite plus the AST regression guard
+	// in no_raw_client_construction_test.go (which allowlists this kind of
+	// post-construction override implicitly by skipping _test.go files).
+	a.client = &http.Client{Timeout: 10 * time.Second}
+	return a
 }
 
 func TestName(t *testing.T) {
@@ -390,6 +399,33 @@ func TestDefaultBaseURL(t *testing.T) {
 	if a.DefaultBaseURL() != "https://musicbrainz.org/ws/2" {
 		t.Errorf("unexpected default base URL: %s", a.DefaultBaseURL())
 	}
+}
+
+// TestSetHTTPClient verifies that SetHTTPClient replaces the adapter's
+// unexported client field. Same-package access lets the test read the
+// field directly; a behavioral test that drives a request through the
+// swapped client lives in handlers_provider_test.go (which is the
+// cross-package use case the setter was added for).
+func TestSetHTTPClient(t *testing.T) {
+	a := newTestAdapter(t, "http://localhost")
+	custom := &http.Client{Timeout: 99 * time.Second}
+	a.SetHTTPClient(custom)
+	if a.client != custom {
+		t.Errorf("SetHTTPClient did not replace the client field")
+	}
+}
+
+// TestSetHTTPClientNilPanics verifies the documented nil-input panic.
+// A silent nil acceptance would crash inside doRequest with a nil
+// dereference far from the misconfiguration site.
+func TestSetHTTPClientNilPanics(t *testing.T) {
+	a := newTestAdapter(t, "http://localhost")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("SetHTTPClient(nil) did not panic")
+		}
+	}()
+	a.SetHTTPClient(nil)
 }
 
 func TestMirrorableSearchArtist(t *testing.T) {
@@ -1289,6 +1325,8 @@ func TestLocalizeMembers_RateLimiterIsInvoked(t *testing.T) {
 	limiter.SetLimit(provider.NameMusicBrainz, 1)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithBaseURL(limiter, logger, srv.URL)
+	// See newTestAdapter for why the SafeClient override is required.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	ctx := provider.WithMetadataLanguages(context.Background(), []string{"ja"})
 	members := []provider.MemberInfo{

--- a/internal/provider/spotify/spotify.go
+++ b/internal/provider/spotify/spotify.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
@@ -49,7 +50,7 @@ func New(limiter *provider.RateLimiterMap, settings SettingsProvider, logger *sl
 // NewWithBaseURL creates a Spotify adapter with custom URLs (for testing).
 func NewWithBaseURL(limiter *provider.RateLimiterMap, settings SettingsProvider, logger *slog.Logger, baseURL, tokenURL string) *Adapter {
 	return &Adapter{
-		client:   &http.Client{Timeout: 10 * time.Second},
+		client:   httpsafe.SafeClient(10 * time.Second),
 		limiter:  limiter,
 		settings: settings,
 		logger:   logger.With(slog.String("provider", "spotify")),

--- a/internal/provider/spotify/spotify_test.go
+++ b/internal/provider/spotify/spotify_test.go
@@ -93,7 +93,10 @@ func newTestAdapter(t *testing.T, baseURL, tokenURL string, keys map[provider.Pr
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	settings := &fakeSettings{keys: keys}
-	return NewWithBaseURL(limiter, settings, logger, baseURL, tokenURL)
+	a := NewWithBaseURL(limiter, settings, logger, baseURL, tokenURL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
+	return a
 }
 
 func TestName(t *testing.T) {

--- a/internal/provider/wikidata/wikidata.go
+++ b/internal/provider/wikidata/wikidata.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/internal/version"
 )
@@ -55,7 +56,7 @@ func NewWithEndpoint(limiter *provider.RateLimiterMap, logger *slog.Logger, endp
 // endpoints. Use this in tests that need to mock both APIs.
 func NewWithEndpoints(limiter *provider.RateLimiterMap, logger *slog.Logger, endpoint, commonsEndpoint string) *Adapter {
 	return &Adapter{
-		client:          &http.Client{Timeout: 15 * time.Second},
+		client:          httpsafe.SafeClient(15 * time.Second),
 		limiter:         limiter,
 		logger:          logger.With(slog.String("provider", "wikidata")),
 		endpoint:        endpoint,

--- a/internal/provider/wikidata/wikidata_test.go
+++ b/internal/provider/wikidata/wikidata_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/provider"
 )
@@ -106,6 +107,8 @@ func TestGetArtist(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	meta, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
 	if err != nil {
@@ -135,6 +138,8 @@ func TestGetArtistNotFound(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetArtist(context.Background(), "00000000-0000-0000-0000-000000000000")
 	if err == nil {
@@ -150,6 +155,8 @@ func TestSearchReturnsNil(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, "http://localhost")
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	results, err := a.SearchArtist(context.Background(), "anything")
 	if err != nil {
@@ -168,6 +175,8 @@ func TestGetImagesBothP18AndP154(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	images, err := a.GetImages(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
 	if err != nil {
@@ -211,6 +220,8 @@ func TestGetImagesP18Only(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	images, err := a.GetImages(context.Background(), "11111111-1111-1111-1111-111111111111")
 	if err != nil {
@@ -235,6 +246,8 @@ func TestGetImagesP154Only(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	images, err := a.GetImages(context.Background(), "22222222-2222-2222-2222-222222222222")
 	if err != nil {
@@ -259,6 +272,8 @@ func TestGetImagesNoProperties(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetImages(context.Background(), "33333333-3333-3333-3333-333333333333")
 	if err == nil {
@@ -278,6 +293,8 @@ func TestGetImagesNotFoundMBID(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetImages(context.Background(), "00000000-0000-0000-0000-000000000000")
 	if err == nil {
@@ -343,6 +360,8 @@ func TestGetArtistInvalidMBID(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, "http://localhost")
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetArtist(context.Background(), "not-a-uuid")
 	if err == nil {
@@ -372,6 +391,8 @@ func TestGetArtist_AcceptsQID(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	meta, err := a.GetArtist(context.Background(), "Q175044")
 	if err != nil {
@@ -412,6 +433,8 @@ func TestGetArtist_AcceptsMBID_PreservesExistingPath(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	mbid := "a74b1b7f-71a5-4011-9441-d0b5e4122711"
 	meta, err := a.GetArtist(context.Background(), mbid)
@@ -462,6 +485,8 @@ func TestGetImagesInvalidMBID(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, "http://localhost", "http://localhost")
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetImages(context.Background(), "not-a-uuid")
 	if err == nil {
@@ -569,6 +594,8 @@ func TestGetArtist_LangPrefPassedToSPARQL(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	ctx := provider.WithMetadataLanguages(context.Background(), []string{"ja", "fr"})
 	_, err := a.GetArtist(ctx, "a74b1b7f-71a5-4011-9441-d0b5e4122711")
@@ -611,6 +638,8 @@ func TestGetImagesCommonsResolutionFailure(t *testing.T) {
 	limiter := provider.NewRateLimiterMap()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
 
 	_, err := a.GetImages(context.Background(), "11111111-1111-1111-1111-111111111111")
 	if err == nil {

--- a/internal/provider/wikidata/wikidata_test.go
+++ b/internal/provider/wikidata/wikidata_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
+// useLoopbackTestClient swaps the SafeClient-backed default for a plain
+// http.Client when tests need to reach an httptest.Server on 127.0.0.1.
+// SafeTransport blocks loopback by design.
+func useLoopbackTestClient(a *Adapter) {
+	a.client = &http.Client{Timeout: 10 * time.Second}
+}
+
 func loadFixture(t *testing.T, name string) []byte {
 	t.Helper()
 	data, err := os.ReadFile("testdata/" + name)
@@ -108,7 +115,7 @@ func TestGetArtist(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	meta, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
 	if err != nil {
@@ -139,7 +146,7 @@ func TestGetArtistNotFound(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.GetArtist(context.Background(), "00000000-0000-0000-0000-000000000000")
 	if err == nil {
@@ -156,7 +163,7 @@ func TestSearchReturnsNil(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, "http://localhost")
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	results, err := a.SearchArtist(context.Background(), "anything")
 	if err != nil {
@@ -176,7 +183,7 @@ func TestGetImagesBothP18AndP154(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	images, err := a.GetImages(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
 	if err != nil {
@@ -221,7 +228,7 @@ func TestGetImagesP18Only(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	images, err := a.GetImages(context.Background(), "11111111-1111-1111-1111-111111111111")
 	if err != nil {
@@ -247,7 +254,7 @@ func TestGetImagesP154Only(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	images, err := a.GetImages(context.Background(), "22222222-2222-2222-2222-222222222222")
 	if err != nil {
@@ -273,7 +280,7 @@ func TestGetImagesNoProperties(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.GetImages(context.Background(), "33333333-3333-3333-3333-333333333333")
 	if err == nil {
@@ -294,7 +301,7 @@ func TestGetImagesNotFoundMBID(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.GetImages(context.Background(), "00000000-0000-0000-0000-000000000000")
 	if err == nil {
@@ -361,7 +368,7 @@ func TestGetArtistInvalidMBID(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, "http://localhost")
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.GetArtist(context.Background(), "not-a-uuid")
 	if err == nil {
@@ -392,7 +399,7 @@ func TestGetArtist_AcceptsQID(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	meta, err := a.GetArtist(context.Background(), "Q175044")
 	if err != nil {
@@ -434,7 +441,7 @@ func TestGetArtist_AcceptsMBID_PreservesExistingPath(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	mbid := "a74b1b7f-71a5-4011-9441-d0b5e4122711"
 	meta, err := a.GetArtist(context.Background(), mbid)
@@ -486,7 +493,7 @@ func TestGetImagesInvalidMBID(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, "http://localhost", "http://localhost")
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.GetImages(context.Background(), "not-a-uuid")
 	if err == nil {
@@ -595,7 +602,7 @@ func TestGetArtist_LangPrefPassedToSPARQL(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoint(limiter, logger, srv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	ctx := provider.WithMetadataLanguages(context.Background(), []string{"ja", "fr"})
 	_, err := a.GetArtist(ctx, "a74b1b7f-71a5-4011-9441-d0b5e4122711")
@@ -639,7 +646,7 @@ func TestGetImagesCommonsResolutionFailure(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
 	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
-	a.client = &http.Client{Timeout: 10 * time.Second}
+	useLoopbackTestClient(a)
 
 	_, err := a.GetImages(context.Background(), "11111111-1111-1111-1111-111111111111")
 	if err == nil {

--- a/internal/provider/wikipedia/wikipedia.go
+++ b/internal/provider/wikipedia/wikipedia.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/internal/version"
 )
@@ -58,7 +59,7 @@ func NewWithEndpoints(
 	actionEndpoint, wikidataEndpoint, wikidataAPIEndpoint string,
 ) *Adapter {
 	return &Adapter{
-		client:              &http.Client{Timeout: 15 * time.Second},
+		client:              httpsafe.SafeClient(15 * time.Second),
 		limiter:             limiter,
 		logger:              logger.With(slog.String("provider", "wikipedia")),
 		actionEndpoint:      actionEndpoint,

--- a/internal/provider/wikipedia/wikipedia_test.go
+++ b/internal/provider/wikipedia/wikipedia_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/provider"
 )
@@ -31,8 +32,11 @@ func newTestAdapter(t *testing.T, actionURL, sparqlURL, wikidataAPIURL string) *
 	if wikidataAPIURL == "" {
 		wikidataAPIURL = "http://unused-wdapi"
 	}
-	return NewWithEndpoints(provider.NewRateLimiterMap(), silentLogger(),
+	a := NewWithEndpoints(provider.NewRateLimiterMap(), silentLogger(),
 		actionURL, sparqlURL, wikidataAPIURL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 15 * time.Second}
+	return a
 }
 
 // --- SPARQL mock helpers ---

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -50,6 +50,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/filesystem"
+	"github.com/sydlexius/stillwater/internal/httpsafe"
 	"github.com/sydlexius/stillwater/internal/version"
 )
 
@@ -295,11 +296,9 @@ type Service struct {
 // NewService creates a new updater Service.
 func NewService(db *sql.DB, logger *slog.Logger) *Service {
 	return &Service{
-		db:     db,
-		logger: logger,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		db:           db,
+		logger:       logger,
+		httpClient:   httpsafe.SafeClient(30 * time.Second),
 		state:        StateIdle,
 		isDocker:     detectDocker(),
 		configChange: make(chan struct{}, 1),


### PR DESCRIPTION
## Summary

- Adds an AST-based regression test that walks every production package (cmd, internal, tools, scripts; Tests=false) and fails if any composite literal resolves to `net/http.Client` outside a documented allowlist. The detector is also exercised against a contrived in-temp-dir fixture so the test fails alongside the production scan if the detector itself regresses.
- Migrates 12 outbound-to-internet sites (11 providers + updater) from raw `&http.Client{...}` to `httpsafe.SafeClient(timeout)`, preserving each site's existing timeout. The 7 LAN/loopback sites (Emby/Jellyfin/Lidarr connection clients and Emby/Jellyfin auth providers) keep raw `http.Client` with per-site rationale comments and appear in the test allowlist; SafeTransport's RFC1918/loopback block would reject user-configured destinations by design.
- `golangci-lint`'s forbidigo linter cannot reliably express the "composite-literal construction only" rule (its regex matcher strips composite-literal braces before matching), so the enforcement lives in the AST test rather than the linter.

## Linked issue

Closes #1565

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`); verified pre- and post-rebase against current main.
- [x] Code review pass complete (`/pr-review-toolkit:review-pr`): code-reviewer, pr-test-analyzer, comment-analyzer, silent-failure-hunter. Critical findings fixed; non-blocking suggestions filed as follow-up issues post-merge.
- [x] Commits squashed into one clean commit before push.
- [x] Labels set: `security`, `chore`, `docs: not-required`.
- [x] Docs label decision made: `docs: not-required` (no user-visible behavioral change; the migration is internal SSRF-protection enforcement).
- [ ] Screenshot attached for any UI change. (n/a -- no UI change)
- [x] UAT performed against the running binary (provider sweep + LAN-client check; see Test plan below).
- [x] OpenAPI spec unchanged (no request or response shape change).
- [x] `templ generate` re-run; no `.templ` files changed.

## Test plan

- [x] `go test -race ./...` passes locally.
- [x] `bash scripts/pre-push-gate.sh` passes locally (all coverage floors held, no fuzz matrix drift).
- [x] Manual UAT steps:
  - [x] **Outbound providers via SafeClient (9 with `TestConnection`):** POST /api/v1/providers/{name}/test for musicbrainz, wikipedia, wikidata, lastfm, fanarttv, audiodb, discogs, genius -- all returned `{\"status\":\"ok\"}` (real outbound HTTPS reached). spotify returned `{\"error\":\"Unable to verify provider credentials\"}` -- credential issue, not SafeClient (the HTTP request executed).
  - [x] **Providers without `TestConnection` (2):** deezer and duckduckgo are covered by the AST guard (no raw client construction = using SafeClient by mechanical guarantee) and unit tests.
  - [x] **Updater via SafeClient:** POST /api/v1/updates/check returned the latest GitHub release (real outbound HTTPS fetch).
  - [x] **LAN-client allowlist (3 connection types, 7 raw-client sites across 5 files):** POST /api/v1/connections/{id}/test for the three configured connections -- Emby @ http://localhost:8096, Jellyfin @ http://localhost:8097, Lidarr @ http://localhost:8686 -- all returned `{\"status\":\"ok\"}`, proving the allowlist reaches loopback destinations that SafeTransport would reject by design.
- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
  - [ ] The AST detector matches `*ast.CompositeLit` only. Alternative idioms (`new(http.Client)`, `var c http.Client` zero-value declaration, dereferenced copy of `http.DefaultClient`) are out of scope -- they are not the regression class observed in PR #1558 and are vanishingly rare. A note in the test preamble documents this; if a future regression uses one of those idioms, extend the visitor to cover `*ast.ValueSpec` / `*ast.CallExpr(new)`.
  - [ ] `musicbrainz.Adapter.SetHTTPClient` is a new exported method added to enable cross-package test injection from `internal/api/handlers_provider_test.go` (which cannot reach the unexported `a.client` field directly). The setter panics on nil; the test fixture pattern at every other provider uses direct unexported-field assignment within the same package.

## Follow-up issues to file post-merge

These were surfaced during the review-toolkit pass but are out-of-scope for this PR:

1. Per-package `newTestAdapter` helper refactor (~95 copy-paste override comments across 11 provider test files).
2. `ErrPrivateAddress` disambiguation across providers (user sees \"provider unavailable\" today when the cause is the SSRF guard rejecting a LAN URL the user configured).
3. MusicBrainz LAN-mirror policy (the mirror config UI allows a LAN URL today; SafeTransport rejects it without explanation).
4. Allowlist `file:line` brittleness -- consider a `//httpsafe:allow operator-supplied-lan` marker-comment scheme that survives reformat.
5. Updater redirect-via-SafeTransport assertion test.
6. Per-provider behavioral test that production constructors are wired via `SafeClient` (proves the chain end-to-end at unit-test scope).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default HTTP clients for integrations now use a safer, SSRF-aware client.

* **Tests**
  * Added regression tests to detect disallowed raw HTTP client construction.
  * Updated test helpers so local test servers remain reachable under the new client behavior.

* **Chores**
  * Added golang.org/x/tools v0.44.0 for enhanced static analysis and testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->