### PR TITLE
feat(provider): synthesize years_active and fix member AttemptedFields

### DIFF
--- a/docs/site/src/reference/providers.md
+++ b/docs/site/src/reference/providers.md
@@ -16,7 +16,7 @@ The table below is generated from the provider definitions in the codebase. Don'
 | Provider | Tier | Sign-up | Rate limit | Mirror | Metadata fields | Image types |
 |---|---|---|---|---|---|---|
 | MusicBrainz | Free | Not required | 1/sec | Yes | Name, Sort name, Type, Gender, Disambiguation, Origin, Born, Formed, Died, Disbanded, Years active, Genres, Styles, Moods, Members, Aliases | None |
-| Wikipedia | Free | Not required | 5/sec | No | Name, Biography, Years active, Origin, Genres, Members | None |
+| Wikipedia | Free | Not required | 5/sec | No | Name, Type, Biography, Born, Died, Years active, Origin, Genres, Members | None |
 | Fanart.tv | Free key | [Sign up](https://fanart.tv/get-an-api-key/) | 3/sec | No | Image only | thumb, fanart, logo, hdlogo, banner |
 | TheAudioDB | Freemium | [Sign up](https://www.theaudiodb.com/pricing) | 30/min | No | Name, Gender, Origin, Biography, Genres, Styles, Moods, Born, Formed, Died, Disbanded, Aliases | thumb, logo, widethumb, banner, fanart |
 | Discogs | Free key | [Sign up](https://www.discogs.com/settings/developers) | 1/sec, 1000/day | No | Name, Biography, Aliases, Members | thumb |

--- a/internal/api/handlers_refresh.go
+++ b/internal/api/handlers_refresh.go
@@ -306,10 +306,16 @@ func (r *Router) executeRefreshCtx(ctx context.Context, a *artist.Artist) (*prov
 }
 
 // applyMemberRefresh upserts provider-returned members for an artist when the
-// provider both attempted the "members" field and returned a non-empty list.
-// An empty list is treated as incomplete data (MusicBrainz relation data is
-// often sparse), not an intentional clear. Existing members are left untouched
-// when the provider was not attempted or returned zero members.
+// provider both attempted the "members" field and either returned a non-empty
+// list or the result carries MembersAuthoritative=true (indicating the provider
+// asserted a complete roster that happens to be empty -- i.e., the artist has
+// no members -- so existing rows should be cleared).
+//
+// An empty list without MembersAuthoritative is treated as incomplete data
+// (MusicBrainz relation data is often sparse) and leaves existing members
+// untouched. Existing members are also left untouched when the provider did
+// not attempt the field at all, when metadata is nil, or when the field is
+// locked by the user.
 func (r *Router) applyMemberRefresh(ctx context.Context, artistID string, result *provider.FetchResult, locked []string) {
 	if result.Metadata == nil {
 		return
@@ -319,10 +325,13 @@ func (r *Router) applyMemberRefresh(ctx context.Context, artistID string, result
 			return
 		}
 	}
-	if slices.Contains(result.AttemptedFields, "members") && len(result.Metadata.Members) > 0 {
+	if slices.Contains(result.AttemptedFields, "members") && (len(result.Metadata.Members) > 0 || result.MembersAuthoritative) {
 		members := convertProviderMembers(artistID, result.Metadata.Members)
 		if err := r.artistService.UpsertMembers(ctx, artistID, members); err != nil {
-			r.logger.Warn("upserting members after refresh",
+			// A failed member upsert is a real persistence defect: the core
+			// metadata was already committed, but the member roster may now be
+			// stale. Log at Error (not Warn) so monitoring surfaces it.
+			r.logger.Error("upserting members after refresh",
 				"artist_id", artistID,
 				"error", err)
 		}

--- a/internal/api/handlers_refresh_test.go
+++ b/internal/api/handlers_refresh_test.go
@@ -437,6 +437,34 @@ func TestApplyMemberRefresh(t *testing.T) {
 		}
 	})
 
+	t.Run("provider_error_fetch_result_preserves_members", func(t *testing.T) {
+		// Finding 6: when a provider returns an error (timeout, 5xx), the
+		// orchestrator produces a FetchResult with no AttemptedFields and
+		// MembersAuthoritative=false. applyMemberRefresh must leave existing
+		// member rows untouched. This ensures a transient upstream outage cannot
+		// silently clear an artist's member roster.
+		a := addTestArtist(t, artistSvc, "Provider Error Band")
+		seedMembers(t, a.ID)
+
+		if n := countMembers(t, a.ID); n != 2 {
+			t.Fatalf("expected 2 seeded members, got %d", n)
+		}
+
+		// Simulate the FetchResult produced when every provider errors out:
+		// AttemptedFields is empty (no field was attempted), MembersAuthoritative
+		// is false, and Metadata.Members is nil.
+		result := &provider.FetchResult{
+			Metadata:             &provider.ArtistMetadata{Members: nil},
+			AttemptedFields:      nil,   // provider never attempted the field
+			MembersAuthoritative: false, // provider did not assert completeness
+		}
+		r.applyMemberRefresh(context.Background(), a.ID, result, nil)
+
+		if n := countMembers(t, a.ID); n != 2 {
+			t.Errorf("expected 2 members preserved after provider-error fetch result, got %d", n)
+		}
+	})
+
 	t.Run("upsert_error_logged_not_propagated", func(t *testing.T) {
 		// Use an isolated router so closing its DB does not affect other subtests.
 		rIsolated, svcIsolated := testRouter(t)
@@ -456,6 +484,57 @@ func TestApplyMemberRefresh(t *testing.T) {
 		}
 		rIsolated.applyMemberRefresh(context.Background(), a.ID, result, nil)
 		// No assertions beyond "did not panic" -- error is swallowed by design.
+	})
+
+	t.Run("authoritative_empty_clears_members", func(t *testing.T) {
+		// This is the core fix for #1038. When a provider asserts its empty
+		// member list is complete (MembersAuthoritative=true), applyMemberRefresh
+		// must clear existing rows rather than treating the empty result as
+		// incomplete data. The original guard (`len > 0`) blocked this path.
+		//
+		// Real-world scenario: a band entry is re-identified as a solo artist;
+		// the provider returns no members and marks the result authoritative so
+		// the stale band rows are removed.
+		a := addTestArtist(t, artistSvc, "Authoritative Empty Band")
+		seedMembers(t, a.ID)
+
+		if n := countMembers(t, a.ID); n != 2 {
+			t.Fatalf("expected 2 seeded members, got %d", n)
+		}
+
+		// Provider attempted "members", returned empty list, BUT MembersAuthoritative=true.
+		// This must clear the stale rows.
+		result := &provider.FetchResult{
+			Metadata:             &provider.ArtistMetadata{Members: nil},
+			AttemptedFields:      []string{"members"},
+			MembersAuthoritative: true,
+		}
+		r.applyMemberRefresh(context.Background(), a.ID, result, nil)
+
+		if n := countMembers(t, a.ID); n != 0 {
+			t.Errorf("expected 0 members after authoritative-empty clear, got %d", n)
+		}
+	})
+
+	t.Run("non_authoritative_empty_preserves_members", func(t *testing.T) {
+		// Complement of the above: an empty result WITHOUT MembersAuthoritative
+		// (sparse provider data) must leave existing rows untouched. This is
+		// the same assertion as members_attempted_empty_preserves but now
+		// explicitly verifies that MembersAuthoritative=false is the
+		// distinguishing signal, not just the absence of members.
+		a := addTestArtist(t, artistSvc, "Non-Authoritative Empty Band")
+		seedMembers(t, a.ID)
+
+		result := &provider.FetchResult{
+			Metadata:             &provider.ArtistMetadata{Members: nil},
+			AttemptedFields:      []string{"members"},
+			MembersAuthoritative: false, // sparse -- do not clear
+		}
+		r.applyMemberRefresh(context.Background(), a.ID, result, nil)
+
+		if n := countMembers(t, a.ID); n != 2 {
+			t.Errorf("expected 2 members preserved (non-authoritative empty), got %d", n)
+		}
 	})
 }
 

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -833,22 +833,16 @@ func applyRelations(meta *provider.ArtistMetadata, mb *MBArtist, seen map[string
 	}
 }
 
-// synthesizeYearsActive fills meta.YearsActive from formed/disbanded for
-// group-type artists when the provider did not supply one. Output uses
-// "YYYY-YYYY" or "YYYY-present"; partial dates are reduced to the year part.
-func synthesizeYearsActive(meta *provider.ArtistMetadata, mb *MBArtist) {
-	if meta.YearsActive != "" || !isGroupType(mb.Type) {
+// synthesizeYearsActive fills meta.YearsActive from formed/disbanded (groups)
+// or born/died (individuals) when MusicBrainz did not supply one. The
+// derivation logic is shared with the orchestrator's per-field fetch via
+// provider.SynthesizeYearsActive so both paths agree on the output format.
+func synthesizeYearsActive(meta *provider.ArtistMetadata) {
+	if meta.YearsActive != "" {
 		return
 	}
-	formedYear := yearFromDate(meta.Formed)
-	if formedYear == "" {
-		return
-	}
-	disbandedYear := yearFromDate(meta.Disbanded)
-	if disbandedYear != "" {
-		meta.YearsActive = formedYear + "-" + disbandedYear
-	} else {
-		meta.YearsActive = formedYear + "-present"
+	if synth, ok := provider.SynthesizeYearsActive(meta); ok {
+		meta.YearsActive = synth
 	}
 }
 
@@ -891,18 +885,24 @@ func (a *Adapter) mapArtist(ctx context.Context, mb *MBArtist) *provider.ArtistM
 	// when merging duplicates with different name variants.
 	meta.Members = deduplicateMembers(meta.Members, langPrefs)
 
-	synthesizeYearsActive(meta, mb)
+	synthesizeYearsActive(meta)
+
+	// Set MembersAuthoritative for confirmed individual artist types (Person,
+	// Character). An individual by definition has no band members, so an empty
+	// member list from a Person-type MusicBrainz result is authoritatively
+	// complete and may safely clear any stale band-member rows.
+	//
+	// Safety: we deliberately do NOT set the flag for Group, Orchestra, Choir,
+	// Other, or unknown types. A real band has Type="Group" and an empty member
+	// list from MusicBrainz usually reflects sparse relation coverage rather
+	// than a true empty roster, so we leave it false to avoid accidental data
+	// loss. The authoritative-clear path is only safe when the artist type
+	// itself rules out the possibility of members existing.
+	if mb.Type == "Person" || mb.Type == "Character" {
+		meta.MembersAuthoritative = true
+	}
 
 	return meta
-}
-
-// yearFromDate extracts the leading 4-digit year from a date string that may
-// be "YYYY", "YYYY-MM", or "YYYY-MM-DD". Returns "" for empty or short input.
-func yearFromDate(date string) string {
-	if len(date) < 4 {
-		return ""
-	}
-	return date[:4]
 }
 
 // isGroupType returns true for MusicBrainz types that represent ensembles

--- a/internal/provider/musicbrainz/musicbrainz_test.go
+++ b/internal/provider/musicbrainz/musicbrainz_test.go
@@ -1876,3 +1876,117 @@ func TestLocalizeMembers_PreservesNonMBIDMembers(t *testing.T) {
 		t.Errorf("expected user-added member name preserved, got %q", members[0].Name)
 	}
 }
+
+// --- #1038: MembersAuthoritative wiring ---
+
+// TestMapArtist_MembersAuthoritative verifies that mapArtist sets
+// MembersAuthoritative only for confirmed individual artist types (Person,
+// Character) and never for group types or unknown/empty types.
+//
+// Rationale: an individual artist cannot have band members by definition, so
+// an empty member list is authoritatively complete. A real band (Type="Group")
+// may have sparse relation data in MusicBrainz, so an empty list there means
+// "data unavailable", not "no members".
+func TestMapArtist_MembersAuthoritative(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		mbType   string
+		wantTrue bool
+		comment  string
+	}{
+		{
+			// Person type: individual artist, no members possible by definition.
+			// An empty member list is complete and authoritative.
+			name:     "person_type_is_authoritative",
+			mbType:   "Person",
+			wantTrue: true,
+			comment:  "Person type must set MembersAuthoritative=true",
+		},
+		{
+			// Character type: treated identically to Person for this purpose
+			// (e.g. a fictional artist identity). Empty roster is authoritative.
+			name:     "character_type_is_authoritative",
+			mbType:   "Character",
+			wantTrue: true,
+			comment:  "Character type must set MembersAuthoritative=true",
+		},
+		{
+			// Group type: real bands have members, but MusicBrainz relation data
+			// is often sparse. An empty list for a Group means data is unavailable,
+			// not that the band has no members.
+			name:     "group_type_is_not_authoritative",
+			mbType:   "Group",
+			wantTrue: false,
+			comment:  "Group type must NOT set MembersAuthoritative",
+		},
+		{
+			// Orchestra: same rationale as Group.
+			name:     "orchestra_type_is_not_authoritative",
+			mbType:   "Orchestra",
+			wantTrue: false,
+			comment:  "Orchestra type must NOT set MembersAuthoritative",
+		},
+		{
+			// Choir: same rationale as Group.
+			name:     "choir_type_is_not_authoritative",
+			mbType:   "Choir",
+			wantTrue: false,
+			comment:  "Choir type must NOT set MembersAuthoritative",
+		},
+		{
+			// Empty type: unknown, cannot assert completeness.
+			name:     "empty_type_is_not_authoritative",
+			mbType:   "",
+			wantTrue: false,
+			comment:  "Empty/unknown type must NOT set MembersAuthoritative",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc // capture for parallel sub-test
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := newTestAdapter(t, "http://localhost:0")
+			mb := &MBArtist{
+				ID:   "test-mbid",
+				Name: "Test Artist",
+				Type: tc.mbType,
+			}
+			meta := a.mapArtist(context.Background(), mb)
+			if meta.MembersAuthoritative != tc.wantTrue {
+				t.Errorf("%s: MembersAuthoritative = %v, want %v", tc.comment, meta.MembersAuthoritative, tc.wantTrue)
+			}
+		})
+	}
+}
+
+// TestMapArtist_YearsActive_PersonBornAndDied verifies the synthesis path for a
+// Person-type artist with both lifespan begin and end dates. This is Finding 7:
+// an individual with a closed lifespan should produce a "YYYY-YYYY" years_active.
+// The test also confirms MembersAuthoritative is set for the Person type.
+func TestMapArtist_YearsActive_PersonBornAndDied(t *testing.T) {
+	t.Parallel()
+	a := newTestAdapter(t, "http://localhost:0")
+	mb := &MBArtist{
+		ID:   "person-born-died",
+		Name: "Deceased Solo Artist",
+		Type: "Person",
+		LifeSpan: MBLifeSpan{
+			Begin: "1942-08-01",
+			End:   "2018-03-14",
+			Ended: true,
+		},
+	}
+	meta := a.mapArtist(context.Background(), mb)
+
+	// A Person with begin + end dates should synthesize "YYYY-YYYY".
+	if meta.YearsActive != "1942-2018" {
+		t.Errorf("YearsActive = %q, want %q", meta.YearsActive, "1942-2018")
+	}
+	// Person type must also set MembersAuthoritative.
+	if !meta.MembersAuthoritative {
+		t.Error("Person type must set MembersAuthoritative=true")
+	}
+}

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -78,6 +78,18 @@ type FetchResult struct {
 	// This is the mechanism for #952's graceful-fallback contract: an empty
 	// localized lookup must not clobber pre-existing data.
 	PopulatedFields []string `json:"populated_fields,omitempty"`
+	// MembersAuthoritative is true when the contributing provider can assert
+	// that its member list is complete. It distinguishes "provider
+	// authoritatively returned zero members" (an empty roster that should
+	// clear existing rows) from "provider returned zero due to sparse relation
+	// data" (an empty roster that should preserve existing rows).
+	// Currently set by MusicBrainz for confirmed individual artist types
+	// (Person, Character): an individual by definition has no band members,
+	// so an empty member list is definitionally complete and may safely clear
+	// stale rows. Group/Orchestra/Choir types never set it because MusicBrainz
+	// relation data for real bands can be sparse and an empty roster would
+	// represent missing data rather than an authoritative empty result.
+	MembersAuthoritative bool `json:"members_authoritative,omitempty"`
 }
 
 // ScraperExecutor is implemented by the scraper.Executor to avoid circular imports.
@@ -158,6 +170,7 @@ func (o *Orchestrator) FetchMetadata(ctx context.Context, mbid, name string, pro
 		// falsely re-credited here. Reset each iteration.
 		fieldPopulated := false
 		isImageField := isImageFieldName(pri.Field)
+		isMembersField := pri.Field == "members"
 		for _, provName := range pri.EnabledProviders() {
 			if !available[provName] {
 				continue
@@ -186,6 +199,30 @@ func (o *Orchestrator) FetchMetadata(ctx context.Context, mbid, name string, pro
 			// image data is preserved rather than cleared.
 			if isImageField && (!pr.imagesAttempted || pr.imageErr != nil) {
 				continue
+			}
+
+			// For the members field, only mark as queried when the provider
+			// actually returned members OR authoritatively asserted an empty
+			// roster. A provider that returned zero members without asserting
+			// completeness (sparse relation data) must not mark the field as
+			// attempted, so existing member rows are preserved rather than
+			// cleared. This mirrors the image-field guard above.
+			//
+			// A nil meta result (transient error, timeout, 5xx) is treated
+			// identically to the ErrNotFound path in the scraper executor:
+			// the field is NOT marked as queried so existing member rows are
+			// preserved. This mirrors membersFieldQueried in executor.go, which
+			// also returns false for nil meta.
+			if isMembersField {
+				if pr.meta == nil {
+					continue
+				}
+				if len(pr.meta.Members) == 0 && !pr.meta.MembersAuthoritative {
+					continue
+				}
+				if pr.meta.MembersAuthoritative {
+					result.MembersAuthoritative = true
+				}
 			}
 
 			queried = true
@@ -831,6 +868,15 @@ type FieldProviderResult struct {
 	Members  []MemberInfo `json:"members,omitempty"`
 	HasData  bool         `json:"has_data"`
 	Error    string       `json:"error,omitempty"`
+	// Synthesized is true when Value was derived from other fields rather than
+	// returned directly by the provider. It applies to years_active, which the
+	// per-field fetch synthesizes from formed/disbanded or born/died when a
+	// provider computes the value instead of storing it (MusicBrainz) or its
+	// source lacks the literal key (Wikipedia infoboxes). The candidate is
+	// still attributed to the originating provider; this flag only records
+	// that the value is derived. The per-field providers UI renders
+	// synthesized and direct candidates identically.
+	Synthesized bool `json:"synthesized,omitempty"`
 }
 
 // FetchFieldFromProviders queries all configured providers for a given field
@@ -947,6 +993,17 @@ func extractFieldForComparison(fpr *FieldProviderResult, field string, meta *Art
 		if meta.YearsActive != "" {
 			fpr.Value = meta.YearsActive
 			fpr.HasData = true
+			break
+		}
+		// The provider returned no literal years_active. Some providers
+		// compute the value rather than store it (MusicBrainz) and some
+		// sources lack the key entirely (Wikipedia infoboxes without a
+		// "years_active" field), so synthesize a candidate from the same
+		// provider's formed/disbanded or born/died dates.
+		if synth, ok := SynthesizeYearsActive(meta); ok {
+			fpr.Value = synth
+			fpr.HasData = true
+			fpr.Synthesized = true
 		}
 	case "type":
 		if meta.Type != "" {
@@ -963,6 +1020,82 @@ func extractFieldForComparison(fpr *FieldProviderResult, field string, meta *Art
 			fpr.Value = meta.Origin
 			fpr.HasData = true
 		}
+	}
+}
+
+// SynthesizeYearsActive derives a years_active string from an artist's
+// formed/disbanded (groups) or born/died (individuals) dates. It returns the
+// synthesized value and true when synthesis succeeded, or "" and false when
+// the metadata does not support a confident answer.
+//
+// Group/orchestra/choir types synthesize "YYYY-YYYY" when both formed and
+// disbanded are known, or "YYYY-present" when only the formed date is known,
+// matching the Wikipedia infobox convention for still-active groups.
+//
+// Individuals are handled conservatively: a "born-died" range is synthesized
+// only when both dates are present. When only the birth date is known the
+// person's activity cannot be determined from metadata alone, so synthesis is
+// skipped rather than guessing a "YYYY-present" range.
+//
+// Callers must check meta.YearsActive themselves before calling: this helper
+// always synthesizes from the date fields and never reads YearsActive.
+func SynthesizeYearsActive(meta *ArtistMetadata) (string, bool) {
+	if meta == nil {
+		return "", false
+	}
+	if isGroupTypeValue(meta.Type) {
+		formed := yearFromDate(meta.Formed)
+		if formed == "" {
+			return "", false
+		}
+		if disbanded := yearFromDate(meta.Disbanded); disbanded != "" {
+			return formed + "-" + disbanded, true
+		}
+		return formed + "-present", true
+	}
+	// Individuals: only a fully bounded born-died range can be synthesized
+	// with confidence. A lone birth date says nothing about whether the
+	// artist is still active, so skip rather than guess.
+	born := yearFromDate(meta.Born)
+	died := yearFromDate(meta.Died)
+	if born != "" && died != "" {
+		return born + "-" + died, true
+	}
+	return "", false
+}
+
+// yearFromDate extracts the leading 4-digit year from a date string that may
+// be "YYYY", "YYYY-MM", or "YYYY-MM-DD". Returns "" for empty or short input,
+// and also returns "" when the leading 4 characters are not all ASCII digits
+// (e.g. "late 1980s" or "circa 1990" would otherwise produce garbage output).
+func yearFromDate(date string) string {
+	if len(date) < 4 {
+		return ""
+	}
+	prefix := date[:4]
+	for i := range len(prefix) {
+		if prefix[i] < '0' || prefix[i] > '9' {
+			return ""
+		}
+	}
+	return prefix
+}
+
+// isGroupTypeValue reports whether the normalized artist type string
+// represents an ensemble (group, orchestra, choir) rather than an individual.
+// The vocabulary mirrors the normalized values produced by provider adapters
+// (see musicbrainz.mapArtistType): "group", "orchestra", "choir".
+//
+// This is deliberately NOT the negation of isIndividualTypeValue (below): an
+// unknown or empty type is neither group nor individual. years_active synthesis
+// routes such artists through the individual (born/died) branch via
+// !isGroupTypeValue, so the two predicates are kept separate on purpose.
+func isGroupTypeValue(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "group", "orchestra", "choir":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/provider/orchestrator_test.go
+++ b/internal/provider/orchestrator_test.go
@@ -2863,3 +2863,393 @@ func TestIsExcludedForField_BiographyStructuralGuards(t *testing.T) {
 		})
 	}
 }
+
+// TestSynthesizeYearsActive covers the synthesis helper added for #1069.
+// The helper is shared between the MusicBrainz full-refresh path and the
+// per-field fetch pipeline (extractFieldForComparison) so both return
+// consistent values.
+func TestSynthesizeYearsActive(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		meta    *ArtistMetadata
+		want    string // expected synthesized value
+		wantOK  bool   // true when synthesis should succeed
+		comment string // why this outcome is expected
+	}{
+		{
+			// Groups with both formed and disbanded produce a closed "YYYY-YYYY" range.
+			name:    "group_formed_and_disbanded",
+			meta:    &ArtistMetadata{Type: "group", Formed: "1985-01-01", Disbanded: "2003-06-15"},
+			want:    "1985-2003",
+			wantOK:  true,
+			comment: "MB group with formed+disbanded -> closed range",
+		},
+		{
+			// Groups with only a formed date are assumed still active.
+			name:    "group_formed_only",
+			meta:    &ArtistMetadata{Type: "group", Formed: "1997"},
+			want:    "1997-present",
+			wantOK:  true,
+			comment: "MB group with formed only -> open-ended range",
+		},
+		{
+			// Orchestra type also uses the group synthesis path.
+			name:    "orchestra_formed_and_disbanded",
+			meta:    &ArtistMetadata{Type: "orchestra", Formed: "1900", Disbanded: "1950"},
+			want:    "1900-1950",
+			wantOK:  true,
+			comment: "orchestra treated as group type",
+		},
+		{
+			// Individuals with both born and died produce a bounded range.
+			name:    "individual_born_and_died",
+			meta:    &ArtistMetadata{Type: "person", Born: "1942-08-01", Died: "2018-03-14"},
+			want:    "1942-2018",
+			wantOK:  true,
+			comment: "individual with born+died -> bounded range",
+		},
+		{
+			// A living individual with only a birth date: we cannot know whether
+			// they are still active, so synthesis is deliberately skipped rather
+			// than guessing "YYYY-present". See issue #1069 acceptance criteria
+			// and the SynthesizeYearsActive doc comment.
+			name:    "individual_born_only_no_synthesis",
+			meta:    &ArtistMetadata{Type: "person", Born: "1959-10-03"},
+			want:    "",
+			wantOK:  false,
+			comment: "individual with born only must NOT synthesize (ambiguous activity status)",
+		},
+		{
+			// A group with no formed date cannot produce any range.
+			name:    "group_no_formed_date",
+			meta:    &ArtistMetadata{Type: "group", Disbanded: "2010"},
+			want:    "",
+			wantOK:  false,
+			comment: "group without formed date cannot synthesize",
+		},
+		{
+			// A type that is not a recognized group type and has no born+died.
+			name:    "unknown_type_no_dates",
+			meta:    &ArtistMetadata{Type: ""},
+			want:    "",
+			wantOK:  false,
+			comment: "empty type with no dates produces nothing",
+		},
+		{
+			// Nil metadata must not panic.
+			name:    "nil_metadata",
+			meta:    nil,
+			want:    "",
+			wantOK:  false,
+			comment: "nil metadata must return (empty, false) safely",
+		},
+		{
+			// Partial dates: only year portion is extracted ("YYYY-MM-DD" -> "YYYY").
+			name:    "group_partial_dates_year_extracted",
+			meta:    &ArtistMetadata{Type: "group", Formed: "1990-03-15", Disbanded: "2000-12-01"},
+			want:    "1990-2000",
+			wantOK:  true,
+			comment: "year-only extraction from full dates",
+		},
+		{
+			// Malformed date "late 1980s": yearFromDate validates that the leading
+			// 4 characters are all ASCII digits; "late" is not, so no synthesis.
+			// This is Finding 7: prevents garbage output like "late-present".
+			name:    "malformed_date_late_1980s",
+			meta:    &ArtistMetadata{Type: "group", Formed: "late 1980s"},
+			want:    "",
+			wantOK:  false,
+			comment: "malformed date 'late 1980s' must not synthesize (digit check)",
+		},
+		{
+			// Malformed date "circa 1990": same digit-validation path.
+			name:    "malformed_date_circa_1990",
+			meta:    &ArtistMetadata{Type: "group", Formed: "circa 1990"},
+			want:    "",
+			wantOK:  false,
+			comment: "malformed date 'circa 1990' must not synthesize (digit check)",
+		},
+		{
+			// Malformed date "19XX": placeholder digits fail the all-digit check
+			// because 'X' is not an ASCII digit.
+			name:    "malformed_date_19XX",
+			meta:    &ArtistMetadata{Type: "group", Formed: "19XX"},
+			want:    "",
+			wantOK:  false,
+			comment: "malformed date '19XX' must not synthesize (non-digit chars)",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc // capture for parallel sub-test
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := SynthesizeYearsActive(tc.meta)
+			if ok != tc.wantOK {
+				t.Errorf("%s: ok = %v, want %v", tc.comment, ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Errorf("%s: value = %q, want %q", tc.comment, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractFieldForComparison_YearsActiveSynthesis verifies that the per-field
+// fetch pipeline synthesizes years_active from formed/disbanded or born/died
+// when a provider returns metadata without a literal years_active value.
+// This is the core fix for #1069: providers like MusicBrainz that compute the
+// value at full-refresh time must also produce a candidate in the per-field path.
+func TestExtractFieldForComparison_YearsActiveSynthesis(t *testing.T) {
+	t.Parallel()
+
+	t.Run("literal_years_active_used_as_is", func(t *testing.T) {
+		// When the provider populates years_active directly, it must be returned
+		// unchanged and must NOT be marked synthesized.
+		fpr := &FieldProviderResult{}
+		extractFieldForComparison(fpr, "years_active", &ArtistMetadata{
+			YearsActive: "2000-2010",
+		})
+		if !fpr.HasData {
+			t.Error("expected HasData = true for literal years_active")
+		}
+		if fpr.Value != "2000-2010" {
+			t.Errorf("Value = %q, want %q", fpr.Value, "2000-2010")
+		}
+		if fpr.Synthesized {
+			t.Error("expected Synthesized = false for literal years_active")
+		}
+	})
+
+	t.Run("group_synthesized_from_formed_disbanded", func(t *testing.T) {
+		// A MusicBrainz result for a group has formed+disbanded but no literal
+		// years_active. The per-field pipeline must synthesize a candidate.
+		fpr := &FieldProviderResult{}
+		extractFieldForComparison(fpr, "years_active", &ArtistMetadata{
+			Type:      "group",
+			Formed:    "1985",
+			Disbanded: "2003",
+		})
+		if !fpr.HasData {
+			t.Error("expected HasData = true for group synthesis")
+		}
+		if fpr.Value != "1985-2003" {
+			t.Errorf("Value = %q, want %q", fpr.Value, "1985-2003")
+		}
+		if !fpr.Synthesized {
+			t.Error("expected Synthesized = true when value derived from formed/disbanded")
+		}
+	})
+
+	t.Run("wikipedia_infobox_missing_years_active_synthesized_from_formed", func(t *testing.T) {
+		// Wikipedia infoboxes often lack a literal years_active key but may have
+		// formed date. This simulates a Wikipedia result for a still-active group.
+		fpr := &FieldProviderResult{}
+		extractFieldForComparison(fpr, "years_active", &ArtistMetadata{
+			Type:   "group",
+			Formed: "1997",
+			// No Disbanded, no YearsActive -- infobox only had 'formed'.
+		})
+		if !fpr.HasData {
+			t.Error("expected HasData = true for Wikipedia synthesis from formed only")
+		}
+		if fpr.Value != "1997-present" {
+			t.Errorf("Value = %q, want %q", fpr.Value, "1997-present")
+		}
+		if !fpr.Synthesized {
+			t.Error("expected Synthesized = true")
+		}
+	})
+
+	t.Run("individual_born_only_no_synthesis", func(t *testing.T) {
+		// A solo artist (individual type) where only birth year is known.
+		// Synthesis must be skipped to avoid a spurious "YYYY-present" guess.
+		fpr := &FieldProviderResult{}
+		extractFieldForComparison(fpr, "years_active", &ArtistMetadata{
+			Type: "person",
+			Born: "1959-10-03",
+		})
+		if fpr.HasData {
+			t.Error("expected HasData = false for individual with born only")
+		}
+		if fpr.Value != "" {
+			t.Errorf("expected empty Value for individual born-only case, got %q", fpr.Value)
+		}
+	})
+
+	t.Run("empty_metadata_no_synthesis", func(t *testing.T) {
+		// No dates at all: nothing to synthesize.
+		fpr := &FieldProviderResult{}
+		extractFieldForComparison(fpr, "years_active", &ArtistMetadata{})
+		if fpr.HasData {
+			t.Error("expected HasData = false when no date fields present")
+		}
+	})
+}
+
+// TestFetchMetadata_MembersAuthoritative verifies that the orchestrator propagates
+// MembersAuthoritative from a provider's ArtistMetadata to the FetchResult, and
+// that it correctly guards AttemptedFields based on the authoritative flag.
+// This is the core behavior added for #1038.
+func TestFetchMetadata_MembersAuthoritative(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sparse_empty_does_not_mark_members_attempted", func(t *testing.T) {
+		// A provider returning empty members without the authoritative flag
+		// (e.g. MusicBrainz sparse relation data) must NOT add "members" to
+		// AttemptedFields. Downstream consumers must be able to preserve existing
+		// member rows rather than clearing them.
+		registry, settings := setupOrchestratorTest(t)
+		registry.Register(&mockProvider{
+			name: NameMusicBrainz,
+			getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+				return &ArtistMetadata{
+					Name:                 "Sparse Band",
+					Members:              nil,   // no members returned
+					MembersAuthoritative: false, // sparse data
+				}, nil
+			},
+		})
+		if err := settings.SetPriority(context.Background(), "members", []ProviderName{NameMusicBrainz}); err != nil {
+			t.Fatalf("SetPriority: %v", err)
+		}
+
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		orch := NewOrchestrator(registry, settings, logger)
+		result, err := orch.FetchMetadata(context.Background(), "mb-sparse", "Sparse Band", nil)
+		if err != nil {
+			t.Fatalf("FetchMetadata: %v", err)
+		}
+
+		for _, f := range result.AttemptedFields {
+			if f == "members" {
+				t.Error("members must NOT be in AttemptedFields when provider returned sparse-empty (non-authoritative)")
+				break
+			}
+		}
+		if result.MembersAuthoritative {
+			t.Error("MembersAuthoritative must be false when provider is non-authoritative")
+		}
+	})
+
+	t.Run("authoritative_empty_marks_members_attempted", func(t *testing.T) {
+		// A provider that asserts an empty roster authoritatively (e.g. the
+		// artist was re-identified as a solo act) must add "members" to
+		// AttemptedFields and set MembersAuthoritative=true so applyMemberRefresh
+		// can clear stale rows.
+		registry, settings := setupOrchestratorTest(t)
+		registry.Register(&mockProvider{
+			name: NameMusicBrainz,
+			getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+				return &ArtistMetadata{
+					Name:                 "Solo Artist",
+					Members:              nil,  // empty roster
+					MembersAuthoritative: true, // this empty is authoritative
+				}, nil
+			},
+		})
+		if err := settings.SetPriority(context.Background(), "members", []ProviderName{NameMusicBrainz}); err != nil {
+			t.Fatalf("SetPriority: %v", err)
+		}
+
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		orch := NewOrchestrator(registry, settings, logger)
+		result, err := orch.FetchMetadata(context.Background(), "mb-solo", "Solo Artist", nil)
+		if err != nil {
+			t.Fatalf("FetchMetadata: %v", err)
+		}
+
+		found := false
+		for _, f := range result.AttemptedFields {
+			if f == "members" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("members must be in AttemptedFields when provider asserted authoritative-empty")
+		}
+		if !result.MembersAuthoritative {
+			t.Error("MembersAuthoritative must be true when provider asserted authoritative-empty")
+		}
+	})
+
+	t.Run("non_empty_members_marks_attempted", func(t *testing.T) {
+		// A provider returning a real member list always marks the field as
+		// attempted regardless of the authoritative flag.
+		registry, settings := setupOrchestratorTest(t)
+		registry.Register(&mockProvider{
+			name: NameMusicBrainz,
+			getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+				return &ArtistMetadata{
+					Name:    "Real Band",
+					Members: []MemberInfo{{Name: "Alice"}, {Name: "Bob"}},
+				}, nil
+			},
+		})
+		if err := settings.SetPriority(context.Background(), "members", []ProviderName{NameMusicBrainz}); err != nil {
+			t.Fatalf("SetPriority: %v", err)
+		}
+
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		orch := NewOrchestrator(registry, settings, logger)
+		result, err := orch.FetchMetadata(context.Background(), "mb-band", "Real Band", nil)
+		if err != nil {
+			t.Fatalf("FetchMetadata: %v", err)
+		}
+
+		found := false
+		for _, f := range result.AttemptedFields {
+			if f == "members" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("members must be in AttemptedFields when provider returned real member data")
+		}
+		if len(result.Metadata.Members) != 2 {
+			t.Errorf("expected 2 members, got %d", len(result.Metadata.Members))
+		}
+	})
+
+	t.Run("provider_error_does_not_mark_members_attempted", func(t *testing.T) {
+		// Finding 6: a provider that returns a hard error (timeout, 5xx, etc.)
+		// must NOT mark "members" as attempted and must leave MembersAuthoritative
+		// false. The orchestrator skips the entire provider on pr.err != nil
+		// before reaching the members guard, so the field should not appear in
+		// AttemptedFields. Existing member rows must be preserved.
+		registry, settings := setupOrchestratorTest(t)
+		registry.Register(&mockProvider{
+			name: NameMusicBrainz,
+			getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+				// Simulate a transient provider failure (timeout, 5xx, etc.).
+				return nil, fmt.Errorf("connection refused")
+			},
+		})
+		if err := settings.SetPriority(context.Background(), "members", []ProviderName{NameMusicBrainz}); err != nil {
+			t.Fatalf("SetPriority: %v", err)
+		}
+
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		orch := NewOrchestrator(registry, settings, logger)
+		result, err := orch.FetchMetadata(context.Background(), "mb-error", "Error Artist", nil)
+		if err != nil {
+			t.Fatalf("FetchMetadata: %v", err)
+		}
+
+		// "members" must NOT appear in AttemptedFields after a provider error.
+		for _, f := range result.AttemptedFields {
+			if f == "members" {
+				t.Errorf("members must NOT be in AttemptedFields when provider errored, got %v", result.AttemptedFields)
+				break
+			}
+		}
+		// MembersAuthoritative must be false (provider did not contribute).
+		if result.MembersAuthoritative {
+			t.Error("MembersAuthoritative must be false when provider returned an error")
+		}
+	})
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -121,7 +121,7 @@ func ProviderCapabilities() map[ProviderName]ProviderCapability {
 		NameWikipedia: {
 			Tier:            TierFree,
 			RateLimit:       &RateLimitInfo{RequestsPerSecond: 5},
-			SupportedFields: []string{"name", "biography", "years_active", "origin", "genres", "members"},
+			SupportedFields: []string{"name", "type", "biography", "born", "died", "years_active", "origin", "genres", "members"},
 		},
 		NameSpotify: {
 			Tier:            TierPaid,
@@ -261,6 +261,15 @@ type ArtistMetadata struct {
 	SimilarArtists []string          `json:"similar_artists,omitempty"`
 	Aliases        []string          `json:"aliases,omitempty"`
 	URLs           map[string]string `json:"urls,omitempty"`
+	// MembersAuthoritative is set when the provider can assert that its member
+	// list is complete: an empty Members slice then means "this artist has no
+	// members" rather than "data was unavailable". Currently set by
+	// MusicBrainz for confirmed individual artist types (Person, Character),
+	// where an empty member list is definitionally complete because individuals
+	// cannot have band members by definition. Group/Orchestra/Choir types leave
+	// it false because MusicBrainz relation data for ensembles can be sparse.
+	// The orchestrator propagates it to FetchResult.MembersAuthoritative.
+	MembersAuthoritative bool `json:"members_authoritative,omitempty"`
 }
 
 // MemberInfo is a band member as reported by a provider.

--- a/internal/provider/wikipedia/infobox.go
+++ b/internal/provider/wikipedia/infobox.go
@@ -13,6 +13,12 @@ type infoboxData struct {
 	Genres      []string
 	Members     []string
 	PastMembers []string
+	// Born and Died are extracted from birth_date / death_date infobox keys.
+	// They are used by GetArtist to populate ArtistMetadata.Born / .Died so
+	// that the years_active synthesis helper can derive a "YYYY-YYYY" range
+	// for deceased solo artists whose infobox lacks a literal years_active key.
+	Born string
+	Died string
 }
 
 // parseInfobox extracts structured data from a wikitext infobox template.
@@ -56,8 +62,18 @@ func parseInfobox(wikitext string) *infoboxData {
 		data.PastMembers = parseListField(v)
 	}
 
+	// Birth and death dates for solo artists. Wikipedia uses date templates
+	// such as {{birth date|1959|10|23}} or {{birth date and age|1959|10|23}};
+	// extractYear pulls the first 4-digit sequence from the cleaned text.
+	if v := fieldValue(fields, "birth_date"); v != "" {
+		data.Born = extractYear(v)
+	}
+	if v := fieldValue(fields, "death_date"); v != "" {
+		data.Died = extractYear(v)
+	}
+
 	// Return nil if nothing was extracted.
-	if data.Origin == "" && data.YearsActive == "" &&
+	if data.Origin == "" && data.YearsActive == "" && data.Born == "" && data.Died == "" &&
 		len(data.Genres) == 0 && len(data.Members) == 0 && len(data.PastMembers) == 0 {
 		return nil
 	}
@@ -613,6 +629,44 @@ func splitOnBR(s string) []string {
 		}
 	}
 	return parts
+}
+
+// extractYear finds the first 4-digit sequence in a raw infobox date value
+// that looks like a plausible year (leading digit is '1' or '2', covering
+// years 1000-2999). Wikipedia date values are often encoded as templates such
+// as "{{birth date|1959|10|23}}" or "{{birth date and age|1959|10|23}}";
+// because the year argument is the first numeric argument after the template
+// name, scanning the raw value for the first 4-digit run gives the year without
+// needing to fully parse the template structure. The function does NOT strip
+// markup before scanning: cleanMarkup would reduce "{{birth date|1959|10|23}}"
+// to "23" (keeping only the last pipe argument), discarding the year.
+func extractYear(raw string) string {
+	// Walk the raw string looking for a run of exactly 4 ASCII digits that
+	// starts with '1' or '2' (year range 1000-2999). We stop at the first match
+	// so that in "{{death date and age|1991|11|24|1946|9|5}}" we pick "1991"
+	// (the death year, which appears first) rather than "1946" (birth year).
+	for i := 0; i+4 <= len(raw); i++ {
+		if !isDigit(raw[i]) {
+			continue
+		}
+		// Measure the full digit run starting at i.
+		j := i
+		for j < len(raw) && isDigit(raw[j]) {
+			j++
+		}
+		run := raw[i:j]
+		if len(run) == 4 && (run[0] == '1' || run[0] == '2') {
+			return run
+		}
+		// Advance past the entire digit run to avoid re-scanning its tail.
+		i = j - 1
+	}
+	return ""
+}
+
+// isDigit reports whether b is an ASCII decimal digit.
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
 }
 
 // cleanYearsActive normalizes a years_active value.

--- a/internal/provider/wikipedia/infobox_test.go
+++ b/internal/provider/wikipedia/infobox_test.go
@@ -432,3 +432,164 @@ func TestCleanYearsActive(t *testing.T) {
 		})
 	}
 }
+
+// --- #1069: birth_date / death_date extraction ---
+
+// TestParseInfobox_BornAndDied verifies that parseInfobox extracts birth_date
+// and death_date from an infobox and stores them in the Born and Died fields.
+// This data is used by GetArtist to enable years_active synthesis for deceased
+// solo artists whose infobox lacks a literal years_active key.
+func TestParseInfobox_BornAndDied(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		wikitext string
+		wantBorn string
+		wantDied string
+		comment  string
+	}{
+		{
+			// A deceased solo artist with a birth date template and a death date
+			// template. Both years should be extracted.
+			name: "born_and_died_templates",
+			wikitext: `{{Infobox musical artist
+| name        = Freddie Mercury
+| birth_date  = {{birth date|1946|9|5}}
+| death_date  = {{death date and age|1991|11|24|1946|9|5}}
+}}`,
+			wantBorn: "1946",
+			wantDied: "1991",
+			comment:  "birth_date + death_date templates must yield 4-digit years",
+		},
+		{
+			// A living solo artist with only a birth date. Died must be empty
+			// so synthesis is skipped (conservative per #1069 acceptance criterion 3).
+			name: "born_only_no_died",
+			wikitext: `{{Infobox musical artist
+| name       = Weird Al Yankovic
+| birth_date = {{birth date and age|1959|10|23}}
+}}`,
+			wantBorn: "1959",
+			wantDied: "",
+			comment:  "birth_date without death_date must leave Died empty",
+		},
+		{
+			// A band infobox with no birth_date/death_date keys at all.
+			// Both fields must be empty.
+			name: "no_birth_death_keys",
+			wikitext: `{{Infobox musical artist
+| name         = Radiohead
+| origin       = Abingdon, Oxfordshire, England
+| years_active = 1985-present
+| members      = {{flatlist|* Thom Yorke}}
+}}`,
+			wantBorn: "",
+			wantDied: "",
+			comment:  "band infobox without birth/death keys must leave both empty",
+		},
+		{
+			// Plain year strings without templates should also work.
+			name: "plain_year_strings",
+			wikitext: `{{Infobox person
+| name       = Test Person
+| birth_date = 1942
+| death_date = 2018
+}}`,
+			wantBorn: "1942",
+			wantDied: "2018",
+			comment:  "plain YYYY birth/death strings must parse correctly",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc // capture for parallel sub-test
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			data := parseInfobox(tc.wikitext)
+			if tc.wantBorn == "" && tc.wantDied == "" {
+				// When both fields are expected empty, nil is also acceptable
+				// if the infobox has no other extractable data.
+				if data != nil {
+					if data.Born != "" {
+						t.Errorf("%s: Born = %q, want empty", tc.comment, data.Born)
+					}
+					if data.Died != "" {
+						t.Errorf("%s: Died = %q, want empty", tc.comment, data.Died)
+					}
+				}
+				return
+			}
+			if data == nil {
+				t.Fatalf("%s: parseInfobox returned nil", tc.comment)
+			}
+			if data.Born != tc.wantBorn {
+				t.Errorf("%s: Born = %q, want %q", tc.comment, data.Born, tc.wantBorn)
+			}
+			if data.Died != tc.wantDied {
+				t.Errorf("%s: Died = %q, want %q", tc.comment, data.Died, tc.wantDied)
+			}
+		})
+	}
+}
+
+// TestExtractYear verifies the extractYear helper that finds the first 4-digit
+// year in a raw Wikipedia infobox date value.
+func TestExtractYear(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		comment string
+	}{
+		{
+			name:    "birth_date_template",
+			input:   "{{birth date|1959|10|23}}",
+			want:    "1959",
+			comment: "{{birth date|Y|M|D}} must yield first 4-digit year",
+		},
+		{
+			name:    "death_date_and_age_template",
+			input:   "{{death date and age|1991|11|24|1946|9|5}}",
+			want:    "1991",
+			comment: "{{death date and age|Y|M|D|...}} must yield first year (death year)",
+		},
+		{
+			name:    "plain_year",
+			input:   "1942",
+			want:    "1942",
+			comment: "plain 4-digit year string must be returned unchanged",
+		},
+		{
+			name:    "year_with_month_day",
+			input:   "1942-08-01",
+			want:    "1942",
+			comment: "YYYY-MM-DD must yield YYYY portion",
+		},
+		{
+			name:    "empty_string",
+			input:   "",
+			want:    "",
+			comment: "empty string must return empty",
+		},
+		{
+			name:    "no_year_in_string",
+			input:   "unknown",
+			want:    "",
+			comment: "string with no 4-digit sequence must return empty",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc // capture for parallel sub-test
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractYear(tc.input)
+			if got != tc.want {
+				t.Errorf("%s: extractYear(%q) = %q, want %q", tc.comment, tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/provider/wikipedia/wikipedia.go
+++ b/internal/provider/wikipedia/wikipedia.go
@@ -274,6 +274,36 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 		meta.Genres = infobox.Genres
 	}
 
+	// Map birth/death dates so the years_active synthesis helper can derive a
+	// "YYYY-YYYY" range for deceased solo artists whose infobox lacks a
+	// literal years_active key. This is the primary fix for #1069: a Wikipedia
+	// individual with birth_date + death_date will produce a synthesized
+	// years_active in the per-field fetch path via SynthesizeYearsActive.
+	if infobox.Born != "" {
+		meta.Born = infobox.Born
+	}
+	if infobox.Died != "" {
+		meta.Died = infobox.Died
+	}
+
+	// Set meta.Type so SynthesizeYearsActive chooses the correct synthesis
+	// path (group vs individual). The vocabulary mirrors the normalized values
+	// produced by MusicBrainz's mapArtistType:
+	//   "group"  -> uses Formed/Disbanded
+	//   "solo"   -> uses Born/Died (individual)
+	//
+	// Heuristic: if the infobox has members (current or past), it describes a
+	// group; if it has birth/death dates (but no members), it describes a solo
+	// artist. When neither signal is present, leave Type empty so synthesis
+	// does not fire and produces no false positive.
+	hasMembers := len(infobox.Members) > 0 || len(infobox.PastMembers) > 0
+	hasBirthDeath := infobox.Born != "" || infobox.Died != ""
+	if hasMembers {
+		meta.Type = "group"
+	} else if hasBirthDeath {
+		meta.Type = "solo"
+	}
+
 	// Combine current and past members into the Members slice.
 	for _, memberName := range infobox.Members {
 		meta.Members = append(meta.Members, provider.MemberInfo{

--- a/internal/provider/wikipedia/wikipedia_test.go
+++ b/internal/provider/wikipedia/wikipedia_test.go
@@ -1043,3 +1043,149 @@ func isErrNotFound(err error, target **provider.ErrNotFound) bool {
 func isErrUnavailable(err error, target **provider.ErrProviderUnavailable) bool {
 	return errors.As(err, target)
 }
+
+// --- #1069: Wikipedia infobox birth/death date mapping and synthesis ---
+
+// TestGetArtist_DeceasedIndividual_BornDiedMapped verifies that GetArtist maps
+// infobox.Born and infobox.Died to ArtistMetadata.Born and .Died, sets
+// meta.Type="solo" for an individual infobox (birth/death present, no members),
+// and that the synthesized years_active would be produced correctly by
+// SynthesizeYearsActive for a deceased individual. This is the core fix for
+// #1069: a Wikipedia entry for a deceased solo artist whose infobox has
+// birth_date + death_date (but no years_active key) now produces a candidate
+// in the per-field fetch path.
+func TestGetArtist_DeceasedIndividual_BornDiedMapped(t *testing.T) {
+	t.Parallel()
+
+	// Infobox for a deceased solo artist with birth_date and death_date but
+	// no years_active key -- the scenario from #1069.
+	wikitext := `{{Infobox musical artist
+| name       = Freddie Mercury
+| birth_date = {{birth date|1946|9|5}}
+| death_date = {{death date and age|1991|11|24|1946|9|5}}
+| genres     = [[Rock music|Rock]]
+}}`
+
+	sparqlSrv := sparqlServerReturning(t, "https://en.wikipedia.org/wiki/Freddie_Mercury")
+	defer sparqlSrv.Close()
+
+	actionSrv := actionExtractAndWikitextServer(t, "Freddie Mercury",
+		"Freddie Mercury was a British singer and songwriter.", wikitext)
+	defer actionSrv.Close()
+
+	adapter := newTestAdapter(t, actionSrv.URL, sparqlSrv.URL, "")
+
+	meta, err := adapter.GetArtist(context.Background(), "0383dadf-2a4e-4d10-a46a-e9e041da8eb3")
+	if err != nil {
+		t.Fatalf("GetArtist: %v", err)
+	}
+
+	// Born and Died must be populated from the infobox date templates.
+	if meta.Born != "1946" {
+		t.Errorf("Born = %q, want %q", meta.Born, "1946")
+	}
+	if meta.Died != "1991" {
+		t.Errorf("Died = %q, want %q", meta.Died, "1991")
+	}
+
+	// Type must be "solo" (individual with birth/death, no members in infobox).
+	if meta.Type != "solo" {
+		t.Errorf("Type = %q, want %q", meta.Type, "solo")
+	}
+
+	// With Born="1946" and Died="1991", SynthesizeYearsActive must produce
+	// "1946-1991". This is the synthesis that fires in the per-field fetch path.
+	got, ok := provider.SynthesizeYearsActive(meta)
+	if !ok {
+		t.Error("SynthesizeYearsActive returned ok=false; expected synthesis to succeed for deceased individual")
+	}
+	if got != "1946-1991" {
+		t.Errorf("SynthesizeYearsActive = %q, want %q", got, "1946-1991")
+	}
+}
+
+// TestGetArtist_LivingIndividual_NoSynthesis verifies that a living solo
+// artist (birth_date present but no death_date) does NOT produce a synthesized
+// years_active. This enforces #1069 acceptance criterion 3: synthesis for
+// individuals requires both born and died to be known.
+func TestGetArtist_LivingIndividual_NoSynthesis(t *testing.T) {
+	t.Parallel()
+
+	wikitext := `{{Infobox musical artist
+| name       = Weird Al Yankovic
+| birth_date = {{birth date and age|1959|10|23}}
+| genres     = [[Comedy music|Comedy]]
+}}`
+
+	sparqlSrv := sparqlServerReturning(t, "https://en.wikipedia.org/wiki/Weird_Al_Yankovic")
+	defer sparqlSrv.Close()
+
+	actionSrv := actionExtractAndWikitextServer(t, "Weird Al Yankovic",
+		"Weird Al Yankovic is an American singer-songwriter.", wikitext)
+	defer actionSrv.Close()
+
+	adapter := newTestAdapter(t, actionSrv.URL, sparqlSrv.URL, "")
+
+	meta, err := adapter.GetArtist(context.Background(), "1bccf464-5083-4c30-ad0d-057448d11e49")
+	if err != nil {
+		t.Fatalf("GetArtist: %v", err)
+	}
+
+	// Born must be populated; Died must be empty (living artist).
+	if meta.Born != "1959" {
+		t.Errorf("Born = %q, want %q", meta.Born, "1959")
+	}
+	if meta.Died != "" {
+		t.Errorf("Died = %q, want empty for living artist", meta.Died)
+	}
+
+	// Type must be "solo".
+	if meta.Type != "solo" {
+		t.Errorf("Type = %q, want %q", meta.Type, "solo")
+	}
+
+	// Synthesis must NOT produce a years_active for a living individual --
+	// we cannot know whether they are still active without a death date.
+	_, ok := provider.SynthesizeYearsActive(meta)
+	if ok {
+		t.Error("SynthesizeYearsActive must return ok=false for living individual (born only, no died)")
+	}
+}
+
+// TestGetArtist_Band_TypeSetToGroup verifies that a band infobox (with members)
+// results in meta.Type="group". This ensures the synthesis path is not triggered
+// for groups (they rely on Formed/Disbanded, not Born/Died).
+func TestGetArtist_Band_TypeSetToGroup(t *testing.T) {
+	t.Parallel()
+
+	wikitext := `{{Infobox musical artist
+| name         = Test Band
+| origin       = London, England
+| years_active = 1985-present
+| members      = {{flatlist|* Alice * Bob}}
+}}`
+
+	sparqlSrv := sparqlServerReturning(t, "https://en.wikipedia.org/wiki/Test_Band")
+	defer sparqlSrv.Close()
+
+	actionSrv := actionExtractAndWikitextServer(t, "Test Band",
+		"Test Band is an English rock band.", wikitext)
+	defer actionSrv.Close()
+
+	adapter := newTestAdapter(t, actionSrv.URL, sparqlSrv.URL, "")
+
+	meta, err := adapter.GetArtist(context.Background(), "some-band-mbid")
+	if err != nil {
+		t.Fatalf("GetArtist: %v", err)
+	}
+
+	// A band infobox (members present) must set Type="group".
+	if meta.Type != "group" {
+		t.Errorf("Type = %q, want %q", meta.Type, "group")
+	}
+
+	// YearsActive must come directly from the infobox (no synthesis needed).
+	if meta.YearsActive != "1985-present" {
+		t.Errorf("YearsActive = %q, want %q", meta.YearsActive, "1985-present")
+	}
+}

--- a/internal/scraper/executor.go
+++ b/internal/scraper/executor.go
@@ -241,6 +241,7 @@ func (e *Executor) scrapeField(
 ) FieldResult {
 	queried := false
 	isImage := CategoryFor(field.Field) == CategoryImages
+	isMembers := field.Field == FieldMembers
 
 	// For image fields, track the first provider that contributed images
 	// so we can report it in the FieldResult, and all contributing
@@ -254,8 +255,9 @@ func (e *Executor) scrapeField(
 		pr := e.getProviderResult(ctx, field.Primary, mbid, name, providerIDs, cache, mu)
 		if pr.err == nil {
 			provider.EnrichProviderIDs(pr.meta, providerIDs)
-			// See imageFieldQueried for the marking rationale.
-			if !isImage || imageFieldQueried(pr) {
+			// See imageFieldQueried and membersFieldQueried for the rationale.
+			if (!isImage || imageFieldQueried(pr)) &&
+				(!isMembers || membersFieldQueried(pr, result)) {
 				queried = true
 			}
 			if applyFieldValue(field.Field, pr, result) {
@@ -282,8 +284,9 @@ func (e *Executor) scrapeField(
 		}
 
 		provider.EnrichProviderIDs(pr.meta, providerIDs)
-		// See imageFieldQueried for the marking rationale.
-		if !isImage || imageFieldQueried(pr) {
+		// See imageFieldQueried and membersFieldQueried for the rationale.
+		if (!isImage || imageFieldQueried(pr)) &&
+			(!isMembers || membersFieldQueried(pr, result)) {
 			queried = true
 		}
 		if applyFieldValue(field.Field, pr, result) {
@@ -457,6 +460,27 @@ func (e *Executor) getProviderResult(
 // as attempted so that existing image data is preserved rather than cleared.
 func imageFieldQueried(pr *providerResult) bool {
 	return pr.imagesAttempted && pr.imageErr == nil
+}
+
+// membersFieldQueried reports whether the members field should be marked as
+// queried for this provider result. A provider that returned no members
+// without asserting completeness (sparse relation data) must not mark the
+// field as attempted, so existing member rows are preserved rather than
+// cleared. Marking is allowed only when the provider returned members OR
+// authoritatively asserted an empty roster; in the latter case the
+// authoritative signal is propagated to the merged result so downstream
+// consumers can distinguish an intentional clear from missing data.
+func membersFieldQueried(pr *providerResult, result *provider.FetchResult) bool {
+	if pr.meta == nil {
+		return false
+	}
+	if len(pr.meta.Members) == 0 && !pr.meta.MembersAuthoritative {
+		return false
+	}
+	if pr.meta.MembersAuthoritative {
+		result.MembersAuthoritative = true
+	}
+	return true
 }
 
 // fieldApplier copies one field from a provider's metadata into the merged

--- a/internal/scraper/executor_test.go
+++ b/internal/scraper/executor_test.go
@@ -1221,3 +1221,76 @@ func TestApplyFieldValue_ImageFields(t *testing.T) {
 		})
 	}
 }
+
+// TestMembersFieldQueried covers the membersFieldQueried helper introduced
+// for #1038. The helper is the canonical gate that determines whether the
+// scraper executor marks "members" as attempted for a given provider result.
+// Finding 6: a nil-meta result (provider error) must NOT mark the field.
+func TestMembersFieldQueried(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name              string
+		pr                *providerResult // the provider result to test
+		wantQueried       bool            // expected return value
+		wantAuthoritative bool            // expected FetchResult.MembersAuthoritative after call
+		comment           string
+	}{
+		{
+			// Nil meta: provider returned an error (timeout, 5xx). The field must
+			// NOT be marked as queried (Finding 6) and MembersAuthoritative stays false.
+			name:              "nil_meta_not_queried",
+			pr:                &providerResult{meta: nil},
+			wantQueried:       false,
+			wantAuthoritative: false,
+			comment:           "nil meta (provider error) must return false",
+		},
+		{
+			// Sparse empty: provider returned metadata but no members and no
+			// authoritative flag. MusicBrainz sparse-relation data case.
+			name:              "sparse_empty_not_queried",
+			pr:                &providerResult{meta: &provider.ArtistMetadata{Members: nil, MembersAuthoritative: false}},
+			wantQueried:       false,
+			wantAuthoritative: false,
+			comment:           "sparse-empty (non-authoritative) must return false",
+		},
+		{
+			// Authoritative empty: provider asserted a complete empty roster.
+			// MembersAuthoritative must be propagated to the merged result and the
+			// field marked as queried so downstream can clear stale rows.
+			name:              "authoritative_empty_is_queried",
+			pr:                &providerResult{meta: &provider.ArtistMetadata{Members: nil, MembersAuthoritative: true}},
+			wantQueried:       true,
+			wantAuthoritative: true,
+			comment:           "authoritative-empty must return true and propagate flag",
+		},
+		{
+			// Non-empty members: real data always marks the field as queried.
+			name: "nonempty_members_is_queried",
+			pr: &providerResult{meta: &provider.ArtistMetadata{
+				Members: []provider.MemberInfo{{Name: "Alice"}},
+			}},
+			wantQueried:       true,
+			wantAuthoritative: false,
+			comment:           "non-empty member list must return true",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc // capture for parallel sub-test
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := &provider.FetchResult{
+				Metadata: &provider.ArtistMetadata{},
+			}
+			got := membersFieldQueried(tc.pr, result)
+			if got != tc.wantQueried {
+				t.Errorf("%s: membersFieldQueried = %v, want %v", tc.comment, got, tc.wantQueried)
+			}
+			if result.MembersAuthoritative != tc.wantAuthoritative {
+				t.Errorf("%s: FetchResult.MembersAuthoritative = %v, want %v",
+					tc.comment, result.MembersAuthoritative, tc.wantAuthoritative)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- The `years_active` per-field fetch (the Fetch button on the Years Active field) now synthesizes a value from `formed`/`disbanded` (groups) or `born`/`died` (individuals) when providers that compute rather than store the field return empty. This closes the "no candidates" UX hole where MusicBrainz and non-conforming Wikipedia infoboxes left the field unfetchable (#1069). The Wikipedia infobox parser now also extracts `birth_date`/`death_date`, so synthesis can fire for deceased Wikipedia individuals. Because the Wikipedia adapter's `GetArtist` now populates `type`/`born`/`died`, the generated provider capability matrix (`docs/site/src/reference/providers.md`) is regenerated to list those fields for Wikipedia.
- Member refresh now distinguishes an authoritative-empty member result ("provider definitively reports no members") from sparse no-data, via a new `MembersAuthoritative` flag. MusicBrainz sets it for confirmed individual artist types (Person, Character) only, where an empty member list is definitionally complete. This lets a refresh auto-clear stale band members after a solo re-identification, with zero data-loss risk to real bands (which are Group-typed and never set the flag) (#1038).
- Reviewers: the `applyMemberRefresh` guard change in `handlers_refresh.go` and the MusicBrainz `MembersAuthoritative` wiring are the safety-critical paths.

## Linked issue

Closes #1069
Closes #1038

## Pre-flight checklist

- [x] Pre-push gate green locally (ran via the pre-push hook on push).
- [x] Code review pass complete (3-agent review toolkit on the foundation, focused code-review on the expansion; all findings fixed before push).
- [x] Commits squashed into clean, logical commits before the first push (single commit, 13 hand-written files).
- [x] At least one label set on `gh pr create --label ...`.
- [x] Docs label decision made: `needs-docs-review` (user-visible: the Years Active fetch behavior changes).
- [ ] Screenshot attached for any UI change (not applicable: provider and refresh logic only, no template change).
- [x] UAT performed for user-visible changes -- both #1069 synthesis and #1038 member-clear conclusively verified against the running binary; see Test plan.
- [ ] OpenAPI spec updated if any request or response shape changed (not applicable: `handlers_refresh.go` change is internal logic, no request/response shape change).
- [ ] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed (not applicable: no `.templ` file changed).

## Test plan

- [x] `go test -race ./...` passes locally (run by the implementing agent and again by the pre-push gate).
- [x] `bash scripts/pre-push-gate.sh` passes locally (via the pre-push hook on push).
- [x] Manual UAT against the running binary (native build from this branch, server on `localhost:1973`):
  - [x] #1069 synthesis -- per-field fetch of `years_active` on Aaron Copland (deceased solo artist, b.1900 d.1990): AudioDB returns `1900-1990` with an explicit `"synthesized": true` flag in the API response; MusicBrainz returns `1900-1990` (synthesized inside its adapter). `1900-1990` is Copland's birth-death range; no provider stores a literal `years_active` for a person, so the value can only be born/died synthesis.
  - [x] #1038 authoritative-empty member clear -- a stale band member was injected into Aaron Copland (a Person-type artist) via direct DB write, then the artist was refreshed: the stale member was cleared (verified across 3 runs). `applyMemberRefresh` (`handlers_refresh.go:303`) is the only member-writer in the refresh path; its guard clears an empty member list only when `MembersAuthoritative` is true, which only the new MusicBrainz Person/Character wiring sets.
  - [x] #1038 no-regression -- refresh of 12 Stones (a Group-type artist) returns HTTP 200; Group types never set `MembersAuthoritative`, so the conservative (preserve) path is intact.

Reviewer follow-ups (for the reviewer to sanity-check; not author-completed items):

- The MusicBrainz `MembersAuthoritative` wiring: confirm Person/Character set it and Group/Orchestra/Choir/unknown never do.
- The Wikipedia infobox `extractYear` heuristic: it scans a raw template field value for the first 4-digit year run.

## Notes

The #1038 authoritative-empty auto-clear path also has unit coverage via integration-style handler tests against real SQLite (`handlers_refresh_test.go`: `authoritative_empty_clears_members`, `non_authoritative_empty_preserves_members`, `provider_error_fetch_result_preserves_members`). The dangerous failure path (a provider error must not be treated as authoritative-empty) has an explicit regression test in both the orchestrator and handler suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced member roster handling: system now distinguishes between authoritative (complete) and sparse member data, improving roster accuracy.
  * Years active synthesis: automatically calculates date ranges from formation/disbanding dates for groups and birth/death dates for individuals when explicit years aren't available.
  * Birth/death date extraction: Wikipedia provider now extracts individual artist birth and death dates.
  * Artist type detection: improved classification of artists as solo or group based on available metadata.

* **Tests**
  * Added comprehensive test coverage for member roster authoritativeness, years active synthesis, and provider integration behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->