### PR TITLE
fix(settings): correct Web Image Search help text (DuckDuckGo)

### DIFF
--- a/docs/site/src/reference/settings-by-tab.md
+++ b/docs/site/src/reference/settings-by-tab.md
@@ -94,7 +94,7 @@ Most metadata providers (Fanart.tv, Discogs, TheAudioDB, and others) require a f
 
 ### Web Image Search  {#settings-providers-web-search}
 
-Authoritative sources like Fanart.tv and TheAudioDB curate a fixed catalogue of images per artist; for obscure or local artists they often have nothing. Web search providers (Bing, Brave, and similar) crawl the open web for matches, giving Stillwater far more candidates at the cost of mixed quality. No API key required.
+Authoritative sources like Fanart.tv and TheAudioDB curate a fixed catalogue of images per artist; for obscure or local artists they often have nothing. Web image search (DuckDuckGo) crawls the open web for matches, giving Stillwater far more candidates at the cost of mixed quality. No API key required.
 
 ### Provider Priorities  {#settings-providers-priorities}
 

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -2009,7 +2009,7 @@
   "settings.users.user": "User",
   "settings.users.user_accounts": "User accounts",
   "settings.users.user_accounts.description": "An account is anyone who has signed in successfully and exists in Stillwater's user table, regardless of which auth provider verified them. This table lists every active account; use the row controls to promote or demote a user's role or deactivate them.",
-  "settings.web_search.description": "Authoritative sources like Fanart.tv and TheAudioDB curate a fixed catalogue of images per artist; for obscure or local artists they often have nothing. Web search providers (Bing, Brave, and similar) crawl the open web for matches, giving Stillwater far more candidates at the cost of mixed quality. No API key required.",
+  "settings.web_search.description": "Authoritative sources like Fanart.tv and TheAudioDB curate a fixed catalogue of images per artist; for obscure or local artists they often have nothing. Web image search (DuckDuckGo) crawls the open web for matches, giving Stillwater far more candidates at the cost of mixed quality. No API key required.",
   "settings.web_search.help": "Falls back to general-purpose web image search when authoritative providers (MusicBrainz, Fanart.tv, etc.) don't return an image. Useful for obscure artists; results vary in quality so review before saving.",
   "settings.web_search.title": "Web Image Search",
   "settings.webhooks.add": "Add Webhook",


### PR DESCRIPTION
## Summary

- The Web Image Search section on **Settings -> Providers** described "Web search providers (Bing, Brave, and similar)". Neither provider exists: `AllWebSearchProviderNames()` (`internal/provider/provider.go`) returns only DuckDuckGo, and there is no Bing or Brave adapter anywhere in `internal/provider/`.
- Fixed the i18n source string `settings.web_search.description` to name the single web image search provider that actually ships (DuckDuckGo).
- Regenerated `docs/site/src/reference/settings-by-tab.md`, which `gen-settings-reference` derives from that string -- the doc carried the same wrong text downstream.

## Linked issue

No tracked issue. Drift surfaced while comparing a live accessibility snapshot of the Providers tab against the codebase.

## Pre-flight checklist

- [x] Pre-push gate green locally (pre-push hook ran it on push).
- [x] Code review pass: two-line copy fix; verified the provider roster against `internal/provider/provider.go`.
- [x] Commits squashed into one clean commit.
- [x] At least one label set (`bug`).
- [x] Docs label decision made: doc update (`settings-by-tab.md`) is included in this PR, so neither `docs: not-required` nor `needs-docs-review` applies.
- [x] Screenshot: not applicable (text-only copy change).
- [x] OpenAPI: not applicable (no request/response shape change).
- [x] templ: not applicable (no `.templ` change; i18n strings load at runtime).

## Test plan

- [x] `go test -race ./...`: not applicable; no Go logic changed (i18n JSON + generated Markdown only).
- [x] `make generate-docs` produces exactly the expected one-line change in `settings-by-tab.md` (no other generated drift).
- [x] UAT: rebuilt via `scripts/dev-restart.sh` and loaded `/settings?tab=providers` -- the Web Image Search description now renders "Web image search (DuckDuckGo) crawls the open web for matches..." with no Bing/Brave mention.