### PR TITLE
fix(foreign): dedup foreign-file ledger by content hash

### DIFF
--- a/docs/site/src/core-concepts/conflict-gate.md
+++ b/docs/site/src/core-concepts/conflict-gate.md
@@ -85,3 +85,17 @@ The conflict gate and [field locks](field-locks.md) protect against different th
 Both apply regardless of the other. A locked artist still benefits from the gate pausing writes when a platform is meddling. An unlocked artist still gets the gate's protection even though locks aren't set.
 
 For [rules](rules.md), the conflict gate is consulted before any fix that produces an image or NFO write. If the gate is active when a rule fixer runs, the write is deferred and the violation stays open rather than silently failing.
+
+## Foreign files
+
+When a connected media server writes an image file to an artist directory without a Stillwater provenance tag, Stillwater records it in the **foreign-files ledger**. Each entry appears in the Settings page under Foreign Files so you can review, allowlist, or delete it.
+
+### Deduplicated display
+
+The list collapses entries that share the same byte content into a single row. When the same physical file is linked to more than one artist record, one representative row appears with a **linked from N artists** badge. Allowlisting or deleting that row acts on the representative artist only; the sibling rows for the other artists remain in the ledger until you clear them with the **Dismiss (allowlist all)** button at the top of the page, which removes every entry globally in one pass.
+
+Entries recorded before a library rescan may not yet have a computed content fingerprint. Those entries are never collapsed and each appear as a separate row until the next scan computes their fingerprints.
+
+### Dismiss (allowlist all)
+
+The **Dismiss (allowlist all)** button at the top of the Foreign Files page adds every currently detected file to the global allowlist in a single operation, then clears the entire ledger. The allowlist suppresses future re-detection of those files on all subsequent scans. Individual allow or delete actions are available per row for more targeted control.

--- a/docs/site/src/reference/_doc-anchors.txt
+++ b/docs/site/src/reference/_doc-anchors.txt
@@ -22,7 +22,10 @@ core-concepts/auto-provisioning#what-happens-when-an-upstream-user-is-removed
 core-concepts/conflict-gate#banner-states
 core-concepts/conflict-gate#coalesce-and-the-detection-cache
 core-concepts/conflict-gate#conflict-gate
+core-concepts/conflict-gate#deduplicated-display
+core-concepts/conflict-gate#dismiss-allowlist-all
 core-concepts/conflict-gate#feature-toggles-on-connections
+core-concepts/conflict-gate#foreign-files
 core-concepts/conflict-gate#how-writes-are-gated
 core-concepts/conflict-gate#let-stillwater-manage-and-auto-re-disable
 core-concepts/conflict-gate#relationship-to-field-locks-and-rules

--- a/internal/api/handlers_foreign_files.go
+++ b/internal/api/handlers_foreign_files.go
@@ -253,7 +253,13 @@ func (r *Router) handleForeignFilesDismiss(w http.ResponseWriter, req *http.Requ
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "foreign-file scanner not configured"})
 		return
 	}
-	entries, err := r.foreignRepo.List(req.Context())
+	// ListRaw returns every ledger row (un-collapsed) so the dismiss loop
+	// can call DeleteByPath for every (artist_id, file_path) pair. Using the
+	// collapsed List here would leave sibling rows behind: when two artists
+	// share the same content hash, List returns one representative row but
+	// the other row's ledger entry would survive and the banner would not
+	// clear until the next scan.
+	entries, err := r.foreignRepo.ListRaw(req.Context())
 	if err != nil {
 		r.logger.Error("listing foreign files for dismiss", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "listing foreign files"})
@@ -405,16 +411,17 @@ func (r *Router) requireForeignAdmin(w http.ResponseWriter, req *http.Request) b
 
 // foreignEntryToRow converts a domain entry to its template row shape.
 // Pointer receiver keeps copy cost minimal under gocritic's rangeValCopy
-// budget after Entry grew to include content_hash.
+// budget after Entry grew to include content_hash and DuplicateCount.
 func foreignEntryToRow(e *foreign.Entry) templates.ForeignFileRow {
 	return templates.ForeignFileRow{
-		ID:         e.ID,
-		ArtistID:   e.ArtistID,
-		ArtistName: e.ArtistName,
-		FilePath:   e.FilePath,
-		FileName:   e.FileName,
-		SizeBytes:  e.SizeBytes,
-		DetectedAt: e.DetectedAt.Format(time.RFC3339),
+		ID:             e.ID,
+		ArtistID:       e.ArtistID,
+		ArtistName:     e.ArtistName,
+		FilePath:       e.FilePath,
+		FileName:       e.FileName,
+		SizeBytes:      e.SizeBytes,
+		DetectedAt:     e.DetectedAt.Format(time.RFC3339),
+		DuplicateCount: e.DuplicateCount,
 	}
 }
 

--- a/internal/api/handlers_foreign_files_test.go
+++ b/internal/api/handlers_foreign_files_test.go
@@ -855,6 +855,100 @@ func TestHandleForeignFilesDismiss_SameBasenameDistinctBytes(t *testing.T) {
 	}
 }
 
+// TestHandleForeignFilesDismiss_SharedContentHash regression-protects the
+// choice to use ListRaw (un-collapsed) instead of the collapsed List in the
+// dismiss handler. It seeds two artist rows whose ledger entries share the
+// same content_hash -- the cross-artist shared-hash case. List would return
+// only one representative row; ListRaw returns both. After dismiss the ledger
+// must be fully empty (count == 0). A future refactor swapping ListRaw back
+// to List would currently pass every other handler test; this test catches it.
+func TestHandleForeignFilesDismiss_SharedContentHash(t *testing.T) {
+	t.Parallel()
+	r, db := newTestRouterWithForeign(t)
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	// Both artists share byte-for-byte identical content, producing one
+	// common content_hash. The physical files must exist on disk so that
+	// resolveForeignHash (called inside handleForeignFilesDismiss) can read
+	// and hash them when no pre-computed hash is stored on the entry.
+	sharedBody := []byte("shared-content-identical-bytes")
+	sharedHash := sha256HexAPI(sharedBody)
+	pathA := filepath.Join(dirA, "backdrop.jpg")
+	pathB := filepath.Join(dirB, "backdrop.jpg")
+	if err := os.WriteFile(pathA, sharedBody, 0o644); err != nil {
+		t.Fatalf("write A: %v", err)
+	}
+	if err := os.WriteFile(pathB, sharedBody, 0o644); err != nil {
+		t.Fatalf("write B: %v", err)
+	}
+
+	mustExec(t, db, `INSERT INTO artists (id, name, path) VALUES ('a1','Aretha',?), ('a2','Beth',?)`, dirA, dirB)
+
+	// Seed two ledger rows with the same content_hash -- one per artist.
+	if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{
+		ArtistID: "a1", FilePath: pathA, FileName: "backdrop.jpg", ContentHash: sharedHash,
+	}); err != nil {
+		t.Fatalf("seed a1: %v", err)
+	}
+	if err := r.foreignRepo.Upsert(context.Background(), foreign.Entry{
+		ArtistID: "a2", FilePath: pathB, FileName: "backdrop.jpg", ContentHash: sharedHash,
+	}); err != nil {
+		t.Fatalf("seed a2: %v", err)
+	}
+
+	// Confirm the precondition: List collapses the two rows to one (same
+	// hash), while the raw ledger really has two entries.
+	collapsed, err := r.foreignRepo.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(collapsed) != 1 {
+		t.Fatalf("precondition: List should collapse two same-hash rows to 1; got %d", len(collapsed))
+	}
+	// Count uses the same collapsed grouping as List; query raw row count
+	// directly to confirm two physical ledger rows exist.
+	var rawCount int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM foreign_files`).Scan(&rawCount); err != nil {
+		t.Fatalf("raw count: %v", err)
+	}
+	if rawCount != 2 {
+		t.Fatalf("precondition: raw ledger should have 2 rows; got %d", rawCount)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/foreign-files/dismiss", nil)
+	rec := httptest.NewRecorder()
+	r.handleForeignFilesDismiss(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dismiss should return 200; got %d", rec.Code)
+	}
+
+	// Both sibling ledger rows must be gone -- not just the representative
+	// one that List would have returned. Query the raw row count so this
+	// assertion is immune to any future changes in how Count aggregates.
+	var afterCount int
+	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM foreign_files`).Scan(&afterCount); err != nil {
+		t.Fatalf("raw count after dismiss: %v", err)
+	}
+	if afterCount != 0 {
+		t.Errorf("ledger should be fully cleared after dismiss (both shared-hash rows); got %d raw rows", afterCount)
+	}
+
+	// Exactly one global allowlist row should exist for the shared hash.
+	rows, _ := r.foreignRepo.ListAllowlist(context.Background())
+	if len(rows) != 1 {
+		t.Errorf("expected 1 allowlist row for the shared content_hash; got %d", len(rows))
+	}
+	if len(rows) == 1 {
+		if rows[0].ContentHash != sharedHash {
+			t.Errorf("allowlist row content_hash = %q; want %q", rows[0].ContentHash, sharedHash)
+		}
+		if rows[0].Scope != foreign.ScopeGlobal {
+			t.Errorf("allowlist row scope = %q; want global", rows[0].Scope)
+		}
+	}
+}
+
 // TestResolveForeignHash_BackfillsFromDisk covers the on-demand rehash
 // path for pre-008 ledger rows whose content_hash column is empty. The
 // handler must recompute the digest from disk so the allowlist write

--- a/internal/api/handlers_foreign_files_test.go
+++ b/internal/api/handlers_foreign_files_test.go
@@ -906,14 +906,15 @@ func TestHandleForeignFilesDismiss_SharedContentHash(t *testing.T) {
 	if len(collapsed) != 1 {
 		t.Fatalf("precondition: List should collapse two same-hash rows to 1; got %d", len(collapsed))
 	}
-	// Count uses the same collapsed grouping as List; query raw row count
-	// directly to confirm two physical ledger rows exist.
-	var rawCount int
-	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM foreign_files`).Scan(&rawCount); err != nil {
-		t.Fatalf("raw count: %v", err)
+	// Confirm two physical ledger rows exist via the repo's uncollapsed path.
+	// Using ListRaw keeps this assertion at the repository contract level and
+	// also exercises ListRaw itself against the seeded data.
+	rawRows, err := r.foreignRepo.ListRaw(context.Background())
+	if err != nil {
+		t.Fatalf("ListRaw precondition: %v", err)
 	}
-	if rawCount != 2 {
-		t.Fatalf("precondition: raw ledger should have 2 rows; got %d", rawCount)
+	if len(rawRows) != 2 {
+		t.Fatalf("precondition: raw ledger should have 2 rows; got %d", len(rawRows))
 	}
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/foreign-files/dismiss", nil)
@@ -924,14 +925,14 @@ func TestHandleForeignFilesDismiss_SharedContentHash(t *testing.T) {
 	}
 
 	// Both sibling ledger rows must be gone -- not just the representative
-	// one that List would have returned. Query the raw row count so this
-	// assertion is immune to any future changes in how Count aggregates.
-	var afterCount int
-	if err := db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM foreign_files`).Scan(&afterCount); err != nil {
-		t.Fatalf("raw count after dismiss: %v", err)
+	// one that List would have returned. ListRaw sees the un-collapsed ledger
+	// so this assertion is immune to future changes in how Count aggregates.
+	rawRowsAfter, err := r.foreignRepo.ListRaw(context.Background())
+	if err != nil {
+		t.Fatalf("ListRaw after dismiss: %v", err)
 	}
-	if afterCount != 0 {
-		t.Errorf("ledger should be fully cleared after dismiss (both shared-hash rows); got %d raw rows", afterCount)
+	if len(rawRowsAfter) != 0 {
+		t.Errorf("ledger should be fully cleared after dismiss (both shared-hash rows); got %d raw rows", len(rawRowsAfter))
 	}
 
 	// Exactly one global allowlist row should exist for the shared hash.

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1668,6 +1668,13 @@ components:
         One row in the foreign_files ledger. A foreign file is an image whose
         basename matches a media-server naming pattern but whose EXIF
         ImageDescription does not carry the Stillwater provenance tag.
+
+        The list endpoint collapses multiple ledger rows that share the same
+        non-empty content_hash into a single entry (display-time dedup). The
+        representative entry is the row with the smallest id. Rows with an
+        empty content_hash (recorded before migration 008) are never collapsed.
+        duplicate_count reflects how many ledger rows share this file's hash;
+        a value of 1 means no duplicates exist.
       properties:
         id:
           type: string
@@ -1695,7 +1702,15 @@ components:
         detected_at:
           type: string
           format: date-time
-      required: [id, artist_id, artist_name, file_path, file_name, content_hash, size_bytes, detected_at]
+        duplicate_count:
+          type: integer
+          description: |
+            Number of ledger rows that share this file's content_hash (always
+            >= 1). A value greater than 1 means the same physical file is
+            referenced by multiple artist records or path spellings; the list
+            collapses them into this single entry. The UI shows a hint badge
+            when duplicate_count > 1.
+      required: [id, artist_id, artist_name, file_path, file_name, content_hash, size_bytes, detected_at, duplicate_count]
 
     ForeignAllowlistEntry:
       type: object
@@ -11435,11 +11450,17 @@ paths:
     get:
       summary: List detected foreign image files
       description: |
-        Returns every row in the foreign_files ledger, joined with the owning
-        artist name. Foreign files are images matching media-server naming
-        patterns ("backdrop*", "fanart*", "poster*", "logo*", "banner*",
-        "thumb*", "clearart*", "disc*", "landscape*") that lack Stillwater
-        EXIF provenance. Recorded by the periodic foreign-file scanner; never
+        Returns one entry per distinct file (by content_hash) from the
+        foreign_files ledger, joined with the owning artist name. Ledger rows
+        sharing the same non-empty content_hash are collapsed into one entry
+        (display-time dedup); the representative row is the one with the
+        smallest id. Rows with an empty content_hash (pre-migration-008) are
+        never collapsed.
+
+        Foreign files are images matching media-server naming patterns
+        ("backdrop*", "fanart*", "poster*", "logo*", "banner*", "thumb*",
+        "clearart*", "disc*", "landscape*") that lack Stillwater EXIF
+        provenance. Recorded by the periodic foreign-file scanner; never
         modified by this endpoint.
       operationId: listForeignFiles
       tags:

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1704,6 +1704,7 @@ components:
           format: date-time
         duplicate_count:
           type: integer
+          minimum: 1
           description: |
             Number of ledger rows that share this file's content_hash (always
             >= 1). A value greater than 1 means the same physical file is

--- a/internal/foreign/model.go
+++ b/internal/foreign/model.go
@@ -21,15 +21,21 @@ import "time"
 // distinct files sharing a basename like "poster.jpg" no longer collide.
 // Rows recorded before migration 008 may carry an empty hash and are
 // backfilled on the first post-migration scan.
+//
+// DuplicateCount is set by Repository.List to indicate how many ledger rows
+// share this entry's content hash (always >=1; 1 means no duplicates).
+// Rows with an empty content hash are never collapsed and always have
+// DuplicateCount=1. Pre-008 rows therefore never over-collapse.
 type Entry struct {
-	ID          string    `json:"id"`
-	ArtistID    string    `json:"artist_id"`
-	ArtistName  string    `json:"artist_name,omitempty"`
-	FilePath    string    `json:"file_path"`
-	FileName    string    `json:"file_name"`
-	ContentHash string    `json:"content_hash"`
-	SizeBytes   int64     `json:"size_bytes"`
-	DetectedAt  time.Time `json:"detected_at"`
+	ID             string    `json:"id"`
+	ArtistID       string    `json:"artist_id"`
+	ArtistName     string    `json:"artist_name,omitempty"`
+	FilePath       string    `json:"file_path"`
+	FileName       string    `json:"file_name"`
+	ContentHash    string    `json:"content_hash"`
+	SizeBytes      int64     `json:"size_bytes"`
+	DetectedAt     time.Time `json:"detected_at"`
+	DuplicateCount int       `json:"duplicate_count"`
 }
 
 // AllowlistScope identifies whether an allowlist row matches every artist

--- a/internal/foreign/repository.go
+++ b/internal/foreign/repository.go
@@ -117,14 +117,50 @@ func (r *Repository) GetByID(ctx context.Context, id string) (Entry, error) {
 	return e, nil
 }
 
-// List returns every ledger row joined with the owning artist name, sorted
-// by artist then file path so the UI rendering is stable across reloads.
+// List returns one entry per distinct file (by content hash), collapsing
+// duplicate ledger rows that share the same non-empty content_hash into a
+// single representative entry. The representative is the row with the
+// smallest id (MIN(id) -- arbitrary but stable across scans). DuplicateCount
+// is set to the number of ledger rows that share the same content_hash; a
+// value of 1 means no duplicates exist for that file.
+//
+// Rows whose content_hash is empty (recorded before migration 008) are never
+// collapsed: each gets a unique grouping key equal to its own id, so two
+// pre-008 rows with empty hashes always produce two distinct entries.
+//
+// The ordering is by artist name then file path on the representative row, so
+// the list is stable across reloads.
 func (r *Repository) List(ctx context.Context) ([]Entry, error) {
+	// The grouping subquery builds a deduplication key (gkey) per row:
+	//   - for rows with a non-empty content_hash: gkey = content_hash
+	//     -> rows that represent the same physical file share a gkey and
+	//        collapse into one representative (MIN(id)).
+	//   - for rows with an empty/NULL content_hash: gkey = the row's own id
+	//     -> each pre-008 row gets a unique gkey and is never collapsed.
+	//
+	// rep_id = MIN(id) selects one representative row per group.
+	// dup_count = COUNT(*) is the number of ledger rows sharing that gkey.
+	//
+	// The outer query joins back to foreign_files on the representative id
+	// so every returned column (id, artist_id, file_path, …) is internally
+	// consistent -- the representative's artist and path are used for
+	// per-row delete/allowlist actions.
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT f.id, f.artist_id, f.file_path, f.file_name,
 		       COALESCE(f.content_hash, ''), f.size_bytes, f.detected_at,
-		       a.name
-		FROM foreign_files f
+		       a.name, g.dup_count
+		FROM (
+			SELECT
+				CASE WHEN COALESCE(content_hash, '') = ''
+				     THEN id
+				     ELSE content_hash
+				END AS gkey,
+				MIN(id)    AS rep_id,
+				COUNT(*)   AS dup_count
+			FROM foreign_files
+			GROUP BY gkey
+		) g
+		JOIN foreign_files f ON f.id = g.rep_id
 		LEFT JOIN artists a ON a.id = f.artist_id
 		ORDER BY a.name COLLATE NOCASE, f.file_path`)
 	if err != nil {
@@ -136,7 +172,8 @@ func (r *Repository) List(ctx context.Context) ([]Entry, error) {
 		var e Entry
 		var detected string
 		var artistName sql.NullString
-		if err := rows.Scan(&e.ID, &e.ArtistID, &e.FilePath, &e.FileName, &e.ContentHash, &e.SizeBytes, &detected, &artistName); err != nil {
+		if err := rows.Scan(&e.ID, &e.ArtistID, &e.FilePath, &e.FileName,
+			&e.ContentHash, &e.SizeBytes, &detected, &artistName, &e.DuplicateCount); err != nil {
 			return nil, fmt.Errorf("foreign: scan list row: %w", err)
 		}
 		if t, perr := time.Parse(time.RFC3339, detected); perr == nil {
@@ -153,11 +190,71 @@ func (r *Repository) List(ctx context.Context) ([]Entry, error) {
 	return out, nil
 }
 
-// Count returns the number of foreign-file ledger rows. Used by the banner
-// to decide whether to show the slate/blue warning.
+// ListRaw returns every ledger row without any content-hash deduplication,
+// one entry per (artist_id, file_path). DuplicateCount is always 1 on raw
+// entries; the field exists only for structural consistency with Entry.
+//
+// Use ListRaw in operations that must touch every sibling row -- for example
+// the bulk-dismiss handler, which must call DeleteByPath for every row so the
+// ledger is fully cleared even when multiple rows share the same content hash.
+func (r *Repository) ListRaw(ctx context.Context) ([]Entry, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT f.id, f.artist_id, f.file_path, f.file_name,
+		       COALESCE(f.content_hash, ''), f.size_bytes, f.detected_at,
+		       a.name
+		FROM foreign_files f
+		LEFT JOIN artists a ON a.id = f.artist_id
+		ORDER BY a.name COLLATE NOCASE, f.file_path`)
+	if err != nil {
+		return nil, fmt.Errorf("foreign: list raw: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only cursor
+	var out []Entry
+	for rows.Next() {
+		var e Entry
+		var detected string
+		var artistName sql.NullString
+		if err := rows.Scan(&e.ID, &e.ArtistID, &e.FilePath, &e.FileName,
+			&e.ContentHash, &e.SizeBytes, &detected, &artistName); err != nil {
+			return nil, fmt.Errorf("foreign: scan raw list row: %w", err)
+		}
+		if t, perr := time.Parse(time.RFC3339, detected); perr == nil {
+			e.DetectedAt = t
+		}
+		if artistName.Valid {
+			e.ArtistName = artistName.String
+		}
+		e.DuplicateCount = 1
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("foreign: iterate raw list rows: %w", err)
+	}
+	return out, nil
+}
+
+// Count returns the number of distinct foreign files (by content hash).
+// Matches the collapsing logic in List so the banner count equals the
+// number of entries the user sees in the table: two rows for the same
+// physical file count as one.
+//
+// Rows with an empty/NULL content_hash each count as one distinct file
+// (same treatment as in List -- they are never over-collapsed).
 func (r *Repository) Count(ctx context.Context) (int, error) {
+	// COUNT(*) over the same grouping subquery used in List, so the number
+	// is always the number of displayed rows, not the raw ledger row count.
 	var n int
-	if err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM foreign_files`).Scan(&n); err != nil {
+	err := r.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM (
+			SELECT
+				CASE WHEN COALESCE(content_hash, '') = ''
+				     THEN id
+				     ELSE content_hash
+				END AS gkey
+			FROM foreign_files
+			GROUP BY gkey
+		)`).Scan(&n)
+	if err != nil {
 		return 0, fmt.Errorf("foreign: count: %w", err)
 	}
 	return n, nil

--- a/internal/foreign/repository.go
+++ b/internal/foreign/repository.go
@@ -114,6 +114,11 @@ func (r *Repository) GetByID(ctx context.Context, id string) (Entry, error) {
 	if artistName.Valid {
 		e.ArtistName = artistName.String
 	}
+	// GetByID returns a single-row lookup so there are no siblings to
+	// collapse; DuplicateCount is therefore always 1. This satisfies the
+	// documented invariant (always >= 1) even when the caller does not
+	// use the field.
+	e.DuplicateCount = 1
 	return e, nil
 }
 

--- a/internal/foreign/repository_test.go
+++ b/internal/foreign/repository_test.go
@@ -1,0 +1,333 @@
+package foreign
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// seedRow inserts a foreign_files row using raw SQL into the same *sql.DB
+// that backs the repository. contentHash may be empty to simulate pre-008
+// rows.
+func seedRow(t *testing.T, repo *Repository, id, artistID, filePath, fileName, contentHash string) {
+	t.Helper()
+	var hashArg interface{}
+	if contentHash != "" {
+		hashArg = contentHash
+	}
+	_, err := repo.db.Exec(
+		`INSERT INTO foreign_files (id, artist_id, file_path, file_name, content_hash, size_bytes, detected_at)
+		 VALUES (?, ?, ?, ?, ?, 100, ?)`,
+		id, artistID, filePath, fileName, hashArg, time.Now().UTC().Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("seedRow(%q, %q): %v", artistID, filePath, err)
+	}
+}
+
+// seedArtist inserts an artists row needed by the LEFT JOIN in List/ListRaw.
+func seedArtist(t *testing.T, repo *Repository, id, name string) {
+	t.Helper()
+	_, err := repo.db.Exec(`INSERT INTO artists (id, name, path) VALUES (?, ?, '')`, id, name)
+	if err != nil {
+		t.Fatalf("seedArtist(%q): %v", id, err)
+	}
+}
+
+// TestList_CollapsesByContentHash verifies that two ledger rows sharing a
+// non-empty content_hash are collapsed into one entry by Repository.List,
+// and that DuplicateCount reflects the number of raw rows.
+func TestList_CollapsesByContentHash(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	seedArtist(t, repo, "a1", "Artist One")
+	seedArtist(t, repo, "a2", "Artist Two")
+
+	// Both rows carry the same content_hash -- same physical file, two artists.
+	const hash = "aabbccdd00112233aabbccdd00112233aabbccdd00112233aabbccdd00112233"
+	// Row with the smaller id ("id-1") becomes the representative (MIN(id)).
+	seedRow(t, repo, "id-1", "a1", "/music/foo/fanart.jpg", "fanart.jpg", hash)
+	seedRow(t, repo, "id-2", "a2", "/symlink/foo/fanart.jpg", "fanart.jpg", hash)
+
+	entries, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 collapsed entry, got %d: %+v", len(entries), entries)
+	}
+	got := entries[0]
+	if got.ID != "id-1" {
+		t.Errorf("representative ID: got %q, want %q", got.ID, "id-1")
+	}
+	if got.DuplicateCount != 2 {
+		t.Errorf("DuplicateCount: got %d, want 2", got.DuplicateCount)
+	}
+	if got.ContentHash != hash {
+		t.Errorf("ContentHash: got %q, want %q", got.ContentHash, hash)
+	}
+}
+
+// TestList_ThreeWayCollapse verifies a file linked from three artist records
+// still produces one entry with DuplicateCount=3.
+func TestList_ThreeWayCollapse(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	for i := 1; i <= 3; i++ {
+		id := fmt.Sprintf("a%d", i)
+		name := fmt.Sprintf("Artist %d", i)
+		seedArtist(t, repo, id, name)
+	}
+
+	const hash = "deadbeef00000000deadbeef00000000deadbeef00000000deadbeef00000000"
+	for i := 1; i <= 3; i++ {
+		rowID := fmt.Sprintf("row-%d", i)
+		artistID := fmt.Sprintf("a%d", i)
+		filePath := fmt.Sprintf("/path/%d/backdrop.jpg", i)
+		seedRow(t, repo, rowID, artistID, filePath, "backdrop.jpg", hash)
+	}
+
+	entries, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 collapsed entry, got %d", len(entries))
+	}
+	if entries[0].DuplicateCount != 3 {
+		t.Errorf("DuplicateCount: got %d, want 3", entries[0].DuplicateCount)
+	}
+}
+
+// TestList_EmptyHashNoCollapse verifies that rows with an empty content_hash
+// (pre-008 rows) are never collapsed together, even when they share the same
+// empty hash. Each empty-hash row must produce its own distinct entry.
+func TestList_EmptyHashNoCollapse(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	seedArtist(t, repo, "a1", "Legacy Artist One")
+	seedArtist(t, repo, "a2", "Legacy Artist Two")
+
+	// Both rows have empty content_hash -- simulating pre-008 ledger rows.
+	// They must not be collapsed into a single entry.
+	seedRow(t, repo, "leg-1", "a1", "/music/a1/backdrop.jpg", "backdrop.jpg", "")
+	seedRow(t, repo, "leg-2", "a2", "/music/a2/backdrop.jpg", "backdrop.jpg", "")
+
+	entries, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries for 2 empty-hash rows, got %d: %+v", len(entries), entries)
+	}
+	for _, e := range entries {
+		if e.DuplicateCount != 1 {
+			t.Errorf("empty-hash row %q: DuplicateCount should be 1, got %d", e.ID, e.DuplicateCount)
+		}
+	}
+}
+
+// TestList_SingleRowDuplicateCount1 verifies that a single row with a
+// non-empty content_hash produces DuplicateCount=1 (no duplicates).
+func TestList_SingleRowDuplicateCount1(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	seedArtist(t, repo, "a1", "Solo Artist")
+	seedRow(t, repo, "r1", "a1", "/music/a1/poster.jpg", "poster.jpg",
+		"cafebabe00000000cafebabe00000000cafebabe00000000cafebabe00000000")
+
+	entries, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].DuplicateCount != 1 {
+		t.Errorf("DuplicateCount: got %d, want 1", entries[0].DuplicateCount)
+	}
+}
+
+// TestCount_MatchesList verifies that Count returns the same number of entries
+// as List -- both use the same grouping logic so the banner count and the
+// table row count are always in sync.
+func TestCount_MatchesList(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	seedArtist(t, repo, "a1", "Artist One")
+	seedArtist(t, repo, "a2", "Artist Two")
+	seedArtist(t, repo, "a3", "Artist Three")
+
+	const hashA = "aaaa000000000000aaaa000000000000aaaa000000000000aaaa000000000000"
+	const hashB = "bbbb000000000000bbbb000000000000bbbb000000000000bbbb000000000000"
+
+	// Two rows sharing hashA -> collapses to 1.
+	seedRow(t, repo, "r1", "a1", "/music/a1/fanart.jpg", "fanart.jpg", hashA)
+	seedRow(t, repo, "r2", "a2", "/music/a2/fanart.jpg", "fanart.jpg", hashA)
+	// One row with hashB -> 1.
+	seedRow(t, repo, "r3", "a3", "/music/a3/poster.jpg", "poster.jpg", hashB)
+	// One row with empty hash -> 1 (own key).
+	seedRow(t, repo, "r4", "a1", "/music/a1/backdrop.jpg", "backdrop.jpg", "")
+
+	// Expected: 3 distinct entries (hashA group + hashB + empty-hash).
+	entries, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	listLen := len(entries)
+
+	count, err := repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if count != listLen {
+		t.Errorf("Count()=%d does not match len(List())=%d", count, listLen)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 distinct entries, got %d", count)
+	}
+}
+
+// TestListRaw_ReturnsAllRows verifies that ListRaw returns every ledger row
+// without any content-hash deduplication, with DuplicateCount=1 on each row.
+func TestListRaw_ReturnsAllRows(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	seedArtist(t, repo, "a1", "Artist One")
+	seedArtist(t, repo, "a2", "Artist Two")
+
+	const hash = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	seedRow(t, repo, "raw-1", "a1", "/music/a1/fanart.jpg", "fanart.jpg", hash)
+	seedRow(t, repo, "raw-2", "a2", "/music/a2/fanart.jpg", "fanart.jpg", hash)
+
+	raw, err := repo.ListRaw(ctx)
+	if err != nil {
+		t.Fatalf("ListRaw: %v", err)
+	}
+	// ListRaw must return both rows even though they share a content_hash.
+	if len(raw) != 2 {
+		t.Fatalf("ListRaw: expected 2 rows, got %d", len(raw))
+	}
+	for _, e := range raw {
+		if e.DuplicateCount != 1 {
+			t.Errorf("ListRaw row %q: DuplicateCount should be 1, got %d", e.ID, e.DuplicateCount)
+		}
+	}
+}
+
+// TestDismiss_DeletesAllSiblingRows verifies that iterating over ListRaw and
+// calling DeleteByPath for each row fully clears the ledger when rows share
+// a content_hash. This mirrors the dismiss handler's loop and confirms that
+// a List-based dismiss would have left rows behind.
+func TestDismiss_DeletesAllSiblingRows(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	seedArtist(t, repo, "a1", "Artist One")
+	seedArtist(t, repo, "a2", "Artist Two")
+
+	const hash = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+	seedRow(t, repo, "d-1", "a1", "/music/a1/fanart.jpg", "fanart.jpg", hash)
+	seedRow(t, repo, "d-2", "a2", "/music/a2/fanart.jpg", "fanart.jpg", hash)
+
+	// Simulate the dismiss loop: list raw, allowlist once per hash, delete
+	// every path.
+	raw, err := repo.ListRaw(ctx)
+	if err != nil {
+		t.Fatalf("ListRaw: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, e := range raw {
+		if !seen[e.ContentHash] {
+			if err := repo.AddAllowlist(ctx, AllowlistEntry{
+				Scope:       ScopeGlobal,
+				FileName:    e.FileName,
+				ContentHash: e.ContentHash,
+				Note:        "test dismiss",
+			}); err != nil {
+				t.Fatalf("AddAllowlist: %v", err)
+			}
+			seen[e.ContentHash] = true
+		}
+		if err := repo.DeleteByPath(ctx, e.ArtistID, e.FilePath); err != nil {
+			t.Fatalf("DeleteByPath(%q, %q): %v", e.ArtistID, e.FilePath, err)
+		}
+	}
+
+	// After dismiss, the ledger should be empty.
+	count, err := repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count after dismiss: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 rows after dismiss, got %d", count)
+	}
+}
+
+// TestList_MixedHashAndEmpty verifies that a mix of hashed rows and
+// empty-hash rows are all returned, with correct collapsing: hashed rows
+// collapse by hash, empty rows are each their own entry.
+func TestList_MixedHashAndEmpty(t *testing.T) {
+	db := newTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	seedArtist(t, repo, "a1", "Artist A")
+	seedArtist(t, repo, "a2", "Artist B")
+
+	const hash = "0011223344556677001122334455667700112233445566770011223344556677"
+	// Two hashed rows -> 1 entry.
+	seedRow(t, repo, "h1", "a1", "/music/a1/fanart.jpg", "fanart.jpg", hash)
+	seedRow(t, repo, "h2", "a2", "/music/a2/fanart.jpg", "fanart.jpg", hash)
+	// One empty-hash row -> 1 entry.
+	seedRow(t, repo, "e1", "a1", "/music/a1/backdrop.jpg", "backdrop.jpg", "")
+
+	entries, err := repo.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// Expect 2 entries: the collapsed hashed group + the empty-hash row.
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(entries), entries)
+	}
+
+	// Verify the hashed group has DuplicateCount=2 and the empty-hash row has 1.
+	byID := map[string]Entry{}
+	for _, e := range entries {
+		byID[e.ID] = e
+	}
+	hashed, ok := byID["h1"]
+	if !ok {
+		t.Fatalf("representative row h1 not in List results; IDs present: %v",
+			func() []string {
+				ids := make([]string, 0, len(byID))
+				for id := range byID {
+					ids = append(ids, id)
+				}
+				return ids
+			}())
+	}
+	if hashed.DuplicateCount != 2 {
+		t.Errorf("hashed group DuplicateCount: got %d, want 2", hashed.DuplicateCount)
+	}
+	emptyRow, ok := byID["e1"]
+	if !ok {
+		t.Fatalf("empty-hash row e1 not in List results")
+	}
+	if emptyRow.DuplicateCount != 1 {
+		t.Errorf("empty-hash row DuplicateCount: got %d, want 1", emptyRow.DuplicateCount)
+	}
+}

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -646,6 +646,8 @@
   "foreign_files.dismiss_confirm": "Allowlist every detected foreign file globally?",
   "foreign_files.dismiss_response_error": "Could not dismiss all foreign files. Refresh and try again.",
   "foreign_files.dismiss_send_error": "Network error dismissing foreign files. Try again.",
+  "foreign_files.duplicate_hint": "linked from multiple artists",
+  "foreign_files.duplicate_hint_tooltip": "This file is referenced by more than one artist record. One entry is shown. Allowlisting or deleting it acts on this artist only; other sibling rows remain until you dismiss them separately.",
   "foreign_files.empty_state": "No foreign image files detected. Stillwater scans your library on a fixed cadence; new entries will appear here automatically.",
   "foreign_files.manage_allowlist": "Manage allowlist",
   "foreign_files.page_title": "Foreign Files",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -647,7 +647,7 @@
   "foreign_files.dismiss_response_error": "Could not dismiss all foreign files. Refresh and try again.",
   "foreign_files.dismiss_send_error": "Network error dismissing foreign files. Try again.",
   "foreign_files.duplicate_hint": "linked from multiple artists",
-  "foreign_files.duplicate_hint_tooltip": "This file is referenced by more than one artist record. One entry is shown. Allowlisting or deleting it acts on this artist only; other sibling rows remain until you dismiss them separately.",
+  "foreign_files.duplicate_hint_tooltip": "This file is referenced by more than one artist record. One entry is shown. Allowlisting or deleting it acts on this artist only; other sibling rows remain until you use Dismiss (allowlist all).",
   "foreign_files.empty_state": "No foreign image files detected. Stillwater scans your library on a fixed cadence; new entries will appear here automatically.",
   "foreign_files.manage_allowlist": "Manage allowlist",
   "foreign_files.page_title": "Foreign Files",

--- a/web/components/_doc-anchors.txt
+++ b/web/components/_doc-anchors.txt
@@ -22,7 +22,10 @@ core-concepts/auto-provisioning#what-happens-when-an-upstream-user-is-removed
 core-concepts/conflict-gate#banner-states
 core-concepts/conflict-gate#coalesce-and-the-detection-cache
 core-concepts/conflict-gate#conflict-gate
+core-concepts/conflict-gate#deduplicated-display
+core-concepts/conflict-gate#dismiss-allowlist-all
 core-concepts/conflict-gate#feature-toggles-on-connections
+core-concepts/conflict-gate#foreign-files
 core-concepts/conflict-gate#how-writes-are-gated
 core-concepts/conflict-gate#let-stillwater-manage-and-auto-re-disable
 core-concepts/conflict-gate#relationship-to-field-locks-and-rules

--- a/web/templates/foreign_files.templ
+++ b/web/templates/foreign_files.templ
@@ -4,14 +4,20 @@ package templates
 // Constructed by the API handler from foreign.Entry; kept on the templates
 // side so the template never imports internal/foreign and the test surface
 // for rendering stays narrow.
+//
+// DuplicateCount is the number of ledger rows that share this file's content
+// hash (set by Repository.List). A value > 1 means the same physical file is
+// referenced by multiple artist records or path spellings; the table renders
+// a hint so the user understands why only one row is shown per distinct file.
 type ForeignFileRow struct {
-	ID         string
-	ArtistID   string
-	ArtistName string
-	FilePath   string
-	FileName   string
-	SizeBytes  int64
-	DetectedAt string
+	ID             string
+	ArtistID       string
+	ArtistName     string
+	FilePath       string
+	FileName       string
+	SizeBytes      int64
+	DetectedAt     string
+	DuplicateCount int
 }
 
 // ForeignFilesPageView is the view model for /settings/foreign-files. Count
@@ -83,7 +89,15 @@ templ ForeignFilesTable(view ForeignFilesPageView) {
 				<tbody class="divide-y divide-gray-200 dark:divide-gray-700">
 					for _, r := range view.Rows {
 						<tr id={ "foreign-row-" + r.ID }>
-							<td class="px-4 py-2 text-gray-900 dark:text-gray-100">{ r.ArtistName }</td>
+							<td class="px-4 py-2 text-gray-900 dark:text-gray-100">
+								{ r.ArtistName }
+								if r.DuplicateCount > 1 {
+									<span
+										class="ml-1 inline-block rounded px-1.5 py-0.5 text-xs font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300"
+										title={ t(ctx, "foreign_files.duplicate_hint_tooltip") }
+									>{ t(ctx, "foreign_files.duplicate_hint") }</span>
+								}
+							</td>
 							<td class="px-4 py-2 font-mono text-xs text-gray-700 dark:text-gray-300" title={ r.FilePath }>{ r.FileName }</td>
 							<td class="px-4 py-2 text-right text-gray-600 dark:text-gray-400">{ humanBytes(r.SizeBytes) }</td>
 							<td class="px-4 py-2 text-gray-600 dark:text-gray-400">{ r.DetectedAt }</td>

--- a/web/templates/foreign_files_templ.go
+++ b/web/templates/foreign_files_templ.go
@@ -12,14 +12,20 @@ import templruntime "github.com/a-h/templ/runtime"
 // Constructed by the API handler from foreign.Entry; kept on the templates
 // side so the template never imports internal/foreign and the test surface
 // for rendering stays narrow.
+//
+// DuplicateCount is the number of ledger rows that share this file's content
+// hash (set by Repository.List). A value > 1 means the same physical file is
+// referenced by multiple artist records or path spellings; the table renders
+// a hint so the user understands why only one row is shown per distinct file.
 type ForeignFileRow struct {
-	ID         string
-	ArtistID   string
-	ArtistName string
-	FilePath   string
-	FileName   string
-	SizeBytes  int64
-	DetectedAt string
+	ID             string
+	ArtistID       string
+	ArtistName     string
+	FilePath       string
+	FileName       string
+	SizeBytes      int64
+	DetectedAt     string
+	DuplicateCount int
 }
 
 // ForeignFilesPageView is the view model for /settings/foreign-files. Count
@@ -74,7 +80,7 @@ func ForeignFilesPage(assets AssetPaths, view ForeignFilesPageView) templ.Compon
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.title"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 33, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 39, Col: 66}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -87,7 +93,7 @@ func ForeignFilesPage(assets AssetPaths, view ForeignFilesPageView) templ.Compon
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.subtitle"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 35, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 41, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -100,7 +106,7 @@ func ForeignFilesPage(assets AssetPaths, view ForeignFilesPageView) templ.Compon
 			var templ_7745c5c3_Var5 templ.SafeURL
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/settings/foreign-files/allowlist")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 40, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 46, Col: 66}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -113,7 +119,7 @@ func ForeignFilesPage(assets AssetPaths, view ForeignFilesPageView) templ.Compon
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.manage_allowlist"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 41, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 47, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -131,7 +137,7 @@ func ForeignFilesPage(assets AssetPaths, view ForeignFilesPageView) templ.Compon
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.dismiss_confirm"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 47, Col: 59}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 53, Col: 59}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var7)
 				if templ_7745c5c3_Err != nil {
@@ -144,7 +150,7 @@ func ForeignFilesPage(assets AssetPaths, view ForeignFilesPageView) templ.Compon
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.dismiss_response_error"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 50, Col: 69}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 56, Col: 69}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
 				if templ_7745c5c3_Err != nil {
@@ -157,7 +163,7 @@ func ForeignFilesPage(assets AssetPaths, view ForeignFilesPageView) templ.Compon
 				var templ_7745c5c3_Var9 string
 				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.dismiss_send_error"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 51, Col: 69}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 57, Col: 69}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
 				if templ_7745c5c3_Err != nil {
@@ -170,7 +176,7 @@ func ForeignFilesPage(assets AssetPaths, view ForeignFilesPageView) templ.Compon
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.dismiss_all"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 54, Col: 44}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 60, Col: 44}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -239,7 +245,7 @@ func ForeignFilesTable(view ForeignFilesPageView) templ.Component {
 			var templ_7745c5c3_Var12 string
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.empty_state"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 70, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 76, Col: 41}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -257,7 +263,7 @@ func ForeignFilesTable(view ForeignFilesPageView) templ.Component {
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.col_artist"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 76, Col: 119}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 82, Col: 119}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -270,7 +276,7 @@ func ForeignFilesTable(view ForeignFilesPageView) templ.Component {
 			var templ_7745c5c3_Var14 string
 			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.col_file"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 77, Col: 117}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 83, Col: 117}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 			if templ_7745c5c3_Err != nil {
@@ -283,7 +289,7 @@ func ForeignFilesTable(view ForeignFilesPageView) templ.Component {
 			var templ_7745c5c3_Var15 string
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.col_size"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 78, Col: 118}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 84, Col: 118}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
@@ -296,7 +302,7 @@ func ForeignFilesTable(view ForeignFilesPageView) templ.Component {
 			var templ_7745c5c3_Var16 string
 			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.col_detected"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 79, Col: 121}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 85, Col: 121}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 			if templ_7745c5c3_Err != nil {
@@ -309,7 +315,7 @@ func ForeignFilesTable(view ForeignFilesPageView) templ.Component {
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.col_actions"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 80, Col: 121}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 86, Col: 121}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
@@ -327,7 +333,7 @@ func ForeignFilesTable(view ForeignFilesPageView) templ.Component {
 				var templ_7745c5c3_Var18 string
 				templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue("foreign-row-" + r.ID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 85, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 91, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
 				if templ_7745c5c3_Err != nil {
@@ -340,192 +346,228 @@ func ForeignFilesTable(view ForeignFilesPageView) templ.Component {
 				var templ_7745c5c3_Var19 string
 				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(r.ArtistName)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 86, Col: 76}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 93, Col: 22}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</td><td class=\"px-4 py-2 font-mono text-xs text-gray-700 dark:text-gray-300\" title=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var20 string
-				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(r.FilePath)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 87, Col: 98}
+				if r.DuplicateCount > 1 {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<span class=\"ml-1 inline-block rounded px-1.5 py-0.5 text-xs font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300\" title=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var20 string
+					templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.duplicate_hint_tooltip"))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 97, Col: 64}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var21 string
+					templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.duplicate_hint"))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 98, Col: 50}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</span>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var21 string
-				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(r.FileName)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 87, Col: 113}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</td><td class=\"px-4 py-2 text-right text-gray-600 dark:text-gray-400\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</td><td class=\"px-4 py-2 font-mono text-xs text-gray-700 dark:text-gray-300\" title=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var22 string
-				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(humanBytes(r.SizeBytes))
+				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue(r.FilePath)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 88, Col: 98}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 101, Col: 98}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var22)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</td><td class=\"px-4 py-2 text-gray-600 dark:text-gray-400\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var23 string
-				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(r.DetectedAt)
+				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(r.FileName)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 89, Col: 76}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 101, Col: 113}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</td><td class=\"px-4 py-2 text-right\"><button type=\"button\" class=\"px-2 py-1 rounded-md bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-xs hover:bg-blue-100\" hx-post=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</td><td class=\"px-4 py-2 text-right text-gray-600 dark:text-gray-400\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var24 string
-				templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.ResolveAttributeValue("/api/v1/foreign-files/" + r.ID + "/allowlist")
+				templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(humanBytes(r.SizeBytes))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 94, Col: 65}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 102, Col: 98}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var24)
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" hx-target=\"#foreign-files-table\" hx-swap=\"outerHTML\" data-sw-error=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</td><td class=\"px-4 py-2 text-gray-600 dark:text-gray-400\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var25 string
-				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.allowlist_response_error"))
+				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(r.DetectedAt)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 97, Col: 73}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 103, Col: 76}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var25)
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" data-sw-net-error=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</td><td class=\"px-4 py-2 text-right\"><button type=\"button\" class=\"px-2 py-1 rounded-md bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-xs hover:bg-blue-100\" hx-post=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var26 string
-				templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.allowlist_send_error"))
+				templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue("/api/v1/foreign-files/" + r.ID + "/allowlist")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 98, Col: 73}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 108, Col: 65}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var26)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" hx-on::response-error=\"alert(this.dataset.swError)\" hx-on::send-error=\"alert(this.dataset.swNetError)\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" hx-target=\"#foreign-files-table\" hx-swap=\"outerHTML\" data-sw-error=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var27 string
-				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.action_allowlist"))
+				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.allowlist_response_error"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 101, Col: 51}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 111, Col: 73}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var27)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</button> <button type=\"button\" class=\"ml-1 px-2 py-1 rounded-md bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 text-xs hover:bg-rose-100\" hx-delete=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\" data-sw-net-error=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var28 string
-				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue("/api/v1/foreign-files/" + r.ID + "/file")
+				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.allowlist_send_error"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 105, Col: 62}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 112, Col: 73}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var28)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" hx-confirm=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\" hx-on::response-error=\"alert(this.dataset.swError)\" hx-on::send-error=\"alert(this.dataset.swNetError)\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var29 string
-				templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.delete_confirm"))
+				templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.action_allowlist"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 106, Col: 60}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 115, Col: 51}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var29)
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\" hx-target=\"#foreign-files-table\" hx-swap=\"outerHTML\" data-sw-error=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</button> <button type=\"button\" class=\"ml-1 px-2 py-1 rounded-md bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 text-xs hover:bg-rose-100\" hx-delete=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var30 string
-				templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.delete_response_error"))
+				templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue("/api/v1/foreign-files/" + r.ID + "/file")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 109, Col: 70}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 119, Col: 62}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\" data-sw-net-error=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\" hx-confirm=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var31 string
-				templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.delete_send_error"))
+				templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.delete_confirm"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 110, Col: 70}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 120, Col: 60}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var31)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\" hx-on::response-error=\"alert(this.dataset.swError)\" hx-on::send-error=\"alert(this.dataset.swNetError)\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\" hx-target=\"#foreign-files-table\" hx-swap=\"outerHTML\" data-sw-error=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var32 string
-				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.action_delete"))
+				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.delete_response_error"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 113, Col: 48}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 123, Col: 70}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var32)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</button></td></tr>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\" data-sw-net-error=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var33 string
+				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "foreign_files.delete_send_error"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 124, Col: 70}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var33)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\" hx-on::response-error=\"alert(this.dataset.swError)\" hx-on::send-error=\"alert(this.dataset.swNetError)\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var34 string
+				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.action_delete"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 127, Col: 48}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</button></td></tr>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</tbody></table>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</tbody></table>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -567,12 +609,12 @@ func ForeignAllowlistPage(assets AssetPaths, view ForeignAllowlistPageView) temp
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var33 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var33 == nil {
-			templ_7745c5c3_Var33 = templ.NopComponent
+		templ_7745c5c3_Var35 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var35 == nil {
+			templ_7745c5c3_Var35 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var34 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var36 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -584,59 +626,59 @@ func ForeignAllowlistPage(assets AssetPaths, view ForeignAllowlistPageView) temp
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<div class=\"space-y-6\"><div class=\"sw-card rounded-lg px-6 py-4\"><h1 class=\"text-2xl font-bold\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<div class=\"space-y-6\"><div class=\"sw-card rounded-lg px-6 py-4\"><h1 class=\"text-2xl font-bold\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var35 string
-			templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_title"))
+			var templ_7745c5c3_Var37 string
+			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_title"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 145, Col: 76}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</h1><p class=\"mt-1 text-sm text-gray-500 dark:text-gray-400\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var36 string
-			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_subtitle"))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 147, Col: 49}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</p><div class=\"mt-3\"><a class=\"text-sm text-blue-600 dark:text-blue-400 underline-offset-2 hover:underline\" href=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var37 templ.SafeURL
-			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/settings/foreign-files")
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 152, Col: 56}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 159, Col: 76}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</h1><p class=\"mt-1 text-sm text-gray-500 dark:text-gray-400\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var38 string
-			templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.back_to_detected"))
+			templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_subtitle"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 153, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 161, Col: 49}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</a></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</p><div class=\"mt-3\"><a class=\"text-sm text-blue-600 dark:text-blue-400 underline-offset-2 hover:underline\" href=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var39 templ.SafeURL
+			templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/settings/foreign-files")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 166, Col: 56}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var40 string
+			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.back_to_detected"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 167, Col: 48}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</a></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -644,13 +686,13 @@ func ForeignAllowlistPage(assets AssetPaths, view ForeignAllowlistPageView) temp
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = Layout(t(ctx, "foreign_files.allowlist_page_title"), assets).Render(templ.WithChildren(ctx, templ_7745c5c3_Var34), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Layout(t(ctx, "foreign_files.allowlist_page_title"), assets).Render(templ.WithChildren(ctx, templ_7745c5c3_Var36), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -675,226 +717,226 @@ func ForeignAllowlistTable(view ForeignAllowlistPageView) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var39 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var39 == nil {
-			templ_7745c5c3_Var39 = templ.NopComponent
+		templ_7745c5c3_Var41 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var41 == nil {
+			templ_7745c5c3_Var41 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<div id=\"foreign-allowlist-table\" class=\"sw-card rounded-lg p-0 overflow-hidden\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<div id=\"foreign-allowlist-table\" class=\"sw-card rounded-lg p-0 overflow-hidden\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(view.Rows) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<div class=\"px-6 py-8 text-center text-sm text-gray-500 dark:text-gray-400\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var40 string
-			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_empty"))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 166, Col: 45}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<table class=\"min-w-full text-sm\"><thead class=\"bg-gray-50 dark:bg-gray-800/50\"><tr><th class=\"px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-300\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var41 string
-			templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_col_scope"))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 172, Col: 128}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</th><th class=\"px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-300\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<div class=\"px-6 py-8 text-center text-sm text-gray-500 dark:text-gray-400\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var42 string
-			templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_col_artist"))
+			templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_empty"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 173, Col: 129}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 180, Col: 45}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</th><th class=\"px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-300\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<table class=\"min-w-full text-sm\"><thead class=\"bg-gray-50 dark:bg-gray-800/50\"><tr><th class=\"px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-300\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var43 string
-			templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_col_filename"))
+			templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_col_scope"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 174, Col: 131}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 186, Col: 128}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</th><th class=\"px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-300\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</th><th class=\"px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-300\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var44 string
-			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_col_added"))
+			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_col_artist"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 175, Col: 128}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 187, Col: 129}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "</th><th class=\"px-4 py-2 text-right font-medium text-gray-700 dark:text-gray-300\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</th><th class=\"px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-300\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var45 string
-			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_col_actions"))
+			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_col_filename"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 176, Col: 131}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 188, Col: 131}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</th></tr></thead> <tbody class=\"divide-y divide-gray-200 dark:divide-gray-700\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "</th><th class=\"px-4 py-2 text-left font-medium text-gray-700 dark:text-gray-300\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var46 string
+			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_col_added"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 189, Col: 128}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</th><th class=\"px-4 py-2 text-right font-medium text-gray-700 dark:text-gray-300\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var47 string
+			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.allowlist_col_actions"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 190, Col: 131}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "</th></tr></thead> <tbody class=\"divide-y divide-gray-200 dark:divide-gray-700\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, r := range view.Rows {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<tr id=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<tr id=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var46 string
-				templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.ResolveAttributeValue("allowlist-row-" + r.ID)
+				var templ_7745c5c3_Var48 string
+				templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.ResolveAttributeValue("allowlist-row-" + r.ID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 181, Col: 38}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 195, Col: 38}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var46)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\"><td class=\"px-4 py-2 text-gray-900 dark:text-gray-100\">")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var48)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var47 string
-				templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(r.Scope)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 182, Col: 71}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "\"><td class=\"px-4 py-2 text-gray-900 dark:text-gray-100\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</td><td class=\"px-4 py-2 text-gray-900 dark:text-gray-100\">")
+				var templ_7745c5c3_Var49 string
+				templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(r.Scope)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 196, Col: 71}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</td><td class=\"px-4 py-2 text-gray-900 dark:text-gray-100\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if r.Scope == "global" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "<span class=\"text-gray-500 dark:text-gray-400 italic\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "<span class=\"text-gray-500 dark:text-gray-400 italic\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var48 string
-					templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.scope_global"))
+					var templ_7745c5c3_Var50 string
+					templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.scope_global"))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 185, Col: 101}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 199, Col: 101}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</span>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</span>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				} else {
-					var templ_7745c5c3_Var49 string
-					templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(r.ArtistName)
+					var templ_7745c5c3_Var51 string
+					templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(r.ArtistName)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 187, Col: 23}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 201, Col: 23}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</td><td class=\"px-4 py-2 font-mono text-xs text-gray-700 dark:text-gray-300\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var50 string
-				templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(r.FileName)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 190, Col: 92}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</td><td class=\"px-4 py-2 text-gray-600 dark:text-gray-400\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var51 string
-				templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(r.CreatedAt)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 191, Col: 75}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</td><td class=\"px-4 py-2 text-right\"><button type=\"button\" class=\"px-2 py-1 rounded-md bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 text-xs hover:bg-rose-100\" hx-delete=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</td><td class=\"px-4 py-2 font-mono text-xs text-gray-700 dark:text-gray-300\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var52 string
-				templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.ResolveAttributeValue("/api/v1/foreign-file-allowlist/" + r.ID)
+				templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(r.FileName)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 196, Col: 61}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 204, Col: 92}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var52)
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "\" hx-target=\"#foreign-allowlist-table\" hx-swap=\"outerHTML\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</td><td class=\"px-4 py-2 text-gray-600 dark:text-gray-400\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var53 string
-				templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.action_remove"))
+				templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(r.CreatedAt)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 199, Col: 48}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 205, Col: 75}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</button></td></tr>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</td><td class=\"px-4 py-2 text-right\"><button type=\"button\" class=\"px-2 py-1 rounded-md bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 text-xs hover:bg-rose-100\" hx-delete=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var54 string
+				templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.ResolveAttributeValue("/api/v1/foreign-file-allowlist/" + r.ID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 210, Col: 61}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var54)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "\" hx-target=\"#foreign-allowlist-table\" hx-swap=\"outerHTML\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var55 string
+				templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "foreign_files.action_remove"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/foreign_files.templ`, Line: 213, Col: 48}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "</button></td></tr>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</tbody></table>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "</tbody></table>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- The foreign-file ledger listed one entry per `(artist_id, file_path)` row, so a single image copied into multiple artist directories showed up as several duplicate entries (and inflated the banner count).
- `foreign.Repository.List` and `Count` now collapse rows that share a non-empty `content_hash` into one displayed entry, tagged "linked from multiple artists". Pre-008 rows with an empty hash keep a per-row grouping key so they never over-collapse.
- The bulk-dismiss handler switches to a new un-collapsed `ListRaw` so every sibling row sharing a hash is still deleted; otherwise dismiss would leave rows behind and the banner would not clear.

User-visible change: fewer, de-duplicated foreign-file entries with a "linked from multiple artists" hint.

## Linked issue

Closes #1611

## Pre-flight checklist

- [x] Pre-push gate green locally (ran via the pre-push hook on push).
- [x] Code review pass complete (`pr-review-toolkit` code-reviewer); the one flagged test gap was closed.
- [x] Commits squashed into one clean commit before the first push.
- [x] At least one label set.
- [x] Docs label decision made: `needs-docs-review` (user-visible list behavior change).
- [ ] Screenshot attached (UAT screenshot of the collapsed ledger captured locally).
- [x] UAT performed against a native build (see Test plan).
- [x] OpenAPI spec updated: `ForeignFileEntry` gains a required `duplicate_count` field (`make check-openapi` passes).
- [x] `templ generate` re-run and `foreign_files_templ.go` committed.

## Test plan

- [x] `go test -race ./...` passes (run by the pre-push gate).
- [x] `bash scripts/pre-push-gate.sh` passes.
- [x] Manual UAT steps (dev DB had no foreign files, so five rows were seeded directly, then removed):
  - [x] Two rows sharing one `content_hash` collapse into a single displayed entry tagged "linked from multiple artists".
  - [x] Two rows with an empty `content_hash` do NOT collapse (shown as separate entries).
  - [x] A row with a unique hash is shown on its own.
  - [x] The banner count ("4 files") matches the collapsed list length.
- [x] Dismiss-deletes-all-siblings is covered by `TestDismiss_DeletesAllSiblingRows` and the new `TestHandleForeignFilesDismiss_SharedContentHash`.
- [ ] Reviewer follow-ups:
  - [ ] Representative-row selection is `MIN(id)` (arbitrary but stable); confirm that is acceptable vs an ordered pick.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * UI shows duplicate-file indicators with tooltip when a file is linked from multiple artists.
  * API now exposes a duplicate_count for foreign-file entries and the list/count endpoints reflect deduplicated display groups.

* **Bug Fixes**
  * Dismiss action now correctly clears all sibling ledger rows for shared files and creates a single allowlist entry per distinct file.

* **Documentation**
  * Docs updated to explain deduplication and dismiss/allowlist behavior.

* **Tests**
  * Added tests covering deduplication, raw listing, counting, and dismiss semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->