### PR TITLE
chore(release): bump dev fallback version to 1.2.0

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // These variables are set at build time via -ldflags.
 var (
-	Version = "1.1.0"
+	Version = "1.2.0"
 	Commit  = "unknown"
 	Date    = "unknown"
 )


### PR DESCRIPTION
## Summary

- Bumps `internal/version/version.go` `Version` from `1.1.0` to `1.2.0`, the dev-build fallback constant. Release builds inject the real version via goreleaser ldflags from the git tag; this constant only affects `go run` / unlagged local builds.
- Release prep for the M50 (Localization and Provider Depth) v1.2.0 release. All 16 M50 dispatch units have merged.
- No runtime behavior change.

## Linked issue

N/A -- release-prep chore. Per `.claude/release.toml`, `version.go` is the designated dev fallback version file; bumping it in its own PR avoids a direct-to-main commit (branch protection).

## Pre-flight checklist

- [x] Pre-commit hooks (gofmt, golangci-lint, typos) passed locally; the full pre-push gate runs in CI.
- [x] Self-reviewed: single-constant change, no logic.
- [x] Single clean commit.
- [x] Label set (`chore`).
- [x] `docs: not-required` -- no user-visible behavioral change.
- [x] No UI change (no screenshot needed).
- [x] No request/response shape change (OpenAPI unaffected).
- [x] No `.templ` change.

## Test plan

- [x] `gofmt` / `golangci-lint` clean (pre-commit).
- [ ] `go test -race ./...` and `bash scripts/pre-push-gate.sh` -- run by CI on this PR.
- Manual UAT: not applicable -- the constant is read only by the version reporter; release artifacts override it via ldflags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version updated to 1.2.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->