### PR TITLE
docs: add Running Long Tests section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,25 @@ make docker-build   # Build Docker image
 make docker-run     # Start via docker compose
 ```
 
+## Running Long Tests
+
+A test run's output is a deterministic artifact: capture it once, grep it
+many times. Never re-run a long suite (race tests especially) just to
+re-filter the output. Pipe it to a file, then search the file:
+
+```bash
+. scripts/lib/run-paths.sh   # provides $SW_RUN_DIR (per-worktree, ephemeral)
+go test -race -count=1 ./internal/<pkg>/ 2>&1 | tee "$SW_RUN_DIR/race.log"
+grep -nE 'WARNING: DATA RACE|--- FAIL' "$SW_RUN_DIR/race.log"
+```
+
+Do not run the full `./...` race suite as a pre-PR check -- that is the
+pre-push gate's job and the pre-push git hook runs it automatically. The
+capture rule is for targeted runs while debugging. When dispatching a
+subagent that runs tests, paste this rule into its prompt; subagents do not
+load project memory. The `capture-race-test-output` hookify rule blocks
+uncaptured `go test -race` invocations.
+
 ## GitHub Issue Hints
 
 When working on a GitHub issue, look for these tags in the issue body:


### PR DESCRIPTION
## Summary

- Adds a "Running Long Tests" section to CLAUDE.md codifying
  capture-once, grep-many: tee a long test run's output to a file, then
  grep the file. Re-running a race suite just to re-filter its output (a
  different grep, or head vs tail) discards the 3-5 min run for something
  a grep on a saved file answers instantly.
- Clarifies that the full `./...` race suite is the pre-push gate's job
  and the pre-push hook runs it automatically; it should not be run
  standalone as a pre-PR self-check.
- Notes that subagents do not load project memory, so the rule must be
  pasted into dispatch prompts when an agent runs tests.

No user-visible product behavior changes; this is project-instruction
documentation only. It is paired with a local `capture-race-test-output`
hookify rule (gitignored, not part of this PR) that blocks uncaptured
race-test invocations.

## Linked issue

None -- direct change requested by the maintainer.

## Pre-flight checklist

- [x] Single, clean commit.
- [x] Labels set at creation: `documentation`, `scope: small`, `docs: not-required`.
- [x] Docs label decision: `docs: not-required` -- no user-visible behavior change.
- [ ] Pre-push gate intentionally skipped: the diff is CLAUDE.md only
  (repo-meta), so the Go test suite is a 3-5 min no-op. Skipped per the
  repo's meta-only-diff convention.
- [ ] Code review toolkit not run: no code changed; nothing to assess.
- [ ] No UI change -- no screenshot needed.
- [ ] No user-visible change -- no UAT needed.
- [ ] No API shape change -- OpenAPI untouched.
- [ ] No `.templ` change -- no generated files affected.

## Test plan

- [ ] No Go files changed; the test suite is not applicable.
- [ ] Pre-push gate skipped (meta-only diff, per repo convention).
- Manual verification done: the paired hookify rule's regex was checked
  against 14 representative command strings. Real race-test invocations
  are blocked; `tee`-captured commands, non-race tests, `make test-race`,
  the gate script, and quoted mentions are correctly left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for running long tests more efficiently. Developers can now capture deterministic test output, including race condition detection, to a per-worktree log directory and re-filter saved artifacts for analysis. This eliminates the need to rerun complete test suites, significantly improving development workflow efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->