### PR TITLE
chore(gate): regenerate styles.css in pre-commit when .templ / input.css change (#1656)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -134,6 +134,38 @@ else
 fi
 
 # --------------------------------------------------------------------------
+# 3a. tailwind freshness -- if any .templ or input.css file is staged, the
+#     Tailwind class set the page references may have changed; regenerate
+#     styles.css and require the new output to be staged. Mirrors the
+#     templ-generate check at section 3 so contributors get a fail-fast
+#     instead of finding out via CI's Gate / Generated Files job (#1656).
+# --------------------------------------------------------------------------
+STAGED_TAILWIND_SRC=$(git diff --cached --name-only --diff-filter=ACM -- '*.templ' 'web/static/css/input.css' || true)
+if [ -n "$STAGED_TAILWIND_SRC" ]; then
+    if ! command -v tailwindcss >/dev/null 2>&1; then
+        echo -e "${RED}${BOLD}FAIL${RESET} tailwind: 'tailwindcss' binary not on PATH."
+        echo "      Install it (see README) so staged .templ / input.css changes"
+        echo "      can regenerate web/static/css/styles.css before commit."
+        exit 1
+    fi
+    if ! tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minify 2>/tmp/pre-commit-tailwind.log; then
+        echo -e "${RED}${BOLD}FAIL${RESET} tailwind regenerate:"
+        cat /tmp/pre-commit-tailwind.log | head -20
+        exit 1
+    fi
+    DIRTY_CSS=$(git diff --name-only -- web/static/css/styles.css || true)
+    if [ -n "$DIRTY_CSS" ]; then
+        echo -e "${RED}${BOLD}FAIL${RESET} tailwind: web/static/css/styles.css is out of date."
+        echo "      The regenerated output differs from what is committed."
+        echo "      Run: make tailwind && git add web/static/css/styles.css"
+        exit 1
+    fi
+    pass "tailwind regenerate"
+else
+    warn "tailwind (no staged .templ / input.css files)"
+fi
+
+# --------------------------------------------------------------------------
 # 3b. OpenAPI spec reminder -- warn if API handlers changed without the spec
 # --------------------------------------------------------------------------
 STAGED_API_GO=$(git diff --cached --name-only --diff-filter=ACM -- 'internal/api/handlers.go' 'internal/api/handlers_*.go' | grep -v '_test\.go$' || true)

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -140,7 +140,7 @@ fi
 #     templ-generate check at section 3 so contributors get a fail-fast
 #     instead of finding out via CI's Gate / Generated Files job (#1656).
 # --------------------------------------------------------------------------
-STAGED_TAILWIND_SRC=$(git diff --cached --name-only --diff-filter=ACM -- '*.templ' 'web/static/css/input.css' || true)
+STAGED_TAILWIND_SRC=$(git diff --cached --name-only --diff-filter=ACMRD -- '*.templ' 'web/static/css/input.css' || true)
 if [ -n "$STAGED_TAILWIND_SRC" ]; then
     if ! command -v tailwindcss >/dev/null 2>&1; then
         echo -e "${RED}${BOLD}FAIL${RESET} tailwind: 'tailwindcss' binary not on PATH."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
         name: tailwind-generate
         language: system
         entry: |
-          bash -c 'set -e; tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minify; dirty=$(git diff --name-only -- web/static/css/styles.css); if [ -n "$dirty" ]; then echo "tailwind styles.css is stale; run: make tailwind && git add web/static/css/styles.css"; exit 1; fi' --
+          bash -c 'set -e; if ! command -v tailwindcss >/dev/null 2>&1; then echo "tailwindcss not found on PATH. Install it (see README) so staged .templ / input.css changes can regenerate web/static/css/styles.css before commit."; exit 1; fi; tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minify; dirty=$(git diff --name-only -- web/static/css/styles.css); if [ -n "$dirty" ]; then echo "tailwind styles.css is stale; run make tailwind && git add web/static/css/styles.css"; exit 1; fi' --
         files: '\.templ$|^web/static/css/input\.css$'
         pass_filenames: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,9 +65,15 @@ repos:
       - id: tailwind-generate
         name: tailwind-generate
         language: system
+        # always_run + an inline git diff gate is required (instead of the
+        # usual files: regex) because pre-commit's files: matcher excludes
+        # deleted paths from the candidate set even when pass_filenames is
+        # false. Without always_run, deleting the last consumer of a Tailwind
+        # class set would slip past this hook while the canonical
+        # .githooks/pre-commit catches it. See pre-commit/pre-commit#749.
+        always_run: true
         entry: |
-          bash -c 'set -e; if ! command -v tailwindcss >/dev/null 2>&1; then echo "tailwindcss not found on PATH. Install it (see README) so staged .templ / input.css changes can regenerate web/static/css/styles.css before commit."; exit 1; fi; tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minify; dirty=$(git diff --name-only -- web/static/css/styles.css); if [ -n "$dirty" ]; then echo "tailwind styles.css is stale; run make tailwind && git add web/static/css/styles.css"; exit 1; fi' --
-        files: '\.templ$|^web/static/css/input\.css$'
+          bash -c 'set -e; staged=$(git diff --cached --name-only --diff-filter=ACMRD -- "*.templ" "web/static/css/input.css"); if [ -z "$staged" ]; then exit 0; fi; if ! command -v tailwindcss >/dev/null 2>&1; then echo "tailwindcss not found on PATH. Install it (see README) so staged .templ / input.css changes can regenerate web/static/css/styles.css before commit."; exit 1; fi; tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minify; dirty=$(git diff --name-only -- web/static/css/styles.css); if [ -n "$dirty" ]; then echo "tailwind styles.css is stale; run make tailwind && git add web/static/css/styles.css"; exit 1; fi' --
         pass_filenames: false
 
       - id: gofmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,19 @@ repos:
         files: '\.templ$'
         pass_filenames: false
 
+      # Mirrors the tailwind-generate section in .githooks/pre-commit (the
+      # canonical hook). When a .templ or input.css change lands in a commit,
+      # styles.css must be regenerated; this hook fails if it drifts so
+      # contributors don't ship a commit that CI's Gate / Generated Files job
+      # will reject (#1656).
+      - id: tailwind-generate
+        name: tailwind-generate
+        language: system
+        entry: |
+          bash -c 'set -e; tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minify; dirty=$(git diff --name-only -- web/static/css/styles.css); if [ -n "$dirty" ]; then echo "tailwind styles.css is stale; run: make tailwind && git add web/static/css/styles.css"; exit 1; fi' --
+        files: '\.templ$|^web/static/css/input\.css$'
+        pass_filenames: false
+
       - id: gofmt
         name: gofmt
         language: system


### PR DESCRIPTION
## Summary

- Closes the local-side gap that lets `web/static/css/styles.css` drift between local commits and CI's Gate / Generated Files job. Pre-commit now regenerates styles.css with the same command the Makefile's `tailwind` target uses and fails fast if the result differs from what is committed.
- Mirrors the existing templ-generate section's structure -- skip silently when nothing relevant is staged, fail loudly otherwise. Pure local-side robustness; CI Gate / Generated Files stays as the backstop.
- The flake was caught surfaced during PR #1655 round 1: the merge modal added new Tailwind classes (`bg-green-100`, ring offsets etc.), local pre-commit passed, CI failed because styles.css was stale by one line.

## Linked issue

Closes #1656

## Pre-flight checklist

- [x] Pre-push gate green locally (ran via the pre-push hook on the push that created this branch).
- [x] Code review pass complete (single-file structural mirror of the existing templ-generate hook).
- [x] Commits squashed into clean, logical commits before the first push (single commit: 92a5929d).
- [x] At least one label set on `gh pr create --label ...` (`chore`, `docs: not-required`).
- [x] Docs label decision made: `docs: not-required` (contributor-facing hook change, no user-visible behavior shift).
- [x] No UI change.
- [x] UAT for the hook itself: the no-op path was exercised by the pre-commit hook run on this PR's own commit (no .templ files staged, hook reported "no files to check" -- correct skip).
- [x] OpenAPI untouched.
- [x] No templ files changed.

## Test plan

- [x] `bash scripts/pre-push-gate.sh` passes locally (pre-push hook).
- [x] Hook fired on this PR's own commit and correctly skipped (no .templ / input.css staged).
- [ ] Reviewer follow-ups:
  - [ ] Validate the hook actually catches drift by checking the next M52 PR that touches a .templ -- e.g. PR9 (settings UI polish) will exercise it heavily.
  - [ ] If contributors hit a missing-tailwind-binary error frequently, consider documenting the install step in CONTRIBUTING.md or add a make target that bootstraps it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced pre-commit validation: when template or style source files are modified, the commit hook will regenerate minified CSS and block the commit if the regenerated CSS differs from the staged version, instructing developers to regenerate and stage the updated CSS. Existing other pre-commit checks (build/lint/security/markdown) remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->