### PR TITLE
fix(provider): remove Wikidata from default biography priority list

### DIFF
--- a/docs/site/src/reference/providers.md
+++ b/docs/site/src/reference/providers.md
@@ -33,7 +33,7 @@ For every field Stillwater can populate (name, biography, genres, thumb, fanart,
 
 1. Stillwater walks the priority list from top to bottom.
 2. Providers that aren't available (no API key, disabled in settings, missing the right ID) are skipped.
-3. Providers that structurally cannot supply the field (e.g., MusicBrainz never returns biography text) are skipped.
+3. Providers that structurally cannot supply the field (e.g., neither MusicBrainz nor Wikidata returns biography text) are skipped.
 4. The first provider that returns a usable value populates the field -- with one important caveat below.
 
 The lists are configured under **Settings > Providers > Priorities**. You can override the global list per library, so a classical-music library can prefer different sources than a regular library.

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -1137,3 +1137,144 @@ func TestMarkPre002Applied_FreshDBSkips(t *testing.T) {
 		t.Errorf("goose_db_version table count after fresh-DB shim = %d, want 0 (shim must not create the tracker)", n)
 	}
 }
+
+// TestMigration007_RemovesWikidataFromBiographyPriority covers the migration
+// shipped for issue #1029. The 001 seed lists wikidata as the fifth provider
+// in provider.priority.biography. Wikidata's mapArtist never populates the
+// Biography field, so the entry was a no-op that wasted a fetch slot and
+// surfaced misleading "attempted" telemetry.
+//
+// openMigratedDB runs every migration including 007, so on a fresh DB the
+// stored biography priority should already be Wikidata-free. We then seed a
+// pre-007 shape (wikidata present, plus a non-default entry that simulates
+// a user reorder) and re-run the migration's UPDATE to confirm:
+//   - wikidata is removed,
+//   - the surrounding entries keep their order,
+//   - the run is idempotent,
+//   - rows without wikidata are not rewritten.
+func TestMigration007_RemovesWikidataFromBiographyPriority(t *testing.T) {
+	db := openMigratedDB(t)
+	ctx := context.Background()
+
+	// Fresh-install assertion: 001 seed -> 007 scrub, so the stored value
+	// must not include wikidata after Migrate.
+	var fresh string
+	if err := db.QueryRowContext(ctx,
+		`SELECT value FROM settings WHERE key = 'provider.priority.biography'`).Scan(&fresh); err != nil {
+		t.Fatalf("reading fresh biography priority: %v", err)
+	}
+	if strings.Contains(fresh, "wikidata") {
+		t.Errorf("fresh biography priority still contains wikidata: %s", fresh)
+	}
+
+	// Re-seed a pre-007 row (wikidata present) and prove the UPDATE removes
+	// it without disturbing the other providers' order. Use REPLACE so the
+	// row is overwritten rather than producing a UNIQUE conflict on key.
+	preSeven := `["musicbrainz","lastfm","wikidata","audiodb","discogs"]`
+	if _, err := db.ExecContext(ctx,
+		`INSERT OR REPLACE INTO settings (key, value) VALUES ('provider.priority.biography', ?)`,
+		preSeven); err != nil {
+		t.Fatalf("seeding pre-007 row: %v", err)
+	}
+
+	// Run the same UPDATE statement migration 007 ships with. Mirrors the
+	// migration-004 test pattern: assert on the SQL contract, not on goose
+	// replaying an already-applied migration.
+	if _, err := db.ExecContext(ctx, `
+		UPDATE settings
+		SET value = (
+			SELECT json_group_array(j.value)
+			FROM json_each(settings.value) j
+			WHERE j.value != 'wikidata'
+		)
+		WHERE key = 'provider.priority.biography'
+		  AND EXISTS (
+			SELECT 1 FROM json_each(settings.value) WHERE value = 'wikidata'
+		  )
+	`); err != nil {
+		t.Fatalf("running migration 007 UPDATE: %v", err)
+	}
+
+	var scrubbed string
+	if err := db.QueryRowContext(ctx,
+		`SELECT value FROM settings WHERE key = 'provider.priority.biography'`).Scan(&scrubbed); err != nil {
+		t.Fatalf("reading scrubbed row: %v", err)
+	}
+	want := `["musicbrainz","lastfm","audiodb","discogs"]`
+	if scrubbed != want {
+		t.Errorf("biography priority after scrub = %q, want %q (order around wikidata must survive)", scrubbed, want)
+	}
+
+	// Multi-wikidata corner case: a user reorder via Settings could put
+	// wikidata in multiple positions. Every occurrence must be stripped --
+	// json_each yields one row per element and json_group_array rebuilds
+	// from only the rows the filter kept.
+	multi := `["wikidata","musicbrainz","wikidata"]`
+	if _, err := db.ExecContext(ctx,
+		`INSERT OR REPLACE INTO settings (key, value) VALUES ('provider.priority.biography', ?)`,
+		multi); err != nil {
+		t.Fatalf("seeding multi-wikidata row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		UPDATE settings
+		SET value = (
+			SELECT json_group_array(j.value)
+			FROM json_each(settings.value) j
+			WHERE j.value != 'wikidata'
+		)
+		WHERE key = 'provider.priority.biography'
+		  AND EXISTS (
+			SELECT 1 FROM json_each(settings.value) WHERE value = 'wikidata'
+		  )
+	`); err != nil {
+		t.Fatalf("running migration 007 UPDATE on multi-wikidata row: %v", err)
+	}
+	var multiScrubbed string
+	if err := db.QueryRowContext(ctx,
+		`SELECT value FROM settings WHERE key = 'provider.priority.biography'`).Scan(&multiScrubbed); err != nil {
+		t.Fatalf("reading multi-scrubbed row: %v", err)
+	}
+	if multiScrubbed != `["musicbrainz"]` {
+		t.Errorf("multi-wikidata scrub = %q, want %q (every occurrence must be stripped)", multiScrubbed, `["musicbrainz"]`)
+	}
+
+	// Idempotent re-run on a row that no longer contains wikidata: the
+	// EXISTS guard must short-circuit the UPDATE so RowsAffected is 0.
+	// We do not check updated_at because the migration does not set it and
+	// SQLite does not auto-bump it without a trigger, so equality would
+	// hold whether the guard fired or not.
+	res, err := db.ExecContext(ctx, `
+		UPDATE settings
+		SET value = (
+			SELECT json_group_array(j.value)
+			FROM json_each(settings.value) j
+			WHERE j.value != 'wikidata'
+		)
+		WHERE key = 'provider.priority.biography'
+		  AND EXISTS (
+			SELECT 1 FROM json_each(settings.value) WHERE value = 'wikidata'
+		  )
+	`)
+	if err != nil {
+		t.Fatalf("idempotent re-run: %v", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		t.Fatalf("RowsAffected: %v", err)
+	}
+	if affected != 0 {
+		t.Errorf("idempotent re-run affected %d rows, want 0 (EXISTS guard must skip clean rows)", affected)
+	}
+
+	// Other fields whose default still includes Wikidata must be untouched
+	// by the migration. Use members (the canonical Wikidata-bearing field)
+	// to prove the WHERE key= filter is doing its job.
+	var members string
+	if err := db.QueryRowContext(ctx,
+		`SELECT value FROM settings WHERE key = 'provider.priority.members'`).Scan(&members); err != nil {
+		t.Fatalf("reading members priority: %v", err)
+	}
+	if !strings.Contains(members, "wikidata") {
+		t.Errorf("members priority lost wikidata: %s (migration must only touch biography)", members)
+	}
+}

--- a/internal/database/migrations/007_remove_wikidata_from_biography_priority.sql
+++ b/internal/database/migrations/007_remove_wikidata_from_biography_priority.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+-- Issue #1029: remove Wikidata from the default biography priority list.
+-- Wikidata stores structured facts (formed, members, type, gender, origin
+-- ...) but its mapArtist never populates Biography, so including it in the
+-- biography priority wasted a fetch iteration and surfaced misleading
+-- "attempted" telemetry. New installs no longer include it via
+-- DefaultPriorities(); this migration scrubs existing installs.
+--
+-- The UPDATE rebuilds the JSON array by selecting every element that is
+-- not 'wikidata'. The EXISTS guard makes the statement a no-op (RowsAffected
+-- = 0) when 'wikidata' is already absent, so re-runs are safe. Exact-element
+-- matching via json_each avoids any partial-string false positives a REPLACE
+-- would have allowed.
+
+UPDATE settings
+SET value = (
+    SELECT json_group_array(j.value)
+    FROM json_each(settings.value) j
+    WHERE j.value != 'wikidata'
+)
+WHERE key = 'provider.priority.biography'
+  AND EXISTS (
+    SELECT 1 FROM json_each(settings.value) WHERE value = 'wikidata'
+  );
+
+-- +goose Down
+-- Restoration is intentionally a no-op. Wikidata cannot return biographies,
+-- so adding it back has no behavioral effect; preserving "what the user had"
+-- across a re-up would require a separate ledger this migration does not
+-- carry.
+SELECT 1;

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -44,10 +44,11 @@ type FieldSource struct {
 }
 
 // fieldProviderExclusions lists providers that structurally cannot provide data
-// for specific fields. MusicBrainz, for example, does not return biography text
-// so the field is always empty when sourced from MusicBrainz.
+// for specific fields. MusicBrainz and Wikidata, for example, do not return
+// biography text so the field is always empty when sourced from either, even
+// if a user explicitly includes them in the biography priority list.
 var fieldProviderExclusions = map[string]map[ProviderName]bool{
-	"biography": {NameMusicBrainz: true},
+	"biography": {NameMusicBrainz: true, NameWikidata: true},
 }
 
 // IsExcludedForField returns true if a provider is structurally unable to

--- a/internal/provider/orchestrator_test.go
+++ b/internal/provider/orchestrator_test.go
@@ -2831,3 +2831,35 @@ func TestParseSpotifyURL(t *testing.T) {
 		})
 	}
 }
+
+// TestIsExcludedForField_BiographyStructuralGuards pins the orchestrator-side
+// belt-and-suspenders defense for #1029: MusicBrainz and Wikidata are
+// structurally incapable of returning biography (neither's mapArtist populates
+// the field), so they MUST be excluded even if a user explicitly puts them in
+// the biography priority list via the Settings UI. A future refactor that
+// drops either name from fieldProviderExclusions reintroduces the wasted
+// fetch + misleading "attempted" telemetry symptoms.
+func TestIsExcludedForField_BiographyStructuralGuards(t *testing.T) {
+	cases := []struct {
+		field string
+		prov  ProviderName
+		want  bool
+	}{
+		{"biography", NameMusicBrainz, true},
+		{"biography", NameWikidata, true},
+		{"biography", NameWikipedia, false},
+		{"biography", NameLastFM, false},
+		{"biography", NameAudioDB, false},
+		{"biography", NameDiscogs, false},
+		{"biography", NameGenius, false},
+		{"members", NameWikidata, false},
+		{"genres", NameMusicBrainz, false},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.prov)+"/"+tc.field, func(t *testing.T) {
+			if got := IsExcludedForField(tc.field, tc.prov); got != tc.want {
+				t.Errorf("IsExcludedForField(%q, %q) = %v, want %v", tc.field, tc.prov, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/provider/settings.go
+++ b/internal/provider/settings.go
@@ -312,7 +312,7 @@ func (fp FieldPriority) EnabledProviders() []ProviderName {
 // DefaultPriorities returns the default provider priority order per field.
 func DefaultPriorities() []FieldPriority {
 	return []FieldPriority{
-		{Field: "biography", Providers: []ProviderName{NameWikipedia, NameLastFM, NameAudioDB, NameDiscogs, NameWikidata, NameGenius}},
+		{Field: "biography", Providers: []ProviderName{NameWikipedia, NameLastFM, NameAudioDB, NameDiscogs, NameGenius}},
 		{Field: "genres", Providers: []ProviderName{NameMusicBrainz, NameLastFM, NameAudioDB, NameDiscogs, NameSpotify, NameWikipedia}},
 		{Field: "styles", Providers: []ProviderName{NameDiscogs, NameAudioDB, NameLastFM, NameMusicBrainz}},
 		{Field: "moods", Providers: []ProviderName{NameAudioDB, NameLastFM}},

--- a/internal/provider/settings_test.go
+++ b/internal/provider/settings_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"database/sql"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1141,5 +1142,60 @@ func TestResetPrioritiesPreservesEnabledWebSearch(t *testing.T) {
 	}
 	if !stillEnabled {
 		t.Errorf("web search provider %s should remain enabled after reset", wsName)
+	}
+}
+
+// TestDefaultPriorities_BiographyExcludesWikidata pins #1029: Wikidata's
+// mapArtist never populates Biography, so it must not appear in the default
+// biography priority list. Other fields where Wikidata is a real data source
+// (members, formed, born, ...) keep it -- this test only locks down the
+// biography slot. Paired with migration 007 which scrubs existing installs.
+func TestDefaultPriorities_BiographyExcludesWikidata(t *testing.T) {
+	defaults := DefaultPriorities()
+
+	var bio FieldPriority
+	for _, p := range defaults {
+		if p.Field == "biography" {
+			bio = p
+			break
+		}
+	}
+	if len(bio.Providers) == 0 {
+		t.Fatal("biography field missing from DefaultPriorities()")
+	}
+	for _, p := range bio.Providers {
+		if p == NameWikidata {
+			t.Errorf("biography default contains %s; Wikidata cannot return biographies (see #1029)", NameWikidata)
+		}
+	}
+
+	// Pin the exact contents so a future refactor that renames or drops one
+	// of the remaining biography providers fails loudly instead of silently
+	// reordering the default chain.
+	wantBio := []ProviderName{NameWikipedia, NameLastFM, NameAudioDB, NameDiscogs, NameGenius}
+	if !reflect.DeepEqual(bio.Providers, wantBio) {
+		t.Errorf("biography default = %v, want %v", bio.Providers, wantBio)
+	}
+
+	// Sanity: Wikidata must still appear in at least one fact-shaped field so
+	// this test fails loudly if a later refactor strips it everywhere.
+	factFields := map[string]bool{
+		"members": false, "formed": false, "born": false, "died": false,
+		"disbanded": false, "type": false, "gender": false, "origin": false,
+	}
+	for _, p := range defaults {
+		if _, ok := factFields[p.Field]; !ok {
+			continue
+		}
+		for _, prov := range p.Providers {
+			if prov == NameWikidata {
+				factFields[p.Field] = true
+			}
+		}
+	}
+	for field, present := range factFields {
+		if !present {
+			t.Errorf("Wikidata missing from %s default priority; #1029 only removes it from biography", field)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Wikidata's `mapArtist` (`internal/provider/wikidata/wikidata.go`) never populates `Biography`, and `NameWikidata.SupportedFields` already excludes "biography". Yet Wikidata appeared in the biography priority list -- a wasted fetch slot that surfaced misleading "attempted" telemetry.
- Three-layer fix:
  1. `DefaultPriorities()` biography slice drops `NameWikidata` (new installs).
  2. New additive migration `007_remove_wikidata_from_biography_priority.sql` scrubs existing-install biography priority rows using SQLite JSON1 (`json_each` + `json_group_array`), with an `EXISTS` guard for idempotency. Other fields' priorities (members, formed, born, died, etc.) are untouched.
  3. `orchestrator.fieldProviderExclusions` now lists `NameWikidata` for biography alongside the existing `NameMusicBrainz` entry. The Settings UI already filters by `SupportedFields` so neither is reachable via the priority editor, but this mirrors the pre-existing MusicBrainz pattern and defends against direct DB writes, settings imports of older shapes, and any future `SupportedFields` refactor.
- `docs/site/src/reference/providers.md` updated to name Wikidata alongside MusicBrainz in the structural-exclusion example (CR feedback).

**Behavioral note for release notes:** existing biography priority rows that contain Wikidata have it stripped automatically on next startup. The priority editor never allowed adding it in the first place, so the only ways such a row exists are the pre-#1029 default seed and direct DB or settings-import writes.

## Linked issue

Closes #1029

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Code review pass complete (`/pr-review-toolkit:review-pr`: code-reviewer flagged a non-falsifying `updated_at` assertion -- fixed; silent-failure-hunter flagged the missing structural exclusion -- fixed; SUGGESTION-tier deep-equal pin on biography default -- fixed; CR flagged docs/code drift -- fixed).
- [x] Commits squashed into clean, logical commits before the first push (single commit).
- [x] At least one label set (`enhancement`, `needs-docs-review`).
- [x] Docs label decision made: `needs-docs-review` since the behavior change should be called out in release notes; `docs/site/src/reference/providers.md` updated to keep the structural-exclusion example in sync with the code.
- [ ] Screenshot attached -- not applicable, no UI surface change.
- [x] UAT performed against the running binary (`bash scripts/dev-restart.sh` from this worktree; verified dev DB's `provider.priority.biography` changed from `["audiodb","wikipedia","discogs","wikidata","lastfm","genius"]` to `["audiodb","wikipedia","discogs","lastfm","genius"]` -- surrounding order preserved -- and other-field priorities still contain Wikidata).
- [ ] OpenAPI spec updated -- not applicable.
- [ ] `templ generate` re-run -- not applicable.

## Test plan

- [x] `go test -race ./...` passes locally including three new tests:
  - `TestDefaultPriorities_BiographyExcludesWikidata` (settings_test.go): asserts biography excludes Wikidata, other fact fields still include it, pins the exact biography default contents.
  - `TestMigration007_RemovesWikidataFromBiographyPriority` (migrate_test.go): fresh-DB scrub, single-occurrence scrub with order preservation, multi-occurrence scrub, idempotency via `RowsAffected == 0`, other-field priorities untouched.
  - `TestIsExcludedForField_BiographyStructuralGuards` (orchestrator_test.go): table-driven assertions that MusicBrainz and Wikidata are skipped for biography while the legitimate biography providers are not.
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] Manual UAT steps:
  - [x] Dev DB before rebuild: biography priority contained `wikidata`; migrations applied 0-5.
  - [x] `bash scripts/dev-restart.sh` from the worktree built and started cleanly on port 1973.
  - [x] Dev DB after restart: biography priority no longer contains `wikidata`; migration 7 added to `goose_db_version`; other-field priorities (members, formed, born, died, disbanded) still contain `wikidata`.
- Reviewer follow-ups:
  - Pre-existing seed-vs-`DefaultPriorities()` drift (the seed in `001_initial_schema.sql:530` lists 5 providers including wikidata, while `DefaultPriorities()` pre-edit listed 6 including wikipedia and genius) is out of scope here and may warrant a separate cleanup issue.
  - `GetPriorities()` silently falls back to defaults on `json.Unmarshal` failure with no `slog.Error` log (`settings.go:348-351`). Pre-existing pattern, flag for a possible follow-up issue rather than blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed Wikidata from the biography provider priority so biography text is sourced from alternative providers; Wikidata remains available for other data types (members, dates, genres).

* **Tests**
  * Added regression and unit tests covering the migration, exclusion behavior, idempotency, and provider priority ordering.

* **Documentation**
  * Clarified fallback behavior: providers may be skipped when they structurally cannot supply a requested field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->