### PR TITLE
refactor(provider): remove dead locale-scoring code from deduplicateMembers

### DIFF
--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -881,9 +881,7 @@ func (a *Adapter) mapArtist(ctx context.Context, mb *MBArtist) *provider.ArtistM
 
 	// Deduplicate members by MBID. When the same person appears multiple times
 	// (e.g., different active periods), merge their date ranges and instruments.
-	// Language preferences are passed so the preferred locale name is selected
-	// when merging duplicates with different name variants.
-	meta.Members = deduplicateMembers(meta.Members, langPrefs)
+	meta.Members = deduplicateMembers(meta.Members)
 
 	synthesizeYearsActive(meta)
 
@@ -987,17 +985,22 @@ func deduplicateStyles(styles, genres []string) []string {
 
 // deduplicateMembers merges duplicate member entries that share the same MBID.
 // When duplicates exist, their date ranges and instruments are combined into a
-// single entry. If langPrefs is non-empty, the preferred locale name is selected
-// when merging members with different name variants.
-func deduplicateMembers(members []provider.MemberInfo, langPrefs []string) []provider.MemberInfo {
+// single entry. The merged entry keeps the first canonical name seen for the
+// MBID.
+//
+// Note: MusicBrainz "member of band" relation stubs carry only "name" and
+// "sort-name" fields -- no alias or locale data is present in the response
+// (confirmed by live BUCK-TICK query with inc=aliases+artist-rels; see #1020).
+// Locale-aware name selection is therefore not possible at this stage and is
+// not attempted.
+func deduplicateMembers(members []provider.MemberInfo) []provider.MemberInfo {
 	if len(members) <= 1 {
 		return members
 	}
 
 	type mergedMember struct {
-		info      provider.MemberInfo
-		periods   [][2]string // pairs of [joined, left]
-		nameScore int         // best language preference score for the current name (-1 = unscored)
+		info    provider.MemberInfo
+		periods [][2]string // pairs of [joined, left]
 	}
 
 	// Track insertion order so the output is deterministic.
@@ -1016,37 +1019,15 @@ func deduplicateMembers(members []provider.MemberInfo, langPrefs []string) []pro
 		if !ok {
 			order = append(order, key)
 			byMBID[key] = &mergedMember{
-				info:      m,
-				periods:   [][2]string{{m.DateJoined, m.DateLeft}},
-				nameScore: -1,
+				info:    m,
+				periods: [][2]string{{m.DateJoined, m.DateLeft}},
 			}
 			continue
 		}
 
 		// Merge: combine date range and instruments from the duplicate.
+		// The first canonical name for this MBID is kept as-is.
 		existing.periods = append(existing.periods, [2]string{m.DateJoined, m.DateLeft})
-
-		// Select the preferred locale name when language preferences are set.
-		// Each duplicate member name is scored against the preference list and
-		// the best-scoring name wins. When scores are tied, the first name is kept.
-		if len(langPrefs) > 0 && m.Name != existing.info.Name {
-			// Score the incoming name. MusicBrainz member names do not carry an
-			// explicit locale, but the name itself may match a language preference
-			// if it was populated from a locale-specific alias. We use the MBID
-			// as a proxy -- the first entry keeps its score; the incoming entry
-			// is scored and compared.
-			if existing.nameScore < 0 {
-				// Score the existing name on first collision.
-				existing.nameScore = provider.MatchLanguagePreference(existing.info.Name, langPrefs)
-			}
-			incomingScore := provider.MatchLanguagePreference(m.Name, langPrefs)
-			// Lower non-negative score wins. If the existing has no match (-1)
-			// and the incoming does, the incoming wins.
-			if incomingScore >= 0 && (existing.nameScore < 0 || incomingScore < existing.nameScore) {
-				existing.info.Name = m.Name
-				existing.nameScore = incomingScore
-			}
-		}
 
 		// Merge instruments, avoiding duplicates.
 		instrSet := make(map[string]bool, len(existing.info.Instruments))

--- a/internal/provider/musicbrainz/musicbrainz_test.go
+++ b/internal/provider/musicbrainz/musicbrainz_test.go
@@ -969,7 +969,7 @@ func TestMapArtist_AlsoPerformsAs_DoesNotAddSelfName(t *testing.T) {
 // --- deduplicateMembers unit tests ---
 
 func TestDeduplicateMembers_EmptySlice(t *testing.T) {
-	result := deduplicateMembers(nil, nil)
+	result := deduplicateMembers(nil)
 	if result != nil {
 		t.Errorf("expected nil for nil input, got %v", result)
 	}
@@ -977,7 +977,7 @@ func TestDeduplicateMembers_EmptySlice(t *testing.T) {
 
 func TestDeduplicateMembers_SingleMember(t *testing.T) {
 	members := []provider.MemberInfo{{Name: "Solo", MBID: "m1"}}
-	result := deduplicateMembers(members, nil)
+	result := deduplicateMembers(members)
 	if len(result) != 1 || result[0].Name != "Solo" {
 		t.Errorf("expected single member unchanged, got %v", result)
 	}
@@ -989,7 +989,7 @@ func TestDeduplicateMembers_NoMBID(t *testing.T) {
 		{Name: "Unknown A"},
 		{Name: "Unknown B"},
 	}
-	result := deduplicateMembers(members, nil)
+	result := deduplicateMembers(members)
 	if len(result) != 2 {
 		t.Errorf("expected 2 members without MBIDs kept separate, got %d", len(result))
 	}
@@ -1013,7 +1013,7 @@ func TestDeduplicateMembers_NoMBIDIdenticalNameKeptSeparate(t *testing.T) {
 		},
 	}
 
-	result := deduplicateMembers(members, nil)
+	result := deduplicateMembers(members)
 
 	if len(result) != 2 {
 		t.Fatalf("expected 2 separate members, got %d", len(result))
@@ -1026,9 +1026,10 @@ func TestDeduplicateMembers_NoMBIDIdenticalNameKeptSeparate(t *testing.T) {
 	}
 }
 
-func TestDeduplicateMembers_LocalePreference(t *testing.T) {
+func TestDeduplicateMembers_DuplicateMBIDKeepsFirstName(t *testing.T) {
 	// Two entries for the same member (same MBID) with different name variants.
-	// When language preferences favor "ja", the Japanese name should be selected.
+	// MusicBrainz relation stubs carry no alias/locale data, so locale-aware
+	// selection is not possible. The first canonical name seen is kept (#1020).
 	members := []provider.MemberInfo{
 		{
 			Name:       "Taro Yamada",
@@ -1037,50 +1038,24 @@ func TestDeduplicateMembers_LocalePreference(t *testing.T) {
 			IsActive:   true,
 		},
 		{
-			Name:       "ja",
+			Name:       "Alternative Name",
 			MBID:       "aaa-bbb-ccc",
 			DateJoined: "2005",
 			IsActive:   false,
 		},
 	}
 
-	// With "ja" preference, the name "ja" scores 0 (exact match at index 0)
-	// while "Taro Yamada" scores -1 (no match). So "ja" wins.
-	langPrefs := []string{"ja"}
-	result := deduplicateMembers(members, langPrefs)
+	result := deduplicateMembers(members)
 
 	if len(result) != 1 {
 		t.Fatalf("expected 1 member, got %d", len(result))
 	}
-	if result[0].Name != "ja" {
-		t.Errorf("expected locale-preferred name %q, got %q", "ja", result[0].Name)
+	if result[0].Name != "Taro Yamada" {
+		t.Errorf("expected first canonical name %q to be kept, got %q", "Taro Yamada", result[0].Name)
 	}
 	// Verify merge still works: should be active since first entry was active.
 	if !result[0].IsActive {
 		t.Error("expected merged member to be active")
-	}
-}
-
-func TestDeduplicateMembers_LocalePreference_NoPrefs(t *testing.T) {
-	// Without language preferences, the first name should be retained.
-	members := []provider.MemberInfo{
-		{
-			Name: "First Name",
-			MBID: "aaa-bbb-ccc",
-		},
-		{
-			Name: "Second Name",
-			MBID: "aaa-bbb-ccc",
-		},
-	}
-
-	result := deduplicateMembers(members, nil)
-
-	if len(result) != 1 {
-		t.Fatalf("expected 1 member, got %d", len(result))
-	}
-	if result[0].Name != "First Name" {
-		t.Errorf("expected first name to be retained, got %q", result[0].Name)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Issue #1020 mandated an investigation before choosing an implementation path. **Investigation result (acceptance criterion 1):** the MusicBrainz API does not return alias/locale data in `member of band` relation stubs. A live query of BUCK-TICK (`inc=aliases+artist-rels`) shows each member stub carries only `name` and `sort-name` -- no `aliases` key at all -- and `inc=...+artists` is rejected (HTTP 400, "not a valid inc parameter"). There is no API expansion that surfaces per-member alias data.
- Therefore **Path A**: `deduplicateMembers` contained a locale-scoring path that passed a person's display name where `provider.MatchLanguagePreference` expects a BCP 47 locale tag, so it always returned -1 and never fired. That dead code is removed, the now-unused `langPrefs` parameter is dropped, and the limitation is documented in a comment citing #1020.
- Behavior is unchanged: the merged member already kept the first canonical name per MBID (the scoring never altered it). No `MemberInfo.Locale` field is added; `MatchLanguagePreference` is untouched (still used for primary-artist name resolution).

## Linked issue

Closes #1020

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Code review: diff verified by the parent session; review-toolkit skipped per the small-PR rule -- a ~30-line dead-code removal plus a test rewrite, no new logic.
- [x] Commits squashed into a single clean commit.
- [x] At least one label set.
- [x] Docs label: `docs: not-required` -- pure dead-code removal, behavior unchanged, no user-visible change.
- [x] No UI change -- no screenshot.
- [x] OpenAPI: no request/response shape changed.
- [x] No `.templ` files changed.

## Test plan

- [x] `go test -race ./internal/provider/...` passes locally (via the pre-push gate).
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] All existing `TestDeduplicateMembers_*` tests pass with the new `deduplicateMembers(members)` signature (regression).
- [x] `TestDeduplicateMembers_LocalePreference` rewritten to `TestDeduplicateMembers_DuplicateMBIDKeepsFirstName`: the old test asserted "ja"-name-wins behavior that never worked (it relied on the literal string `"ja"` being a member name); the rewrite asserts the actual Path A contract -- first canonical name per MBID is retained. A fully redundant `_NoPrefs` variant was removed.
- [x] Manual UAT not applicable: issue #1020 scopes manual validation to Paths B/C; Path A is behavior-unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified member data deduplication logic to improve consistency when consolidating duplicate artist member entries from the music database.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->