### PR TITLE
docs(readme): replace em-dashes with project-standard punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Stillwater is a self-hosted web app for keeping your music library's artist
 and composer metadata clean and consistent. It reads and writes NFO files,
-manages artwork, and pulls metadata from MusicBrainz and Fanart.tv — all
+manages artwork, and pulls metadata from MusicBrainz and Fanart.tv, all
 from one web UI that works alongside Emby, Jellyfin, and Kodi.
 
 **Full documentation:** <https://sydlexius.github.io/stillwater/>
@@ -53,7 +53,7 @@ Then open <http://localhost:1973>.
 
 Looking for a different install path, configuration knobs, or details on
 how Stillwater plays with media-server NFO write-back? It's all on the
-**[project site](https://sydlexius.github.io/stillwater/)** — install
+**[project site](https://sydlexius.github.io/stillwater/)**: install
 guides (Docker, binary, Unraid Community Applications, reverse proxy),
 environment-variable reference, encryption-key handling, the
 round-trip-conflict gate, and the full OpenAPI reference.
@@ -61,7 +61,7 @@ round-trip-conflict gate, and the full OpenAPI reference.
 Binary downloads live on the
 [Releases](https://github.com/sydlexius/stillwater/releases) page.
 Nightly builds (`nightly-YYYYMMDD`) ship from `main` each day there are
-new commits — see the
+new commits. See the
 [self-update guide](https://sydlexius.github.io/stillwater/how-to/self-update/)
 for the nightly channel.
 


### PR DESCRIPTION
## Summary

- README.md contained three em-dashes, which `CLAUDE.md` forbids project-wide ("No em-dashes in any output").
- Replaced each with the punctuation that best matches the original cadence: comma in the lead paragraph, colon in the project-site callout, and a period + new sentence in the nightly-builds note.
- Prose-only change. No code, generated files, or behavior affected.

## Linked issue

(No tracking issue; spotted by user during review of README.)

## Pre-flight checklist

- [x] Pre-push gate green locally (pre-push hook ran on push; docs-only diff skipped Go/templ/openapi checks per the gate's own short-circuits).
- [x] Code review pass complete (3-line prose diff; manual review).
- [x] Commits squashed into clean, logical commits before the first push (single commit).
- [x] At least one label set on `gh pr create --label ...` (`documentation`, `docs: not-required`).
- [x] Docs label decision made (`docs: not-required` -- README cleanup, no user-visible behavioral change).
- [ ] Screenshot attached for any UI change. (n/a)
- [ ] UAT performed for user-visible changes. (n/a -- prose only)
- [x] OpenAPI spec updated if any request or response shape changed. (n/a)
- [x] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed. (n/a)

## Test plan

- [x] `grep -nP '[\x{2013}\x{2014}]' README.md` returns no matches (verified locally post-edit).
- [x] Pre-push hook passed on push.
- [ ] Manual UAT steps (n/a -- README prose only):
  - [ ]
- [ ] Reviewer follow-ups:
  - [ ] Confirm replacement punctuation reads naturally in each of the three spots.