### PR TITLE
feat(foreign): hash-based allowlist semantics

### DIFF
--- a/internal/api/handlers_foreign_files.go
+++ b/internal/api/handlers_foreign_files.go
@@ -270,21 +270,25 @@ func (r *Router) handleForeignFilesDismiss(w http.ResponseWriter, req *http.Requ
 			r.logger.Warn("dismiss content-hash resolve failed", "path", e.FilePath, "error", herr)
 			continue
 		}
-		if seen[hash] {
-			continue
-		}
-		seen[hash] = true
-		if err := r.foreignRepo.AddAllowlist(req.Context(), foreign.AllowlistEntry{
-			Scope:       foreign.ScopeGlobal,
-			FileName:    e.FileName,
-			ContentHash: hash,
-			Note:        "bulk dismiss from banner",
-		}); err != nil {
-			// Skip the ledger delete on failure: clearing the row would hide
-			// the warning even though dismissal was not actually persisted,
-			// and the file would only re-appear on the next scan cycle.
-			r.logger.Warn("dismiss bulk allowlist failed for file", "file", e.FileName, "error", err)
-			continue
+		// AddAllowlist runs once per distinct hash, but DeleteByPath must
+		// run for every entry: two files with identical bytes share one
+		// allowlist row yet each keep their own ledger row. seen[hash] is
+		// set only after AddAllowlist succeeds so a failed write is
+		// retried on the next duplicate rather than silently skipped.
+		if !seen[hash] {
+			if err := r.foreignRepo.AddAllowlist(req.Context(), foreign.AllowlistEntry{
+				Scope:       foreign.ScopeGlobal,
+				FileName:    e.FileName,
+				ContentHash: hash,
+				Note:        "bulk dismiss from banner",
+			}); err != nil {
+				// Skip the ledger delete on failure: clearing the row would hide
+				// the warning even though dismissal was not actually persisted,
+				// and the file would only re-appear on the next scan cycle.
+				r.logger.Warn("dismiss bulk allowlist failed for file", "file", e.FileName, "error", err)
+				continue
+			}
+			seen[hash] = true
 		}
 		if err := r.foreignRepo.DeleteByPath(req.Context(), e.ArtistID, e.FilePath); err != nil && !errors.Is(err, foreign.ErrNotFound) {
 			// Error not Warn: the global allowlist write succeeded but the

--- a/internal/api/handlers_foreign_files.go
+++ b/internal/api/handlers_foreign_files.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/api/middleware"
@@ -51,8 +54,8 @@ func (r *Router) loadForeignFilesView(ctx context.Context) (templates.ForeignFil
 		return view, err
 	}
 	view.Rows = make([]templates.ForeignFileRow, 0, len(entries))
-	for _, e := range entries {
-		view.Rows = append(view.Rows, foreignEntryToRow(e))
+	for i := range entries {
+		view.Rows = append(view.Rows, foreignEntryToRow(&entries[i]))
 	}
 	view.Count = len(view.Rows)
 	return view, nil
@@ -69,7 +72,8 @@ func (r *Router) loadForeignAllowlistView(ctx context.Context) (templates.Foreig
 		return view, err
 	}
 	view.Rows = make([]templates.ForeignAllowlistRow, 0, len(entries))
-	for _, e := range entries {
+	for i := range entries {
+		e := &entries[i]
 		view.Rows = append(view.Rows, templates.ForeignAllowlistRow{
 			ID:         e.ID,
 			Scope:      string(e.Scope),
@@ -157,11 +161,18 @@ func (r *Router) handleForeignFileAllowlist(w http.ResponseWriter, req *http.Req
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "loading foreign-file row"})
 		return
 	}
+	hash, err := resolveForeignHash(&entry)
+	if err != nil {
+		r.logger.Error("resolving content hash for allowlist", "id", id, "path", entry.FilePath, "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "resolving content hash"})
+		return
+	}
 	if err := r.foreignRepo.AddAllowlist(req.Context(), foreign.AllowlistEntry{
-		Scope:    foreign.ScopeArtist,
-		ArtistID: entry.ArtistID,
-		FileName: entry.FileName,
-		Note:     "added from foreign-files page",
+		Scope:       foreign.ScopeArtist,
+		ArtistID:    entry.ArtistID,
+		FileName:    entry.FileName,
+		ContentHash: hash,
+		Note:        "added from foreign-files page",
 	}); err != nil {
 		r.logger.Error("writing artist-scoped allowlist", "id", id, "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "writing allowlist"})
@@ -249,16 +260,25 @@ func (r *Router) handleForeignFilesDismiss(w http.ResponseWriter, req *http.Requ
 		return
 	}
 	seen := map[string]bool{}
-	for _, e := range entries {
-		key := strings.ToLower(e.FileName)
-		if seen[key] {
+	for i := range entries {
+		e := &entries[i]
+		hash, herr := resolveForeignHash(e)
+		if herr != nil {
+			// Skip-don't-clear: an unreadable file may be transient
+			// (perm flap, mid-write). Surface the failure so a chronic
+			// hash failure does not silently swallow every dismiss.
+			r.logger.Warn("dismiss content-hash resolve failed", "path", e.FilePath, "error", herr)
 			continue
 		}
-		seen[key] = true
+		if seen[hash] {
+			continue
+		}
+		seen[hash] = true
 		if err := r.foreignRepo.AddAllowlist(req.Context(), foreign.AllowlistEntry{
-			Scope:    foreign.ScopeGlobal,
-			FileName: e.FileName,
-			Note:     "bulk dismiss from banner",
+			Scope:       foreign.ScopeGlobal,
+			FileName:    e.FileName,
+			ContentHash: hash,
+			Note:        "bulk dismiss from banner",
 		}); err != nil {
 			// Skip the ledger delete on failure: clearing the row would hide
 			// the warning even though dismissal was not actually persisted,
@@ -380,7 +400,9 @@ func (r *Router) requireForeignAdmin(w http.ResponseWriter, req *http.Request) b
 }
 
 // foreignEntryToRow converts a domain entry to its template row shape.
-func foreignEntryToRow(e foreign.Entry) templates.ForeignFileRow {
+// Pointer receiver keeps copy cost minimal under gocritic's rangeValCopy
+// budget after Entry grew to include content_hash.
+func foreignEntryToRow(e *foreign.Entry) templates.ForeignFileRow {
 	return templates.ForeignFileRow{
 		ID:         e.ID,
 		ArtistID:   e.ArtistID,
@@ -390,4 +412,35 @@ func foreignEntryToRow(e foreign.Entry) templates.ForeignFileRow {
 		SizeBytes:  e.SizeBytes,
 		DetectedAt: e.DetectedAt.Format(time.RFC3339),
 	}
+}
+
+// resolveForeignHash returns the entry's stored content hash, or computes
+// it from disk when the row predates migration 008 and the column is empty.
+// Allowlist writes key on this value, so an empty hash would silently
+// produce duplicate rows under the partial-index WHERE clause and break
+// dedupe; rehashing on demand keeps the dismiss/allowlist paths correct
+// for legacy rows until the next scan refreshes the column. Pointer
+// receiver avoids the rangeValCopy lint hit on the dismiss loop.
+func resolveForeignHash(e *foreign.Entry) (string, error) {
+	if e.ContentHash != "" {
+		return e.ContentHash, nil
+	}
+	return hashFile(e.FilePath)
+}
+
+// hashFile streams the file at path through sha256 and returns the
+// lowercase hex digest. Mirrors the scanner's helper so the handler
+// package does not need to import internal/foreign just for the same
+// computation. Streaming avoids loading large files into memory.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path) //nolint:gosec // G304: path comes from a server-managed ledger row, not user input
+	if err != nil {
+		return "", fmt.Errorf("hash open: %w", err)
+	}
+	defer f.Close() //nolint:errcheck // read-only handle
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hash read: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/internal/api/handlers_foreign_files_test.go
+++ b/internal/api/handlers_foreign_files_test.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -17,6 +19,14 @@ import (
 	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/foreign"
 )
+
+// sha256HexAPI returns the lowercase hex sha256 of b. Mirrors the
+// foreign-package test helper so handler tests can pre-compute the hash
+// they expect the scanner / resolver to derive from on-disk bytes.
+func sha256HexAPI(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
 
 // newTestRouterWithForeign builds a Router with an initialized foreign-file
 // repo backed by an in-memory SQLite. Auth is intentionally omitted -- the
@@ -40,6 +50,7 @@ func newTestRouterWithForeign(t *testing.T) (*Router, *sql.DB) {
 			artist_id TEXT NOT NULL,
 			file_path TEXT NOT NULL,
 			file_name TEXT NOT NULL,
+			content_hash TEXT,
 			size_bytes INTEGER NOT NULL DEFAULT 0,
 			detected_at TEXT NOT NULL DEFAULT (datetime('now')),
 			UNIQUE(artist_id, file_path))`,
@@ -48,10 +59,15 @@ func newTestRouterWithForeign(t *testing.T) (*Router, *sql.DB) {
 			scope TEXT NOT NULL,
 			artist_id TEXT,
 			file_name TEXT NOT NULL,
+			content_hash TEXT,
 			note TEXT NOT NULL DEFAULT '',
 			created_at TEXT NOT NULL DEFAULT (datetime('now')))`,
-		`CREATE UNIQUE INDEX idx_foreign_allowlist_global ON foreign_file_allowlist(file_name) WHERE scope = 'global'`,
-		`CREATE UNIQUE INDEX idx_foreign_allowlist_artist ON foreign_file_allowlist(artist_id, file_name) WHERE scope = 'artist'`,
+		`CREATE UNIQUE INDEX idx_foreign_allowlist_global_hash
+			ON foreign_file_allowlist(content_hash)
+			WHERE scope = 'global' AND content_hash IS NOT NULL`,
+		`CREATE UNIQUE INDEX idx_foreign_allowlist_artist_hash
+			ON foreign_file_allowlist(artist_id, content_hash)
+			WHERE scope = 'artist' AND content_hash IS NOT NULL`,
 	} {
 		if _, err := db.Exec(s); err != nil {
 			t.Fatalf("schema: %v", err)
@@ -96,9 +112,15 @@ func TestHandleForeignFilesList(t *testing.T) {
 func TestHandleForeignFileAllowlist(t *testing.T) {
 	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
-	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','Aretha','/m/Aretha')`)
+	dir := t.TempDir()
+	target := filepath.Join(dir, "backdrop.jpg")
+	body := []byte("allowlist target bytes")
+	if err := os.WriteFile(target, body, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','Aretha',?)`, dir)
 	if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{
-		ArtistID: "a1", FilePath: "/m/Aretha/backdrop.jpg", FileName: "backdrop.jpg",
+		ArtistID: "a1", FilePath: target, FileName: "backdrop.jpg", ContentHash: sha256HexAPI(body),
 	}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -117,9 +139,9 @@ func TestHandleForeignFileAllowlist(t *testing.T) {
 	if count != 0 {
 		t.Errorf("ledger row should be cleared after allowlist; got %d", count)
 	}
-	allowed, _ := r.foreignRepo.IsAllowlisted(context.Background(), "a1", "backdrop.jpg")
+	allowed, _ := r.foreignRepo.IsAllowlisted(context.Background(), "a1", sha256HexAPI(body))
 	if !allowed {
-		t.Errorf("expected entry to be allowlisted")
+		t.Errorf("expected entry to be allowlisted by hash")
 	}
 
 	// 404 path: missing id.
@@ -170,7 +192,7 @@ func TestHandleForeignAllowlistRemove(t *testing.T) {
 	r, db := newTestRouterWithForeign(t)
 	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','Aretha','/m/Aretha')`)
 	if err := r.foreignRepo.AddAllowlist(context.Background(), foreign.AllowlistEntry{
-		Scope: foreign.ScopeGlobal, FileName: "fanart.jpg",
+		Scope: foreign.ScopeGlobal, FileName: "fanart.jpg", ContentHash: sha256HexAPI([]byte("fanart")),
 	}); err != nil {
 		t.Fatalf("AddAllowlist: %v", err)
 	}
@@ -203,7 +225,7 @@ func TestHandleForeignAllowlistList(t *testing.T) {
 	t.Parallel()
 	r, _ := newTestRouterWithForeign(t)
 	if err := r.foreignRepo.AddAllowlist(context.Background(), foreign.AllowlistEntry{
-		Scope: foreign.ScopeGlobal, FileName: "fanart.jpg",
+		Scope: foreign.ScopeGlobal, FileName: "fanart.jpg", ContentHash: sha256HexAPI([]byte("fanart")),
 	}); err != nil {
 		t.Fatalf("AddAllowlist: %v", err)
 	}
@@ -247,10 +269,16 @@ func TestForeignSummaryForBanner(t *testing.T) {
 func TestHandleForeignFilesDismiss(t *testing.T) {
 	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
-	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','x','/x')`)
+	dir := t.TempDir()
+	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','x',?)`, dir)
 	for _, fn := range []string{"backdrop.jpg", "fanart.jpg"} {
+		body := []byte("body-" + fn)
+		path := filepath.Join(dir, fn)
+		if err := os.WriteFile(path, body, 0o644); err != nil {
+			t.Fatalf("write %s: %v", fn, err)
+		}
 		if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{
-			ArtistID: "a1", FilePath: "/x/" + fn, FileName: fn,
+			ArtistID: "a1", FilePath: path, FileName: fn, ContentHash: sha256HexAPI(body),
 		}); err != nil {
 			t.Fatalf("seed %s: %v", fn, err)
 		}
@@ -374,20 +402,27 @@ func mustExec(t *testing.T, db *sql.DB, q string, args ...any) {
 func TestHandleForeignFile_RenderRefreshedTable_AfterRowActions(t *testing.T) {
 	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
-	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','Aretha','/m/Aretha')`)
-	dir := t.TempDir()
-	target := filepath.Join(dir, "backdrop.jpg")
-	if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {
-		t.Fatalf("write: %v", err)
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	bodyA := []byte("artist-A")
+	bodyB := []byte("artist-B")
+	targetA := filepath.Join(dirA, "backdrop.jpg")
+	targetB := filepath.Join(dirB, "backdrop.jpg")
+	if err := os.WriteFile(targetA, bodyA, 0o644); err != nil {
+		t.Fatalf("write A: %v", err)
 	}
-	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a2','Beth',?)`, dir)
+	if err := os.WriteFile(targetB, bodyB, 0o644); err != nil {
+		t.Fatalf("write B: %v", err)
+	}
+	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','Aretha',?)`, dirA)
+	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a2','Beth',?)`, dirB)
 	if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{
-		ArtistID: "a1", FilePath: "/m/Aretha/backdrop.jpg", FileName: "backdrop.jpg",
+		ArtistID: "a1", FilePath: targetA, FileName: "backdrop.jpg", ContentHash: sha256HexAPI(bodyA),
 	}); err != nil {
 		t.Fatalf("seed allowlist target: %v", err)
 	}
 	if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{
-		ArtistID: "a2", FilePath: target, FileName: "backdrop.jpg",
+		ArtistID: "a2", FilePath: targetB, FileName: "backdrop.jpg", ContentHash: sha256HexAPI(bodyB),
 	}); err != nil {
 		t.Fatalf("seed delete target: %v", err)
 	}
@@ -433,7 +468,7 @@ func TestHandleForeignAllowlistRemove_RendersRefreshedTable(t *testing.T) {
 	t.Parallel()
 	r, _ := newTestRouterWithForeign(t)
 	if err := r.foreignRepo.AddAllowlist(context.Background(), foreign.AllowlistEntry{
-		Scope: foreign.ScopeGlobal, FileName: "fanart.jpg",
+		Scope: foreign.ScopeGlobal, FileName: "fanart.jpg", ContentHash: sha256HexAPI([]byte("fanart")),
 	}); err != nil {
 		t.Fatalf("AddAllowlist: %v", err)
 	}
@@ -464,10 +499,16 @@ func TestHandleForeignAllowlistRemove_RendersRefreshedTable(t *testing.T) {
 func TestHandleForeignFilesDismiss_RendersSurvivingRows(t *testing.T) {
 	t.Parallel()
 	r, db := newTestRouterWithForeign(t)
-	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','x','/x')`)
+	dir := t.TempDir()
+	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','x',?)`, dir)
 	for _, fn := range []string{"backdrop.jpg", "fanart.jpg"} {
+		body := []byte("body-" + fn)
+		path := filepath.Join(dir, fn)
+		if err := os.WriteFile(path, body, 0o644); err != nil {
+			t.Fatalf("write %s: %v", fn, err)
+		}
 		if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{
-			ArtistID: "a1", FilePath: "/x/" + fn, FileName: fn,
+			ArtistID: "a1", FilePath: path, FileName: fn, ContentHash: sha256HexAPI(body),
 		}); err != nil {
 			t.Fatalf("seed %s: %v", fn, err)
 		}
@@ -604,7 +645,7 @@ func TestLoadForeignAllowlistView(t *testing.T) {
 	}
 
 	if err := r.foreignRepo.AddAllowlist(context.Background(), foreign.AllowlistEntry{
-		Scope: foreign.ScopeGlobal, FileName: "fanart.jpg", Note: "stock",
+		Scope: foreign.ScopeGlobal, FileName: "fanart.jpg", ContentHash: sha256HexAPI([]byte("fanart")), Note: "stock",
 	}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -732,5 +773,91 @@ func TestHandleForeignFile_RenderListErrorAfterMutation(t *testing.T) {
 	// "load foreign-file row for allowlist" logger.Error branch.
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("expected 500; got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleForeignFilesDismiss_SameBasenameDistinctBytes is the headline
+// behavior the migration is here to support: bulk dismiss creates one
+// allowlist row PER distinct content hash, so two "poster.jpg" files in
+// different artist directories with different bytes do not collide on a
+// single global allowlist row.
+func TestHandleForeignFilesDismiss_SameBasenameDistinctBytes(t *testing.T) {
+	t.Parallel()
+	r, db := newTestRouterWithForeign(t)
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	bodyA := []byte("artist-A poster")
+	bodyB := []byte("artist-B poster")
+	pathA := filepath.Join(dirA, "poster.jpg")
+	pathB := filepath.Join(dirB, "poster.jpg")
+	if err := os.WriteFile(pathA, bodyA, 0o644); err != nil {
+		t.Fatalf("write A: %v", err)
+	}
+	if err := os.WriteFile(pathB, bodyB, 0o644); err != nil {
+		t.Fatalf("write B: %v", err)
+	}
+	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','A',?), ('a2','B',?)`, dirA, dirB)
+	if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{
+		ArtistID: "a1", FilePath: pathA, FileName: "poster.jpg", ContentHash: sha256HexAPI(bodyA),
+	}); err != nil {
+		t.Fatalf("seed A: %v", err)
+	}
+	if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{
+		ArtistID: "a2", FilePath: pathB, FileName: "poster.jpg", ContentHash: sha256HexAPI(bodyB),
+	}); err != nil {
+		t.Fatalf("seed B: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/foreign-files/dismiss", nil)
+	rec := httptest.NewRecorder()
+	r.handleForeignFilesDismiss(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dismiss status: got %d", rec.Code)
+	}
+	rows, _ := r.foreignRepo.ListAllowlist(context.Background())
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 distinct global allowlist rows (one per content hash); got %d", len(rows))
+	}
+	// Each row should carry a distinct content_hash matching one of the
+	// seeded bodies. Sort-insensitive comparison via a set.
+	wantHashes := map[string]bool{sha256HexAPI(bodyA): true, sha256HexAPI(bodyB): true}
+	for _, row := range rows {
+		if !wantHashes[row.ContentHash] {
+			t.Errorf("unexpected content_hash %q on dismissed row", row.ContentHash)
+		}
+		if row.FileName != "poster.jpg" {
+			t.Errorf("expected file_name preserved as %q; got %q", "poster.jpg", row.FileName)
+		}
+	}
+}
+
+// TestResolveForeignHash_BackfillsFromDisk covers the on-demand rehash
+// path for pre-008 ledger rows whose content_hash column is empty. The
+// handler must recompute the digest from disk so the allowlist write
+// has a non-empty key.
+func TestResolveForeignHash_BackfillsFromDisk(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	body := []byte("backfill bytes")
+	target := filepath.Join(dir, "backdrop.jpg")
+	if err := os.WriteFile(target, body, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Legacy entry: ContentHash empty.
+	got, err := resolveForeignHash(&foreign.Entry{FilePath: target})
+	if err != nil {
+		t.Fatalf("resolveForeignHash: %v", err)
+	}
+	if got != sha256HexAPI(body) {
+		t.Errorf("backfilled hash = %q; want sha256(body)", got)
+	}
+	// Already-hashed entry: short-circuits without touching disk.
+	const sentinel = "sentinel-precomputed-hash"
+	got, err = resolveForeignHash(&foreign.Entry{FilePath: "/does/not/exist", ContentHash: sentinel})
+	if err != nil {
+		t.Fatalf("resolveForeignHash precomputed: %v", err)
+	}
+	if got != sentinel {
+		t.Errorf("expected stored hash to short-circuit; got %q", got)
 	}
 }

--- a/internal/api/handlers_foreign_files_test.go
+++ b/internal/api/handlers_foreign_files_test.go
@@ -821,12 +821,22 @@ func TestHandleForeignFilesDismiss_SameBasenameDistinctBytes(t *testing.T) {
 	// Each row should carry a distinct content_hash matching one of the
 	// seeded bodies. Sort-insensitive comparison via a set.
 	wantHashes := map[string]bool{sha256HexAPI(bodyA): true, sha256HexAPI(bodyB): true}
+	seenHashes := map[string]int{}
 	for _, row := range rows {
 		if !wantHashes[row.ContentHash] {
 			t.Errorf("unexpected content_hash %q on dismissed row", row.ContentHash)
 		}
+		seenHashes[row.ContentHash]++
 		if row.FileName != "poster.jpg" {
 			t.Errorf("expected file_name preserved as %q; got %q", "poster.jpg", row.FileName)
+		}
+	}
+	// Both distinct hashes must be persisted exactly once. The membership
+	// check above still passes if both rows accidentally reuse one hash;
+	// the per-hash count is what proves the bytes were keyed separately.
+	for want := range wantHashes {
+		if seenHashes[want] != 1 {
+			t.Errorf("content_hash %q persisted %d times; want exactly 1", want, seenHashes[want])
 		}
 	}
 }
@@ -859,5 +869,12 @@ func TestResolveForeignHash_BackfillsFromDisk(t *testing.T) {
 	}
 	if got != sentinel {
 		t.Errorf("expected stored hash to short-circuit; got %q", got)
+	}
+	// Legacy entry whose file is gone: the on-demand rehash must fail
+	// loudly rather than return an empty hash that would later produce a
+	// malformed allowlist row.
+	got, err = resolveForeignHash(&foreign.Entry{FilePath: filepath.Join(dir, "missing.jpg")})
+	if err == nil {
+		t.Errorf("expected error for empty hash with missing file; got hash %q", got)
 	}
 }

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -10866,10 +10866,11 @@ paths:
     post:
       summary: Bulk allowlist every active foreign file globally
       description: |
-        Inserts a global-scope allowlist row for every distinct file_name
+        Inserts a global-scope allowlist row for every distinct content_hash
         currently in the foreign_files ledger and clears the ledger.
-        Subsequent scans suppress those names across every artist. Returns
-        the re-rendered conflict banner so HTMX can swap it in place.
+        Subsequent scans suppress matching byte content across every artist
+        (file_name is display-only). Returns the re-rendered conflict banner
+        so HTMX can swap it in place.
       operationId: dismissForeignFiles
       tags:
         - Foreign Files
@@ -10909,7 +10910,7 @@ paths:
       summary: Allowlist a single ledger row (artist-scoped)
       description: |
         Adds an artist-scoped allowlist entry matching (entry.artist_id,
-        entry.file_name) and removes the ledger row. The file remains on
+        entry.content_hash) and removes the ledger row. The file remains on
         disk; future scans will not re-record it for that artist.
       operationId: allowlistForeignFile
       tags:
@@ -11058,7 +11059,8 @@ paths:
       summary: Remove an allowlist entry
       description: |
         Removes an allowlist row, re-enabling foreign-file detection for the
-        matching file_name (artist-scoped or global, depending on the row).
+        matching content_hash (artist-scoped or global, depending on the row).
+        file_name is not part of matching semantics.
       operationId: removeForeignFileAllowlist
       tags:
         - Foreign Files

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -10913,7 +10913,8 @@ paths:
         Adds an artist-scoped allowlist entry matching (entry.artist_id,
         resolved content_hash) and removes the ledger row; the hash is the
         stored value when present, otherwise hashed from file bytes for
-        legacy rows. The file remains on disk; future scans will not
+        legacy rows. file_name is display-only and not part of matching
+        semantics. The file remains on disk; future scans will not
         re-record it for that artist.
       operationId: allowlistForeignFile
       tags:

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1636,20 +1636,30 @@ components:
         file_name:
           type: string
           description: Basename, e.g. "backdrop.jpg".
+        content_hash:
+          type: string
+          description: |
+            Lowercase hex sha256 of the file's bytes. Used as the dedupe
+            key for allowlisting so two files sharing a basename but with
+            different byte content can each be allowlisted independently.
+            Empty for rows recorded before migration 008; the scanner
+            backfills on the next pass.
         size_bytes:
           type: integer
           format: int64
         detected_at:
           type: string
           format: date-time
-      required: [id, artist_id, artist_name, file_path, file_name, size_bytes, detected_at]
+      required: [id, artist_id, artist_name, file_path, file_name, content_hash, size_bytes, detected_at]
 
     ForeignAllowlistEntry:
       type: object
       description: |
         One row in the foreign_file_allowlist table. scope=global matches
         every artist (artist_id is empty); scope=artist matches a specific
-        artist (artist_id required).
+        artist (artist_id required). Matching keys on content_hash so
+        identical byte sequences cannot be allowlisted twice in the same
+        scope; file_name is preserved for human readability in the UI.
       properties:
         id:
           type: string
@@ -1662,12 +1672,18 @@ components:
           type: string
         file_name:
           type: string
+        content_hash:
+          type: string
+          description: |
+            Lowercase hex sha256 of the allowlisted byte sequence; the
+            dedupe key. Empty only for legacy rows that have not yet been
+            rewritten by an allowlist mutation against the new schema.
         note:
           type: string
         created_at:
           type: string
           format: date-time
-      required: [id, scope, file_name, note, created_at]
+      required: [id, scope, file_name, content_hash, note, created_at]
 
 paths:
   /health:

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -10866,11 +10866,12 @@ paths:
     post:
       summary: Bulk allowlist every active foreign file globally
       description: |
-        Inserts a global-scope allowlist row for every distinct content_hash
-        currently in the foreign_files ledger and clears the ledger.
-        Subsequent scans suppress matching byte content across every artist
-        (file_name is display-only). Returns the re-rendered conflict banner
-        so HTMX can swap it in place.
+        Inserts a global-scope allowlist row for every distinct resolved
+        content_hash across active foreign_files entries (the stored hash
+        when present, otherwise hashed from file bytes for legacy rows) and
+        clears the ledger. Subsequent scans suppress matching byte content
+        across every artist (file_name is display-only). Returns the
+        re-rendered conflict banner so HTMX can swap it in place.
       operationId: dismissForeignFiles
       tags:
         - Foreign Files
@@ -10910,8 +10911,10 @@ paths:
       summary: Allowlist a single ledger row (artist-scoped)
       description: |
         Adds an artist-scoped allowlist entry matching (entry.artist_id,
-        entry.content_hash) and removes the ledger row. The file remains on
-        disk; future scans will not re-record it for that artist.
+        resolved content_hash) and removes the ledger row; the hash is the
+        stored value when present, otherwise hashed from file bytes for
+        legacy rows. The file remains on disk; future scans will not
+        re-record it for that artist.
       operationId: allowlistForeignFile
       tags:
         - Foreign Files

--- a/internal/database/migrations/008_foreign_files_content_hash.sql
+++ b/internal/database/migrations/008_foreign_files_content_hash.sql
@@ -1,0 +1,44 @@
+-- +goose Up
+-- Adds content_hash to foreign_files and foreign_file_allowlist so
+-- detection and allowlisting key on the file's byte sequence (sha256 hex)
+-- rather than its basename. Two distinct files that happen to share a
+-- name like "poster.jpg" are no longer conflated when one is allowlisted.
+--
+-- content_hash is nullable: pre-existing rows have no hash recorded and
+-- are populated lazily on the first post-migration scan (the scanner
+-- recomputes the hash from disk and updates the row via UPSERT). Rows
+-- written by every code path after this migration always carry the hash.
+
+ALTER TABLE foreign_files ADD COLUMN content_hash TEXT;
+ALTER TABLE foreign_file_allowlist ADD COLUMN content_hash TEXT;
+
+-- Re-detection lookup index: scoped queries match (scope, artist_id,
+-- content_hash) so the per-file scan path stays cheap.
+CREATE INDEX IF NOT EXISTS idx_foreign_allowlist_hash
+    ON foreign_file_allowlist(scope, artist_id, content_hash);
+
+-- Partial unique indexes pinned to content_hash so identical byte
+-- sequences cannot be allowlisted twice in the same scope. file_name is
+-- still stored on the row for human readability in the UI but no longer
+-- participates in dedupe. The old file_name unique indexes are dropped
+-- so two distinct files sharing a basename can each have their own row.
+DROP INDEX IF EXISTS idx_foreign_allowlist_global;
+DROP INDEX IF EXISTS idx_foreign_allowlist_artist;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_foreign_allowlist_global_hash
+    ON foreign_file_allowlist(content_hash)
+    WHERE scope = 'global' AND content_hash IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_foreign_allowlist_artist_hash
+    ON foreign_file_allowlist(artist_id, content_hash)
+    WHERE scope = 'artist' AND content_hash IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_foreign_allowlist_artist_hash;
+DROP INDEX IF EXISTS idx_foreign_allowlist_global_hash;
+DROP INDEX IF EXISTS idx_foreign_allowlist_hash;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_foreign_allowlist_global
+    ON foreign_file_allowlist(file_name) WHERE scope = 'global';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_foreign_allowlist_artist
+    ON foreign_file_allowlist(artist_id, file_name) WHERE scope = 'artist';
+-- SQLite cannot drop columns prior to 3.35; the columns remain in place
+-- on rollback, which is benign because the new readers ignore unknown
+-- columns and the old readers never reference content_hash.

--- a/internal/foreign/model.go
+++ b/internal/foreign/model.go
@@ -16,15 +16,20 @@ import "time"
 
 // Entry is one foreign file detected in an artist directory. The record is
 // keyed by (artist_id, file_path) so re-detecting the same file is a no-op
-// at the DB layer (UPSERT in repository.go).
+// at the DB layer (UPSERT in repository.go). ContentHash is the lowercase
+// hex sha256 of the file's bytes; allowlist matching keys on it so two
+// distinct files sharing a basename like "poster.jpg" no longer collide.
+// Rows recorded before migration 008 may carry an empty hash and are
+// backfilled on the first post-migration scan.
 type Entry struct {
-	ID         string    `json:"id"`
-	ArtistID   string    `json:"artist_id"`
-	ArtistName string    `json:"artist_name,omitempty"`
-	FilePath   string    `json:"file_path"`
-	FileName   string    `json:"file_name"`
-	SizeBytes  int64     `json:"size_bytes"`
-	DetectedAt time.Time `json:"detected_at"`
+	ID          string    `json:"id"`
+	ArtistID    string    `json:"artist_id"`
+	ArtistName  string    `json:"artist_name,omitempty"`
+	FilePath    string    `json:"file_path"`
+	FileName    string    `json:"file_name"`
+	ContentHash string    `json:"content_hash"`
+	SizeBytes   int64     `json:"size_bytes"`
+	DetectedAt  time.Time `json:"detected_at"`
 }
 
 // AllowlistScope identifies whether an allowlist row matches every artist
@@ -40,15 +45,19 @@ const (
 // AllowlistEntry is one row of the permanent re-detection suppression list.
 // For ScopeGlobal entries ArtistID is empty and the row matches every
 // artist; for ScopeArtist entries ArtistID is required and the row matches
-// only that artist. FileName is the basename (e.g. "backdrop.jpg").
+// only that artist. ContentHash (lowercase hex sha256) is the dedupe key
+// so two distinct files sharing a basename can each be allowlisted
+// independently. FileName is preserved on the row for human readability in
+// the UI but does not participate in matching.
 type AllowlistEntry struct {
-	ID         string         `json:"id"`
-	Scope      AllowlistScope `json:"scope"`
-	ArtistID   string         `json:"artist_id,omitempty"`
-	ArtistName string         `json:"artist_name,omitempty"`
-	FileName   string         `json:"file_name"`
-	Note       string         `json:"note,omitempty"`
-	CreatedAt  time.Time      `json:"created_at"`
+	ID          string         `json:"id"`
+	Scope       AllowlistScope `json:"scope"`
+	ArtistID    string         `json:"artist_id,omitempty"`
+	ArtistName  string         `json:"artist_name,omitempty"`
+	FileName    string         `json:"file_name"`
+	ContentHash string         `json:"content_hash"`
+	Note        string         `json:"note,omitempty"`
+	CreatedAt   time.Time      `json:"created_at"`
 }
 
 // Summary aggregates current foreign-file ledger counts for the banner. A

--- a/internal/foreign/repository.go
+++ b/internal/foreign/repository.go
@@ -27,6 +27,8 @@ var ErrNotFound = errors.New("foreign: not found")
 
 // Upsert records (or refreshes the detected_at on) a foreign-file entry.
 // Idempotent on (artist_id, file_path) so re-scans never duplicate rows.
+// content_hash may be empty for pre-008 rows; the scanner backfills it on
+// the next pass via this same upsert path.
 func (r *Repository) Upsert(ctx context.Context, e Entry) error {
 	if e.ArtistID == "" || e.FilePath == "" || e.FileName == "" {
 		return fmt.Errorf("foreign: upsert requires artist_id, file_path, file_name")
@@ -37,14 +39,19 @@ func (r *Repository) Upsert(ctx context.Context, e Entry) error {
 	if e.DetectedAt.IsZero() {
 		e.DetectedAt = time.Now().UTC()
 	}
+	var hashArg interface{}
+	if e.ContentHash != "" {
+		hashArg = e.ContentHash
+	}
 	_, err := r.db.ExecContext(ctx, `
-		INSERT INTO foreign_files (id, artist_id, file_path, file_name, size_bytes, detected_at)
-		VALUES (?, ?, ?, ?, ?, ?)
+		INSERT INTO foreign_files (id, artist_id, file_path, file_name, content_hash, size_bytes, detected_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(artist_id, file_path) DO UPDATE SET
-			file_name   = excluded.file_name,
-			size_bytes  = excluded.size_bytes,
-			detected_at = excluded.detected_at`,
-		e.ID, e.ArtistID, e.FilePath, e.FileName, e.SizeBytes, e.DetectedAt.UTC().Format(time.RFC3339))
+			file_name    = excluded.file_name,
+			content_hash = excluded.content_hash,
+			size_bytes   = excluded.size_bytes,
+			detected_at  = excluded.detected_at`,
+		e.ID, e.ArtistID, e.FilePath, e.FileName, hashArg, e.SizeBytes, e.DetectedAt.UTC().Format(time.RFC3339))
 	if err != nil {
 		return fmt.Errorf("foreign: upsert: %w", err)
 	}
@@ -89,11 +96,12 @@ func (r *Repository) GetByID(ctx context.Context, id string) (Entry, error) {
 	var detected string
 	var artistName sql.NullString
 	err := r.db.QueryRowContext(ctx, `
-		SELECT f.id, f.artist_id, f.file_path, f.file_name, f.size_bytes, f.detected_at,
+		SELECT f.id, f.artist_id, f.file_path, f.file_name,
+		       COALESCE(f.content_hash, ''), f.size_bytes, f.detected_at,
 		       a.name
 		FROM foreign_files f
 		LEFT JOIN artists a ON a.id = f.artist_id
-		WHERE f.id = ?`, id).Scan(&e.ID, &e.ArtistID, &e.FilePath, &e.FileName, &e.SizeBytes, &detected, &artistName)
+		WHERE f.id = ?`, id).Scan(&e.ID, &e.ArtistID, &e.FilePath, &e.FileName, &e.ContentHash, &e.SizeBytes, &detected, &artistName)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return Entry{}, ErrNotFound
@@ -113,7 +121,8 @@ func (r *Repository) GetByID(ctx context.Context, id string) (Entry, error) {
 // by artist then file path so the UI rendering is stable across reloads.
 func (r *Repository) List(ctx context.Context) ([]Entry, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT f.id, f.artist_id, f.file_path, f.file_name, f.size_bytes, f.detected_at,
+		SELECT f.id, f.artist_id, f.file_path, f.file_name,
+		       COALESCE(f.content_hash, ''), f.size_bytes, f.detected_at,
 		       a.name
 		FROM foreign_files f
 		LEFT JOIN artists a ON a.id = f.artist_id
@@ -127,7 +136,7 @@ func (r *Repository) List(ctx context.Context) ([]Entry, error) {
 		var e Entry
 		var detected string
 		var artistName sql.NullString
-		if err := rows.Scan(&e.ID, &e.ArtistID, &e.FilePath, &e.FileName, &e.SizeBytes, &detected, &artistName); err != nil {
+		if err := rows.Scan(&e.ID, &e.ArtistID, &e.FilePath, &e.FileName, &e.ContentHash, &e.SizeBytes, &detected, &artistName); err != nil {
 			return nil, fmt.Errorf("foreign: scan list row: %w", err)
 		}
 		if t, perr := time.Parse(time.RFC3339, detected); perr == nil {
@@ -154,18 +163,22 @@ func (r *Repository) Count(ctx context.Context) (int, error) {
 	return n, nil
 }
 
-// IsAllowlisted reports whether (artistID, fileName) is suppressed from
-// re-detection by either an artist-scoped or global allowlist row. Both
-// scopes are checked in one query so this stays cheap inside the per-file
-// scanner loop.
-func (r *Repository) IsAllowlisted(ctx context.Context, artistID, fileName string) (bool, error) {
-	fileName = strings.ToLower(fileName)
+// IsAllowlisted reports whether (artistID, contentHash) is suppressed from
+// re-detection by either an artist-scoped or global allowlist row. Matching
+// is on byte content (sha256 hex) so two distinct files sharing a basename
+// no longer collide. An empty contentHash never matches; the scanner
+// rehashes on demand for pre-008 rows so the input is well-formed by the
+// time this is called.
+func (r *Repository) IsAllowlisted(ctx context.Context, artistID, contentHash string) (bool, error) {
+	if contentHash == "" {
+		return false, nil
+	}
 	var n int
 	err := r.db.QueryRowContext(ctx, `
 		SELECT COUNT(*) FROM foreign_file_allowlist
-		WHERE LOWER(file_name) = ?
+		WHERE content_hash = ?
 		  AND (scope = 'global' OR (scope = 'artist' AND artist_id = ?))`,
-		fileName, artistID).Scan(&n)
+		contentHash, artistID).Scan(&n)
 	if err != nil {
 		return false, fmt.Errorf("foreign: allowlist check: %w", err)
 	}
@@ -175,9 +188,14 @@ func (r *Repository) IsAllowlisted(ctx context.Context, artistID, fileName strin
 // AddAllowlist inserts an allowlist row. ArtistID must be non-empty when
 // scope is "artist" and empty when scope is "global"; the writer rejects
 // the inverse combinations to keep the partial unique indexes sound.
+// ContentHash is required: dedupe keys on it, so an empty hash would
+// silently produce duplicate rows under the partial-index WHERE clauses.
 func (r *Repository) AddAllowlist(ctx context.Context, e AllowlistEntry) error {
 	if e.FileName == "" {
 		return fmt.Errorf("foreign: allowlist requires file_name")
+	}
+	if e.ContentHash == "" {
+		return fmt.Errorf("foreign: allowlist requires content_hash")
 	}
 	switch e.Scope {
 	case ScopeGlobal:
@@ -202,9 +220,9 @@ func (r *Repository) AddAllowlist(ctx context.Context, e AllowlistEntry) error {
 		artistArg = e.ArtistID
 	}
 	_, err := r.db.ExecContext(ctx, `
-		INSERT INTO foreign_file_allowlist (id, scope, artist_id, file_name, note, created_at)
-		VALUES (?, ?, ?, ?, ?, ?)`,
-		e.ID, string(e.Scope), artistArg, strings.ToLower(e.FileName), e.Note, e.CreatedAt.UTC().Format(time.RFC3339))
+		INSERT INTO foreign_file_allowlist (id, scope, artist_id, file_name, content_hash, note, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		e.ID, string(e.Scope), artistArg, strings.ToLower(e.FileName), e.ContentHash, e.Note, e.CreatedAt.UTC().Format(time.RFC3339))
 	if err != nil {
 		// Treat unique-constraint failures as benign so callers (e.g. the
 		// banner Dismiss bulk action) can replay safely without surfacing
@@ -254,7 +272,8 @@ func (r *Repository) RemoveAllowlist(ctx context.Context, id string) error {
 // can render the artist name in the management page.
 func (r *Repository) ListAllowlist(ctx context.Context) ([]AllowlistEntry, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT al.id, al.scope, COALESCE(al.artist_id, ''), al.file_name, al.note, al.created_at,
+		SELECT al.id, al.scope, COALESCE(al.artist_id, ''), al.file_name,
+		       COALESCE(al.content_hash, ''), al.note, al.created_at,
 		       COALESCE(a.name, '')
 		FROM foreign_file_allowlist al
 		LEFT JOIN artists a ON a.id = al.artist_id
@@ -267,7 +286,7 @@ func (r *Repository) ListAllowlist(ctx context.Context) ([]AllowlistEntry, error
 	for rows.Next() {
 		var e AllowlistEntry
 		var scope, created string
-		if err := rows.Scan(&e.ID, &scope, &e.ArtistID, &e.FileName, &e.Note, &created, &e.ArtistName); err != nil {
+		if err := rows.Scan(&e.ID, &scope, &e.ArtistID, &e.FileName, &e.ContentHash, &e.Note, &created, &e.ArtistName); err != nil {
 			return nil, fmt.Errorf("foreign: scan allowlist row: %w", err)
 		}
 		e.Scope = AllowlistScope(scope)

--- a/internal/foreign/repository.go
+++ b/internal/foreign/repository.go
@@ -48,7 +48,7 @@ func (r *Repository) Upsert(ctx context.Context, e Entry) error {
 		VALUES (?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(artist_id, file_path) DO UPDATE SET
 			file_name    = excluded.file_name,
-			content_hash = excluded.content_hash,
+			content_hash = COALESCE(excluded.content_hash, foreign_files.content_hash),
 			size_bytes   = excluded.size_bytes,
 			detected_at  = excluded.detected_at`,
 		e.ID, e.ArtistID, e.FilePath, e.FileName, hashArg, e.SizeBytes, e.DetectedAt.UTC().Format(time.RFC3339))
@@ -222,7 +222,7 @@ func (r *Repository) AddAllowlist(ctx context.Context, e AllowlistEntry) error {
 	_, err := r.db.ExecContext(ctx, `
 		INSERT INTO foreign_file_allowlist (id, scope, artist_id, file_name, content_hash, note, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		e.ID, string(e.Scope), artistArg, strings.ToLower(e.FileName), e.ContentHash, e.Note, e.CreatedAt.UTC().Format(time.RFC3339))
+		e.ID, string(e.Scope), artistArg, e.FileName, e.ContentHash, e.Note, e.CreatedAt.UTC().Format(time.RFC3339))
 	if err != nil {
 		// Treat unique-constraint failures as benign so callers (e.g. the
 		// banner Dismiss bulk action) can replay safely without surfacing

--- a/internal/foreign/scanner.go
+++ b/internal/foreign/scanner.go
@@ -210,6 +210,22 @@ func (s *Scanner) scanArtist(ctx context.Context, a artist.Artist) (int, int, in
 		}
 		fullPath := filepath.Join(a.Path, name)
 
+		// Provenance is checked before hashing: a Stillwater-managed
+		// image is not foreign and never reaches the allowlist, so on a
+		// steady-state library this skips a full-file read for the
+		// common case.
+		meta, err := img.ReadProvenance(fullPath)
+		if err != nil {
+			s.logger.Debug("read provenance failed; skipping",
+				slog.String("path", fullPath),
+				slog.Any("error", err))
+			continue
+		}
+		if meta != nil {
+			// Has Stillwater provenance -- not foreign.
+			continue
+		}
+
 		// Hash is computed before the allowlist check because the
 		// allowlist now keys on byte content rather than basename. If
 		// hashing fails (permission, partial write) we skip the file
@@ -232,18 +248,6 @@ func (s *Scanner) scanArtist(ctx context.Context, a artist.Artist) (int, int, in
 			continue
 		}
 		if allowed {
-			continue
-		}
-
-		meta, err := img.ReadProvenance(fullPath)
-		if err != nil {
-			s.logger.Debug("read provenance failed; skipping",
-				slog.String("path", fullPath),
-				slog.Any("error", err))
-			continue
-		}
-		if meta != nil {
-			// Has Stillwater provenance -- not foreign.
 			continue
 		}
 
@@ -393,11 +397,11 @@ func (s *Scanner) listForArtist(ctx context.Context, artistID string) ([]Entry, 
 	return out, rows.Err()
 }
 
-// hashFile returns the lowercase hex sha256 of the file at path. Used by
-// the scanner to key allowlist matching on byte content rather than
-// basename, and by the handlers when an old ledger row predates migration
-// 008 and needs a hash computed on demand. Reading is streamed so very
-// large foreign files do not balloon scanner memory.
+// hashFile returns the lowercase hex sha256 of the file at path. The
+// scanner uses it to key allowlist matching on byte content rather than
+// basename, and to rehash legacy rows that predate migration 008 during
+// reconciliation. Reading is streamed so very large foreign files do not
+// balloon scanner memory.
 func hashFile(path string) (string, error) {
 	f, err := os.Open(path) //nolint:gosec // G304: path is built from artist directory + DirEntry name, both server-controlled
 	if err != nil {

--- a/internal/foreign/scanner.go
+++ b/internal/foreign/scanner.go
@@ -2,8 +2,11 @@ package foreign
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -207,7 +210,20 @@ func (s *Scanner) scanArtist(ctx context.Context, a artist.Artist) (int, int, in
 		}
 		fullPath := filepath.Join(a.Path, name)
 
-		allowed, err := s.repo.IsAllowlisted(ctx, a.ID, name)
+		// Hash is computed before the allowlist check because the
+		// allowlist now keys on byte content rather than basename. If
+		// hashing fails (permission, partial write) we skip the file
+		// silently; re-detection on the next scan catches it once the
+		// file is readable.
+		hash, err := hashFile(fullPath)
+		if err != nil {
+			s.logger.Debug("hash file failed; skipping",
+				slog.String("path", fullPath),
+				slog.Any("error", err))
+			continue
+		}
+
+		allowed, err := s.repo.IsAllowlisted(ctx, a.ID, hash)
 		if err != nil {
 			s.logger.Warn("allowlist check failed; skipping file",
 				slog.String("artist_id", a.ID),
@@ -221,9 +237,6 @@ func (s *Scanner) scanArtist(ctx context.Context, a artist.Artist) (int, int, in
 
 		meta, err := img.ReadProvenance(fullPath)
 		if err != nil {
-			// Could not read the file (permission, partial write); skip
-			// silently rather than recording a noisy row. Re-detection on
-			// the next scan will catch it once the file is readable.
 			s.logger.Debug("read provenance failed; skipping",
 				slog.String("path", fullPath),
 				slog.Any("error", err))
@@ -239,11 +252,12 @@ func (s *Scanner) scanArtist(ctx context.Context, a artist.Artist) (int, int, in
 			size = info.Size()
 		}
 		entry := Entry{
-			ArtistID:   a.ID,
-			FilePath:   fullPath,
-			FileName:   name,
-			SizeBytes:  size,
-			DetectedAt: time.Now().UTC(),
+			ArtistID:    a.ID,
+			FilePath:    fullPath,
+			FileName:    name,
+			ContentHash: hash,
+			SizeBytes:   size,
+			DetectedAt:  time.Now().UTC(),
 		}
 		if err := s.repo.Upsert(ctx, entry); err != nil {
 			s.logger.Warn("upsert foreign-file entry",
@@ -266,13 +280,32 @@ func (s *Scanner) scanArtist(ctx context.Context, a artist.Artist) (int, int, in
 		return recorded, 0, 0
 	}
 	cleared := 0
-	for _, ex := range existing {
+	for i := range existing {
+		ex := &existing[i]
 		if _, present := onDisk[ex.FileName]; present {
 			// Still on disk; only clear if it has gained provenance OR is
 			// now allowlisted. Both already filtered above (we would have
 			// continued before upserting), but the row may pre-date the
 			// fix, so re-evaluate here.
-			allowed, err := s.repo.IsAllowlisted(ctx, a.ID, ex.FileName)
+			//
+			// Allowlist matching keys on content_hash. Pre-008 rows may
+			// have an empty hash; backfill by rehashing on demand so the
+			// allowlist check has a key to compare against. The next
+			// upsert path (above) writes the hash back so subsequent
+			// scans skip the rehash.
+			hash := ex.ContentHash
+			if hash == "" {
+				h, herr := hashFile(ex.FilePath)
+				if herr != nil {
+					s.logger.Debug("rehash for reconcile failed; leaving row in place",
+						slog.String("artist_id", a.ID),
+						slog.String("file_path", ex.FilePath),
+						slog.Any("error", herr))
+					continue
+				}
+				hash = h
+			}
+			allowed, err := s.repo.IsAllowlisted(ctx, a.ID, hash)
 			if err != nil {
 				// Skip this row; leaving it in place is correct under the
 				// skip-don't-clear policy, but the failure must be visible
@@ -337,7 +370,7 @@ func (s *Scanner) scanArtist(ctx context.Context, a artist.Artist) (int, int, in
 // the listing predicate stays close to the only caller that needs it.
 func (s *Scanner) listForArtist(ctx context.Context, artistID string) ([]Entry, error) {
 	rows, err := s.repo.db.QueryContext(ctx,
-		`SELECT id, artist_id, file_path, file_name, size_bytes, detected_at
+		`SELECT id, artist_id, file_path, file_name, COALESCE(content_hash, ''), size_bytes, detected_at
 		   FROM foreign_files WHERE artist_id = ?`, artistID)
 	if err != nil {
 		return nil, fmt.Errorf("listing artist foreign files: %w", err)
@@ -347,7 +380,7 @@ func (s *Scanner) listForArtist(ctx context.Context, artistID string) ([]Entry, 
 	for rows.Next() {
 		var e Entry
 		var detected string
-		if err := rows.Scan(&e.ID, &e.ArtistID, &e.FilePath, &e.FileName, &e.SizeBytes, &detected); err != nil {
+		if err := rows.Scan(&e.ID, &e.ArtistID, &e.FilePath, &e.FileName, &e.ContentHash, &e.SizeBytes, &detected); err != nil {
 			return nil, fmt.Errorf("scanning artist foreign file row: %w", err)
 		}
 		// Mirror Repository.GetByID/List parsing so DetectedAt is populated
@@ -358,6 +391,24 @@ func (s *Scanner) listForArtist(ctx context.Context, artistID string) ([]Entry, 
 		out = append(out, e)
 	}
 	return out, rows.Err()
+}
+
+// hashFile returns the lowercase hex sha256 of the file at path. Used by
+// the scanner to key allowlist matching on byte content rather than
+// basename, and by the handlers when an old ledger row predates migration
+// 008 and needs a hash computed on demand. Reading is streamed so very
+// large foreign files do not balloon scanner memory.
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path) //nolint:gosec // G304: path is built from artist directory + DirEntry name, both server-controlled
+	if err != nil {
+		return "", fmt.Errorf("hash open: %w", err)
+	}
+	defer f.Close() //nolint:errcheck // read-only handle
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("hash read: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // StartScheduler runs the scan on a fixed interval (after startupDelay) until

--- a/internal/foreign/scanner_test.go
+++ b/internal/foreign/scanner_test.go
@@ -2,7 +2,9 @@ package foreign
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"errors"
 	"log/slog"
 	"os"
@@ -15,6 +17,15 @@ import (
 
 	"github.com/sydlexius/stillwater/internal/artist"
 )
+
+// sha256Hex returns the lowercase hex sha256 of b. Used by tests to
+// pre-compute the content hash that the scanner would compute at runtime,
+// so allowlist seeding can match the same hash the scanner derives from
+// the on-disk file.
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
 
 // stubArtistLister returns a fixed artist list to the scanner, paginated to
 // match the artist.ListParams interface used by Scanner.Scan.
@@ -38,7 +49,8 @@ func newTestDB(t *testing.T) *sql.DB {
 	db.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = db.Close() })
 	// Minimal schema needed by the tests: artists + foreign_files +
-	// foreign_file_allowlist mirrored from 001_initial_schema.sql.
+	// foreign_file_allowlist mirrored from 001_initial_schema.sql plus
+	// migration 008 (content_hash column + hash-keyed unique indexes).
 	stmts := []string{
 		`CREATE TABLE artists (id TEXT PRIMARY KEY, name TEXT NOT NULL DEFAULT '', path TEXT NOT NULL DEFAULT '')`,
 		`CREATE TABLE foreign_files (
@@ -46,6 +58,7 @@ func newTestDB(t *testing.T) *sql.DB {
 			artist_id TEXT NOT NULL,
 			file_path TEXT NOT NULL,
 			file_name TEXT NOT NULL,
+			content_hash TEXT,
 			size_bytes INTEGER NOT NULL DEFAULT 0,
 			detected_at TEXT NOT NULL DEFAULT (datetime('now')),
 			UNIQUE(artist_id, file_path))`,
@@ -54,12 +67,15 @@ func newTestDB(t *testing.T) *sql.DB {
 			scope TEXT NOT NULL,
 			artist_id TEXT,
 			file_name TEXT NOT NULL,
+			content_hash TEXT,
 			note TEXT NOT NULL DEFAULT '',
 			created_at TEXT NOT NULL DEFAULT (datetime('now')))`,
-		`CREATE UNIQUE INDEX idx_foreign_allowlist_global
-			ON foreign_file_allowlist(file_name) WHERE scope = 'global'`,
-		`CREATE UNIQUE INDEX idx_foreign_allowlist_artist
-			ON foreign_file_allowlist(artist_id, file_name) WHERE scope = 'artist'`,
+		`CREATE UNIQUE INDEX idx_foreign_allowlist_global_hash
+			ON foreign_file_allowlist(content_hash)
+			WHERE scope = 'global' AND content_hash IS NOT NULL`,
+		`CREATE UNIQUE INDEX idx_foreign_allowlist_artist_hash
+			ON foreign_file_allowlist(artist_id, content_hash)
+			WHERE scope = 'artist' AND content_hash IS NOT NULL`,
 	}
 	for _, s := range stmts {
 		if _, err := db.Exec(s); err != nil {
@@ -134,13 +150,14 @@ func TestScanner_RespectsAllowlist(t *testing.T) {
 	repo := NewRepository(db)
 
 	dir := t.TempDir()
-	mustWrite(t, filepath.Join(dir, "fanart.jpg"), []byte("not a real image"))
+	body := []byte("not a real image")
+	mustWrite(t, filepath.Join(dir, "fanart.jpg"), body)
 
 	if _, err := db.Exec(`INSERT INTO artists (id, name, path) VALUES (?, ?, ?)`, "a1", "Test Artist", dir); err != nil {
 		t.Fatalf("insert artist: %v", err)
 	}
 	if err := repo.AddAllowlist(context.Background(), AllowlistEntry{
-		Scope: ScopeGlobal, FileName: "fanart.jpg",
+		Scope: ScopeGlobal, FileName: "fanart.jpg", ContentHash: sha256Hex(body),
 	}); err != nil {
 		t.Fatalf("AddAllowlist: %v", err)
 	}
@@ -191,36 +208,50 @@ func TestRepository_AllowlistScopes(t *testing.T) {
 	db := newTestDB(t)
 	repo := NewRepository(db)
 	ctx := context.Background()
+	hashA := sha256Hex([]byte("file-A bytes"))
 
 	// global rejects artist_id.
-	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeGlobal, ArtistID: "a1", FileName: "x.jpg"}); err == nil {
+	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeGlobal, ArtistID: "a1", FileName: "x.jpg", ContentHash: hashA}); err == nil {
 		t.Error("expected global+artist_id to be rejected")
 	}
 	// artist requires artist_id.
-	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeArtist, FileName: "x.jpg"}); err == nil {
+	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeArtist, FileName: "x.jpg", ContentHash: hashA}); err == nil {
 		t.Error("expected artist scope without artist_id to be rejected")
 	}
-	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeArtist, ArtistID: "a1", FileName: "Backdrop.JPG"}); err != nil {
+	// content_hash is required.
+	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeArtist, ArtistID: "a1", FileName: "x.jpg"}); err == nil {
+		t.Error("expected missing content_hash to be rejected")
+	}
+	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeArtist, ArtistID: "a1", FileName: "Backdrop.JPG", ContentHash: hashA}); err != nil {
 		t.Fatalf("valid artist allowlist: %v", err)
 	}
-	allowed, err := repo.IsAllowlisted(ctx, "a1", "backdrop.jpg")
+	allowed, err := repo.IsAllowlisted(ctx, "a1", hashA)
 	if err != nil {
 		t.Fatalf("IsAllowlisted: %v", err)
 	}
 	if !allowed {
-		t.Errorf("expected case-insensitive match on file_name to be allowlisted")
+		t.Errorf("expected hash match to be allowlisted")
 	}
 	// Wrong artist must not match an artist-scoped row.
-	allowed, err = repo.IsAllowlisted(ctx, "other", "backdrop.jpg")
+	allowed, err = repo.IsAllowlisted(ctx, "other", hashA)
 	if err != nil {
 		t.Fatalf("IsAllowlisted other: %v", err)
 	}
 	if allowed {
 		t.Errorf("artist-scoped allowlist must not match a different artist")
 	}
+	// Empty hash never matches; the writer guarantees stored hashes are
+	// non-empty so this is the only way an unhashable lookup is answered.
+	allowed, err = repo.IsAllowlisted(ctx, "a1", "")
+	if err != nil {
+		t.Fatalf("IsAllowlisted empty: %v", err)
+	}
+	if allowed {
+		t.Errorf("empty hash must never match")
+	}
 	// Replaying the same allowlist row is a no-op (unique-constraint
 	// collisions are swallowed by the writer).
-	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeArtist, ArtistID: "a1", FileName: "backdrop.jpg"}); err != nil {
+	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeArtist, ArtistID: "a1", FileName: "backdrop.jpg", ContentHash: hashA}); err != nil {
 		t.Fatalf("idempotent allowlist insert: %v", err)
 	}
 }
@@ -292,10 +323,12 @@ func TestRepository_AllowlistList(t *testing.T) {
 	if _, err := db.Exec(`INSERT INTO artists (id, name, path) VALUES ('a1','Aretha','/m/Aretha')`); err != nil {
 		t.Fatalf("insert artist: %v", err)
 	}
-	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeGlobal, FileName: "fanart.jpg", Note: "stock"}); err != nil {
+	hashF := sha256Hex([]byte("fanart bytes"))
+	hashB := sha256Hex([]byte("backdrop bytes"))
+	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeGlobal, FileName: "fanart.jpg", ContentHash: hashF, Note: "stock"}); err != nil {
 		t.Fatalf("AddAllowlist: %v", err)
 	}
-	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeArtist, ArtistID: "a1", FileName: "backdrop.jpg"}); err != nil {
+	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeArtist, ArtistID: "a1", FileName: "backdrop.jpg", ContentHash: hashB}); err != nil {
 		t.Fatalf("AddAllowlist artist: %v", err)
 	}
 	rows, err := repo.ListAllowlist(ctx)
@@ -629,5 +662,106 @@ func TestScanner_ReconcileIsAllowlistedErrorPreservesRow(t *testing.T) {
 	}
 	if len(rows) != 1 {
 		t.Errorf("row must persist when IsAllowlisted errors; got %d rows", len(rows))
+	}
+}
+
+// TestScanner_HashDedupesDistinctFilesWithSameBasename is the headline
+// behavior the migration is here to support: two foreign files with the
+// same basename ("poster.jpg") in different artist directories produce
+// two distinct ledger rows because their byte content (and therefore
+// content_hash) differs.
+func TestScanner_HashDedupesDistinctFilesWithSameBasename(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	bytesA := []byte("artist-A poster bytes")
+	bytesB := []byte("artist-B poster bytes")
+	mustWrite(t, filepath.Join(dirA, "poster.jpg"), bytesA)
+	mustWrite(t, filepath.Join(dirB, "poster.jpg"), bytesB)
+	if _, err := db.Exec(`INSERT INTO artists (id, name, path) VALUES ('a1','A',?), ('a2','B',?)`, dirA, dirB); err != nil {
+		t.Fatalf("insert artists: %v", err)
+	}
+	listing := stubArtistLister{artists: []artist.Artist{
+		{ID: "a1", Name: "A", Path: dirA},
+		{ID: "a2", Name: "B", Path: dirB},
+	}}
+	scanner := NewScanner(repo, listing, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	if err := scanner.Scan(context.Background()); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	got, err := repo.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rows for two distinct files with shared basename; got %d", len(got))
+	}
+	// Globally allowlist file A's bytes; only A should be suppressed.
+	if err := repo.AddAllowlist(context.Background(), AllowlistEntry{
+		Scope: ScopeGlobal, FileName: "poster.jpg", ContentHash: sha256Hex(bytesA),
+	}); err != nil {
+		t.Fatalf("AddAllowlist A: %v", err)
+	}
+	// Wipe the ledger so the next scan re-records only the still-unsuppressed file.
+	for _, e := range got {
+		if err := repo.DeleteByID(context.Background(), e.ID); err != nil {
+			t.Fatalf("clear ledger row %s: %v", e.ID, err)
+		}
+	}
+	if err := scanner.Scan(context.Background()); err != nil {
+		t.Fatalf("Scan after allowlist: %v", err)
+	}
+	got, err = repo.List(context.Background())
+	if err != nil {
+		t.Fatalf("List after allowlist: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 row after allowlisting A's bytes; got %d", len(got))
+	}
+	if got[0].ArtistID != "a2" {
+		t.Errorf("expected the SURVIVOR to be artist B (different bytes); got artist_id=%q hash=%q",
+			got[0].ArtistID, got[0].ContentHash)
+	}
+}
+
+// TestScanner_BackfillsHashOnLegacyRow simulates a row recorded before
+// migration 008 (content_hash NULL) and asserts the next scan recomputes
+// the hash from disk and writes it back so subsequent reconcile passes
+// can use the indexed lookup.
+func TestScanner_BackfillsHashOnLegacyRow(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	dir := t.TempDir()
+	body := []byte("legacy bytes")
+	target := filepath.Join(dir, "backdrop.jpg")
+	mustWrite(t, target, body)
+	if _, err := db.Exec(`INSERT INTO artists (id, name, path) VALUES ('a1','x',?)`, dir); err != nil {
+		t.Fatalf("insert artist: %v", err)
+	}
+	// Seed a pre-008 ledger row directly with a NULL content_hash so the
+	// scanner's backfill path is exercised.
+	if _, err := db.Exec(`INSERT INTO foreign_files
+		(id, artist_id, file_path, file_name, content_hash, size_bytes, detected_at)
+		VALUES (?, 'a1', ?, 'backdrop.jpg', NULL, ?, datetime('now'))`,
+		"legacy-row", target, len(body)); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+	listing := stubArtistLister{artists: []artist.Artist{{ID: "a1", Name: "x", Path: dir}}}
+	scanner := NewScanner(repo, listing, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	if err := scanner.Scan(context.Background()); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	got, err := repo.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 row after backfill scan; got %d", len(got))
+	}
+	want := sha256Hex(body)
+	if got[0].ContentHash != want {
+		t.Errorf("legacy row should be backfilled to sha256(file); got %q want %q",
+			got[0].ContentHash, want)
 	}
 }

--- a/internal/foreign/scanner_test.go
+++ b/internal/foreign/scanner_test.go
@@ -218,9 +218,12 @@ func TestRepository_AllowlistScopes(t *testing.T) {
 	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeArtist, FileName: "x.jpg", ContentHash: hashA}); err == nil {
 		t.Error("expected artist scope without artist_id to be rejected")
 	}
-	// content_hash is required.
+	// content_hash is required for both scopes.
 	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeArtist, ArtistID: "a1", FileName: "x.jpg"}); err == nil {
 		t.Error("expected missing content_hash to be rejected")
+	}
+	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeGlobal, FileName: "x.jpg"}); err == nil {
+		t.Error("expected global scope without content_hash to be rejected")
 	}
 	if err := repo.AddAllowlist(ctx, AllowlistEntry{Scope: ScopeArtist, ArtistID: "a1", FileName: "Backdrop.JPG", ContentHash: hashA}); err != nil {
 		t.Fatalf("valid artist allowlist: %v", err)


### PR DESCRIPTION
## Summary

- Foreign-file detection and allowlisting previously deduped on case-insensitive `file_name`, so two distinct files sharing a basename (`poster.jpg`, `banner.jpg`) were conflated -- dismissing one globally suppressed detection of an unrelated file with the same name.
- This PR plumbs a streamed sha256 content hash through detection and allowlisting. Matching is now on `(scope, artist_id, content_hash)`; `file_name` is retained on the row for human readability but no longer participates in dedupe.
- Migration `008_foreign_files_content_hash.sql` adds a nullable `content_hash` column to `foreign_files` and `foreign_file_allowlist`, swaps the filename-keyed unique indexes for partial unique indexes on `content_hash` (`WHERE content_hash IS NOT NULL`), and adds a covering lookup index. Pre-migration rows backfill lazily on the first post-migration scan.

**Migration numbering:** numbered `008`, not the next contiguous `006`. Sibling migration `007` (#1029) merged to main first; `008` keeps the applied order monotonic for any database that already recorded `007`. The gap at `006` is cosmetic -- goose applies by sorted version and tolerates gaps.

## Linked issue

Closes #1248

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Code review pass complete (`/pr-review-toolkit:review-pr` code-reviewer: SHIP verdict, no CRITICAL/IMPORTANT; all three self-reported departures verified safe. SUGGESTION-tier divergent error wrapping between the two `hashFile` copies -- fixed: the handler copy now wraps with `hash open`/`hash read` to match the scanner copy and honor the "Mirrors the scanner's helper" comment).
- [x] Commits squashed into clean, logical commits before the first push (single commit).
- [x] At least one label set (`enhancement`, `needs-docs-review`).
- [x] Docs label decision made: `needs-docs-review` -- behavior change (allowlist now keyed on content, not filename) worth a release-notes mention.
- [ ] Screenshot attached -- not applicable, no UI surface change.
- [x] UAT performed against the running binary (see Test plan).
- [x] OpenAPI spec updated (`content_hash` added to `ForeignFileEntry` and `ForeignAllowlistEntry`; `make check-openapi` passes).
- [ ] `templ generate` re-run -- not applicable (no `.templ` changes).

## Test plan

- [x] `go test -race ./...` passes locally, including:
  - `TestScanner_HashDedupesDistinctFilesWithSameBasename` -- two `poster.jpg` files with different bytes get separate ledger rows.
  - `TestHandleForeignFilesDismiss_SameBasenameDistinctBytes` -- allowlisting one suppresses only that exact byte sequence.
  - `TestScanner_BackfillsHashOnLegacyRow` -- a pre-008 NULL-hash row is backfilled on the next scan.
  - `TestResolveForeignHash_BackfillsFromDisk` -- on-demand rehash path for legacy rows in the handler.
- [x] `bash scripts/pre-push-gate.sh` passes locally (patch coverage 70.5%, above the 70% floor).
- [x] Manual UAT against the running binary on `localhost:1973`:
  - [x] Pre-migration: dev DB had 325 `foreign_files` rows, no `content_hash` column, migrations `0-5,7`.
  - [x] `bash scripts/dev-restart.sh` from this worktree: migration `008` applied in 2.82ms; `goose_db_version` -> `0,1,2,3,4,5,7,8` (monotonic, applied after the merged `007`); `content_hash` column added; old filename unique indexes dropped; three hash-keyed indexes created.
  - [x] Scheduled foreign-file scan ran: `recorded=325 cleared=0 skipped=0`; all **325/325** legacy rows backfilled with valid 64-char sha256 hex.
  - [x] Real-data dedupe proof: `banner.jpg` appears 226 times across artists with **226 distinct hashes** (the exact conflation the old filename scheme would have collapsed); `logo.png` 57 rows / 56 hashes correctly collapses 2 byte-identical files.
- Reviewer follow-ups:
  - `hashFile` is intentionally duplicated (~12 lines) in `internal/foreign/scanner.go` and `internal/api/handlers_foreign_files.go` -- consolidating would force exporting an unexported helper purely for a stdlib wrapper; the reviewer agreed the duplication is the better trade.
  - The `hashFile` `os.Open` / `io.Copy` error branches are uncovered (skip-don't-clear on a mid-scan unreadable file); structurally simple, non-blocking. A `chmod 000` test would close the gap if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Foreign files are deduplicated and allowlisted by SHA-256 content hash; scans compute/backfill hashes and actions use resolved hashes.

* **Bug Fixes**
  * Prevents incorrect deduplication/allowlisting from filename collisions; dismiss/allowlist now target file content.

* **Documentation**
  * API schemas and endpoint docs updated to include and explain content_hash.

* **Tests**
  * Updated and added tests covering content-hash deduplication, allowlist/dismiss semantics, backfill, and UI partial refreshes.

* **Chores**
  * Database migration to support content_hash and hash-based indexes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->