### PR TITLE
chore(gate): add measurement-linter re-pass to close local-vs-CI gap (#1645)

### DIFF
--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -143,6 +143,34 @@ if ! command -v golangci-lint >/dev/null 2>&1; then
   exit 1
 fi
 golangci-lint run --new-from-rev="$BASE" ./...
+
+# Second pass: re-lint the touched Go files with measurement linters that
+# `--new-from-rev` can silently dedup. `--new-from-rev` keys on
+# file:line:linter:message, so a pre-existing function whose body changes
+# enough to push gocognit/cyclop/funlen past their threshold reports the
+# same message string at the same file:line and gets dedup'd away. CI runs
+# the full lint without `--new-from-rev` and surfaces the bump as a failure;
+# this pass closes that local-vs-CI gap.
+#
+# Scoped to changed files (not ./...) so the cost is bounded; excludes
+# _templ.go because generated code is excluded from the configured ruleset
+# elsewhere and we don't want to drag templ noise into a focused gate. Only
+# gocognit is enabled in .golangci.yml today among the measurement linters;
+# if cyclop/funlen are added later, extend --enable-only to match.
+#
+# Motivation: M52 PR #1644 bumped SSEHub.SubscribeToEventBus from
+# cog=28 to cog=34 (cap 30); local gate PASS, CI FAIL. Issue #1645.
+MODIFIED_GO=$(git diff --name-only --diff-filter=ACMR "$BASE" -- '*.go' \
+  | grep -v '_templ\.go$' || true)
+if [ -n "$MODIFIED_GO" ]; then
+  echo "--- measurement-linter re-pass on $(echo "$MODIFIED_GO" | wc -l | tr -d ' ') changed file(s) ---"
+  # --default=none + --enable=gocognit narrows the active linter set to just
+  # gocognit while still reading .golangci.yml for settings (so the
+  # min-complexity: 30 threshold is honored). _test.go files inherit the
+  # `_test\.go -> gocognit` exclusion in .golangci.yml.
+  # shellcheck disable=SC2086  # word-splitting on newlines is intentional
+  golangci-lint run --default=none --enable=gocognit $MODIFIED_GO
+fi
 echo "OK"
 
 echo ""


### PR DESCRIPTION
## Summary

- `scripts/pre-push-gate.sh` runs `golangci-lint --new-from-rev=BASE`, which dedups by `file:line:linter:message`. Measurement linters (gocognit, cyclop, funlen) re-emit the same message string at the same `file:line` when a pre-existing function bumps past its threshold, so the local gate dedups the warning away while CI -- which lints the full codebase without `--new-from-rev` -- catches it.
- Add a second pass scoped to the diff's `*.go` files (excluding `_templ.go`) that runs `--default=none --enable=gocognit`, honoring the configured threshold from `.golangci.yml`. Cost stays bounded because it lints only touched files.
- Only `gocognit` is currently enabled in `.golangci.yml`; the inline comment notes to extend `--enable` if `cyclop` or `funlen` are added later.

## Linked issue

Closes #1645

## Pre-flight checklist

- [x] Pre-push gate green locally (pre-push hook ran on `git push`)
- [x] Code review pass complete (single-file gate-script change, no Go surface)
- [x] Commits squashed into clean, logical commits before the first push (single commit)
- [x] At least one label set on `gh pr create --label ...`
- [x] Docs label decision made: `docs: not-required` (gate-only change with no user-visible behavioral effect)
- [ ] Screenshot attached for any UI change (N/A)
- [x] UAT performed for user-visible changes (gate-script change; manually UAT'd by bumping a function to cog=55 and confirming the new pass caught it pre-push)
- [ ] OpenAPI spec updated if any request or response shape changed (N/A)
- [ ] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed (N/A)

## Test plan

- [x] `go test -race ./...` passes locally (no Go source changed; race suite is a no-op for this diff)
- [x] `bash scripts/pre-push-gate.sh` passes locally (run via pre-push hook)
- [x] Manual UAT steps:
  - [x] Created throwaway `internal/version/throwaway_complexity.go` with a `cog=55` function; new pass reported `is high (> 30) (gocognit)`, exit=1; gate correctly failed pre-push. File removed before commit.
  - [x] On the real diff (script-only), the new pass cleanly skips because no `*.go` files changed; full gate exits 0.
- [ ] Reviewer follow-ups:
  - [ ] If we ever enable `cyclop` or `funlen` in `.golangci.yml`, extend `--enable=gocognit` to `--enable=gocognit,cyclop,funlen` (called out in the inline comment).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pre-push quality gate with additional linting verification for modified code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->