### PR TITLE
docs(site): publish developer docs to mkdocs site via snippets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,15 +6,16 @@ and pull requests, and where to ask questions.
 
 ## Code of conduct
 
-This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By
+This project follows the [Contributor Covenant](https://github.com/sydlexius/stillwater/blob/main/CODE_OF_CONDUCT.md). By
 participating you agree to abide by its terms.
 
 ## Development environment
 
-See [docs/dev-setup.md](docs/dev-setup.md) for the full setup. Quick summary:
+See [Dev setup](https://github.com/sydlexius/stillwater/blob/main/docs/dev-setup.md) for the full setup. Quick summary:
 
 - Go 1.26 or newer
-- Node.js (for Tailwind CSS v4 and the templ toolchain)
+- Tailwind CSS standalone CLI (no Node.js required; see Dev setup for download
+  instructions)
 - `make build` produces a working binary; `make dev` enables hot reload
   via `air`
 
@@ -36,15 +37,15 @@ background workers).
 - No em-dashes in any output
 - Run `make fmt` before committing (Go and templ formatters)
 - Run `make lint` (`golangci-lint`) before opening a PR
-- Follow the patterns documented in [.golangci.yml](.golangci.yml) and the
+- Follow the patterns documented in [.golangci.yml](https://github.com/sydlexius/stillwater/blob/main/.golangci.yml) and the
   per-package guidance in `.github/instructions/`
 
-Style and conventions live in [CLAUDE.md](CLAUDE.md), which doubles as
+Style and conventions live in [CLAUDE.md](https://github.com/sydlexius/stillwater/blob/main/CLAUDE.md), which doubles as
 project-wide guidance for both human contributors and AI tools.
 
 ## Pull request workflow
 
-The full workflow is documented in [docs/pr-workflow.md](docs/pr-workflow.md).
+The full workflow is documented in [PR workflow](https://github.com/sydlexius/stillwater/blob/main/docs/pr-workflow.md).
 Short version:
 
 1. Branch from `main`. Never commit to `main` directly; branch protection

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -8,7 +8,7 @@ Prerequisites and instructions for building Stillwater from source.
 |------|---------|---------|---------|
 | Go | 1.26.1+ | Compiler and runtime | https://go.dev/dl/ |
 | templ | latest | HTML template code generation | `go install github.com/a-h/templ/cmd/templ@latest` |
-| Tailwind CSS | v4.2.0 | CSS build (standalone CLI) | See below |
+| Tailwind CSS | see `ARG TAILWIND_VERSION` in [`build/docker/Dockerfile`](https://github.com/sydlexius/stillwater/blob/main/build/docker/Dockerfile) | CSS build (standalone CLI) | See below |
 | Git | any | Version control | https://git-scm.com/ |
 
 ### Optional Tools
@@ -22,27 +22,33 @@ Prerequisites and instructions for building Stillwater from source.
 
 ## Installing Tailwind CSS Standalone CLI
 
-The project uses the Tailwind CSS standalone CLI (no Node.js required). Download the correct binary for your platform from the GitHub releases page:
+The project uses the Tailwind CSS standalone CLI (no Node.js required).
+The canonical version is `ARG TAILWIND_VERSION` in
+[`build/docker/Dockerfile`](https://github.com/sydlexius/stillwater/blob/main/build/docker/Dockerfile).
+Download the matching binary for your platform from the GitHub releases page:
 
-https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.2.0
+https://github.com/tailwindlabs/tailwindcss/releases
+
+Replace `<VERSION>` in the commands below with the value of `TAILWIND_VERSION`
+from the Dockerfile (for example `v4.2.0`).
 
 **Linux:**
 ```bash
-curl -sLo tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/v4.2.0/tailwindcss-linux-x64
+curl -sLo tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/<VERSION>/tailwindcss-linux-x64
 chmod +x tailwindcss
 sudo mv tailwindcss /usr/local/bin/
 ```
 
 **macOS (Apple Silicon):**
 ```bash
-curl -sLo tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/v4.2.0/tailwindcss-macos-arm64
+curl -sLo tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/<VERSION>/tailwindcss-macos-arm64
 chmod +x tailwindcss
 sudo mv tailwindcss /usr/local/bin/
 ```
 
 **Windows:**
 ```powershell
-curl -Lo tailwindcss.exe https://github.com/tailwindlabs/tailwindcss/releases/download/v4.2.0/tailwindcss-windows-x64.exe
+curl -Lo tailwindcss.exe https://github.com/tailwindlabs/tailwindcss/releases/download/<VERSION>/tailwindcss-windows-x64.exe
 # Move to a directory on your PATH, or keep in the repo root (it is gitignored)
 ```
 
@@ -85,7 +91,7 @@ Equivalent Docker commands:
 
 ```bash
 make docker-build   # build Docker image
-make docker-run     # start via docker-compose.local.yml
+make docker-run     # start via docker-compose.yml
 ```
 
 ## Running Locally
@@ -195,22 +201,21 @@ go test -v -count=1 ./internal/image/...
 
 ## Environment Variables
 
+The full, generated reference for every `SW_` environment variable is on the
+published docs site:
+
+[Reference: Environment variables](https://sydlexius.github.io/stillwater/reference/environment-variables/)
+
+That page is generated from the configuration definition (`internal/config/config.go`)
+via `make generate-docs` and is always up to date. Do not maintain a separate
+table here.
+
+For the Docker container, two additional variables control file ownership:
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `SW_DB_PATH` | `/config/stillwater.db` | SQLite database file path (container default; `make run` overrides to `./data/stillwater.db`) |
-| `SW_LOG_LEVEL` | `info` | Log level: debug, info, warn, error |
-| `SW_LOG_FORMAT` | `json` | Log format: json, text |
-| `SW_PORT` | `1973` | HTTP port |
-| `SW_BASE_PATH` | (empty) | URL prefix for reverse proxy (e.g., `/stillwater`) |
-| `SW_MUSIC_PATH` | `/music` | Music library root directory |
-| `SW_SESSION_SECRET` | (unused) | Reserved for future session cookie signing support; current sessions use a random server-stored token |
-| `SW_ENCRYPTION_KEY` | (auto-generated) | Base64-encoded AES-256 key for encrypting API keys at rest |
-| `SW_BACKUP_PATH` | (empty) | Database backup directory |
-| `SW_BACKUP_ENABLED` | `true` | Enable automatic database backups |
-| `SW_BACKUP_INTERVAL` | `24` | Hours between backups |
-| `SW_BACKUP_RETENTION` | `7` | Number of backups to keep |
-| `SW_SCANNER_EXCLUSIONS` | (empty) | Comma-separated artist names to skip during scan |
-| `PUID` / `PGID` | `99` / `100` | User/group ID for Docker container file ownership |
+| `PUID` | `99` | User ID the container process runs as. Set to your host UID to avoid permission issues on mounted volumes. |
+| `PGID` | `100` | Group ID the container process runs as. Set to your host GID. |
 
 ## Project Structure
 
@@ -240,8 +245,11 @@ Releases are automated with [GoReleaser](https://goreleaser.com/). Pushing a sem
 
 ### Tag and push
 
+Tags must be signed annotated tags (`-s`) to earn the GitHub Verified badge.
+This requires a GPG or SSH signing key configured in your git config.
+
 ```bash
-git tag -a v0.2.0 -m "Release v0.2.0"
+git tag -s v0.2.0 -m "Release v0.2.0"
 git push origin v0.2.0
 ```
 

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -3,6 +3,17 @@ site_description: Self-hosted artist and composer metadata management for Emby, 
 site_url: https://sydlexius.github.io/stillwater/
 repo_url: https://github.com/sydlexius/stillwater
 repo_name: sydlexius/stillwater
+# edit_uri points at docs/site/src/ for most pages.
+# The Contributing section pages are thin stubs that include canonical files
+# via pymdownx.snippets. MkDocs does not support per-page edit_uri overrides,
+# so "Edit this page" on Contributing pages points at the stub, not the
+# canonical file. Canonical file locations for reference:
+#   contributing/index.md       -> CONTRIBUTING.md (repo root)
+#   contributing/dev-setup.md   -> docs/dev-setup.md
+#   contributing/architecture-decisions.md -> docs/architecture-decisions.md
+#   contributing/pr-workflow.md -> docs/pr-workflow.md
+#   contributing/worktrees.md   -> docs/worktrees.md
+#   contributing/milestone-protocol.md -> docs/milestone-protocol.md
 edit_uri: edit/main/docs/site/src/
 
 docs_dir: src
@@ -120,4 +131,11 @@ nav:
   - Troubleshooting:
       - troubleshooting/index.md
       - Platform authentication: troubleshooting/platform-auth.md
-  - API Reference: api/index.html
+  - Contributing:
+      - Overview: contributing/index.md
+      - Dev setup: contributing/dev-setup.md
+      - Architecture decisions: contributing/architecture-decisions.md
+      - PR workflow: contributing/pr-workflow.md
+      - Worktrees: contributing/worktrees.md
+      - Milestone protocol: contributing/milestone-protocol.md
+  - API Reference: api/index.md

--- a/docs/site/src/api/index.md
+++ b/docs/site/src/api/index.md
@@ -1,0 +1,19 @@
+---
+description: Stillwater REST API reference, rendered from the OpenAPI spec.
+hide:
+  - navigation
+  - toc
+---
+
+# API Reference
+
+The API reference is published as a standalone Redoc page. It covers every
+endpoint Stillwater exposes under `/api/v1/`, including request bodies,
+response shapes, and authentication requirements.
+
+[Open the API reference on GitHub Pages](https://sydlexius.github.io/stillwater/api/index.html){ .md-button .md-button--primary }
+
+> **Note for local builds:** The Redoc page (`api/index.html`) is generated
+> by the CI pipeline after the MkDocs build step. It is not present in local
+> `mkdocs build` output. See `.github/workflows/pages.yml` for the generation
+> step.

--- a/docs/site/src/contributing/architecture-decisions.md
+++ b/docs/site/src/contributing/architecture-decisions.md
@@ -1,0 +1,5 @@
+---
+description: Key architecture decisions that affect implementation across milestones in the Stillwater project.
+---
+
+--8<-- "docs/architecture-decisions.md"

--- a/docs/site/src/contributing/dev-setup.md
+++ b/docs/site/src/contributing/dev-setup.md
@@ -1,0 +1,5 @@
+---
+description: Prerequisites and instructions for building Stillwater from source, including Go, Tailwind CLI, Docker, and release tagging.
+---
+
+--8<-- "docs/dev-setup.md"

--- a/docs/site/src/contributing/index.md
+++ b/docs/site/src/contributing/index.md
@@ -1,0 +1,5 @@
+---
+description: How to contribute to Stillwater -- development setup, code style, pull request workflow, and project conventions.
+---
+
+--8<-- "CONTRIBUTING.md"

--- a/docs/site/src/contributing/milestone-protocol.md
+++ b/docs/site/src/contributing/milestone-protocol.md
@@ -1,0 +1,5 @@
+---
+description: Protocol for planning and executing milestone work in Stillwater, from scope assessment through post-merge cleanup.
+---
+
+--8<-- "docs/milestone-protocol.md"

--- a/docs/site/src/contributing/pr-workflow.md
+++ b/docs/site/src/contributing/pr-workflow.md
@@ -1,0 +1,5 @@
+---
+description: Pull request workflow for Stillwater, including the pre-push gate, squash policy, issue creation, and review process.
+---
+
+--8<-- "docs/pr-workflow.md"

--- a/docs/site/src/contributing/worktrees.md
+++ b/docs/site/src/contributing/worktrees.md
@@ -1,0 +1,5 @@
+---
+description: Git worktree protocol for concurrent development on Stillwater, including naming conventions, creation, and cleanup.
+---
+
+--8<-- "docs/worktrees.md"

--- a/docs/site/src/index.md
+++ b/docs/site/src/index.md
@@ -55,7 +55,7 @@ Single binary or container. SQLite. No cloud, no telemetry, no account. Your lib
 - [Install Stillwater](getting-started/index.md): binary, Docker, or Docker Compose.
 - [Set up NFO writeback (preferred)](getting-started/first-run-oobe.md): point Stillwater at your music library.
 - [Connect a media server](getting-started/index.md#3-pick-a-delivery-mode): the API-push alternative for Emby or Jellyfin.
-- [Browse the API](api/index.html): every feature, scriptable.
+- [Browse the API](api/index.md): every feature, scriptable.
 
 ---
 

--- a/docs/site/src/reference/index.md
+++ b/docs/site/src/reference/index.md
@@ -46,4 +46,4 @@ The map for "where do I find the exact list of X?" Each page is a deep enumerati
 
 The complete REST API specification is published separately and rendered from `api/openapi.yaml`. It covers every endpoint Stillwater exposes under `/api/v1/`, including request bodies, response shapes, and authentication. The Web UI consumes the same API via HTMX, so anything the UI can do can also be scripted.
 
-[Open the API reference &rarr;](../api/index.html){ .md-button }
+[Open the API reference &rarr;](../api/index.md){ .md-button }


### PR DESCRIPTION
## Summary

- Publishes six developer docs to the mkdocs site under a new **Contributing** nav section: `CONTRIBUTING.md`, `dev-setup.md`, `architecture-decisions.md`, `pr-workflow.md`, `worktrees.md`, `milestone-protocol.md`.
- Each site page is a thin stub that renders the canonical file via `pymdownx.snippets` (`--8<--`). No content is duplicated into `docs/site/src/`; the root/`docs/` files stay the single source of truth.
- Refreshes outdated content in the canonical files in the same pass (see below).
- Reviewers: note the **API Reference nav change** -- it now points at a markdown landing page (`api/index.md`) that links out to the CI-generated Redoc page, instead of pointing directly at `api/index.html`. This was required to make `mkdocs build --strict` pass (a nav entry to a build-time-absent file fails strict mode; that failure pre-existed on `main`).

## Linked issue

Closes #1571

## Outdated content corrected

- `CONTRIBUTING.md`: removed the false "Node.js required" claim (project uses the Tailwind standalone CLI).
- `dev-setup.md`: compose file corrected to `docker-compose.yml`; release section now uses signed annotated tags (`git tag -s`); hardcoded Tailwind `v4.2.0` replaced with a pointer to `ARG TAILWIND_VERSION` in the Dockerfile; hand-maintained env-var table replaced with a link to the generated reference page.
- Verified against code: `SW_SESSION_SECRET` is actually used for session-cookie signing (the old "unused/reserved" note was wrong -- now resolved by deferring to the generated reference); `PUID`/`PGID` defaults `99`/`100` confirmed against `build/docker/entrypoint.sh`.
- Cross-reference relative links in the included files rewritten to absolute `github.com/.../blob/main/` URLs so they resolve in both the GitHub browser and the rendered site.

## Pre-flight checklist

- [x] Docs-only change: no Go, templ, OpenAPI, or migration files touched. The full pre-push gate / CI is a no-op for behavior.
- [x] Self-reviewed the 12-file diff (link rewrites, stub pages, nav).
- [x] Single clean commit.
- [x] Labels set (`documentation`, `chore`).
- [x] No UI/runtime change; no screenshot applicable.
- [x] UAT: `mkdocs build --strict` passes locally with zero warnings.
- [x] No OpenAPI or `.templ` change.

## Test plan

- [x] `mkdocs build --strict --config-file docs/site/mkdocs.yml` -- built clean, zero warnings.
- [x] New **Contributing** section and its six pages present in `mkdocs.yml` nav; each renders its canonical file via snippet.
- [ ] CI **Build site** / **Docs** checks -- run by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured docs site with a new dedicated Contributing section (architecture decisions, dev setup, PR workflow, worktrees)
  * Added an API reference page for REST endpoints and guidance on generated output
  * Updated development setup to align with Docker builds, Docker Compose instructions, Tailwind CLI versioning, and environment variable referencing
  * Refreshed contributor guidance and links (including Code of Conduct) and updated release tagging requirement to signed annotated tags

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->