### PR TITLE
chore(safe-push): de-stillwater the wrapper for portable reuse

### DIFF
--- a/docs/pr-workflow.md
+++ b/docs/pr-workflow.md
@@ -31,7 +31,7 @@ bash scripts/safe-push.sh "$branch"        # push named branch
 bash scripts/safe-push.sh "$branch" --force-with-lease   # extra flags forwarded
 ```
 
-It writes the full push transcript to `$SW_RUN_DIR/safe-push.log`, queries `git ls-remote origin <branch>` after the push returns, and exits non-zero with a clear message if the remote SHA does not match the local HEAD. Catches silent failures that `cmd | tail` would have swallowed.
+It writes the full push transcript to `<git-dir>/safe-push.log` (`.git/safe-push.log` for the main worktree, or the worktree-specific `.git/worktrees/<name>/safe-push.log` for linked worktrees), with mode `0600` so the transcript is private to the current user. The wrapper then queries `git ls-remote origin <branch>` after the push returns and exits non-zero with a clear message if the remote SHA does not match the local HEAD. Catches silent failures that `cmd | tail` would have swallowed.
 
 ## Squash before first push
 

--- a/scripts/safe-push.sh
+++ b/scripts/safe-push.sh
@@ -47,6 +47,11 @@ if [ -z "$git_dir" ]; then
   exit 2
 fi
 LOG="$git_dir/safe-push.log"
+# Truncate and lock down permissions before any write so the transcript is
+# private to the current user even on shared systems. .git/ inherits 0755
+# from git defaults, so the file's own mode is what protects it.
+: >"$LOG"
+chmod 600 "$LOG"
 
 branch="${1:-}"
 shift_count=0

--- a/scripts/safe-push.sh
+++ b/scripts/safe-push.sh
@@ -16,7 +16,7 @@
 #
 # This wrapper:
 #   1. Resolves the local HEAD and the branch (or current symbolic-ref).
-#   2. Runs `git push` with full output captured to $SW_RUN_DIR/safe-push.log
+#   2. Runs `git push` with full output captured to <git-dir>/safe-push.log
 #      and mirrored to stderr so the caller can stream it.
 #   3. After push returns, queries `git ls-remote origin <branch>` and
 #      verifies the remote SHA matches local HEAD.
@@ -35,10 +35,18 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-. "$SCRIPT_DIR/lib/run-paths.sh"
-
-LOG="$SW_RUN_DIR/safe-push.log"
+# Repo-agnostic log location. `git rev-parse --git-dir` resolves correctly
+# for the main worktree (.git), linked worktrees (.git/worktrees/<name>),
+# and submodules. Previously sourced lib/run-paths.sh for $SW_RUN_DIR --
+# dropped so this wrapper has no project-specific dependency and can be
+# kept in sync with the repo-agnostic gist copy at
+# ~/.claude/scripts/safe-push.sh.
+git_dir=$(git rev-parse --git-dir 2>/dev/null || true)
+if [ -z "$git_dir" ]; then
+  echo "safe-push: not inside a git repository" >&2
+  exit 2
+fi
+LOG="$git_dir/safe-push.log"
 
 branch="${1:-}"
 shift_count=0


### PR DESCRIPTION
## Summary

- Replaces `scripts/safe-push.sh`'s dependency on `lib/run-paths.sh` (`$SW_RUN_DIR`) with a repo-agnostic `git rev-parse --git-dir`/safe-push.log log location.
- Same exit codes and behavior; only the log path changes (now `.git/safe-push.log`, scoped per-worktree by git's own rules).
- Lets the gist copy at `~/.claude/scripts/safe-push.sh` stay byte-equivalent so Claude skills can call the gist version unconditionally without losing the in-repo invocation pattern that hooks and devs already use.

## Linked issue

No issue. Tooling/devex-only change.

## Pre-flight checklist

- [x] Pre-push gate -- N/A for shell-script-only diff (skipped per `feedback_skip_gate_for_meta_only`); shellcheck runs in CI.
- [x] Code review pass complete -- diff is structurally equivalent to the gist version smoke-tested against the same repo.
- [x] Commits squashed -- single commit on branch.
- [x] At least one label set -- `chore`, `docs: not-required`.
- [x] Docs label decision made -- `docs: not-required` (no user-visible behavior; same exit codes, same invocation, same wrapper contract).
- [ ] Screenshot -- N/A.
- [x] UAT performed -- this PR was pushed via the new wrapper itself; `safe-push: verified origin/chore/safe-push-portable -> c17bca40` confirms the post-push verification path still works.
- [ ] OpenAPI -- N/A.
- [ ] `templ generate` -- N/A.

## Test plan

- [x] Dogfood push (this very PR) succeeded via `bash scripts/safe-push.sh chore/safe-push-portable`; verification message printed and `.git/safe-push.log` written.
- [x] Pre-existing `lib/run-paths.sh` consumers (`pre-push-gate.sh`, `dev-restart.sh`, `smoke.sh`, `coverage-floor.sh`) are unaffected -- they each source the lib directly; only `safe-push.sh` is dropping the dependency.
- [ ] Reviewer follow-ups: confirm the comment-block edit at line 17 matches your preferred phrasing (`<git-dir>/safe-push.log` vs other forms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved push log storage to use a more generic Git directory resolution mechanism, making the push script more portable across different repository configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->