### PR TITLE
feat(scraper): localize genre/style/mood tags in the scraper-executor path

### DIFF
--- a/internal/provider/language.go
+++ b/internal/provider/language.go
@@ -95,12 +95,15 @@ func languageBase(tag string) string {
 	return tag
 }
 
-// firstMetadataLang returns the primary-language subtag of the user's first
+// FirstMetadataLang returns the primary-language subtag of the user's first
 // non-blank preferred metadata language from ctx. Blank or whitespace-only
 // entries are skipped so a stray empty preference does not mask a later valid
 // language. Returns an empty string when no usable preference is stored
 // (callers should treat this as "en" / no localization).
-func firstMetadataLang(ctx context.Context) string {
+//
+// It is exported so the scraper executor (a separate package) can derive the
+// same metadata locale the orchestrator uses for locale-aware tag handling.
+func FirstMetadataLang(ctx context.Context) string {
 	for _, raw := range MetadataLanguages(ctx) {
 		if lang := languageBase(strings.ToLower(strings.TrimSpace(raw))); lang != "" {
 			return lang

--- a/internal/provider/language_test.go
+++ b/internal/provider/language_test.go
@@ -143,8 +143,8 @@ func TestFirstMetadataLang(t *testing.T) {
 			if tc.langs != nil {
 				ctx = WithMetadataLanguages(ctx, tc.langs)
 			}
-			if got := firstMetadataLang(ctx); got != tc.want {
-				t.Errorf("firstMetadataLang(%v) = %q, want %q", tc.langs, got, tc.want)
+			if got := FirstMetadataLang(ctx); got != tc.want {
+				t.Errorf("FirstMetadataLang(%v) = %q, want %q", tc.langs, got, tc.want)
 			}
 		})
 	}

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -155,7 +155,7 @@ func (o *Orchestrator) FetchMetadata(ctx context.Context, mbid, name string, pro
 		Metadata: &ArtistMetadata{
 			URLs: make(map[string]string),
 		},
-		MetadataLocale: firstMetadataLang(ctx),
+		MetadataLocale: FirstMetadataLang(ctx),
 	}
 
 	// Ensure providerIDs is writable so EnrichProviderIDs can populate it

--- a/internal/scraper/executor.go
+++ b/internal/scraper/executor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/provider"
+	"github.com/sydlexius/stillwater/internal/provider/tagdict"
 )
 
 // Executor performs per-field metadata scraping with fallback chain execution.
@@ -90,6 +91,9 @@ func (e *Executor) ScrapeAll(ctx context.Context, mbid, name, scope string, prov
 		Metadata: &provider.ArtistMetadata{
 			URLs: make(map[string]string),
 		},
+		// MetadataLocale drives locale-aware genre/style/mood handling in the
+		// fieldAppliers below, matching the legacy orchestrator path.
+		MetadataLocale: provider.FirstMetadataLang(ctx),
 	}
 
 	// Cache provider results to avoid duplicate API calls
@@ -498,25 +502,30 @@ var fieldAppliers = map[FieldName]fieldApplier{
 		r.Metadata.Biography = m.Biography
 		return true
 	},
+	// Genre/style/mood are routed through tagdict: tags are canonicalized to a
+	// consistent spelling and, when the user has a metadata-language preference
+	// (r.MetadataLocale), translated to that locale. An empty locale degrades to
+	// plain canonicalization. This mirrors the legacy orchestrator path so both
+	// fetch paths surface tags identically.
 	FieldGenres: func(m *provider.ArtistMetadata, r *provider.FetchResult) bool {
 		if len(m.Genres) == 0 {
 			return false
 		}
-		r.Metadata.Genres = m.Genres
+		r.Metadata.Genres = tagdict.MergeAndDeduplicateLocale(nil, m.Genres, r.MetadataLocale)
 		return true
 	},
 	FieldStyles: func(m *provider.ArtistMetadata, r *provider.FetchResult) bool {
 		if len(m.Styles) == 0 {
 			return false
 		}
-		r.Metadata.Styles = m.Styles
+		r.Metadata.Styles = tagdict.MergeAndDeduplicateLocale(nil, m.Styles, r.MetadataLocale)
 		return true
 	},
 	FieldMoods: func(m *provider.ArtistMetadata, r *provider.FetchResult) bool {
 		if len(m.Moods) == 0 {
 			return false
 		}
-		r.Metadata.Moods = m.Moods
+		r.Metadata.Moods = tagdict.MergeAndDeduplicateLocale(nil, m.Moods, r.MetadataLocale)
 		return true
 	},
 	FieldMembers: func(m *provider.ArtistMetadata, r *provider.FetchResult) bool {

--- a/internal/scraper/executor_test.go
+++ b/internal/scraper/executor_test.go
@@ -927,7 +927,8 @@ func TestExecutorPriorityFallbackPreservesUnlistedProviders(t *testing.T) {
 		t.Fatalf("ScrapeAll: %v", err)
 	}
 
-	if len(result.Metadata.Genres) == 0 || result.Metadata.Genres[0] != "jazz" {
+	// "jazz" from the provider is canonicalized to "Jazz" by tagdict.
+	if len(result.Metadata.Genres) == 0 || result.Metadata.Genres[0] != "Jazz" {
 		t.Errorf("expected genres from Wikidata chain fallback, got %v", result.Metadata.Genres)
 	}
 
@@ -1063,7 +1064,7 @@ func TestApplyFieldValue_PerFieldTable(t *testing.T) {
 		{
 			field:    FieldGenres,
 			populate: func(m *provider.ArtistMetadata) { m.Genres = []string{"rock"} },
-			readBack: func(m *provider.ArtistMetadata) bool { return len(m.Genres) == 1 && m.Genres[0] == "rock" },
+			readBack: func(m *provider.ArtistMetadata) bool { return len(m.Genres) == 1 && m.Genres[0] == "Rock" },
 		},
 		{
 			field:    FieldStyles,
@@ -1138,6 +1139,75 @@ func TestApplyFieldValue_PerFieldTable(t *testing.T) {
 				t.Fatalf("applyFieldValue(%s) with empty meta = true, want false", tc.field)
 			}
 		})
+	}
+}
+
+// TestApplyFieldValue_LocalizesGenres verifies that the executor path routes
+// genre tags through tagdict: tags are canonicalized always, and translated to
+// the result's metadata locale when one is set. This is the executor-path
+// counterpart to the legacy orchestrator's locale-aware tag merge (#1589).
+func TestApplyFieldValue_LocalizesGenres(t *testing.T) {
+	tests := []struct {
+		name   string
+		locale string
+		want   string
+	}{
+		{"japanese locale localizes", "ja", "ロック"},
+		{"empty locale canonicalizes only", "", "Rock"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := &providerResult{meta: &provider.ArtistMetadata{Genres: []string{"rock"}}}
+			result := &provider.FetchResult{
+				Metadata:       &provider.ArtistMetadata{},
+				MetadataLocale: tc.locale,
+			}
+			if !applyFieldValue(FieldGenres, pr, result) {
+				t.Fatalf("applyFieldValue(genres) = false, want true")
+			}
+			if len(result.Metadata.Genres) != 1 || result.Metadata.Genres[0] != tc.want {
+				t.Errorf("genres = %v, want [%s]", result.Metadata.Genres, tc.want)
+			}
+		})
+	}
+}
+
+// TestScrapeAll_LocalizesGenresFromMetadataLanguage verifies the full executor
+// path: ScrapeAll derives the metadata locale from the request context and
+// applies it to genre tags, so a ja preference yields localized genres (#1589).
+func TestScrapeAll_LocalizesGenresFromMetadataLanguage(t *testing.T) {
+	registry, settings, svc, logger := setupExecutorTest(t)
+
+	registry.Register(&mockProvider{
+		name:    provider.NameMusicBrainz,
+		authReq: false,
+		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+			return &provider.ArtistMetadata{Genres: []string{"rock"}}, nil
+		},
+	})
+
+	cfg := &ScraperConfig{
+		Scope: ScopeGlobal,
+		Fields: []FieldConfig{
+			{Field: FieldGenres, Primary: provider.NameMusicBrainz, Enabled: true, Category: CategoryMetadata},
+		},
+		FallbackChains: []FallbackChain{
+			{Category: CategoryMetadata, Providers: []provider.ProviderName{provider.NameMusicBrainz}},
+		},
+	}
+	if err := svc.SaveConfig(context.Background(), ScopeGlobal, cfg, nil); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	exec := NewExecutor(svc, registry, settings, logger)
+	ctx := provider.WithMetadataLanguages(context.Background(), []string{"ja"})
+	result, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
+	if err != nil {
+		t.Fatalf("ScrapeAll: %v", err)
+	}
+
+	if len(result.Metadata.Genres) != 1 || result.Metadata.Genres[0] != "ロック" {
+		t.Errorf("expected genres localized to ja [ロック], got %v", result.Metadata.Genres)
 	}
 }
 


### PR DESCRIPTION
## Summary

- The scraper executor builds its `FetchResult` through its own first-write-wins `fieldAppliers`, which set `Genres`/`Styles`/`Moods` straight from the winning provider without ever consulting `tagdict`. So the locale-aware canonicalization and translation added in #1119 only reached the legacy `Orchestrator.FetchMetadata` path, never the executor path that runs whenever a scraper config is present.
- The executor now derives the metadata locale from the request context (`FetchResult.MetadataLocale`) and routes genre/style/mood through `tagdict.MergeAndDeduplicateLocale`, matching the legacy path: tags are canonicalized always, and translated to the user's first metadata-language preference when one is set.
- `firstMetadataLang` is promoted to the exported `provider.FirstMetadataLang` so the scraper package can derive the same locale the orchestrator uses.
- User-visible effect: genre/style/mood tags from the executor fetch path are now canonicalized (e.g. `alternative rock` -> `Alternative Rock`) and localized for users with a non-English metadata-language preference.

## Linked issue

Closes #1589

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Code review: review-toolkit skipped per the small-PR rule -- the change reuses the already-toolkit-reviewed, 100%-covered `tagdict.MergeAndDeduplicateLocale`; ~30 lines of real logic, no concurrency/error/security/API-contract surface. CodeRabbit reviews on the PR.
- [x] Commits squashed into a single clean commit.
- [x] At least one label set.
- [x] Docs label: `docs: not-required` -- examined the docs-drift advisory's 5 candidate pages; the metadata-languages docs (`settings-by-tab.md`, `configure-provider-priorities.md`) updated in #1588 already describe genre/style/mood localization without qualifying the fetch path, so #1590 (an internal-consistency fix that makes that behavior reach the executor path) needs no new docs.
- [x] No UI change (genre label text only) -- no screenshot.
- [x] OpenAPI: no request/response shape changed (`MetadataLocale` is `json:"-"`).
- [x] No `.templ` files changed.

## Test plan

- [x] `go test -race ./...` passes locally (via the pre-push gate).
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] Unit test `TestApplyFieldValue_LocalizesGenres` -- ja locale localizes (`rock` -> `ロック`), empty locale canonicalizes (`rock` -> `Rock`).
- [x] Integration test `TestScrapeAll_LocalizesGenresFromMetadataLanguage` -- drives the real `ScrapeAll` with a `ja` metadata-language context end to end.
- [x] Manual UAT: refreshed an artist through the executor path; genres went from `['alternative rock', 'christian rock', 'hard rock', 'post-grunge', 'rock']` to `['Alternative Rock', 'christian rock', 'hard rock', 'post-grunge', 'Rock']` -- known vocab canonicalized, unknown vocab passed through unchanged.
