### PR TITLE
fix(nfo): preserve discography across NFO write-back

### DIFF
--- a/internal/nfo/writeback.go
+++ b/internal/nfo/writeback.go
@@ -3,6 +3,7 @@ package nfo
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -67,6 +68,11 @@ func WriteBackArtistNFO(ctx context.Context, a *artist.Artist, ss *SnapshotServi
 //
 // The <stillwater> provenance element is always written so external
 // overwrites can be detected on read regardless of the lock setting.
+//
+// Discography (<album> entries) is preserved from the existing on-disk NFO
+// (#1616). Discography is not stored in the database, so a write-back driven
+// by a DB-loaded artist would otherwise erase it; see the inline comment at
+// the preservation step for details.
 func WriteBackArtistNFOWithFieldMap(ctx context.Context, a *artist.Artist, ss *SnapshotService, logger *slog.Logger, fm NFOFieldMap, lockNFO bool) error {
 	if a == nil {
 		return fmt.Errorf("write artist nfo: artist is nil")
@@ -77,23 +83,80 @@ func WriteBackArtistNFOWithFieldMap(ctx context.Context, a *artist.Artist, ss *S
 
 	target := filepath.Join(a.Path, "artist.nfo")
 
-	// Save a snapshot of the existing NFO before overwriting (best effort)
-	if ss != nil {
-		if existing, err := os.ReadFile(target); err == nil && len(existing) > 0 { //nolint:gosec // G304: path from trusted artist.Path
-			if _, snapErr := ss.Save(ctx, a.ID, string(existing)); snapErr != nil {
-				log := logger
-				if log == nil {
-					log = slog.Default()
-				}
-				log.Warn("NFO snapshot save failed (proceeding with write)",
-					slog.String("artist_id", a.ID),
-					slog.String("error", snapErr.Error()),
-				)
+	// Read the existing on-disk NFO once. The bytes are needed for two
+	// independent best-effort purposes below: the optional pre-write snapshot
+	// and discography preservation. The write-back stays best-effort, but the
+	// two read-failure cases are not equivalent: a missing file is benign
+	// (nothing to preserve), while a permission or I/O error means an NFO
+	// very likely exists and the write below will overwrite it without its
+	// discography. Log the latter loudly so it is not a silent data loss.
+	existingContent, readErr := os.ReadFile(target) //nolint:gosec // G304: path from trusted artist.Path
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		log := logger
+		if log == nil {
+			log = slog.Default()
+		}
+		log.Warn("could not read existing NFO before write-back; discography (if any) will not be preserved",
+			slog.String("artist_id", a.ID),
+			slog.String("nfo_path", target),
+			slog.String("error", readErr.Error()),
+		)
+	}
+
+	// Save a snapshot of the existing NFO before overwriting (best effort).
+	if ss != nil && readErr == nil && len(existingContent) > 0 {
+		if _, snapErr := ss.Save(ctx, a.ID, string(existingContent)); snapErr != nil {
+			log := logger
+			if log == nil {
+				log = slog.Default()
 			}
+			log.Warn("NFO snapshot save failed (proceeding with write)",
+				slog.String("artist_id", a.ID),
+				slog.String("error", snapErr.Error()),
+			)
 		}
 	}
 
 	nfoData := FromArtistWithFieldMap(a, fm)
+
+	// Preserve the existing discography (#1616).
+	//
+	// Discography (<album> entries) is NFO-only: it is never stored in the
+	// database, and the artist.Artist model loaded from the DB carries an
+	// empty Discography slice. FromArtistWithFieldMap therefore produces an
+	// ArtistNFO with no <album> entries. Without the merge below, every
+	// write-back triggered from a DB-loaded artist (connection auto-push,
+	// metadata refresh) would silently wipe whatever discography the on-disk
+	// NFO already contained -- including entries written by the "Fetch
+	// discography" button (#1065) or the discography rule (#1063).
+	//
+	// To avoid that, carry the existing on-disk discography forward whenever
+	// nfoData itself does not already supply one. If the in-memory artist
+	// does carry discography (e.g. freshly scanned from the same NFO), that
+	// value wins and the on-disk parse is not needed.
+	if len(nfoData.Albums) == 0 && readErr == nil && len(existingContent) > 0 {
+		if existingNFO, parseErr := Parse(bytes.NewReader(existingContent)); parseErr == nil {
+			if len(existingNFO.Albums) > 0 {
+				nfoData.Albums = existingNFO.Albums
+			}
+		} else {
+			// An unparsable existing NFO must not block the write-back; the
+			// write is best-effort and proceeds without discography
+			// preservation. Log at Warn, not Debug: this branch drops every
+			// <album> entry the old NFO held, and discography is NFO-only with
+			// no DB copy to recover from, so operators must see it on a
+			// default log level.
+			log := logger
+			if log == nil {
+				log = slog.Default()
+			}
+			log.Warn("existing NFO could not be parsed; its discography entries will not be carried into the rewritten file",
+				slog.String("artist_id", a.ID),
+				slog.String("nfo_path", target),
+				slog.String("error", parseErr.Error()),
+			)
+		}
+	}
 
 	// Lockdata is opt-in per library (issue #1264). The previous unconditional
 	// stamp blocked Emby/Jellyfin refreshes for every artist Stillwater wrote.

--- a/internal/nfo/writeback_test.go
+++ b/internal/nfo/writeback_test.go
@@ -464,6 +464,198 @@ func TestWriteBackArtistNFO_Discography(t *testing.T) {
 	}
 }
 
+// TestWriteBackArtistNFO_PreservesOnDiskDiscography covers the #1616
+// data-loss regression. Discography (<album> entries) is NFO-only -- it is
+// never persisted to the database -- so an artist.Artist loaded from the DB
+// carries an empty Discography slice. Before the fix, a write-back over an
+// NFO that already had <album> entries would silently drop every one of
+// them. This test seeds an on-disk NFO with discography, writes back a
+// DB-style artist (empty Discography), and asserts the entries survive.
+func TestWriteBackArtistNFO_PreservesOnDiskDiscography(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed an existing on-disk NFO that already carries a discography.
+	seed := &ArtistNFO{
+		Name: "Old Name",
+		Albums: []DiscographyAlbum{
+			{Title: "Bleach", Year: "1989"},
+			{Title: "Nevermind", Year: "1991", MusicBrainzReleaseGroupID: "rg-nevermind"},
+			{Title: "In Utero", Year: "1993"},
+		},
+	}
+	if err := WriteNFOAtomic(filepath.Join(dir, "artist.nfo"), seed); err != nil {
+		t.Fatalf("seeding nfo: %v", err)
+	}
+
+	// A DB-loaded artist: metadata is present but Discography is empty,
+	// because the database has no discography column.
+	a := &artist.Artist{
+		ID:       "art-preserve",
+		Name:     "Nirvana",
+		SortName: "Nirvana",
+		Path:     dir,
+		// Discography intentionally left nil.
+	}
+
+	if err := WriteBackArtistNFO(context.Background(), a, nil, nil); err != nil {
+		t.Fatalf("WriteBackArtistNFO: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "artist.nfo"))
+	if err != nil {
+		t.Fatalf("reading nfo: %v", err)
+	}
+	parsed, err := Parse(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("parsing nfo: %v", err)
+	}
+
+	// The metadata write-back should have applied.
+	if parsed.Name != "Nirvana" {
+		t.Errorf("Name = %q, want %q", parsed.Name, "Nirvana")
+	}
+
+	// The on-disk discography must survive the write-back.
+	if len(parsed.Albums) != len(seed.Albums) {
+		t.Fatalf("Albums count = %d, want %d; serialized:\n%s",
+			len(parsed.Albums), len(seed.Albums), string(data))
+	}
+	for i, want := range seed.Albums {
+		got := parsed.Albums[i]
+		if got.Title != want.Title || got.Year != want.Year ||
+			got.MusicBrainzReleaseGroupID != want.MusicBrainzReleaseGroupID {
+			t.Errorf("album[%d] = %+v, want %+v", i, got, want)
+		}
+	}
+}
+
+// TestWriteBackArtistNFO_NoDiscographyToPreserve verifies that when the
+// existing on-disk NFO has no <album> entries, the write-back still succeeds
+// and the output likewise has none -- no crash, no spurious entries.
+func TestWriteBackArtistNFO_NoDiscographyToPreserve(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed an existing NFO with metadata but no discography.
+	seed := &ArtistNFO{Name: "Old Name"}
+	if err := WriteNFOAtomic(filepath.Join(dir, "artist.nfo"), seed); err != nil {
+		t.Fatalf("seeding nfo: %v", err)
+	}
+
+	a := &artist.Artist{
+		ID:       "art-nodisco",
+		Name:     "Solo Act",
+		SortName: "Solo Act",
+		Path:     dir,
+	}
+
+	if err := WriteBackArtistNFO(context.Background(), a, nil, nil); err != nil {
+		t.Fatalf("WriteBackArtistNFO: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "artist.nfo"))
+	if err != nil {
+		t.Fatalf("reading nfo: %v", err)
+	}
+	parsed, err := Parse(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("parsing nfo: %v", err)
+	}
+	if len(parsed.Albums) != 0 {
+		t.Errorf("Albums = %v, want none", parsed.Albums)
+	}
+}
+
+// TestWriteBackArtistNFO_UnparsableExistingNFO verifies that a corrupt or
+// otherwise unparsable existing NFO does not break the write-back. The fix
+// is best-effort: discography preservation is skipped, but the write itself
+// still succeeds and produces a valid NFO.
+func TestWriteBackArtistNFO_UnparsableExistingNFO(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed a file that is not valid NFO XML.
+	garbage := []byte("this is not xml at all <<< &&& >>>")
+	if err := os.WriteFile(filepath.Join(dir, "artist.nfo"), garbage, 0o644); err != nil {
+		t.Fatalf("seeding garbage nfo: %v", err)
+	}
+
+	a := &artist.Artist{
+		ID:       "art-corrupt",
+		Name:     "Recovered Artist",
+		SortName: "Recovered Artist",
+		Path:     dir,
+	}
+
+	// The write-back must not fail despite the unparsable existing file.
+	if err := WriteBackArtistNFO(context.Background(), a, nil, nil); err != nil {
+		t.Fatalf("WriteBackArtistNFO over unparsable NFO: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "artist.nfo"))
+	if err != nil {
+		t.Fatalf("reading nfo: %v", err)
+	}
+	parsed, err := Parse(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("parsing rewritten nfo: %v", err)
+	}
+	if parsed.Name != "Recovered Artist" {
+		t.Errorf("Name = %q, want %q", parsed.Name, "Recovered Artist")
+	}
+	// No discography could be recovered from the garbage input.
+	if len(parsed.Albums) != 0 {
+		t.Errorf("Albums = %v, want none", parsed.Albums)
+	}
+}
+
+// TestWriteBackArtistNFO_ArtistDiscographyWinsOverOnDisk verifies that when
+// the in-memory artist itself carries discography (e.g. freshly scanned from
+// the same NFO), that value is used and is not silently replaced by a stale
+// on-disk parse.
+func TestWriteBackArtistNFO_ArtistDiscographyWinsOverOnDisk(t *testing.T) {
+	dir := t.TempDir()
+
+	// On-disk NFO has an outdated single-album discography.
+	seed := &ArtistNFO{
+		Name:   "Old Name",
+		Albums: []DiscographyAlbum{{Title: "Stale Album", Year: "1900"}},
+	}
+	if err := WriteNFOAtomic(filepath.Join(dir, "artist.nfo"), seed); err != nil {
+		t.Fatalf("seeding nfo: %v", err)
+	}
+
+	// The in-memory artist carries a fresher, different discography.
+	a := &artist.Artist{
+		ID:       "art-wins",
+		Name:     "Updated Artist",
+		SortName: "Updated Artist",
+		Path:     dir,
+		Discography: []artist.DiscographyAlbum{
+			{Title: "Fresh Album One", Year: "2020"},
+			{Title: "Fresh Album Two", Year: "2024", MusicBrainzReleaseGroupID: "rg-fresh"},
+		},
+	}
+
+	if err := WriteBackArtistNFO(context.Background(), a, nil, nil); err != nil {
+		t.Fatalf("WriteBackArtistNFO: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "artist.nfo"))
+	if err != nil {
+		t.Fatalf("reading nfo: %v", err)
+	}
+	parsed, err := Parse(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("parsing nfo: %v", err)
+	}
+
+	if len(parsed.Albums) != 2 {
+		t.Fatalf("Albums count = %d, want 2; serialized:\n%s", len(parsed.Albums), string(data))
+	}
+	if parsed.Albums[0].Title != "Fresh Album One" || parsed.Albums[1].Title != "Fresh Album Two" {
+		t.Errorf("Albums = %+v, want the in-memory discography to win", parsed.Albums)
+	}
+}
+
 // --- WriteNFOAtomic ---
 
 func TestWriteNFOAtomic_Success(t *testing.T) {
@@ -536,5 +728,44 @@ func TestWriteNFOAtomic_UnwritablePath(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "writing nfo file") {
 		t.Errorf("error = %q, want it to mention 'writing nfo file'", err.Error())
+	}
+}
+
+// TestWriteBackArtistNFO_UnreadableExistingNFO verifies the write-back
+// distinguishes a genuinely-absent NFO from one that exists but cannot be read.
+// Here the artist.nfo path is a directory, so os.ReadFile fails with a
+// non-os.ErrNotExist error: the new readErr branch logs a Warn instead of
+// treating the failure as a benign "no existing NFO". The write-back stays
+// best-effort and still completes (WriteFileAtomic moves the unreadable path
+// aside), but it cannot preserve discography it was unable to read.
+func TestWriteBackArtistNFO_UnreadableExistingNFO(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "artist.nfo")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatalf("mkdir artist.nfo: %v", err)
+	}
+
+	a := &artist.Artist{
+		ID:       "art-unreadable",
+		Name:     "Nirvana",
+		SortName: "Nirvana",
+		Path:     dir,
+	}
+
+	if err := WriteBackArtistNFO(context.Background(), a, nil, nil); err != nil {
+		t.Fatalf("WriteBackArtistNFO over an unreadable NFO path: %v", err)
+	}
+
+	// The path is now a regular NFO file carrying the artist metadata.
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("reading nfo after write-back: %v", err)
+	}
+	parsed, err := Parse(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("parsing nfo: %v", err)
+	}
+	if parsed.Name != "Nirvana" {
+		t.Errorf("Name = %q, want %q", parsed.Name, "Nirvana")
 	}
 }


### PR DESCRIPTION
## Summary

- `WriteBackArtistNFOWithFieldMap` rebuilt `artist.nfo` entirely from the database artist model and overwrote the file. Discography (`<album>` entries) is NFO-file-only (there is no DB column), so every write-back (connection auto-push, metadata refresh) silently erased it.
- The write-back now reads the existing on-disk NFO once and carries its `<album>` entries forward whenever the in-memory artist does not already supply discography.
- This bug defeated #1063 (discography rule) and silently affected merged #1065 (Fetch discography button). Reviewers: see the precedence rule `len(nfoData.Albums) == 0` and the best-effort error handling (read errors distinguish `os.ErrNotExist`; an unparsable existing NFO logs at Warn, not Debug).

## Linked issue

Closes #1616

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`)
- [x] Code review pass complete (pr-review-toolkit code-reviewer + silent-failure-hunter; both HIGH findings fixed before push)
- [x] Commits squashed into one clean commit
- [x] At least one label set (`bug`)
- [x] Docs label decision made: `docs: not-required` -- bug fix with no documentation surface
- [x] No UI change, so no screenshot applies
- [x] UAT performed (see Test plan)
- [x] OpenAPI not applicable -- no request or response shape changed
- [x] No `.templ` file changed, so no `templ generate` needed

## Test plan

- [x] `go test -race ./...` passes locally (via the pre-push gate)
- [x] `bash scripts/pre-push-gate.sh` passes locally
- [x] Manual UAT steps:
  - [x] Populated Aaron Copland's discography via the #1065 Fetch-discography endpoint (274 `<album>` entries written to `artist.nfo`)
  - [x] Triggered a metadata refresh plus connection auto-push write-back; confirmed all 274 `<album>` entries survived (before this fix the write-back left zero)
- [ ] Reviewer follow-up: a write-back over a fully unparsable existing NFO still overwrites it wholesale (only discography rescue is attempted). This is preexisting write-back behavior, out of this fix's scope; flagged for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Album entries in artist NFO files are now preserved during metadata write-back operations, preventing data loss.
  * Enhanced error handling with warnings when NFO file access issues occur.

* **Tests**
  * Expanded test coverage for album data preservation scenarios during NFO file operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->