### PR TITLE
feat(rule): add origin_missing rule to populate empty Origin field

### DIFF
--- a/docs/site/src/reference/rules-catalogue.md
+++ b/docs/site/src/reference/rules-catalogue.md
@@ -2,11 +2,11 @@
 description: Every built-in rule in Stillwater -- what it checks, what the fix does, what's configurable, and the default state.
 ---
 
-<!-- code: internal/rule/service.go (defaultRules, RuleNFO/Thumb/Fanart/Logo/Banner/etc constants, filesystemRules), internal/rule/fixers.go (NFOFixer, MetadataFixer, ImageFixer, ExtraneousImagesFixer, LogoPaddingFixer, DirectoryRenameFixer, BackdropSequencingFixer; CanFix mappings), internal/rule/fixers_language.go (NameLanguageFixer), internal/database/migrations/001_initial_schema.sql (automation_mode DEFAULT 'auto'), internal/rule/service.go SeedDefaults (empty AutomationMode -> auto). 22 rules verified. -->
+<!-- code: internal/rule/service.go (defaultRules, RuleNFO/Thumb/Fanart/Logo/Banner/etc constants, filesystemRules), internal/rule/fixers.go (NFOFixer, MetadataFixer, ImageFixer, ExtraneousImagesFixer, LogoPaddingFixer, DirectoryRenameFixer, BackdropSequencingFixer; CanFix mappings), internal/rule/fixers_language.go (NameLanguageFixer), internal/database/migrations/001_initial_schema.sql (automation_mode DEFAULT 'auto'), internal/rule/service.go SeedDefaults (empty AutomationMode -> auto). 23 rules verified. -->
 
 # Rules catalogue
 
-Stillwater ships with 22 built-in rules across three categories: NFO, image, and metadata. Each section below covers one rule -- what it checks, what the fix does (if it's fixable), what's configurable, and how it ships.
+Stillwater ships with 23 built-in rules across three categories: NFO, image, and metadata. Each section below covers one rule -- what it checks, what the fix does (if it's fixable), what's configurable, and how it ships.
 
 For the *concept* behind enabled/disabled and manual/auto, see [rules](../core-concepts/rules.md). This page is the enumeration.
 
@@ -22,6 +22,7 @@ For the *concept* behind enabled/disabled and manual/auto, see [rules](../core-c
 | [Directory name matches artist](#directory-name-matches-artist) | Metadata | Enabled, manual | Sometimes |
 | [Metadata quality](#metadata-quality) | Metadata | Enabled, manual | Yes |
 | [Artist name matches preferred language](#artist-name-matches-preferred-language) | Metadata | Disabled, manual | Sometimes |
+| [Origin is populated](#origin-is-populated) | Metadata | Disabled, manual | Yes |
 | [Thumbnail image exists](#thumbnail-image-exists) | Image | Enabled, auto | Yes |
 | [Thumbnail is square](#thumbnail-is-square) | Image | Enabled, auto | Yes |
 | [Thumbnail minimum resolution](#thumbnail-minimum-resolution) | Image | Enabled, auto | Yes |
@@ -218,6 +219,31 @@ After:  Name = "Shiina Ringo", SortName = "Ringo, Shiina"
 **Caveats:**
 
 - Only resolves when MusicBrainz returns a locale-specific alias; no change is made if no alias matches.
+
+---
+
+## Origin is populated
+
+**Category:** Metadata &middot; **Default:** Disabled, manual &middot; **Severity:** info
+
+Flags artists with an empty origin field. Violations are fixed by fetching the origin (city, region, or country) from the configured provider priority list. Auto mode applies the highest-priority non-empty result; manual mode surfaces the violation so you can pick a provider value or edit it.
+
+The origin field records where an artist or group is from, displayed on artist detail pages and used for grouping and discovery. The rule fires when the origin field is empty. Different providers report origin at different granularity: MusicBrainz and Wikidata return a country, while Wikipedia and TheAudioDB often return a city or region. In auto mode the first non-empty value from the priority order is applied; in manual mode the violation is surfaced so you can compare provider values or enter your own.
+
+**When this fires:**
+
+- An artist scanned from disk whose source NFO never carried an origin element.
+- An artist identified by name only, with no metadata fetch run for the origin field yet.
+- An artist imported from a media server API that does not expose an origin field.
+
+**What the fix does:** Fetches the artist's origin from the configured provider priority list (Wikipedia, TheAudioDB, Wikidata, MusicBrainz) and saves the first non-empty value.
+
+```
+Before: origin is empty
+After:  origin = "Mandeville, Louisiana", fetched from a provider
+```
+
+**Configurable:** Severity only.
 
 ---
 

--- a/internal/rule/catalogue.go
+++ b/internal/rule/catalogue.go
@@ -32,7 +32,7 @@ type RuleCatalogueEntry struct {
 }
 
 // rulesCatalogue maps rule IDs to their documentation metadata.
-// Entries cover all 22 non-deprecated built-in rules.
+// Entries cover all 23 non-deprecated built-in rules.
 var rulesCatalogue = map[string]RuleCatalogueEntry{
 	RuleNFOExists: {
 		FixBehavior: "Generates an NFO from the artist's stored metadata and writes it to disk.",
@@ -258,6 +258,16 @@ var rulesCatalogue = map[string]RuleCatalogueEntry{
 			"An artist where logo.png and banner.jpg were both fetched from the same provider image source and are visually identical despite different dimensions.",
 			"A library that was seeded by copying the fanart into every image slot as a placeholder before sourcing distinct artwork.",
 		},
+	},
+	RuleOriginMissing: {
+		FixBehavior: "Fetches the artist's origin from the configured provider priority list (Wikipedia, TheAudioDB, Wikidata, MusicBrainz) and saves the first non-empty value.",
+		Guards:      "The origin field records where an artist or group is from, displayed on artist detail pages and used for grouping and discovery. The rule fires when the origin field is empty. Different providers report origin at different granularity: MusicBrainz and Wikidata return a country, while Wikipedia and TheAudioDB often return a city or region. In auto mode the first non-empty value from the priority order is applied; in manual mode the violation is surfaced so you can compare provider values or enter your own.",
+		Examples: []string{
+			"An artist scanned from disk whose source NFO never carried an origin element.",
+			"An artist identified by name only, with no metadata fetch run for the origin field yet.",
+			"An artist imported from a media server API that does not expose an origin field.",
+		},
+		FixExample: "Before: origin is empty\nAfter:  origin = \"Mandeville, Louisiana\", fetched from a provider",
 	},
 }
 

--- a/internal/rule/checkers.go
+++ b/internal/rule/checkers.go
@@ -206,6 +206,24 @@ func checkBioExists(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violat
 	}
 }
 
+// checkOriginMissing flags artists whose origin field is empty. The origin
+// records where an artist or group is from (city, region, or country) and is
+// fixed by fetching it from the configured provider priority list.
+func checkOriginMissing(_ context.Context, a *artist.Artist, cfg RuleConfig) *Violation {
+	if strings.TrimSpace(a.Origin) != "" {
+		return nil
+	}
+
+	return &Violation{
+		RuleID:   RuleOriginMissing,
+		RuleName: "Origin is populated",
+		Category: "metadata",
+		Severity: effectiveSeverity(cfg),
+		Message:  fmt.Sprintf("artist %s has no origin", a.Name),
+		Fixable:  true,
+	}
+}
+
 // makeFanartMinResChecker returns a Checker closure that uses the Engine's
 // DB-stored dimensions (with filesystem fallback) to measure the fanart.
 func (e *Engine) makeFanartMinResChecker() Checker {

--- a/internal/rule/checkers_test.go
+++ b/internal/rule/checkers_test.go
@@ -176,6 +176,51 @@ func TestCheckBioExists(t *testing.T) {
 	}
 }
 
+func TestCheckOriginMissing(t *testing.T) {
+	tests := []struct {
+		name    string
+		origin  string
+		wantNil bool
+	}{
+		{
+			name:    "origin populated",
+			origin:  "Mandeville, Louisiana",
+			wantNil: true,
+		},
+		{
+			name:    "origin empty",
+			origin:  "",
+			wantNil: false,
+		},
+		{
+			name:    "origin whitespace only",
+			origin:  "   ",
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := artist.Artist{Name: "Test", Origin: tt.origin}
+			v := checkOriginMissing(context.Background(), &a, RuleConfig{})
+			if (v == nil) != tt.wantNil {
+				t.Errorf("checkOriginMissing = %v, wantNil = %v", v, tt.wantNil)
+			}
+			if v != nil {
+				if v.RuleID != RuleOriginMissing {
+					t.Errorf("RuleID = %q, want %q", v.RuleID, RuleOriginMissing)
+				}
+				if !v.Fixable {
+					t.Error("origin_missing violation should be fixable")
+				}
+				if v.Category != "metadata" {
+					t.Errorf("Category = %q, want metadata", v.Category)
+				}
+			}
+		})
+	}
+}
+
 func TestCheckThumbSquare(t *testing.T) {
 	e := &Engine{logger: slog.Default()}
 	checker := e.makeThumbSquareChecker()

--- a/internal/rule/engine.go
+++ b/internal/rule/engine.go
@@ -149,6 +149,7 @@ func NewEngine(service *Service, db *sql.DB, platformService *platform.Service, 
 			RuleArtistIDMismatch:      checkArtistIDMismatch,
 			RuleDirectoryNameMismatch: checkDirectoryNameMismatch,
 			RuleMetadataQuality:       checkMetadataQuality,
+			RuleOriginMissing:         checkOriginMissing,
 		},
 	}
 	// Register checkers that need the Engine's FSCache for cached filesystem

--- a/internal/rule/fixers.go
+++ b/internal/rule/fixers.go
@@ -31,6 +31,15 @@ type imageProvider interface {
 	FetchImages(ctx context.Context, mbid string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error)
 }
 
+// metadataOrchestrator is the subset of provider.Orchestrator used by
+// MetadataFixer. Defining it as an interface keeps the fixer testable with a
+// stub instead of requiring a full orchestrator and live provider chain.
+type metadataOrchestrator interface {
+	Search(ctx context.Context, name string) ([]provider.ArtistSearchResult, error)
+	FetchMetadata(ctx context.Context, mbid, name string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error)
+	FetchFieldFromProviders(ctx context.Context, mbid, name, field string, providerIDs map[provider.ProviderName]string) ([]provider.FieldProviderResult, error)
+}
+
 // imageCacheEntry holds a cached FetchImages result (or error) for one MBID.
 type imageCacheEntry struct {
 	result *provider.FetchResult
@@ -128,9 +137,9 @@ func (f *NFOFixer) Fix(ctx context.Context, a *artist.Artist, _ *Violation) (*Fi
 	}, nil
 }
 
-// MetadataFixer populates missing metadata (MBID, biography) from providers.
+// MetadataFixer populates missing metadata (MBID, biography, origin) from providers.
 type MetadataFixer struct {
-	orchestrator *provider.Orchestrator
+	orchestrator metadataOrchestrator
 	logger       *slog.Logger
 }
 
@@ -141,9 +150,11 @@ func NewMetadataFixer(orchestrator *provider.Orchestrator, logger *slog.Logger) 
 	return &MetadataFixer{orchestrator: orchestrator, logger: logger}
 }
 
-// CanFix returns true for nfo_has_mbid, bio_exists, and metadata_quality rules.
+// CanFix returns true for nfo_has_mbid, bio_exists, metadata_quality, and
+// origin_missing rules.
 func (f *MetadataFixer) CanFix(v *Violation) bool {
-	return v.RuleID == RuleNFOHasMBID || v.RuleID == RuleBioExists || v.RuleID == RuleMetadataQuality
+	return v.RuleID == RuleNFOHasMBID || v.RuleID == RuleBioExists ||
+		v.RuleID == RuleMetadataQuality || v.RuleID == RuleOriginMissing
 }
 
 // Fix searches providers and populates the missing metadata.
@@ -155,6 +166,8 @@ func (f *MetadataFixer) Fix(ctx context.Context, a *artist.Artist, v *Violation)
 		return f.fixBio(ctx, a)
 	case RuleMetadataQuality:
 		return f.fixJunkBio(ctx, a)
+	case RuleOriginMissing:
+		return f.fixOrigin(ctx, a)
 	default:
 		return nil, fmt.Errorf("unsupported rule: %s", v.RuleID)
 	}
@@ -254,6 +267,51 @@ func (f *MetadataFixer) fixJunkBio(ctx context.Context, a *artist.Artist) (*FixR
 		Fixed:   true,
 		Message: fmt.Sprintf("replaced junk biography for %s", a.Name),
 	}, nil
+}
+
+// fixOrigin populates a missing origin field by querying providers in priority
+// order for the "origin" field and applying the first non-empty value.
+//
+// FetchFieldFromProviders returns one result per configured provider in the
+// field's priority order (wikipedia, audiodb, wikidata, musicbrainz), so the
+// first result with data is the highest-priority non-empty value. This is the
+// same first-non-empty-wins behavior used for other single-value fields.
+func (f *MetadataFixer) fixOrigin(ctx context.Context, a *artist.Artist) (*FixResult, error) {
+	results, err := f.orchestrator.FetchFieldFromProviders(ctx, a.MusicBrainzID, a.Name, "origin", a.ProviderIDMap())
+	if err != nil {
+		return nil, fmt.Errorf("fetching origin from providers: %w", err)
+	}
+
+	value, source := firstNonEmptyFieldValue(results)
+	if value == "" {
+		return &FixResult{
+			RuleID:  RuleOriginMissing,
+			Fixed:   false,
+			Message: fmt.Sprintf("no origin found for %s", a.Name),
+		}, nil
+	}
+
+	a.Origin = value
+
+	return &FixResult{
+		RuleID:  RuleOriginMissing,
+		Fixed:   true,
+		Message: fmt.Sprintf("populated origin '%s' from %s for %s", value, source, a.Name),
+	}, nil
+}
+
+// firstNonEmptyFieldValue walks per-provider field results in priority order
+// and returns the first value with data, along with the provider that supplied
+// it. Returns empty strings when no provider returned a usable value.
+func firstNonEmptyFieldValue(results []provider.FieldProviderResult) (value, source string) {
+	for _, r := range results {
+		if r.HasData {
+			if trimmed := strings.TrimSpace(r.Value); trimmed != "" {
+				return trimmed, string(r.Provider)
+			}
+		}
+	}
+	return "", ""
 }
 
 // provenanceRecorder records image provenance data (phash, source, file format,

--- a/internal/rule/fixers_origin_test.go
+++ b/internal/rule/fixers_origin_test.go
@@ -91,6 +91,26 @@ func TestMetadataFixer_FixOrigin_NoData(t *testing.T) {
 	}
 }
 
+// TestMetadataFixer_FixOrigin_ProviderError verifies the fixer propagates a
+// FetchFieldFromProviders failure as an error, returns no FixResult, and leaves
+// the artist unmutated.
+func TestMetadataFixer_FixOrigin_ProviderError(t *testing.T) {
+	stub := &stubOriginOrchestrator{fieldErr: errors.New("provider failure")}
+	f := &MetadataFixer{orchestrator: stub, logger: testLogger()}
+
+	a := &artist.Artist{Name: "Test Artist", Origin: ""}
+	fr, err := f.Fix(context.Background(), a, &Violation{RuleID: RuleOriginMissing})
+	if err == nil {
+		t.Fatal("expected error when provider field fetch fails")
+	}
+	if fr != nil {
+		t.Fatalf("expected nil FixResult on error, got %+v", fr)
+	}
+	if a.Origin != "" {
+		t.Errorf("a.Origin = %q, want empty on error", a.Origin)
+	}
+}
+
 func TestFirstNonEmptyFieldValue(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/rule/fixers_origin_test.go
+++ b/internal/rule/fixers_origin_test.go
@@ -95,13 +95,14 @@ func TestMetadataFixer_FixOrigin_NoData(t *testing.T) {
 // FetchFieldFromProviders failure as an error, returns no FixResult, and leaves
 // the artist unmutated.
 func TestMetadataFixer_FixOrigin_ProviderError(t *testing.T) {
-	stub := &stubOriginOrchestrator{fieldErr: errors.New("provider failure")}
+	wantErr := errors.New("provider failure")
+	stub := &stubOriginOrchestrator{fieldErr: wantErr}
 	f := &MetadataFixer{orchestrator: stub, logger: testLogger()}
 
 	a := &artist.Artist{Name: "Test Artist", Origin: ""}
 	fr, err := f.Fix(context.Background(), a, &Violation{RuleID: RuleOriginMissing})
-	if err == nil {
-		t.Fatal("expected error when provider field fetch fails")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected the provider failure error to propagate, got %v", err)
 	}
 	if fr != nil {
 		t.Fatalf("expected nil FixResult on error, got %+v", fr)

--- a/internal/rule/fixers_origin_test.go
+++ b/internal/rule/fixers_origin_test.go
@@ -1,0 +1,316 @@
+package rule
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// stubOriginOrchestrator is a test-only metadataOrchestrator that returns a
+// fixed set of per-provider origin field results. Only FetchFieldFromProviders
+// is exercised by the origin_missing fixer; the other methods are unused here
+// and return zero values.
+type stubOriginOrchestrator struct {
+	fieldResults []provider.FieldProviderResult
+	fieldErr     error
+}
+
+func (s *stubOriginOrchestrator) Search(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+	return nil, nil
+}
+
+func (s *stubOriginOrchestrator) FetchMetadata(_ context.Context, _, _ string, _ map[provider.ProviderName]string) (*provider.FetchResult, error) {
+	return nil, nil
+}
+
+func (s *stubOriginOrchestrator) FetchFieldFromProviders(_ context.Context, _, _, field string, _ map[provider.ProviderName]string) ([]provider.FieldProviderResult, error) {
+	if field != "origin" {
+		return nil, errors.New("unexpected field: " + field)
+	}
+	return s.fieldResults, s.fieldErr
+}
+
+func TestMetadataFixer_CanFix_OriginMissing(t *testing.T) {
+	f := &MetadataFixer{}
+	if !f.CanFix(&Violation{RuleID: RuleOriginMissing}) {
+		t.Error("MetadataFixer should handle origin_missing")
+	}
+}
+
+// TestMetadataFixer_FixOrigin_AppliesFirstNonEmpty verifies auto-mode
+// remediation: FetchFieldFromProviders returns results in priority order, and
+// the fixer applies the first non-empty value, skipping providers that
+// returned no data.
+func TestMetadataFixer_FixOrigin_AppliesFirstNonEmpty(t *testing.T) {
+	stub := &stubOriginOrchestrator{
+		fieldResults: []provider.FieldProviderResult{
+			{Provider: provider.NameWikipedia, HasData: false},
+			{Provider: provider.NameAudioDB, Value: "Mandeville, Louisiana", HasData: true},
+			{Provider: provider.NameWikidata, Value: "United States", HasData: true},
+		},
+	}
+	f := &MetadataFixer{orchestrator: stub, logger: testLogger()}
+
+	a := &artist.Artist{Name: "Test Artist", Origin: ""}
+	fr, err := f.Fix(context.Background(), a, &Violation{RuleID: RuleOriginMissing})
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if !fr.Fixed {
+		t.Fatalf("expected Fixed=true, got false (message: %q)", fr.Message)
+	}
+	if a.Origin != "Mandeville, Louisiana" {
+		t.Errorf("a.Origin = %q, want %q", a.Origin, "Mandeville, Louisiana")
+	}
+}
+
+// TestMetadataFixer_FixOrigin_NoData verifies the fixer reports Fixed=false
+// (not an error) when no provider returns a usable origin value.
+func TestMetadataFixer_FixOrigin_NoData(t *testing.T) {
+	stub := &stubOriginOrchestrator{
+		fieldResults: []provider.FieldProviderResult{
+			{Provider: provider.NameWikipedia, HasData: false},
+			{Provider: provider.NameAudioDB, Value: "   ", HasData: true},
+		},
+	}
+	f := &MetadataFixer{orchestrator: stub, logger: testLogger()}
+
+	a := &artist.Artist{Name: "Test Artist", Origin: ""}
+	fr, err := f.Fix(context.Background(), a, &Violation{RuleID: RuleOriginMissing})
+	if err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+	if fr.Fixed {
+		t.Error("expected Fixed=false when no provider returned a non-empty origin")
+	}
+	if a.Origin != "" {
+		t.Errorf("a.Origin = %q, want empty (no value should be applied)", a.Origin)
+	}
+}
+
+func TestFirstNonEmptyFieldValue(t *testing.T) {
+	tests := []struct {
+		name       string
+		results    []provider.FieldProviderResult
+		wantValue  string
+		wantSource string
+	}{
+		{
+			name:      "all empty",
+			results:   []provider.FieldProviderResult{{Provider: provider.NameWikipedia, HasData: false}},
+			wantValue: "",
+		},
+		{
+			name: "first with data wins",
+			results: []provider.FieldProviderResult{
+				{Provider: provider.NameWikipedia, Value: "London", HasData: true},
+				{Provider: provider.NameMusicBrainz, Value: "United Kingdom", HasData: true},
+			},
+			wantValue:  "London",
+			wantSource: "wikipedia",
+		},
+		{
+			name: "skips has-data-but-blank",
+			results: []provider.FieldProviderResult{
+				{Provider: provider.NameWikipedia, Value: "  ", HasData: true},
+				{Provider: provider.NameMusicBrainz, Value: "United Kingdom", HasData: true},
+			},
+			wantValue:  "United Kingdom",
+			wantSource: "musicbrainz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, source := firstNonEmptyFieldValue(tt.results)
+			if value != tt.wantValue {
+				t.Errorf("value = %q, want %q", value, tt.wantValue)
+			}
+			if source != tt.wantSource {
+				t.Errorf("source = %q, want %q", source, tt.wantSource)
+			}
+		})
+	}
+}
+
+// originFixer is a test-only Fixer that handles origin_missing violations by
+// setting the artist's Origin field in-memory and reporting Fixed=true. It
+// records whether it was invoked so mode tests can prove the pipeline did or
+// did not call the fixer. It deliberately does NOT implement
+// CandidateDiscoverer, mirroring the real MetadataFixer, so manual mode does
+// not invoke it.
+type originFixer struct {
+	applied  string
+	fixCalls int
+}
+
+func (f *originFixer) CanFix(v *Violation) bool {
+	return v.RuleID == RuleOriginMissing
+}
+
+func (f *originFixer) Fix(_ context.Context, a *artist.Artist, v *Violation) (*FixResult, error) {
+	f.fixCalls++
+	a.Origin = f.applied
+	return &FixResult{RuleID: v.RuleID, Fixed: true, Message: "applied by test fixer"}, nil
+}
+
+// TestPipeline_OriginMissing_DisabledMode verifies a disabled origin_missing
+// rule is never evaluated: no violation row is written and the fixer is not
+// called.
+func TestPipeline_OriginMissing_DisabledMode(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	artistSvc := artist.NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	// origin_missing ships disabled by default; disable everything so the
+	// pipeline evaluates nothing.
+	disableAllRulesExcept(t, db)
+
+	a := &artist.Artist{Name: "No Origin", SortName: "No Origin", Origin: ""}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	fixer := &originFixer{applied: "should-not-apply"}
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{fixer}, nil, testLogger())
+
+	if _, err := pipeline.RunForArtist(ctx, a); err != nil {
+		t.Fatalf("RunForArtist: %v", err)
+	}
+
+	if fixer.fixCalls != 0 {
+		t.Errorf("fixer invoked %d times for a disabled rule, want 0", fixer.fixCalls)
+	}
+	_, status, err := lookupViolationByRuleArtist(ctx, db, RuleOriginMissing, a.ID)
+	if err != nil {
+		t.Fatalf("lookupViolationByRuleArtist: %v", err)
+	}
+	if status != "" {
+		t.Errorf("violation row written for disabled rule (status=%q), want none", status)
+	}
+
+	reloaded, err := artistSvc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if reloaded.Origin != "" {
+		t.Errorf("Origin = %q, want empty (disabled rule must not mutate)", reloaded.Origin)
+	}
+}
+
+// TestPipeline_OriginMissing_ManualMode verifies manual mode surfaces an open
+// violation for the user to act on and never auto-applies a value. The real
+// MetadataFixer does not implement CandidateDiscoverer, so the pipeline records
+// the violation without invoking the fixer.
+func TestPipeline_OriginMissing_ManualMode(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	artistSvc := artist.NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	disableAllRulesExcept(t, db, RuleOriginMissing)
+	if _, err := db.ExecContext(ctx,
+		`UPDATE rules SET enabled = 1, automation_mode = ? WHERE id = ?`,
+		AutomationModeManual, RuleOriginMissing); err != nil {
+		t.Fatalf("enabling origin_missing in manual mode: %v", err)
+	}
+
+	a := &artist.Artist{Name: "Manual Origin", SortName: "Manual Origin", Origin: ""}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	fixer := &originFixer{applied: "should-not-apply-in-manual"}
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{fixer}, nil, testLogger())
+
+	if _, err := pipeline.RunForArtist(ctx, a); err != nil {
+		t.Fatalf("RunForArtist: %v", err)
+	}
+
+	// Manual mode must surface the violation as open, not auto-apply.
+	_, status, err := lookupViolationByRuleArtist(ctx, db, RuleOriginMissing, a.ID)
+	if err != nil {
+		t.Fatalf("lookupViolationByRuleArtist: %v", err)
+	}
+	if status != ViolationStatusOpen {
+		t.Errorf("violation status = %q, want %q (manual mode surfaces an open violation)", status, ViolationStatusOpen)
+	}
+	if fixer.fixCalls != 0 {
+		t.Errorf("fixer invoked %d times in manual mode, want 0 (no side-effect fixer in manual mode)", fixer.fixCalls)
+	}
+
+	reloaded, err := artistSvc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if reloaded.Origin != "" {
+		t.Errorf("Origin = %q, want empty (manual mode must not auto-apply)", reloaded.Origin)
+	}
+}
+
+// TestPipeline_OriginMissing_AutoMode verifies auto mode applies the fixer's
+// value and resolves the violation.
+func TestPipeline_OriginMissing_AutoMode(t *testing.T) {
+	db := setupTestDB(t)
+	ruleSvc := NewService(db)
+	artistSvc := artist.NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	disableAllRulesExcept(t, db, RuleOriginMissing)
+	if _, err := db.ExecContext(ctx,
+		`UPDATE rules SET enabled = 1, automation_mode = ? WHERE id = ?`,
+		AutomationModeAuto, RuleOriginMissing); err != nil {
+		t.Fatalf("enabling origin_missing in auto mode: %v", err)
+	}
+
+	a := &artist.Artist{Name: "Auto Origin", SortName: "Auto Origin", Origin: ""}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	fixer := &originFixer{applied: "Seattle, Washington"}
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{fixer}, nil, testLogger())
+
+	runResult, err := pipeline.RunForArtist(ctx, a)
+	if err != nil {
+		t.Fatalf("RunForArtist: %v", err)
+	}
+	if runResult.FixesSucceeded != 1 {
+		t.Fatalf("FixesSucceeded = %d, want 1", runResult.FixesSucceeded)
+	}
+	if fixer.fixCalls != 1 {
+		t.Errorf("fixer invoked %d times in auto mode, want 1", fixer.fixCalls)
+	}
+
+	reloaded, err := artistSvc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if reloaded.Origin != "Seattle, Washington" {
+		t.Errorf("Origin = %q, want %q (auto mode applies the fix)", reloaded.Origin, "Seattle, Washington")
+	}
+
+	_, status, err := lookupViolationByRuleArtist(ctx, db, RuleOriginMissing, a.ID)
+	if err != nil {
+		t.Fatalf("lookupViolationByRuleArtist: %v", err)
+	}
+	if status != ViolationStatusResolved {
+		t.Errorf("violation status = %q, want %q (auto-fix resolves the violation)", status, ViolationStatusResolved)
+	}
+}

--- a/internal/rule/fs_categorization_test.go
+++ b/internal/rule/fs_categorization_test.go
@@ -42,6 +42,7 @@ func TestIsFilesystemDependent(t *testing.T) {
 		RuleBackdropSequencing,
 		RuleBackdropMinCount,
 		RuleNameLanguagePref,
+		RuleOriginMissing,
 	}
 	for _, id := range apiRules {
 		if IsFilesystemDependent(id) {
@@ -81,6 +82,7 @@ func TestAllDefaultRulesAreCategorized(t *testing.T) {
 		RuleBackdropSequencing:    true,
 		RuleBackdropMinCount:      true,
 		RuleNameLanguagePref:      true,
+		RuleOriginMissing:         true,
 	}
 
 	for _, r := range defaultRules {

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -42,6 +42,7 @@ const (
 	RuleBackdropMinCount      = "backdrop_min_count"
 	RuleLogoPadding           = "logo_padding"
 	RuleNameLanguagePref      = "name_language_pref"
+	RuleOriginMissing         = "origin_missing"
 
 	// Deprecated rule IDs kept for migration. These rules have been merged
 	// into other rules but may still have violations in the database.
@@ -233,6 +234,15 @@ var defaultRules = []Rule{
 		Enabled:        false,
 		AutomationMode: AutomationModeManual,
 		Config:         RuleConfig{Severity: "warning"},
+	},
+	{
+		ID:             RuleOriginMissing,
+		Name:           "Origin is populated",
+		Description:    "Flags artists with an empty origin field. Violations are fixed by fetching the origin (city, region, or country) from the configured provider priority list. Auto mode applies the highest-priority non-empty result; manual mode surfaces the violation so you can pick a provider value or edit it.",
+		Category:       RuleCategoryMetadata,
+		Enabled:        false,
+		AutomationMode: AutomationModeManual,
+		Config:         RuleConfig{Severity: "info"},
 	},
 }
 

--- a/internal/rule/service.go
+++ b/internal/rule/service.go
@@ -1206,6 +1206,7 @@ func GroupViolations(violations []RuleViolation, groupBy string) []ViolationGrou
 			"bio":        "metadata",
 			"artist":     "metadata",
 			"name":       "metadata",
+			"origin":     "metadata",
 		}
 		for prefix, cat := range prefixMap {
 			if len(ruleID) >= len(prefix) && ruleID[:len(prefix)] == prefix {


### PR DESCRIPTION
## Summary

- Adds the `origin_missing` rule: detects artists with an empty `origin` field and fixes it by fetching from the configured provider priority list (`wikipedia`, `audiodb`, `wikidata`, `musicbrainz` -- already in `DefaultPriorities()` from #1071).
- Follows the standard disabled/manual/auto three-mode rule pattern (mirrors `bio_exists` for the checker and `metadata_quality` / `name_language_pref` for the fixer). Ships disabled by default, `manual` automation mode, `info` severity.
- Auto mode applies the highest-priority non-empty provider result; manual mode surfaces the violation so the user remediates via the existing per-field provider comparison modal.
- Introduces a `metadataOrchestrator` interface so `MetadataFixer` is testable with a stub instead of a live provider chain (the concrete `*provider.Orchestrator` still flows in via `NewMetadataFixer`).

## Linked issue

Closes #1157

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Code review pass complete (parent self-review per the small-PR review policy -- a new rule mirroring established rule patterns, no novel subsystem; `internal/provider/orchestrator.go` confirmed untouched; conventions clean; three-mode pattern verified).
- [x] Commits squashed into a single clean commit before the first push.
- [x] At least one label set (`enhancement`, `needs-docs-review`).
- [x] Docs label decision made: `needs-docs-review`; `docs/site/src/reference/rules-catalogue.md` regenerated by `cmd/gen-rules-catalogue` and committed.
- [ ] Screenshot attached -- not applicable, no bespoke UI surface (the rule renders through the existing rules list).
- [x] UAT performed against the running binary: `bash scripts/dev-restart.sh` from this worktree, then `GET /api/v1/rules` confirms `origin_missing` registers with `enabled:false`, `automation_mode:manual`, category `metadata`, severity `info`.
- [ ] OpenAPI spec updated -- not applicable (no new API shape; the rule surfaces through the existing rules endpoint).
- [ ] `templ generate` -- not applicable (no `.templ` changes).

## Test plan

- [x] `go test -race ./...` passes locally, including:
  - `TestCheckOriginMissing` -- fires on empty/whitespace origin, not on populated.
  - `fixers_origin_test.go` -- stub-orchestrator auto-apply, no-data path, `firstNonEmptyFieldValue` table test, and three pipeline mode tests (disabled / manual / auto).
- [x] `bash scripts/pre-push-gate.sh` passes locally (patch coverage 93.18%, well above the 70% floor).
- [x] Manual UAT: rule registers in the live `/api/v1/rules` response with the correct mode/severity shape.

## Notes for reviewers

- `en.json` was intentionally NOT touched: this codebase has no `rule.*` i18n label namespace -- rule names/descriptions live in `defaultRules` in `internal/rule/service.go` and the settings UI renders them directly. The label/description were added there, consistent with every existing rule.
- Manual mode does not implement `CandidateDiscoverer` (that interface is image-only). Consistent with `metadata_quality` / `name_language_pref`, manual mode surfaces an open violation that the user remediates through the pre-existing per-field provider comparison modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in rule that detects missing artist origin and can populate it from configured providers (severity configurable; disabled by default; manual automation by default; auto mode applies first non-empty provider result). Rule is grouped under metadata.

* **Documentation**
  * Rules catalogue updated to document the new origin rule, examples, and updated built-in rules count.

* **Tests**
  * Added unit and pipeline tests covering checker, fixer, and disabled/manual/auto behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->