### PR TITLE
fix(gate): scope measurement-linter re-pass to packages, not files (#1650)

### DIFF
--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -152,24 +152,43 @@ golangci-lint run --new-from-rev="$BASE" ./...
 # the full lint without `--new-from-rev` and surfaces the bump as a failure;
 # this pass closes that local-vs-CI gap.
 #
-# Scoped to changed files (not ./...) so the cost is bounded; excludes
+# Scoped to changed packages (not ./...) so the cost is bounded; excludes
 # _templ.go because generated code is excluded from the configured ruleset
 # elsewhere and we don't want to drag templ noise into a focused gate. Only
 # gocognit is enabled in .golangci.yml today among the measurement linters;
 # if cyclop/funlen are added later, extend --enable-only to match.
 #
+# Package directories (not individual file paths) are passed to
+# golangci-lint so the typechecker can resolve cross-file symbols defined
+# in sibling files of the same package. Feeding bare *.go file paths
+# breaks typecheck and silently suppresses gocognit findings (issue #1650).
+# Trade-off: lints the whole touched package(s), not just touched
+# functions; still avoids the full-repo cost of dropping --new-from-rev
+# entirely. For most PRs the package set is 1-3 directories.
+#
 # Motivation: M52 PR #1644 bumped SSEHub.SubscribeToEventBus from
 # cog=28 to cog=34 (cap 30); local gate PASS, CI FAIL. Issue #1645.
-MODIFIED_GO=$(git diff --name-only --diff-filter=ACMR "$BASE" -- '*.go' \
+MODIFIED_GO_FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" -- '*.go' \
   | grep -v '_templ\.go$' || true)
-if [ -n "$MODIFIED_GO" ]; then
-  echo "--- measurement-linter re-pass on $(echo "$MODIFIED_GO" | wc -l | tr -d ' ') changed file(s) ---"
+# Guard against BSD xargs (macOS) running `dirname` with zero args when the
+# input is empty; GNU xargs has --no-run-if-empty but BSD does not. Empty
+# file list -> empty package list -> the `if` block below skips cleanly.
+if [ -n "$MODIFIED_GO_FILES" ]; then
+  MODIFIED_GO_PKGS=$(printf '%s\n' "$MODIFIED_GO_FILES" \
+    | xargs -n1 dirname \
+    | sort -u \
+    | sed 's|^|./|; s|$|/...|')
+else
+  MODIFIED_GO_PKGS=""
+fi
+if [ -n "$MODIFIED_GO_PKGS" ]; then
+  echo "--- measurement-linter re-pass on $(echo "$MODIFIED_GO_PKGS" | wc -l | tr -d ' ') changed package(s) ---"
   # --default=none + --enable=gocognit narrows the active linter set to just
   # gocognit while still reading .golangci.yml for settings (so the
   # min-complexity: 30 threshold is honored). _test.go files inherit the
   # `_test\.go -> gocognit` exclusion in .golangci.yml.
   # shellcheck disable=SC2086  # word-splitting on newlines is intentional
-  golangci-lint run --default=none --enable=gocognit $MODIFIED_GO
+  golangci-lint run --default=none --enable=gocognit $MODIFIED_GO_PKGS
 fi
 echo "OK"
 


### PR DESCRIPTION
## Summary

- PR #1647 added a measurement-linter re-pass to `scripts/pre-push-gate.sh` to close the local-vs-CI `gocognit` gap. The implementation fed individual `*.go` file paths to `golangci-lint run`, which breaks the typechecker -- cross-file symbols from sibling files in the same package were undefined, `gocognit` silently reported `0 issues`, and the gate exited 0 even when violations existed. PR #1648 hit this in round 1: local PASS, CI Lint FAIL on `handleBulkAction` cognitive complexity 31.
- Switch to unique package directories (`xargs -n1 dirname | sort -u | sed` to `./<pkg>/...`). The typechecker now resolves correctly and `gocognit` runs as intended.
- One small deviation from #1650's verbatim snippet: split the file-list capture from the package derivation behind an `if [ -n "$MODIFIED_GO_FILES" ]` guard. BSD `xargs` on macOS lacks `--no-run-if-empty`, so on docs-only PRs the bare pipeline prints a `usage: dirname string [...]` line to stderr on every gate run; the guard keeps the no-op path silent.

Trade-off: lints the whole touched packages instead of just touched functions. Still avoids the full-repo cost of dropping `--new-from-rev` entirely. For most PRs the package set is 1-3 directories.

## Linked issue

Closes #1650.

## Pre-flight checklist

- [x] Pre-push gate green locally (the pre-push hook ran `scripts/pre-push-gate.sh` automatically on push; passed).
- [ ] Code review pass complete (skipped: shell-only 24-line change; CodeRabbit will run on the PR).
- [x] Commits squashed into clean, logical commits before the first push.
- [x] At least one label set (`bug`, `ci`, `docs: not-required`).
- [x] Docs label decision made: `docs: not-required` -- internal tooling, no user-visible behavior change.
- [ ] Screenshot attached for any UI change (N/A).
- [x] UAT performed for user-visible changes (N/A; gate was tested directly with an induced cog>30 violation).
- [ ] OpenAPI spec updated (N/A).
- [ ] `templ generate` re-run (N/A).

## Test plan

- [x] `go test -race ./...` passes locally (pre-push hook).
- [x] `bash scripts/pre-push-gate.sh` passes locally (pre-push hook).
- [x] Manual verification steps:
  - [x] Reproduced the bug on the pre-fix script: induced `cog=42` on `handleBulkAction`; measurement-linter re-pass produced 17 typecheck errors and `0 gocognit issues`; gate exit 0.
  - [x] With the fix applied: same induced violation; re-pass reports `cognitive complexity 42 of func (*Router).handleBulkAction`, no typecheck noise, gate exit 1.
  - [x] No-Go-changes path: `MODIFIED_GO_FILES` empty, `MODIFIED_GO_PKGS=""`, if-block skips silently (no stderr noise from `xargs`/`dirname`).
  - [x] `shellcheck scripts/pre-push-gate.sh` -- no new warnings from the changed block.
- [ ] Reviewer follow-ups: confirm the wider-than-touched-functions cost is acceptable for the typical 1-3 package PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pre-push gate linting process to analyze modified package directories instead of individual files, improving the accuracy of code quality checks during development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->