### PR TITLE
test(tagdict): restore metadata_vocab coverage to the 100% floor

### DIFF
--- a/internal/provider/tagdict/vocab_test.go
+++ b/internal/provider/tagdict/vocab_test.go
@@ -205,6 +205,22 @@ func TestApplyVocabFilter_ExcludeAll(t *testing.T) {
 	}
 }
 
+// TestApplyVocabFilter_BlankTagSkipped verifies that a blank or whitespace-only
+// tag in the input is dropped rather than emitted, even when it matches no
+// exclude pattern.
+func TestApplyVocabFilter_BlankTagSkipped(t *testing.T) {
+	t.Parallel()
+	// A non-empty exclude list keeps the call off the fast path so the
+	// per-tag loop (and its blank-tag guard) runs.
+	cfg := &VocabConfig{Exclude: []string{"junk"}}
+	input := []string{"Rock", "", "   ", "Pop"}
+	got := ApplyVocabFilter(cfg, VocabFieldGenres, input)
+	want := []string{"Rock", "Pop"}
+	if !equalStrings(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
 // TestWildcardMatch covers the wildcard matcher directly, including edge cases.
 func TestWildcardMatch(t *testing.T) {
 	t.Parallel()
@@ -303,5 +319,28 @@ func TestMetadataVocab_ContextRoundTrip(t *testing.T) {
 	got := MetadataVocab(ctx)
 	if got != cfg {
 		t.Fatal("MetadataVocab did not round-trip the stored config")
+	}
+}
+
+// TestMetadataVocab_NilContext verifies the helpers tolerate a nil context:
+// MetadataVocab returns nil rather than panicking, and WithMetadataVocab falls
+// back to context.Background() so the config still round-trips.
+func TestMetadataVocab_NilContext(t *testing.T) {
+	t.Parallel()
+
+	// A nil context.Context value -- both helpers guard against it explicitly.
+	var nilCtx context.Context
+
+	if got := MetadataVocab(nilCtx); got != nil {
+		t.Errorf("MetadataVocab(nil) = %v, want nil", got)
+	}
+
+	cfg := &VocabConfig{Exclude: []string{"junk"}, MaxGenres: 3}
+	ctx := WithMetadataVocab(nilCtx, cfg)
+	if ctx == nil {
+		t.Fatal("WithMetadataVocab(nil, cfg) returned a nil context")
+	}
+	if got := MetadataVocab(ctx); got != cfg {
+		t.Fatal("config did not round-trip through a nil-rooted context")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds tests for three under-covered branches in `internal/provider/tagdict/vocab.go` (the `metadata_vocab` tag-filtering code added by #1595), restoring the package from 97.5% to its 100% coverage floor.
- Branches now covered: `WithMetadataVocab` nil-context fallback, `MetadataVocab` nil-context early return, and `ApplyVocabFilter`'s blank-tag skip.
- Test-only change; no production code touched.

## Linked issue

N/A -- coverage-floor repair surfaced by the pre-push gate during v1.2.0 release prep. #1595 merged the regression because CI does not enforce the per-package coverage floor (only the local pre-push gate does -- the same CI blind spot tracked in #1602 for generated-file freshness).

## Pre-flight checklist

- [x] `go test -coverprofile` confirms `internal/provider/tagdict` back to 100.0%, every function at 100%.
- [x] Pre-commit gofmt + golangci-lint clean; full pre-push gate runs on push and in CI.
- [x] Self-reviewed: 39 lines, two new test functions, no production code.
- [x] Single clean commit.
- [x] Labels set (`chore`, `testing`, `docs: not-required`).
- [x] No OpenAPI or `.templ` change.

## Test plan

- [x] `go test -coverprofile=cov.out ./internal/provider/tagdict/...` -- 100.0% of statements; `go tool cover -func` shows no function below 100%.
- [ ] `go test -race ./...` and `bash scripts/pre-push-gate.sh` -- run by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for vocabulary filtering and context handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->