### PR TITLE
chore(deps): bump axios to >=1.15.2 in Bruno CI harness

### DIFF
--- a/.github/bruno/package-lock.json
+++ b/.github/bruno/package-lock.json
@@ -1743,14 +1743,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-ntlm": {
@@ -1765,6 +1766,18 @@
         "js-md4": "^0.3.2"
       }
     },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/axios/node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -1776,6 +1789,19 @@
         "es-set-tostringtag": "^2.1.0",
         "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
       },
       "engines": {
         "node": ">= 6"
@@ -3876,10 +3902,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.2",

--- a/.github/bruno/package.json
+++ b/.github/bruno/package.json
@@ -8,6 +8,7 @@
     "@usebruno/cli": "3.3.0"
   },
   "overrides": {
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "axios": "^1.15.2"
   }
 }


### PR DESCRIPTION
## Summary

Adds an npm override pinning `axios` to `^1.15.2` in `.github/bruno/package.json`, the Bruno CLI dependency tree used by the `bruno-ci` GitHub Actions workflow. The transitive `axios 1.13.6` pulled in by `@usebruno/cli` carries 15 advisories (3 High, 11 Medium, 1 Low) that Grype surfaces on a pre-release scan. After the override the resolved version is `1.16.1` and Grype reports zero remaining advisories.

axios is in `.github/bruno/` ONLY -- not in the Stillwater runtime image, not in the application binary, not in the published docs site. The override follows the same pattern used for `uuid` in #1610 (per [[reference_nvd_vs_ghsa_patched_versions]]).

This PR is pre-tag work for v1.3.0 -- clearing the docs-bundle CVE noise before tag.

Cleared advisories: GHSA-pf86-5x62-jrwf, GHSA-6chq-wfr3-2hj9, GHSA-3w6x-2g7m-8v23, GHSA-w9j2-pvgh-6h63, GHSA-q8qp-cvcw-x6jj, GHSA-pmwg-cvhr-8vh7, GHSA-445q-vr5w-6q77, GHSA-62hf-57xw-28j9, GHSA-5c9x-8gcm-mpgx, GHSA-vf2m-468p-8v99, GHSA-m7pr-hjqh-92cm, GHSA-3p68-rc4w-qgx5, GHSA-xx6v-rp6x-q39c, GHSA-xhjh-pmcv-23jw, GHSA-fvcv-3m26-pcqx.

## Linked issue

None -- chore work from a pre-tag Grype sweep, no tracking issue filed.

## Pre-flight checklist

- [x] Pre-push gate green (no Go or templ changes -- only `.github/bruno/` files)
- [x] Grype: 0 vulnerabilities after override (was 15)
- [x] npm lockfile regenerated via `npm install --package-lock-only` (hash-pinned)
- [x] Docs: not-required (no user-visible change; CI-only dependency)
- [x] Signed commit

## Test plan

- CI's `Bruno API Tests` job is the test (runs `npm ci` against the regenerated lockfile, then invokes the Bruno collection). Pass = bump compatible.
- Grype verification: `grype dir:.` reports no vulnerabilities locally; the `Go Vulnerability Check` and `Container Scan` jobs are unaffected (different ecosystems).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment dependency configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->