### PR TITLE
feat(provider): add MusicBrainz mirror health check and error visibility

### DIFF
--- a/docs/site/src/reference/settings-by-tab.md
+++ b/docs/site/src/reference/settings-by-tab.md
@@ -137,7 +137,7 @@ Minimum similarity score (0-100) required when matching artist names from search
 {: #settings-providers-provider-config-official }
 - **Beta** -- Send requests to the MusicBrainz beta server. The data set matches the official server, but the deployment runs preview code. Subject to the same one-request-per-second public rate limit.
 {: #settings-providers-provider-config-beta }
-- **Custom mirror** -- Point Stillwater at a self-hosted MusicBrainz mirror. Requests bypass the public rate limit so you can raise throughput, subject to whatever your mirror can sustain.
+- **Custom mirror** -- Point Stillwater at a self-hosted MusicBrainz mirror. Requests bypass the public rate limit so you can raise throughput, subject to whatever your mirror can sustain. If the mirror returns an invalid response (for example an HTML error page instead of JSON), Stillwater logs a warning and automatically retries that request against the official MusicBrainz API, so a misconfigured mirror degrades gracefully instead of silently losing metadata.
 {: #settings-providers-provider-config-custom-mirror }
 - **OAuth Credentials** -- Sub-section for OAuth application credentials used when a provider requires authenticated access. Fill in the Client ID and Client Secret issued by the provider.
 {: #settings-providers-provider-config-oauth-credentials }

--- a/internal/api/handlers_provider_test.go
+++ b/internal/api/handlers_provider_test.go
@@ -55,7 +55,7 @@ func TestHandleSetMirror(t *testing.T) {
 	// Start a local mirror server so the auto-test in the JSON path succeeds.
 	mirrorSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"artists":[]}`))
+		w.Write([]byte(`{"created":"2024-01-01T00:00:00.000Z","count":0,"offset":0,"artists":[]}`))
 	}))
 	defer mirrorSrv.Close()
 
@@ -150,7 +150,7 @@ func TestHandleSetMirrorTrailingSlash(t *testing.T) {
 	t.Parallel()
 	mirrorSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"artists":[]}`))
+		w.Write([]byte(`{"created":"2024-01-01T00:00:00.000Z","count":0,"offset":0,"artists":[]}`))
 	}))
 	defer mirrorSrv.Close()
 
@@ -192,7 +192,7 @@ func TestHandleSetMirrorDefaultRateLimit(t *testing.T) {
 	t.Parallel()
 	mirrorSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"artists":[]}`))
+		w.Write([]byte(`{"created":"2024-01-01T00:00:00.000Z","count":0,"offset":0,"artists":[]}`))
 	}))
 	defer mirrorSrv.Close()
 
@@ -225,7 +225,7 @@ func TestHandleSetMirrorRateLimitCap(t *testing.T) {
 	t.Parallel()
 	mirrorSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"artists":[]}`))
+		w.Write([]byte(`{"created":"2024-01-01T00:00:00.000Z","count":0,"offset":0,"artists":[]}`))
 	}))
 	defer mirrorSrv.Close()
 

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -29,6 +29,10 @@ type Adapter struct {
 	logger  *slog.Logger
 	mu      sync.RWMutex
 	baseURL string
+	// fallbackURL is the retry target when a configured mirror returns an
+	// unparsable body. It is set once at construction (to defaultBaseURL) and
+	// never mutated outside tests, so unlike baseURL it needs no mu guard.
+	fallbackURL string
 }
 
 // New creates a MusicBrainz adapter with the default base URL.
@@ -39,10 +43,11 @@ func New(limiter *provider.RateLimiterMap, logger *slog.Logger) *Adapter {
 // NewWithBaseURL creates a MusicBrainz adapter with a custom base URL (for testing).
 func NewWithBaseURL(limiter *provider.RateLimiterMap, logger *slog.Logger, baseURL string) *Adapter {
 	return &Adapter{
-		client:  httpsafe.SafeClient(10 * time.Second),
-		limiter: limiter,
-		logger:  logger.With(slog.String("provider", "musicbrainz")),
-		baseURL: strings.TrimRight(baseURL, "/"),
+		client:      httpsafe.SafeClient(10 * time.Second),
+		limiter:     limiter,
+		logger:      logger.With(slog.String("provider", "musicbrainz")),
+		baseURL:     strings.TrimRight(baseURL, "/"),
+		fallbackURL: defaultBaseURL,
 	}
 }
 
@@ -70,7 +75,7 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 	}
 
 	var resp SearchResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
+	if err := a.unmarshalWithFallback(ctx, base, "/artist?"+params.Encode(), body, &resp); err != nil {
 		return nil, fmt.Errorf("parsing search response: %w", err)
 	}
 
@@ -127,7 +132,7 @@ func (a *Adapter) GetArtist(ctx context.Context, mbid string) (*provider.ArtistM
 	}
 
 	var mbArtist MBArtist
-	if err := json.Unmarshal(body, &mbArtist); err != nil {
+	if err := a.unmarshalWithFallback(ctx, base, "/artist/"+url.PathEscape(mbid)+"?"+params.Encode(), body, &mbArtist); err != nil {
 		return nil, fmt.Errorf("parsing artist response: %w", err)
 	}
 
@@ -373,7 +378,7 @@ func (a *Adapter) fetchMemberAliases(ctx context.Context, mbid string) (memberAl
 	}
 
 	var resp MBArtist
-	if err := json.Unmarshal(body, &resp); err != nil {
+	if err := a.unmarshalWithFallback(ctx, base, "/artist/"+url.PathEscape(mbid)+"?"+params.Encode(), body, &resp); err != nil {
 		return memberAliasLookup{}, fmt.Errorf("parsing member alias response: %w", err)
 	}
 	return memberAliasLookup{aliases: resp.Aliases, sortName: resp.SortName}, nil
@@ -446,7 +451,7 @@ func (a *Adapter) GetReleaseGroups(ctx context.Context, mbid string) ([]provider
 		}
 
 		var resp MBReleaseGroupSearchResponse
-		if err := json.Unmarshal(body, &resp); err != nil {
+		if err := a.unmarshalWithFallback(ctx, base, "/release-group?"+params.Encode(), body, &resp); err != nil {
 			return nil, fmt.Errorf("parsing release-group response: %w", err)
 		}
 
@@ -472,7 +477,14 @@ func (a *Adapter) GetReleaseGroups(ctx context.Context, mbid string) ([]provider
 	return results, nil
 }
 
-// TestConnection verifies connectivity to the MusicBrainz API.
+// TestConnection verifies connectivity to the MusicBrainz API and validates
+// that the endpoint returns well-formed JSON in the expected search response
+// shape. This catches a common mirror misconfiguration where the server
+// returns a 200 OK with an HTML error page instead of JSON. The existing
+// POST /api/v1/providers/{name}/test endpoint calls this method, so a parse
+// failure here flows directly to the Settings > Providers Test button UI --
+// no additional route is needed (enhancement 2: extending the test path is
+// preferred over adding a separate health endpoint).
 func (a *Adapter) TestConnection(ctx context.Context) error {
 	params := url.Values{
 		"query": {"test"},
@@ -483,8 +495,28 @@ func (a *Adapter) TestConnection(ctx context.Context) error {
 	base := a.baseURL
 	a.mu.RUnlock()
 	reqURL := base + "/artist?" + params.Encode()
-	_, err := a.doRequest(ctx, reqURL)
-	return err
+
+	body, err := a.doRequest(ctx, reqURL)
+	if err != nil {
+		return err
+	}
+
+	// Validate that the response body is well-formed JSON matching the search
+	// response shape. A mirror returning an HTML error page (e.g. a 404/503
+	// page proxied as 200 OK) would fail here with a descriptive error, whereas
+	// the previous implementation discarded the body and reported success.
+	var resp SearchResponse
+	if err := a.unmarshalResponse(base, body, &resp); err != nil {
+		return fmt.Errorf("endpoint returned non-JSON response (check mirror configuration): %w", err)
+	}
+	// Shape check: a genuine MusicBrainz ws/2 search response always carries a
+	// "created" timestamp. A bare JSON object served with HTTP 200 (a proxy
+	// health page, a JSON error body) unmarshals without error but is not a
+	// MusicBrainz endpoint, so reject it rather than report the mirror healthy.
+	if resp.Created == "" {
+		return fmt.Errorf("endpoint returned JSON that is not a MusicBrainz search response (check mirror configuration)")
+	}
+	return nil
 }
 
 // SetBaseURL updates the adapter's base URL for mirror support.
@@ -523,6 +555,85 @@ func (a *Adapter) SetHTTPClient(c *http.Client) {
 		panic("musicbrainz.SetHTTPClient: client must not be nil")
 	}
 	a.client = c
+}
+
+// setFallbackURL overrides the URL used when auto-fallback triggers on a
+// parse error. Only for use in tests; production code always falls back
+// to defaultBaseURL (set by the constructor). This must be called before
+// any requests are issued (no concurrency guard needed for test setup).
+func (a *Adapter) setFallbackURL(u string) {
+	a.fallbackURL = strings.TrimRight(u, "/")
+}
+
+// unmarshalResponse unmarshals body into dst. On failure it logs a WARN with
+// the configured base URL and a short body prefix to help operators diagnose
+// mirror misconfiguration (e.g. a server returning an HTML error page with
+// a 200 OK status). The base URL is included so the log entry identifies the
+// specific mirror endpoint that produced the unexpected response.
+func (a *Adapter) unmarshalResponse(base string, body []byte, dst any) error {
+	if err := json.Unmarshal(body, dst); err != nil {
+		// Surface up to 200 bytes of the body so the log can reveal an HTML
+		// snippet or other non-JSON content without flooding the log.
+		preview := body
+		if len(preview) > 200 {
+			preview = preview[:200]
+		}
+		a.logger.Warn("JSON parse failed; mirror may be returning non-JSON response",
+			slog.String("base_url", base),
+			slog.String("body_preview", string(preview)),
+			slog.Any("err", err))
+		return err
+	}
+	return nil
+}
+
+// unmarshalWithFallback attempts to unmarshal body into dst. When parsing
+// fails AND a mirror is configured (baseURL differs from fallbackURL), it
+// automatically retries the request against the fallback URL (normally the
+// official musicbrainz.org API) and unmarshals that response instead. A
+// network error from the mirror does NOT trigger fallback -- only a
+// successful HTTP 200 with an unparsable body does, because a timeout or
+// connection error signals a network problem rather than a mirror serving
+// bad content.
+//
+// The pathAndQuery argument is the path + query string used to reconstruct
+// the fallback URL (e.g. "/artist?query=test&fmt=json&limit=1").
+func (a *Adapter) unmarshalWithFallback(ctx context.Context, base, pathAndQuery string, body []byte, dst any) error {
+	// unmarshalResponse logs a WARN as a side effect, so call it exactly once
+	// per response body and reuse the captured error rather than re-running it.
+	parseErr := a.unmarshalResponse(base, body, dst)
+	if parseErr == nil {
+		return nil
+	}
+
+	// Parse error: fall back only when a distinct mirror is configured.
+	fallback := a.fallbackURL
+	if fallback == "" || base == fallback {
+		// No distinct fallback configured, or already using the fallback URL.
+		return parseErr
+	}
+
+	// Retry against the fallback URL, logging the switch so operators can
+	// tell why a request went to the official API instead of the mirror.
+	fallbackURL := fallback + pathAndQuery
+	a.logger.Warn("mirror returned non-JSON response; retrying against fallback URL",
+		slog.String("mirror_base_url", base),
+		slog.String("fallback_url", fallbackURL))
+
+	fallbackBody, err := a.doRequest(ctx, fallbackURL)
+	if err != nil {
+		// Fallback request itself failed. Log the fallback error so a double
+		// failure (broken mirror AND unreachable fallback) stays visible, but
+		// return the original parse error: the operator's actionable problem is
+		// the broken mirror, not "can't reach musicbrainz.org".
+		a.logger.Warn("fallback request also failed; returning original mirror parse error",
+			slog.String("fallback_url", fallbackURL),
+			slog.Any("err", err))
+		return parseErr
+	}
+
+	// Use fallback base for the WARN log in case the fallback body also fails.
+	return a.unmarshalResponse(fallback, fallbackBody, dst)
 }
 
 // doRequest executes an HTTP GET with rate limiting and standard headers.

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -632,8 +633,23 @@ func (a *Adapter) unmarshalWithFallback(ctx context.Context, base, pathAndQuery 
 		return parseErr
 	}
 
-	// Use fallback base for the WARN log in case the fallback body also fails.
-	return a.unmarshalResponse(fallback, fallbackBody, dst)
+	// Zero dst before decoding the fallback body. A failed mirror decode can
+	// leave dst partially populated (json.Unmarshal completes "as best it can"
+	// before erroring), and a fallback response that omits those fields would
+	// not overwrite the stale values. Zeroing guarantees dst holds only
+	// fallback data on success.
+	if v := reflect.ValueOf(dst); v.Kind() == reflect.Pointer && !v.IsNil() {
+		v.Elem().Set(reflect.Zero(v.Elem().Type()))
+	}
+
+	// unmarshalResponse logs a WARN for the fallback body if it also fails.
+	if err := a.unmarshalResponse(fallback, fallbackBody, dst); err != nil {
+		// Both the mirror and the fallback returned unparsable bodies. Surface
+		// the original mirror parse error as the actionable root cause: the
+		// configured mirror is the thing the operator can fix.
+		return parseErr
+	}
+	return nil
 }
 
 // doRequest executes an HTTP GET with rate limiting and standard headers.

--- a/internal/provider/musicbrainz/musicbrainz_test.go
+++ b/internal/provider/musicbrainz/musicbrainz_test.go
@@ -3,11 +3,13 @@ package musicbrainz
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -651,6 +653,435 @@ func isErrNotFound(err error) bool {
 func isErrUnavailable(err error) bool {
 	var unavail *provider.ErrProviderUnavailable
 	return errors.As(err, &unavail)
+}
+
+// captureHandler is a minimal slog.Handler that records log entries so tests
+// can assert on log level and attributes without capturing stderr. All
+// instances sharing the same *captureState write to the same slice, so
+// assertions against the root handler see entries produced by child loggers
+// created via logger.With(...) (which calls WithAttrs internally).
+type captureState struct {
+	mu      sync.Mutex
+	entries []captureEntry
+}
+
+type captureEntry struct {
+	level slog.Level
+	msg   string
+	attrs []slog.Attr
+}
+
+type captureHandler struct {
+	state *captureState
+}
+
+func newCaptureState() (*captureHandler, *captureState) {
+	s := &captureState{}
+	return &captureHandler{state: s}, s
+}
+
+func (h *captureHandler) Enabled(_ context.Context, level slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	entry := captureEntry{level: r.Level, msg: r.Message}
+	r.Attrs(func(a slog.Attr) bool {
+		entry.attrs = append(entry.attrs, a)
+		return true
+	})
+	h.state.mu.Lock()
+	h.state.entries = append(h.state.entries, entry)
+	h.state.mu.Unlock()
+	return nil
+}
+
+// WithAttrs returns a child handler that shares the same captureState so
+// entries from logger.With(...) are visible to the original captureState.
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return &captureHandler{state: h.state}
+}
+func (h *captureHandler) WithGroup(_ string) slog.Handler { return h }
+
+// hasWarn returns true when at least one captured entry is at WARN level and
+// contains the given substring in its message or attribute values.
+func (s *captureState) hasWarn(substring string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.entries {
+		if e.level != slog.LevelWarn {
+			continue
+		}
+		if strings.Contains(e.msg, substring) {
+			return true
+		}
+		for _, a := range e.attrs {
+			if strings.Contains(fmt.Sprintf("%v", a.Value), substring) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// warnAttrValue returns the string value of the named attribute from the
+// first WARN entry whose message contains msgSubstr, and whether it was found.
+// Unlike hasWarn it pins a specific (message, attribute) pair so a test can
+// distinguish, for example, the parse-failure WARN from the fallback-retry WARN.
+func (s *captureState) warnAttrValue(msgSubstr, attrKey string) (string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.entries {
+		if e.level != slog.LevelWarn || !strings.Contains(e.msg, msgSubstr) {
+			continue
+		}
+		for _, a := range e.attrs {
+			if a.Key == attrKey {
+				return a.Value.String(), true
+			}
+		}
+	}
+	return "", false
+}
+
+// hasWarnAttr reports whether any WARN entry whose message contains msgSubstr
+// also carries an attribute attrKey whose value equals attrValue exactly.
+func (s *captureState) hasWarnAttr(msgSubstr, attrKey, attrValue string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.entries {
+		if e.level != slog.LevelWarn || !strings.Contains(e.msg, msgSubstr) {
+			continue
+		}
+		for _, a := range e.attrs {
+			if a.Key == attrKey && a.Value.String() == attrValue {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// newCaptureAdapter creates an Adapter backed by a captureHandler logger.
+// The returned *captureState can be inspected for logged entries.
+func newCaptureAdapter(t *testing.T, baseURL string) (*Adapter, *captureState) {
+	t.Helper()
+	h, state := newCaptureState()
+	logger := slog.New(h)
+	limiter := provider.NewRateLimiterMap()
+	limiter.SetLimit(provider.NameMusicBrainz, 1000)
+	a := NewWithBaseURL(limiter, logger, baseURL)
+	a.client = &http.Client{Timeout: 10 * time.Second}
+	return a, state
+}
+
+// --- #1033: mirror health check and error visibility ---
+
+// TestTestConnection_HTMLResponse verifies that a 200 OK response with an
+// HTML body is detected as a failure. This is the core mirror bug: a broken
+// mirror returns an HTML error page with HTTP 200, which previously passed.
+func TestTestConnection_HTMLResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<!DOCTYPE html><html><body>404 Not Found</body></html>`))
+	}))
+	defer srv.Close()
+
+	a, _ := newCaptureAdapter(t, srv.URL)
+	err := a.TestConnection(context.Background())
+	if err == nil {
+		t.Fatal("TestConnection should return an error when server responds with HTML")
+	}
+	if !strings.Contains(err.Error(), "non-JSON") {
+		t.Errorf("error should mention non-JSON response, got: %v", err)
+	}
+}
+
+// TestTestConnection_ValidJSON verifies that a well-formed SearchResponse JSON
+// body does not return an error.
+func TestTestConnection_ValidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":"2024-01-01T00:00:00.000Z","count":0,"offset":0,"artists":[]}`))
+	}))
+	defer srv.Close()
+
+	a, _ := newCaptureAdapter(t, srv.URL)
+	if err := a.TestConnection(context.Background()); err != nil {
+		t.Fatalf("TestConnection should succeed for valid JSON: %v", err)
+	}
+}
+
+// TestUnmarshalResponse_WarnOnParseError verifies that a JSON parse failure
+// logs at WARN level and includes the base URL in the log entry. This covers
+// enhancement 3 (promote mirror parse errors to WARN).
+func TestUnmarshalResponse_WarnOnParseError(t *testing.T) {
+	a, cap := newCaptureAdapter(t, "http://mirror.example.com/ws/2")
+	body := []byte(`<!DOCTYPE html><html><body>Service Unavailable</body></html>`)
+	var resp SearchResponse
+	err := a.unmarshalResponse("http://mirror.example.com/ws/2", body, &resp)
+	if err == nil {
+		t.Fatal("unmarshalResponse should return error for HTML input")
+	}
+	if !cap.hasWarn("mirror.example.com") {
+		t.Error("expected WARN log entry containing the base URL")
+	}
+}
+
+// TestAutoFallback_ParseErrorTriggersFallback verifies that when the configured
+// mirror returns an HTML response, the adapter retries against the fallback
+// URL (enhancement 4). Two httptest.Servers are used: the broken mirror
+// (returns HTML) and the good "official" server (returns valid JSON). The
+// fallback URL is overridden via setFallbackURL so the test does not reach
+// the real musicbrainz.org.
+func TestAutoFallback_ParseErrorTriggersFallback(t *testing.T) {
+	// Good server: returns a valid SearchResponse.
+	goodSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":"2024-01-01T00:00:00.000Z","count":0,"offset":0,"artists":[]}`))
+	}))
+	defer goodSrv.Close()
+
+	// Broken mirror: returns HTML with HTTP 200.
+	brokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`<html><body>Mirror Error</body></html>`))
+	}))
+	defer brokenSrv.Close()
+
+	a, cap := newCaptureAdapter(t, brokenSrv.URL)
+	// Override the fallback to point at the good server instead of musicbrainz.org.
+	a.setFallbackURL(goodSrv.URL)
+
+	_, err := a.SearchArtist(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("SearchArtist should succeed via fallback: %v", err)
+	}
+	// The adapter should have logged a WARN about retrying.
+	if !cap.hasWarn("fallback") {
+		t.Error("expected WARN log entry mentioning fallback retry")
+	}
+}
+
+// TestAutoFallback_NetworkTimeoutDoesNotFallback verifies that a network
+// timeout from the mirror does NOT trigger fallback -- only a successful 200
+// with unparsable body does.
+func TestAutoFallback_NetworkTimeoutDoesNotFallback(t *testing.T) {
+	// Good server: should never be reached.
+	var goodHit atomic.Bool
+	goodSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		goodHit.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"created":"","count":0,"offset":0,"artists":[]}`))
+	}))
+	defer goodSrv.Close()
+
+	// Broken server: immediately closes the connection to simulate a network error.
+	brokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Hijack and close to simulate a connection drop.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		conn, _, _ := hj.Hijack()
+		conn.Close()
+	}))
+	defer brokenSrv.Close()
+
+	a, cap := newCaptureAdapter(t, brokenSrv.URL)
+	a.setFallbackURL(goodSrv.URL)
+
+	_, err := a.SearchArtist(context.Background(), "test")
+	// The request must fail (network error from broken server).
+	if err == nil {
+		t.Fatal("expected error from network-level failure")
+	}
+	// The good server must NOT have been contacted.
+	if goodHit.Load() {
+		t.Error("good server was contacted, but fallback should not trigger on network error")
+	}
+	// No "fallback" WARN should appear -- the network error is reported by doRequest
+	// before the parse stage that triggers fallback.
+	if cap.hasWarn("fallback") {
+		t.Error("fallback WARN should not be logged for a network-level error")
+	}
+}
+
+// htmlServer returns an httptest.Server that responds 200 OK with an HTML
+// body for every request, simulating a misconfigured mirror.
+func htmlServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestSearchArtist_ParseErrorFallbackAlsoFails covers the case where the
+// configured mirror returns HTML and the fallback URL is unreachable: the
+// original mirror parse error is returned (not a fallback network error).
+// The HTML body is deliberately longer than 200 bytes to exercise the
+// body-preview truncation branch in unmarshalResponse.
+func TestSearchArtist_ParseErrorFallbackAlsoFails(t *testing.T) {
+	longHTML := "<!DOCTYPE html><html><body>" + strings.Repeat("mirror error ", 40) + "</body></html>"
+	mirror := htmlServer(t, longHTML)
+
+	// Fallback server drops the connection to simulate a network failure.
+	badFallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		conn, _, _ := hj.Hijack()
+		conn.Close()
+	}))
+	defer badFallback.Close()
+
+	a, _ := newCaptureAdapter(t, mirror.URL)
+	a.setFallbackURL(badFallback.URL)
+
+	if _, err := a.SearchArtist(context.Background(), "test"); err == nil {
+		t.Fatal("SearchArtist should return the mirror parse error when the fallback is unreachable")
+	}
+}
+
+// TestGetArtist_ParseErrorNoFallback covers GetArtist returning a parse error
+// when the configured base URL equals the fallback URL (no distinct mirror,
+// so no fallback retry is warranted).
+func TestGetArtist_ParseErrorNoFallback(t *testing.T) {
+	srv := htmlServer(t, `<html><body>not json</body></html>`)
+	a, _ := newCaptureAdapter(t, srv.URL)
+	a.setFallbackURL(srv.URL) // base == fallback: no fallback retry
+
+	if _, err := a.GetArtist(context.Background(), "00000000-0000-0000-0000-000000000000"); err == nil {
+		t.Fatal("GetArtist should return a parse error for an HTML response")
+	}
+}
+
+// TestFetchMemberAliases_ParseError covers the parse-error path of the
+// per-member alias lookup.
+func TestFetchMemberAliases_ParseError(t *testing.T) {
+	srv := htmlServer(t, `<html><body>not json</body></html>`)
+	a, _ := newCaptureAdapter(t, srv.URL)
+	a.setFallbackURL(srv.URL)
+
+	if _, err := a.fetchMemberAliases(context.Background(), "00000000-0000-0000-0000-000000000000"); err == nil {
+		t.Fatal("fetchMemberAliases should return a parse error for an HTML response")
+	}
+}
+
+// TestGetReleaseGroups_ParseError covers the parse-error path of the
+// release-group fetch.
+func TestGetReleaseGroups_ParseError(t *testing.T) {
+	srv := htmlServer(t, `<html><body>not json</body></html>`)
+	a, _ := newCaptureAdapter(t, srv.URL)
+	a.setFallbackURL(srv.URL)
+
+	if _, err := a.GetReleaseGroups(context.Background(), "00000000-0000-0000-0000-000000000000"); err == nil {
+		t.Fatal("GetReleaseGroups should return a parse error for an HTML response")
+	}
+}
+
+// TestTestConnection_ServerError covers TestConnection surfacing the doRequest
+// error when the endpoint responds with a non-2xx status (HTTP 503), distinct
+// from the non-JSON-body failure path.
+func TestTestConnection_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	a, _ := newCaptureAdapter(t, srv.URL)
+	if err := a.TestConnection(context.Background()); err == nil {
+		t.Fatal("TestConnection should return an error when the endpoint responds 503")
+	}
+}
+
+// TestTestConnection_ValidJSONWrongShape covers the shape check: a 200 OK
+// response whose body is well-formed JSON but is not a MusicBrainz search
+// response (no "created" field) must still be reported as a failure. This is
+// the false-positive the health check exists to prevent: a proxy health page
+// or a JSON error body would otherwise pass JSON-syntax validation.
+func TestTestConnection_ValidJSONWrongShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"error":"rate limit exceeded"}`))
+	}))
+	defer srv.Close()
+
+	a, _ := newCaptureAdapter(t, srv.URL)
+	err := a.TestConnection(context.Background())
+	if err == nil {
+		t.Fatal("TestConnection should reject valid JSON that is not a MusicBrainz search response")
+	}
+	if !strings.Contains(err.Error(), "not a MusicBrainz search response") {
+		t.Errorf("error should mention the wrong-shape response, got: %v", err)
+	}
+}
+
+// TestUnmarshalResponse_EmptyBody covers a 200 OK response with an empty body
+// (a common proxy-truncation failure): json.Unmarshal reports "unexpected end
+// of JSON input", which unmarshalResponse must surface as an error.
+func TestUnmarshalResponse_EmptyBody(t *testing.T) {
+	a, _ := newCaptureAdapter(t, "http://mirror.example.com/ws/2")
+	var resp SearchResponse
+	if err := a.unmarshalResponse("http://mirror.example.com/ws/2", []byte{}, &resp); err == nil {
+		t.Fatal("unmarshalResponse should return an error for an empty body")
+	}
+}
+
+// TestUnmarshalResponse_TruncatesBodyPreview verifies the body_preview log
+// attribute is capped at 200 bytes for an oversized body and left intact for a
+// body at or under the limit.
+func TestUnmarshalResponse_TruncatesBodyPreview(t *testing.T) {
+	long := []byte(strings.Repeat("x", 500))
+	a, capLong := newCaptureAdapter(t, "http://mirror.example.com/ws/2")
+	var resp SearchResponse
+	_ = a.unmarshalResponse("http://mirror.example.com/ws/2", long, &resp)
+	preview, ok := capLong.warnAttrValue("JSON parse failed", "body_preview")
+	if !ok {
+		t.Fatal("expected a JSON-parse-failed WARN with a body_preview attribute")
+	}
+	if len(preview) != 200 {
+		t.Errorf("body_preview for a 500-byte body should be truncated to 200 bytes, got %d", len(preview))
+	}
+
+	short := []byte(strings.Repeat("y", 50))
+	a2, capShort := newCaptureAdapter(t, "http://mirror.example.com/ws/2")
+	_ = a2.unmarshalResponse("http://mirror.example.com/ws/2", short, &resp)
+	previewShort, ok := capShort.warnAttrValue("JSON parse failed", "body_preview")
+	if !ok {
+		t.Fatal("expected a JSON-parse-failed WARN for the short body")
+	}
+	if len(previewShort) != 50 {
+		t.Errorf("body_preview for a 50-byte body should be left intact, got %d", len(previewShort))
+	}
+}
+
+// TestAutoFallback_FallbackBodyAlsoUnparsable covers the case where both the
+// configured mirror and the fallback URL return HTML: SearchArtist returns an
+// error, and a parse-failure WARN is logged against the fallback URL (in
+// addition to the WARN against the mirror).
+func TestAutoFallback_FallbackBodyAlsoUnparsable(t *testing.T) {
+	mirror := htmlServer(t, `<html><body>mirror is broken</body></html>`)
+	fallback := htmlServer(t, `<html><body>fallback is also broken</body></html>`)
+
+	a, capState := newCaptureAdapter(t, mirror.URL)
+	a.setFallbackURL(fallback.URL)
+
+	if _, err := a.SearchArtist(context.Background(), "test"); err == nil {
+		t.Fatal("SearchArtist should return an error when both mirror and fallback return HTML")
+	}
+	if !capState.hasWarnAttr("JSON parse failed", "base_url", fallback.URL) {
+		t.Errorf("expected a parse-failure WARN against the fallback URL %q", fallback.URL)
+	}
+	if !capState.hasWarn("retrying against fallback") {
+		t.Error("expected a WARN noting the fallback retry")
+	}
 }
 
 // --- #973: YearsActive synthesis ---

--- a/internal/provider/musicbrainz/musicbrainz_test.go
+++ b/internal/provider/musicbrainz/musicbrainz_test.go
@@ -944,8 +944,18 @@ func TestSearchArtist_ParseErrorFallbackAlsoFails(t *testing.T) {
 	a, _ := newCaptureAdapter(t, mirror.URL)
 	a.setFallbackURL(badFallback.URL)
 
-	if _, err := a.SearchArtist(context.Background(), "test"); err == nil {
+	_, err := a.SearchArtist(context.Background(), "test")
+	if err == nil {
 		t.Fatal("SearchArtist should return the mirror parse error when the fallback is unreachable")
+	}
+	// The returned error must be the mirror JSON parse failure, not the
+	// fallback's network error: the operator's actionable problem is the
+	// broken mirror.
+	if !strings.Contains(err.Error(), "invalid character '<'") {
+		t.Fatalf("expected the mirror JSON parse error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), badFallback.URL) {
+		t.Fatalf("returned error leaked fallback-network detail, expected only the mirror parse error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `TestConnection` now validates that the response body parses as a MusicBrainz search response (carrying a `created` timestamp), not just that the HTTP status is 200. A mirror serving an HTML error page or a wrong-shape JSON body with a 200 status is now reported as broken instead of healthy.
- MusicBrainz JSON parse failures now log at `WARN` (with the mirror URL and a 200-byte body preview), and a configured mirror that returns an unparsable body auto-falls back to the official `musicbrainz.org` API for that request instead of silently losing data and falling through to Wikipedia.
- User-visible behavior change: the Settings > Providers MusicBrainz "Test" button now fails for a misconfigured mirror returning non-JSON; provider data survives a broken mirror via transparent fallback.
- Reviewers should look first at `unmarshalWithFallback` in `musicbrainz.go`: a network error does NOT trigger fallback (only a successful 200 with an unparsable body does), and a failed fallback returns the original mirror parse error while logging the fallback failure.

## Linked issue

Closes #1033

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`), or run via `/prep-pr` / `/pr-review-toolkit:review-pr` which invokes it.
- [x] Code review pass complete (`/prep-pr` or `/pr-review-toolkit:review-pr`); critical and important findings fixed before pushing.
- [x] Commits squashed into clean, logical commits before the first push (Copilot reviews the diff at PR open).
- [x] At least one label set on `gh pr create --label ...` (the CI label gate fails without one).
- [x] Docs label decision made: `needs-docs-review` for user-visible changes, `docs: not-required` for test, CI, or refactor PRs with no user-visible behavioral change.
- [ ] Screenshot attached for any UI change. (No new UI element; the existing Test button is unchanged visually.)
- [x] UAT performed for user-visible changes (run the binary, not just the test suite).
- [x] OpenAPI spec updated if any request or response shape changed (`make check-openapi`). (No request/response shape changed.)
- [x] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed. (No `.templ` files changed.)

## Test plan

- [x] `go test -race ./...` passes locally.
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] Manual UAT steps (list the specific flows exercised):
  - [x] Test button against the real MusicBrainz API: reports `ok` (the new JSON validation does not false-fail the happy path).
  - [x] Mirror set to `https://musicbrainz.org/search` (returns HTML with HTTP 200): Test button reports `error`; server log shows a `WARN` with the mirror `base_url` and an HTML `body_preview`.
  - [x] Provider search with the broken mirror configured: returns 111 MusicBrainz results via auto-fallback; log shows the `retrying against fallback URL` WARN.
- [x] Reviewer follow-ups (anything you want a second pair of eyes on):
  - [x] `TestConnection` deliberately does NOT use the auto-fallback path, so the Test button reports a misconfigured mirror as broken even though runtime requests would transparently fall back. This asymmetry is intentional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic fallback to an alternative MusicBrainz endpoint when a mirror returns invalid or malformed JSON.

* **Bug Fixes**
  * Stronger connection validation to reject HTML or unexpected response shapes.
  * Fallback retries triggered only for JSON parse failures (not network errors).
  * Prevents partially populated stale data when falling back; improved warning logs include source URL and truncated response preview.

* **Documentation**
  * Help text updated to describe graceful fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->