### PR TITLE
fix(rename): post-merge CR cleanup for #1643 (log truncation, OpenAPI prose, test naming)

### DIFF
--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -10080,17 +10080,15 @@ paths:
           description: >
             Directory renamed. The platforms array carries one entry per
             artist_platform_ids mapping found for the artist (Emby /
-            Jellyfin / Lidarr), plus a synthesized failure entry (with
-            an empty connection_id) when the platform-mapping enumeration
-            itself fails so the response always carries a concrete signal
-            instead of an empty slice that hides a backend error. A single
-            per-platform failure does NOT roll back the rename; the local
-            filesystem + database are already consistent and a stale
-            item-to-path mapping on a peer is recoverable. An empty array
-            means the artist has no platform mappings, but does NOT mean
-            "no issues": clients should treat any entry whose connection_id
-            is empty specially (it is the synthesized enumeration-failure
-            marker, not a real per-platform result).
+            Jellyfin / Lidarr). When the platform-mapping enumeration
+            itself fails, the array also contains one synthesized failure
+            entry whose connection_id is the empty string, so the response
+            always carries a concrete signal instead of an empty slice that
+            hides a backend error. An empty array therefore means exactly
+            "this artist has no platform mappings" with no ambiguity. A
+            single per-platform failure does NOT roll back the rename; the
+            local filesystem + database are already consistent and a stale
+            item-to-path mapping on a peer is recoverable.
           content:
             application/json:
               schema:
@@ -10110,6 +10108,7 @@ paths:
                       properties:
                         connection_id:
                           type: string
+                          description: Platform connection ID. Empty only for the synthesized enumeration-failure entry (result will be "failed" with an explanatory error).
                         result:
                           type: string
                           enum: [ok, failed]

--- a/internal/artist/service_rename_test.go
+++ b/internal/artist/service_rename_test.go
@@ -656,11 +656,12 @@ func TestRenameDirectory_PlatformSyncerReturnsResultsAndErrorPreservesResults(t 
 	}
 }
 
-// TestRenameDirectory_NilSyncerReturnsEmptyPlatforms confirms that the
+// TestRenameDirectory_NilSyncerReturnsNilPlatforms confirms that the
 // no-syncer-configured case (e.g. older tests that never wire the syncer)
-// works and returns a nil platforms slice without panicking. Belt-and-
-// braces against a syncer-required regression.
-func TestRenameDirectory_NilSyncerReturnsEmptyPlatforms(t *testing.T) {
+// works and returns a nil platforms slice (NOT empty) without panicking.
+// Name matches the assertion below; the nil vs empty distinction is
+// load-bearing per the SetPlatformRenameSyncer doc.
+func TestRenameDirectory_NilSyncerReturnsNilPlatforms(t *testing.T) {
 	t.Parallel()
 	svc, a, _ := renameTestArtist(t, "lib-rename-nilsyncer")
 	ctx := context.Background()

--- a/internal/publish/rename_sync.go
+++ b/internal/publish/rename_sync.go
@@ -166,11 +166,15 @@ func (p *Publisher) syncOne(ctx context.Context, artistID, newPath string, pid a
 		// string flows into the JSON response and into operator log lines.
 		// 256 bytes keeps the diagnostic useful without flooding either.
 		res.Error = truncErr(err)
+		// Truncate the log error too: Jellyfin's postFullItem can wrap up
+		// to 1 MB of peer response body into err, and the raw string would
+		// otherwise still flood operator logs even though res.Error is
+		// bounded. truncErr keeps both surfaces in lockstep.
 		p.logger.Error("rename-sync: path update failed",
 			slog.String("artist_id", artistID),
 			slog.String("connection", conn.Name),
 			slog.String("type", conn.Type),
-			slog.String("error", err.Error()))
+			slog.String("error", truncErr(err)))
 		return res
 	}
 


### PR DESCRIPTION
## Summary

Local `coderabbit review --plain` against the squashed PR #1643 diff (run post-merge as audit since the online CR cycle was settled before this round) caught three small follow-up items.

- **Major:** `internal/publish/rename_sync.go` — the log site for the per-platform failure still emitted raw `err.Error()` even though `res.Error` was bounded via `truncErr()`. Jellyfin's `postFullItem` can wrap up to 1 MB of peer response body into err, so the API-side bound was effectively defeated for operators tailing logs. Now `truncErr(err)` is used on both surfaces.
- **Minor:** `internal/api/openapi.yaml` — the `platforms` array description from PR #1643's round-1 review pass contradicted itself ("empty means no mappings" AND "doesn't mean no issues"). Reworded so empty array unambiguously means "no mappings" and the synthesized enumeration-failure sentinel is documented on the `connection_id` field instead.
- **Trivial:** `internal/artist/service_rename_test.go` — renamed `TestRenameDirectory_NilSyncerReturnsEmptyPlatforms` to `...NilPlatforms` to match its `platforms == nil` assertion (the nil vs empty distinction is load-bearing per the syncer doc).

## Linked issue

Follow-up to merged #1643 (commit `f2e5e21d`).

## Pre-flight checklist

- [x] Pre-push gate green locally (pre-push hook ran on push).
- [x] Code review pass: local `coderabbit review --plain` is the source of these fixes.
- [x] Commits: single commit, no squash needed.
- [x] Labels set.
- [x] Docs label: `docs: not-required` — log-truncation has no user-visible surface; OpenAPI changes clarify existing behavior rather than describing new behavior; test rename is internal.
- [ ] Screenshot — no UI change.
- [ ] UAT — log-truncation is hard to manually validate (would need a peer that returns >256B errors); the `truncErr` helper itself was already covered by the PR5 test suite for `res.Error`.
- [x] OpenAPI updated (description only; schema unchanged).
- [ ] `templ generate` — no templ changes.

## Test plan

- [x] `bash scripts/pre-push-gate.sh` passes (via pre-push hook).
- [x] `go test ./internal/publish/...` and `go test ./internal/artist/...` pass (renamed test still runs; truncErr already covered).
- [ ] Manual: not exercised; behavior change is purely log-line bounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)