### PR TITLE
fix(disambig): surface provider failures instead of silent empty results (#1663)

### DIFF
--- a/internal/api/handlers_identify.go
+++ b/internal/api/handlers_identify.go
@@ -468,12 +468,23 @@ func (r *Router) identifyArtist(ctx context.Context, a *artist.Artist, connIdx *
 	hasAlbums := len(localAlbums) > 0
 	if hasAlbums {
 		searchName := filepath.Base(a.Path)
-		results, err := r.orchestrator.SearchForLinking(ctx, searchName, []provider.ProviderName{provider.NameMusicBrainz})
-		if err != nil {
+		results, statuses, err := r.orchestrator.SearchForLinking(ctx, searchName, []provider.ProviderName{provider.NameMusicBrainz})
+		switch {
+		case err != nil:
 			r.logger.Warn("bulk-identify: Tier 2 search failed",
 				"artist", a.Name, "error", err)
 			// Fall through to Tier 3 on search failure only.
-		} else if len(results) > 0 {
+		case len(collectFailedProviderDisplayNames(statuses)) > 0:
+			// A provider returned an error (e.g. MusicBrainz outage). Treat
+			// as a search failure rather than "no matches": empty results
+			// here are not evidence of absence -- the lookup did not run.
+			// Fall through to Tier 3, which applies the same statuses
+			// check and will route to outcomeFailed instead of
+			// outcomeUnmatched.
+			r.logger.Warn("bulk-identify: Tier 2 provider search failed",
+				"artist", a.Name,
+				"failed_providers", collectFailedProviderDisplayNames(statuses))
+		case len(results) > 0:
 			scored := r.enrichAndScoreTier2(ctx, results, localAlbums)
 			tier2Result := r.evaluateTier2(ctx, a, scored)
 			// If Tier 2 ran album comparison and found no match (< 30%),
@@ -485,10 +496,19 @@ func (r *Router) identifyArtist(ctx context.Context, a *artist.Artist, connIdx *
 
 	// Tier 3: Name-only search (only for artists without album subdirectories,
 	// or when Tier 2 search failed due to an error).
-	results, err := r.orchestrator.SearchForLinking(ctx, a.Name, []provider.ProviderName{provider.NameMusicBrainz})
+	results, statuses, err := r.orchestrator.SearchForLinking(ctx, a.Name, []provider.ProviderName{provider.NameMusicBrainz})
 	if err != nil {
 		r.logger.Warn("bulk-identify: Tier 3 search failed",
 			"artist", a.Name, "error", err)
+		return identifyResult{Outcome: outcomeFailed}
+	}
+	if failed := collectFailedProviderDisplayNames(statuses); len(failed) > 0 {
+		// Same rationale as Tier 2: provider outage is not "no match".
+		// Surface as outcomeFailed so the bulk pipeline reports the
+		// artist as something the user needs to retry, not as confirmed-
+		// unmatched (which would suppress future auto-retry attempts).
+		r.logger.Warn("bulk-identify: Tier 3 provider search failed",
+			"artist", a.Name, "failed_providers", failed)
 		return identifyResult{Outcome: outcomeFailed}
 	}
 

--- a/internal/api/handlers_identify_tier2_test.go
+++ b/internal/api/handlers_identify_tier2_test.go
@@ -553,7 +553,7 @@ func TestIdentifyArtist(t *testing.T) {
 		}
 	})
 
-	t.Run("tier 3 search error returns unmatched", func(t *testing.T) {
+	t.Run("tier 3 provider error returns failed", func(t *testing.T) {
 		t.Parallel()
 		r, _ := newIdentifyTestServer(t,
 			func(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
@@ -561,14 +561,15 @@ func TestIdentifyArtist(t *testing.T) {
 			},
 			nil,
 		)
-		// SearchForLinking swallows per-provider errors and returns nil error
-		// with no results, so the path here ends in "no results" => unmatched.
-		// The subtest name mirrors the asserted outcome so `go test -v` output
-		// stays consistent with the orchestrator's actual behavior.
+		// Per #1663: SearchForLinking now reports per-provider failure via
+		// ProviderSearchStatus, and identifyArtist Tier 3 routes a non-empty
+		// failed-provider set to outcomeFailed. The prior assertion
+		// (outcomeUnmatched) encoded the silent-swallow bug as expected
+		// behavior; flipping it here is part of #1663's contract.
 		a := &artist.Artist{Name: "Err"}
 		got := r.identifyArtist(context.Background(), a, nil)
-		if got.Outcome != outcomeUnmatched {
-			t.Errorf("Outcome = %v, want unmatched (orchestrator swallows errors)", got.Outcome)
+		if got.Outcome != outcomeFailed {
+			t.Errorf("Outcome = %v, want failed (provider error must not be hidden as 'no match')", got.Outcome)
 		}
 	})
 

--- a/internal/api/handlers_refresh.go
+++ b/internal/api/handlers_refresh.go
@@ -106,7 +106,7 @@ func (r *Router) handleRefreshSearch(w http.ResponseWriter, req *http.Request) {
 		provider.NameDiscogs,
 	}
 
-	results, err := r.orchestrator.SearchForLinking(req.Context(), query, linkProviders)
+	results, statuses, err := r.orchestrator.SearchForLinking(req.Context(), query, linkProviders)
 	if err != nil {
 		r.logger.Error("search failed", "error", err)
 		writeError(w, req, http.StatusInternalServerError, "search failed")
@@ -120,12 +120,35 @@ func (r *Router) handleRefreshSearch(w http.ResponseWriter, req *http.Request) {
 	}
 
 	candidates := r.enrichWithAlbumComparison(req.Context(), results, localAlbums)
+	failedProviders := collectFailedProviderDisplayNames(statuses)
 
 	if isHTMXRequest(req) {
-		renderTempl(w, req, templates.DisambiguationResults(artistID, candidates))
+		renderTempl(w, req, templates.DisambiguationResults(templates.DisambiguationResultsData{
+			ArtistID:        artistID,
+			Candidates:      candidates,
+			FailedProviders: failedProviders,
+		}))
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"results": candidates})
+	resp := map[string]any{"results": candidates}
+	if len(failedProviders) > 0 {
+		resp["failed_providers"] = failedProviders
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// collectFailedProviderDisplayNames returns the human-readable provider names
+// (DisplayName) for any provider whose SearchForLinking status reports an
+// error. Returns nil when no providers errored so callers can use a simple
+// len() check (and the JSON path can omit the key entirely).
+func collectFailedProviderDisplayNames(statuses []provider.ProviderSearchStatus) []string {
+	var failed []string
+	for _, s := range statuses {
+		if s.Errored {
+			failed = append(failed, s.Provider.DisplayName())
+		}
+	}
+	return failed
 }
 
 // handleRefreshLink stores the selected provider ID from disambiguation,

--- a/internal/api/handlers_refresh_search_test.go
+++ b/internal/api/handlers_refresh_search_test.go
@@ -1,0 +1,252 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// minimalSearchProvider is a stripped-down provider.Provider implementation
+// used only by handleRefreshSearch tests. It supports the SearchArtist hook
+// that SearchForLinking calls; every other method returns zero values.
+type minimalSearchProvider struct {
+	name     provider.ProviderName
+	searchFn func(ctx context.Context, name string) ([]provider.ArtistSearchResult, error)
+}
+
+func (p *minimalSearchProvider) Name() provider.ProviderName { return p.name }
+func (p *minimalSearchProvider) RequiresAuth() bool          { return false }
+func (p *minimalSearchProvider) SearchArtist(ctx context.Context, name string) ([]provider.ArtistSearchResult, error) {
+	if p.searchFn != nil {
+		return p.searchFn(ctx, name)
+	}
+	return nil, nil
+}
+func (p *minimalSearchProvider) GetArtist(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+	return nil, nil
+}
+func (p *minimalSearchProvider) GetImages(_ context.Context, _ string) ([]provider.ImageResult, error) {
+	return nil, nil
+}
+
+// installSearchOrchestrator wires a Registry+Orchestrator into the router so
+// handleRefreshSearch runs against the supplied stub providers. Mirrors the
+// pattern in newIdentifyTestServer but stays local to this test file so the
+// refresh-search assertions are self-contained.
+func installSearchOrchestrator(t *testing.T, r *Router, providers ...*minimalSearchProvider) {
+	t.Helper()
+	registry := provider.NewRegistry()
+	for _, p := range providers {
+		registry.Register(p)
+	}
+	r.providerRegistry = registry
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	orch := provider.NewOrchestrator(registry, nil, logger)
+	r.orchestrator = orch
+}
+
+// TestHandleRefreshSearch_FailedProvidersJSON pins the JSON contract on the
+// disambiguation search endpoint when at least one provider errored. The
+// response must carry a failed_providers list of the human-readable display
+// names so JSON consumers (smoke tests, future API clients) can distinguish
+// "providers errored, results may be incomplete" from "providers all succeeded,
+// no matches exist". Issue #1663.
+func TestHandleRefreshSearch_FailedProvidersJSON(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouter(t)
+	a := addTestArtist(t, artistSvc, "Hiromi Disambig JSON")
+
+	// MB succeeds with one result; Discogs errors. The handler should
+	// return that one result AND a failed_providers list naming Discogs.
+	installSearchOrchestrator(t, r,
+		&minimalSearchProvider{
+			name: provider.NameMusicBrainz,
+			searchFn: func(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+				return []provider.ArtistSearchResult{
+					{Name: "Hiromi", MusicBrainzID: "mb-1", Source: "musicbrainz", Score: 100},
+				}, nil
+			},
+		},
+		&minimalSearchProvider{
+			name: provider.NameDiscogs,
+			searchFn: func(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+				return nil, errors.New("api.discogs.com: 401 unauthorized")
+			},
+		},
+	)
+
+	body := strings.NewReader(`{"query":"Hiromi"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/refresh/search", body)
+	req.SetPathValue("id", a.ID)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(testI18nCtx(t, req.Context()))
+	w := httptest.NewRecorder()
+
+	r.handleRefreshSearch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Results         []map[string]any `json:"results"`
+		FailedProviders []string         `json:"failed_providers"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v, body=%s", err, w.Body.String())
+	}
+	if len(resp.Results) != 1 {
+		t.Errorf("expected 1 result (MB succeeded), got %d", len(resp.Results))
+	}
+	if len(resp.FailedProviders) != 1 {
+		t.Fatalf("expected 1 failed provider, got %d (%v)", len(resp.FailedProviders), resp.FailedProviders)
+	}
+	// Use the canonical DisplayName so a future rename in provider.go
+	// flows through here without an extra patch.
+	want := provider.NameDiscogs.DisplayName()
+	if resp.FailedProviders[0] != want {
+		t.Errorf("failed_providers[0] = %q, want %q", resp.FailedProviders[0], want)
+	}
+}
+
+// TestHandleRefreshSearch_FailedProvidersHTMXBanner pins the HTML render
+// path. When at least one provider errored and the request is HTMX, the
+// rendered fragment must include the providers-unreachable banner so the
+// disambiguation panel surfaces the warning above the (possibly empty)
+// candidate list. Issue #1663.
+func TestHandleRefreshSearch_FailedProvidersHTMXBanner(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouter(t)
+	a := addTestArtist(t, artistSvc, "Hiromi Disambig HTMX")
+
+	// Both providers error -- the harder case: zero results AND a banner.
+	// Without the fix this renders identically to "no matches found".
+	installSearchOrchestrator(t, r,
+		&minimalSearchProvider{
+			name: provider.NameMusicBrainz,
+			searchFn: func(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+				return nil, errors.New("musicbrainz.org: tls handshake failed")
+			},
+		},
+		&minimalSearchProvider{
+			name: provider.NameDiscogs,
+			searchFn: func(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+				return nil, errors.New("api.discogs.com: connection refused")
+			},
+		},
+	)
+
+	body := strings.NewReader(`{"query":"Hiromi"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/refresh/search", body)
+	req.SetPathValue("id", a.ID)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("HX-Request", "true")
+	req = req.WithContext(testI18nCtx(t, req.Context()))
+	w := httptest.NewRecorder()
+
+	r.handleRefreshSearch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body=%s", w.Code, w.Body.String())
+	}
+	html := w.Body.String()
+	if !strings.Contains(html, "providers-unreachable-banner") {
+		t.Errorf("HTMX response missing providers-unreachable-banner; body:\n%s", html)
+	}
+	// Both provider display names must appear in the banner copy.
+	for _, name := range []string{provider.NameMusicBrainz.DisplayName(), provider.NameDiscogs.DisplayName()} {
+		if !strings.Contains(html, name) {
+			t.Errorf("HTMX response missing provider name %q; body:\n%s", name, html)
+		}
+	}
+}
+
+// TestHandleRefreshSearch_NoBannerWhenAllSucceed pins the negative case at
+// the handler level: with no provider errors the JSON payload must omit
+// failed_providers and the HTMX render must not include the banner. This
+// guarantees the legitimate "no matches found" empty state stays distinct
+// from the "providers unreachable" warning -- the whole point of #1663.
+func TestHandleRefreshSearch_NoBannerWhenAllSucceed(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouter(t)
+	a := addTestArtist(t, artistSvc, "Hiromi No Match Clean")
+
+	installSearchOrchestrator(t, r,
+		&minimalSearchProvider{
+			name: provider.NameMusicBrainz,
+			searchFn: func(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+				return nil, nil // success, zero matches
+			},
+		},
+	)
+
+	body := strings.NewReader(`{"query":"Hiromi"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/refresh/search", body)
+	req.SetPathValue("id", a.ID)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("HX-Request", "true")
+	req = req.WithContext(testI18nCtx(t, req.Context()))
+	w := httptest.NewRecorder()
+
+	r.handleRefreshSearch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body=%s", w.Code, w.Body.String())
+	}
+	html := w.Body.String()
+	if strings.Contains(html, "providers-unreachable-banner") {
+		t.Errorf("banner should NOT render when all providers succeed; body:\n%s", html)
+	}
+}
+
+// TestHandleRefreshSearch_JSONOmitsFailedProvidersWhenAllSucceed pins the
+// JSON-path twin of the HTMX banner-omission test above: when no providers
+// errored the failed_providers field must be omitted (not just empty) so
+// JSON consumers can use field presence as the "providers errored" signal
+// without parsing an array length. This is the JSON-side contract for #1663.
+func TestHandleRefreshSearch_JSONOmitsFailedProvidersWhenAllSucceed(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouter(t)
+	a := addTestArtist(t, artistSvc, "Hiromi JSON No Failure")
+
+	installSearchOrchestrator(t, r,
+		&minimalSearchProvider{
+			name: provider.NameMusicBrainz,
+			searchFn: func(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+				return nil, nil
+			},
+		},
+	)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/artists/"+a.ID+"/refresh/search",
+		strings.NewReader(`{"query":"Hiromi"}`),
+	)
+	req.SetPathValue("id", a.ID)
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(testI18nCtx(t, req.Context()))
+	w := httptest.NewRecorder()
+
+	r.handleRefreshSearch(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body=%s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v, body=%s", err, w.Body.String())
+	}
+	if _, ok := resp["failed_providers"]; ok {
+		t.Fatalf("expected failed_providers to be omitted when all providers succeed, body=%s", w.Body.String())
+	}
+}

--- a/internal/api/handlers_reidentify_wizard.go
+++ b/internal/api/handlers_reidentify_wizard.go
@@ -778,10 +778,22 @@ func (r *Router) ensureWizardCandidates(ctx context.Context, sess *reIdentifyWiz
 		if len(localAlbums) > 0 && artistPath != "" {
 			searchName = filepath.Base(artistPath)
 		}
-		results, serr := r.orchestrator.SearchForLinking(ctx, searchName, []provider.ProviderName{provider.NameMusicBrainz})
+		results, statuses, serr := r.orchestrator.SearchForLinking(ctx, searchName, []provider.ProviderName{provider.NameMusicBrainz})
 		if serr != nil {
 			r.logger.Warn("reidentify wizard: provider search failed", "artist", a.Name, "error", serr)
 			fetchErr = serr
+			break
+		}
+		// Per-provider failures now arrive on `statuses` instead of `serr`
+		// (see SearchForLinking in internal/provider/orchestrator.go). The
+		// wizard's per-step search only queries one provider (MusicBrainz);
+		// if it errored, every result is unreliable, so we keep the existing
+		// "step failed" path to preserve the Retry-banner UX. A future
+		// multi-provider wizard query would surface a partial-failure banner
+		// instead -- see issue #1663.
+		failedProviders := collectFailedProviderDisplayNames(statuses)
+		if len(failedProviders) > 0 {
+			fetchErr = errors.New("all queried providers errored during candidate lookup")
 			break
 		}
 		if len(localAlbums) > 0 {

--- a/internal/api/handlers_reidentify_wizard_search_test.go
+++ b/internal/api/handlers_reidentify_wizard_search_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestEnsureWizardCandidates_ProviderFailureRoutesToStepFailed pins the
+// behavior added for issue #1663: with the new SearchForLinking signature
+// per-provider failures arrive on a `statuses` slice instead of via the
+// function-level error. The wizard's single-provider lookup must still
+// translate a fully-errored result into wizardStepFailed so the existing
+// Retry-banner UX keeps working; without this preservation the user would
+// see an empty candidate list with no indication that MusicBrainz failed.
+func TestEnsureWizardCandidates_ProviderFailureRoutesToStepFailed(t *testing.T) {
+	t.Parallel()
+
+	r, _, artistSvc := testRouterWithIdentify(t)
+	// Seed a real artist row so GetByID does not short-circuit.
+	a := &artist.Artist{
+		Name:     "Wizard Provider Failure UAT",
+		SortName: "Wizard Provider Failure UAT",
+		Type:     "person",
+		Path:     "/music/Wizard Provider Failure UAT",
+	}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("seed artist: %v", err)
+	}
+
+	// Wire an orchestrator whose only registered provider errors.
+	registry := provider.NewRegistry()
+	registry.Register(&identifyStubProvider{
+		name: provider.NameMusicBrainz,
+		searchFn: func(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+			return nil, errors.New("musicbrainz.org: tls handshake failed")
+		},
+	})
+	r.providerRegistry = registry
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	r.orchestrator = provider.NewOrchestrator(registry, nil, logger)
+
+	sess, err := r.reIdentifyWizardStore.create([]*reIdentifyWizardStep{
+		{ArtistID: a.ID, ArtistName: a.Name, ArtistPath: a.Path},
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// Run synchronously so we can assert without sleeping.
+	r.ensureWizardCandidates(context.Background(), sess, 0)
+
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	step := sess.Steps[0]
+	if step.state != wizardStepFailed {
+		t.Errorf("step state = %v, want wizardStepFailed; errMsg=%q", step.state, step.errMsg)
+	}
+	if step.errMsg == "" {
+		t.Errorf("expected non-empty errMsg on failed step")
+	}
+}
+
+// TestEnsureWizardCandidates_AllProvidersOKReadiesStep covers the
+// happy path through the new statuses-aware branch: when every queried
+// provider succeeds (even with zero results), the step must reach
+// wizardStepReady, not wizardStepFailed. This is the negative case for
+// the new "all queried providers errored" guard so a future change to
+// the guard cannot silently break the no-match-but-not-errored flow.
+func TestEnsureWizardCandidates_AllProvidersOKReadiesStep(t *testing.T) {
+	t.Parallel()
+
+	r, _, artistSvc := testRouterWithIdentify(t)
+	a := &artist.Artist{
+		Name:     "Wizard Provider OK UAT",
+		SortName: "Wizard Provider OK UAT",
+		Type:     "person",
+		Path:     "/music/Wizard Provider OK UAT",
+	}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("seed artist: %v", err)
+	}
+
+	registry := provider.NewRegistry()
+	registry.Register(&identifyStubProvider{
+		name: provider.NameMusicBrainz,
+		searchFn: func(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+			// Success with one result keeps the assertion specific to
+			// the state transition rather than any candidate post-
+			// processing.
+			return []provider.ArtistSearchResult{
+				{Name: "Wizard Provider OK UAT", MusicBrainzID: "mb-1", Score: 80},
+			}, nil
+		},
+	})
+	r.providerRegistry = registry
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	r.orchestrator = provider.NewOrchestrator(registry, nil, logger)
+
+	sess, err := r.reIdentifyWizardStore.create([]*reIdentifyWizardStep{
+		{ArtistID: a.ID, ArtistName: a.Name, ArtistPath: a.Path},
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	r.ensureWizardCandidates(context.Background(), sess, 0)
+
+	sess.mu.Lock()
+	defer sess.mu.Unlock()
+	step := sess.Steps[0]
+	if step.state != wizardStepReady {
+		t.Errorf("step state = %v, want wizardStepReady; errMsg=%q", step.state, step.errMsg)
+	}
+	if len(step.Candidates) != 1 {
+		t.Errorf("expected 1 candidate on ready step, got %d", len(step.Candidates))
+	}
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -10496,6 +10496,16 @@ paths:
                     items:
                       type: object
                     description: Search results from the refresh operation.
+                  failed_providers:
+                    type: array
+                    items:
+                      type: string
+                    description: |
+                      Human-readable display names of providers that errored
+                      during the search. Present only when at least one
+                      provider failed; absent when every provider succeeded
+                      (so the legitimate "no matches" state stays distinct
+                      from "providers unreachable"). Added in issue #1663.
             text/html:
               schema:
                 type: string

--- a/internal/api/testdata/openapi-coverage-baseline.json
+++ b/internal/api/testdata/openapi-coverage-baseline.json
@@ -58,7 +58,6 @@
   "pushMetadata",
   "refreshArtist",
   "refreshLink",
-  "refreshSearch",
   "reidentifyArtist",
   "removeAlias",
   "resetConnectionScraperConfig",

--- a/internal/api/testdata/openapi-coverage.json
+++ b/internal/api/testdata/openapi-coverage.json
@@ -1215,7 +1215,7 @@
     "method": "POST",
     "path": "/artists/{id}/refresh/search",
     "handler": "handleRefreshSearch",
-    "covered": false
+    "covered": true
   },
   {
     "operationId": "reidentifyArtist",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -59,6 +59,8 @@
   "artist.delete_selected_failed": "Failed to delete selected images: %s",
   "artist.delete_selected_network": "Network error deleting selected images: %s",
   "artist.details": "Details",
+  "artist.disambiguation.providers_unreachable.body": "Search results may be incomplete. The following providers returned an error: %s. Check provider configuration in Settings or wait if rate-limited.",
+  "artist.disambiguation.providers_unreachable.title": "Some providers could not be reached",
   "artist.disbanded_end_date": "Disbanded/EndDate",
   "artist.edit_field": "Edit %s",
   "artist.edit_image": "Edit image",

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -1131,11 +1131,44 @@ func isGroupTypeValue(v string) bool {
 	}
 }
 
+// ProviderSearchStatus reports the outcome of a single provider's call inside
+// SearchForLinking. Callers use it to distinguish "this provider returned no
+// matches" (Errored=false, results may still be empty) from "this provider
+// failed and the empty result is incomplete" (Errored=true). The disambiguation
+// UI uses the latter to surface a banner instead of the ambiguous "no matches
+// found" empty state, which was the bug behind issue #1663.
+type ProviderSearchStatus struct {
+	Provider ProviderName
+	Errored  bool
+	// ScrubbedMessage is the user-presentable, secret-redacted error text
+	// from ScrubError(err). Empty when Errored is false. Stored as a string
+	// (not error) so it can be safely threaded through templates without
+	// risking accidental %v formatting of an unscrubbed error somewhere
+	// down the line.
+	ScrubbedMessage string
+}
+
 // SearchForLinking queries only the specified providers for disambiguation.
 // Unlike Search (which queries all providers), this targets only providers
 // whose IDs need to be linked (e.g., MusicBrainz for MBID, Discogs for DiscogsID).
-func (o *Orchestrator) SearchForLinking(ctx context.Context, name string, providers []ProviderName) ([]ArtistSearchResult, error) {
+//
+// Returns one ProviderSearchStatus per provider that was actually queried, in
+// input order. Providers that are not registered (registry.Get returned nil)
+// are skipped entirely and do NOT emit a status -- the caller asked for a
+// provider the orchestrator does not know about, and treating that as an
+// "errored" provider would confuse the UI banner with a configuration mistake.
+//
+// The function-level error stays nil even when individual providers fail; per
+// provider failures are reported via statuses[i].Errored. A non-nil error is
+// reserved for structural problems (e.g. nil registry) that prevent any
+// search from running.
+func (o *Orchestrator) SearchForLinking(ctx context.Context, name string, providers []ProviderName) ([]ArtistSearchResult, []ProviderSearchStatus, error) {
+	if o.registry == nil {
+		return nil, nil, errors.New("provider registry not configured")
+	}
+
 	var allResults []ArtistSearchResult
+	statuses := make([]ProviderSearchStatus, 0, len(providers))
 
 	for _, provName := range providers {
 		p := o.registry.Get(provName)
@@ -1144,15 +1177,22 @@ func (o *Orchestrator) SearchForLinking(ctx context.Context, name string, provid
 		}
 		results, err := p.SearchArtist(ctx, name)
 		if err != nil {
+			scrubbed := ScrubError(err)
 			o.logger.Warn("provider search failed",
 				slog.String("provider", string(provName)),
-				slog.String("error", ScrubError(err)))
+				slog.String("error", scrubbed))
+			statuses = append(statuses, ProviderSearchStatus{
+				Provider:        provName,
+				Errored:         true,
+				ScrubbedMessage: scrubbed,
+			})
 			continue
 		}
+		statuses = append(statuses, ProviderSearchStatus{Provider: provName})
 		allResults = append(allResults, results...)
 	}
 
-	return allResults, nil
+	return allResults, statuses, nil
 }
 
 // isImageFieldName returns true for metadata fields that represent image slots.

--- a/internal/provider/orchestrator_searchlinking_test.go
+++ b/internal/provider/orchestrator_searchlinking_test.go
@@ -1,0 +1,308 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+// TestSearchForLinking_ReturnsPerProviderStatus covers the new contract added
+// for issue #1663: SearchForLinking now reports a ProviderSearchStatus per
+// queried provider so callers can distinguish "no matches" from "the provider
+// errored and the empty list is incomplete". The handler then surfaces a
+// banner above the disambiguation results.
+//
+// Each subtest registers a fresh set of mockProviders, calls SearchForLinking,
+// and asserts both the results slice and the per-provider status shape.
+func TestSearchForLinking_ReturnsPerProviderStatus(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Helper that returns a fresh orchestrator with the supplied providers
+	// registered. Setup is per-subtest so each scenario gets an isolated
+	// registry and is safe to run with t.Parallel().
+	newOrch := func(t *testing.T, mocks []*mockProvider) *Orchestrator {
+		t.Helper()
+		registry, settings := setupOrchestratorTest(t)
+		for _, m := range mocks {
+			registry.Register(m)
+		}
+		return NewOrchestrator(registry, settings, logger)
+	}
+
+	t.Run("all providers succeed", func(t *testing.T) {
+		t.Parallel()
+		orch := newOrch(t, []*mockProvider{
+			{
+				name: NameMusicBrainz,
+				searchFn: func(_ context.Context, _ string) ([]ArtistSearchResult, error) {
+					return []ArtistSearchResult{{Name: "Hiromi", Source: "musicbrainz", Score: 100}}, nil
+				},
+			},
+			{
+				name: NameDiscogs,
+				searchFn: func(_ context.Context, _ string) ([]ArtistSearchResult, error) {
+					return []ArtistSearchResult{{Name: "Hiromi", Source: "discogs", Score: 80}}, nil
+				},
+			},
+		})
+
+		results, statuses, err := orch.SearchForLinking(
+			context.Background(),
+			"Hiromi",
+			[]ProviderName{NameMusicBrainz, NameDiscogs},
+		)
+		if err != nil {
+			t.Fatalf("unexpected function error: %v", err)
+		}
+		if len(results) != 2 {
+			t.Fatalf("expected 2 results, got %d", len(results))
+		}
+		if len(statuses) != 2 {
+			t.Fatalf("expected 2 statuses, got %d", len(statuses))
+		}
+		for i, s := range statuses {
+			if s.Errored {
+				t.Errorf("status[%d] (%s): expected Errored=false, got true (msg=%q)", i, s.Provider, s.ScrubbedMessage)
+			}
+			if s.ScrubbedMessage != "" {
+				t.Errorf("status[%d] (%s): expected empty ScrubbedMessage on success, got %q", i, s.Provider, s.ScrubbedMessage)
+			}
+		}
+		// Status ordering must match the input provider slice so the UI
+		// can render a deterministic banner list.
+		if statuses[0].Provider != NameMusicBrainz || statuses[1].Provider != NameDiscogs {
+			t.Errorf("status ordering does not match input: got %v, %v", statuses[0].Provider, statuses[1].Provider)
+		}
+	})
+
+	t.Run("one provider errors, others succeed", func(t *testing.T) {
+		t.Parallel()
+		orch := newOrch(t, []*mockProvider{
+			{
+				name: NameMusicBrainz,
+				searchFn: func(_ context.Context, _ string) ([]ArtistSearchResult, error) {
+					return []ArtistSearchResult{{Name: "Hiromi", Source: "musicbrainz", Score: 100}}, nil
+				},
+			},
+			{
+				name: NameDiscogs,
+				searchFn: func(_ context.Context, _ string) ([]ArtistSearchResult, error) {
+					return nil, errors.New("api.discogs.com: connection refused")
+				},
+			},
+		})
+
+		results, statuses, err := orch.SearchForLinking(
+			context.Background(),
+			"Hiromi",
+			[]ProviderName{NameMusicBrainz, NameDiscogs},
+		)
+		if err != nil {
+			t.Fatalf("unexpected function-level error (should be nil for per-provider failures): %v", err)
+		}
+		// The successful MB result must still be returned even though
+		// Discogs errored -- partial results are better than an empty
+		// list with no banner.
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result from MB, got %d", len(results))
+		}
+		if len(statuses) != 2 {
+			t.Fatalf("expected 2 statuses, got %d", len(statuses))
+		}
+		if statuses[0].Errored {
+			t.Errorf("MB status should not be Errored, got %+v", statuses[0])
+		}
+		if !statuses[1].Errored {
+			t.Errorf("Discogs status should be Errored, got %+v", statuses[1])
+		}
+		if statuses[1].ScrubbedMessage == "" {
+			t.Errorf("Discogs Errored status should carry a ScrubbedMessage")
+		}
+	})
+
+	t.Run("all providers error", func(t *testing.T) {
+		t.Parallel()
+		orch := newOrch(t, []*mockProvider{
+			{
+				name: NameMusicBrainz,
+				searchFn: func(_ context.Context, _ string) ([]ArtistSearchResult, error) {
+					return nil, errors.New("musicbrainz.org: timeout")
+				},
+			},
+			{
+				name: NameDiscogs,
+				searchFn: func(_ context.Context, _ string) ([]ArtistSearchResult, error) {
+					return nil, errors.New("api.discogs.com: 401 unauthorized")
+				},
+			},
+		})
+
+		results, statuses, err := orch.SearchForLinking(
+			context.Background(),
+			"Hiromi",
+			[]ProviderName{NameMusicBrainz, NameDiscogs},
+		)
+		if err != nil {
+			t.Fatalf("unexpected function-level error: %v", err)
+		}
+		if len(results) != 0 {
+			t.Fatalf("expected 0 results when every provider errors, got %d", len(results))
+		}
+		if len(statuses) != 2 {
+			t.Fatalf("expected 2 statuses, got %d", len(statuses))
+		}
+		for i, s := range statuses {
+			if !s.Errored {
+				t.Errorf("status[%d] (%s): expected Errored=true, got false", i, s.Provider)
+			}
+		}
+	})
+
+	t.Run("unregistered provider name is skipped without status", func(t *testing.T) {
+		t.Parallel()
+		// Only MB is registered; the caller also asks for Discogs and a
+		// totally-unknown name. Both unregistered names must drop out
+		// silently -- emitting a status for them would confuse the
+		// banner (the user did not misconfigure those providers; the
+		// orchestrator simply does not know them).
+		orch := newOrch(t, []*mockProvider{
+			{
+				name: NameMusicBrainz,
+				searchFn: func(_ context.Context, _ string) ([]ArtistSearchResult, error) {
+					return []ArtistSearchResult{{Name: "Hiromi", Source: "musicbrainz"}}, nil
+				},
+			},
+		})
+
+		results, statuses, err := orch.SearchForLinking(
+			context.Background(),
+			"Hiromi",
+			[]ProviderName{NameMusicBrainz, NameDiscogs, ProviderName("does-not-exist")},
+		)
+		if err != nil {
+			t.Fatalf("unexpected function-level error: %v", err)
+		}
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result from MB, got %d", len(results))
+		}
+		if len(statuses) != 1 {
+			t.Fatalf("expected exactly 1 status (only MB was registered), got %d", len(statuses))
+		}
+		if statuses[0].Provider != NameMusicBrainz {
+			t.Errorf("expected the one status to be for MB, got %v", statuses[0].Provider)
+		}
+	})
+
+	t.Run("scrubbed message redacts api keys", func(t *testing.T) {
+		t.Parallel()
+		orch := newOrch(t, []*mockProvider{
+			{
+				name: NameDiscogs,
+				searchFn: func(_ context.Context, _ string) ([]ArtistSearchResult, error) {
+					return nil, errors.New("Get \"https://api.discogs.com/database/search?q=hiromi&token=SECRET123\": no such host")
+				},
+			},
+		})
+
+		_, statuses, err := orch.SearchForLinking(
+			context.Background(),
+			"Hiromi",
+			[]ProviderName{NameDiscogs},
+		)
+		if err != nil {
+			t.Fatalf("unexpected function-level error: %v", err)
+		}
+		if len(statuses) != 1 || !statuses[0].Errored {
+			t.Fatalf("expected one errored status, got %+v", statuses)
+		}
+		// The raw token must not survive ScrubError -- this is the
+		// load-bearing contract that lets the template render the
+		// message safely.
+		if contains := statuses[0].ScrubbedMessage; containsToken(contains) {
+			t.Errorf("ScrubbedMessage leaked the token: %q", contains)
+		}
+	})
+
+	// "Provider succeeds with zero results" is the branch that distinguishes
+	// "the lookup ran and found nothing" from "the lookup failed". It is the
+	// negative case for the #1663 banner: callers must NOT render the
+	// providers-unreachable warning when the empty list is legitimate.
+	t.Run("provider succeeds with zero results", func(t *testing.T) {
+		t.Parallel()
+		orch := newOrch(t, []*mockProvider{
+			{
+				name: NameMusicBrainz,
+				searchFn: func(_ context.Context, _ string) ([]ArtistSearchResult, error) {
+					return nil, nil
+				},
+			},
+		})
+
+		results, statuses, err := orch.SearchForLinking(
+			context.Background(),
+			"Hiromi",
+			[]ProviderName{NameMusicBrainz},
+		)
+		if err != nil {
+			t.Fatalf("unexpected function-level error: %v", err)
+		}
+		if len(results) != 0 {
+			t.Fatalf("expected zero results, got %d", len(results))
+		}
+		if len(statuses) != 1 {
+			t.Fatalf("expected one status, got %d", len(statuses))
+		}
+		if statuses[0].Errored {
+			t.Errorf("expected Errored=false on success-with-no-results, got true (msg=%q)", statuses[0].ScrubbedMessage)
+		}
+		if statuses[0].ScrubbedMessage != "" {
+			t.Errorf("expected empty ScrubbedMessage on success, got %q", statuses[0].ScrubbedMessage)
+		}
+	})
+}
+
+// TestSearchForLinking_NilRegistry covers the structural-failure branch where
+// the orchestrator was constructed without a provider registry. Callers
+// depend on receiving a function-level error (not a silent empty result) so
+// they can distinguish "no providers configured" from "every provider
+// errored", which routes differently in the bulk-identify pipeline.
+func TestSearchForLinking_NilRegistry(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	// Construct an Orchestrator with a nil registry. NewOrchestrator does
+	// not guard against this in production wiring; the test exercises the
+	// SearchForLinking nil-receiver branch directly.
+	orch := &Orchestrator{registry: nil, logger: logger}
+
+	results, statuses, err := orch.SearchForLinking(
+		context.Background(),
+		"Hiromi",
+		[]ProviderName{NameMusicBrainz},
+	)
+	if err == nil {
+		t.Fatalf("expected non-nil function-level error from nil registry, got nil")
+	}
+	if results != nil {
+		t.Errorf("expected nil results on nil-registry error, got %v", results)
+	}
+	if statuses != nil {
+		t.Errorf("expected nil statuses on nil-registry error, got %v", statuses)
+	}
+}
+
+// containsToken is a tiny helper for the scrub-message subtest; lifting it
+// keeps the assertion line readable.
+func containsToken(s string) bool {
+	const token = "SECRET123"
+	for i := 0; i+len(token) <= len(s); i++ {
+		if s[i:i+len(token)] == token {
+			return true
+		}
+	}
+	return false
+}

--- a/web/templates/artist_refresh.templ
+++ b/web/templates/artist_refresh.templ
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/sydlexius/stillwater/internal/artist"
 	img "github.com/sydlexius/stillwater/internal/image"
@@ -68,17 +69,52 @@ templ RefreshDisambiguationForm(artistID, artistName string) {
 	</div>
 }
 
+// disambiguationProviderErrorBanner surfaces a warning when one or more
+// providers failed during the disambiguation search. The empty result list
+// would otherwise be indistinguishable from a clean "no matches found"; the
+// banner names the unreachable providers so the operator knows to check
+// provider configuration or wait out a rate limit instead of giving up on
+// the identify flow. Issue #1663.
+templ disambiguationProviderErrorBanner(failed []string) {
+	<div
+		class="rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 text-amber-900 dark:text-amber-200 px-4 py-3 text-sm mb-3"
+		role="status"
+		aria-live="polite"
+		data-testid="providers-unreachable-banner"
+	>
+		<div class="font-medium">{ t(ctx, "artist.disambiguation.providers_unreachable.title") }</div>
+		<p class="mt-1 text-xs">
+			{ tf(ctx, "artist.disambiguation.providers_unreachable.body", strings.Join(failed, ", ")) }
+		</p>
+	</div>
+}
+
+// DisambiguationResultsData is the view model for DisambiguationResults.
+// FailedProviders carries the human-readable names of providers whose search
+// failed during the lookup (per ProviderSearchStatus). When non-empty the
+// template renders a warning banner above the results so the user can tell
+// "providers errored, results may be incomplete" apart from the legitimate
+// "providers all succeeded, no matches exist" empty state.
+type DisambiguationResultsData struct {
+	ArtistID        string
+	Candidates      []DisambiguationCandidate
+	FailedProviders []string
+}
+
 // DisambiguationResults renders the list of search result cards for MBID linking.
-templ DisambiguationResults(artistID string, candidates []DisambiguationCandidate) {
-	if len(candidates) == 0 {
+templ DisambiguationResults(data DisambiguationResultsData) {
+	if len(data.FailedProviders) > 0 {
+		@disambiguationProviderErrorBanner(data.FailedProviders)
+	}
+	if len(data.Candidates) == 0 {
 		<p class="text-sm text-gray-500 italic py-2">{ t(ctx, "image.no_results_found") }</p>
 	} else {
 		<div class="space-y-2">
-			for _, c := range candidates {
+			for _, c := range data.Candidates {
 				<button
 					type="button"
 					class="group/link relative w-full text-left rounded border border-gray-200 dark:border-gray-700 p-3 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:border-blue-300 dark:hover:border-blue-700 transition-colors [&.htmx-request]:border-blue-400 [&.htmx-request]:dark:border-blue-600"
-					hx-post={ "/api/v1/artists/" + artistID + "/refresh/link" }
+					hx-post={ "/api/v1/artists/" + data.ArtistID + "/refresh/link" }
 					hx-vals={ disambiguationHxVals(c.Result) }
 					hx-target="#refresh-panel"
 					hx-swap="innerHTML"

--- a/web/templates/artist_refresh_templ.go
+++ b/web/templates/artist_refresh_templ.go
@@ -10,6 +10,7 @@ import templruntime "github.com/a-h/templ/runtime"
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/sydlexius/stillwater/internal/artist"
 	img "github.com/sydlexius/stillwater/internal/image"
@@ -61,7 +62,7 @@ func RefreshDisambiguationForm(artistID, artistName string) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.mbid_required"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 31, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 32, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -87,7 +88,7 @@ func RefreshDisambiguationForm(artistID, artistName string) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.mbid_required_description"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 40, Col: 46}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 41, Col: 46}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -100,7 +101,7 @@ func RefreshDisambiguationForm(artistID, artistName string) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue("/api/v1/artists/" + artistID + "/refresh/search")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 43, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 44, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
 		if templ_7745c5c3_Err != nil {
@@ -113,7 +114,7 @@ func RefreshDisambiguationForm(artistID, artistName string) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(artistName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 53, Col: 23}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 54, Col: 23}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
 		if templ_7745c5c3_Err != nil {
@@ -126,7 +127,7 @@ func RefreshDisambiguationForm(artistID, artistName string) templ.Component {
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(t(ctx, "image.artist_name_placeholder"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 54, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 55, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 		if templ_7745c5c3_Err != nil {
@@ -143,7 +144,7 @@ func RefreshDisambiguationForm(artistID, artistName string) templ.Component {
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.search"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 62, Col: 30}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 63, Col: 30}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
@@ -156,7 +157,7 @@ func RefreshDisambiguationForm(artistID, artistName string) templ.Component {
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.searching"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 67, Col: 101}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 68, Col: 101}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
@@ -170,8 +171,13 @@ func RefreshDisambiguationForm(artistID, artistName string) templ.Component {
 	})
 }
 
-// DisambiguationResults renders the list of search result cards for MBID linking.
-func DisambiguationResults(artistID string, candidates []DisambiguationCandidate) templ.Component {
+// disambiguationProviderErrorBanner surfaces a warning when one or more
+// providers failed during the disambiguation search. The empty result list
+// would otherwise be indistinguishable from a clean "no matches found"; the
+// banner names the unreachable providers so the operator knows to check
+// provider configuration or wait out a rate limit instead of giving up on
+// the identify flow. Issue #1663.
+func disambiguationProviderErrorBanner(failed []string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -192,363 +198,437 @@ func DisambiguationResults(artistID string, candidates []DisambiguationCandidate
 			templ_7745c5c3_Var9 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		if len(candidates) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<p class=\"text-sm text-gray-500 italic py-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"rounded-md border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 text-amber-900 dark:text-amber-200 px-4 py-3 text-sm mb-3\" role=\"status\" aria-live=\"polite\" data-testid=\"providers-unreachable-banner\"><div class=\"font-medium\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var10 string
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artist.disambiguation.providers_unreachable.title"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 85, Col: 88}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div><p class=\"mt-1 text-xs\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var11 string
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "artist.disambiguation.providers_unreachable.body", strings.Join(failed, ", ")))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 87, Col: 92}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</p></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// DisambiguationResultsData is the view model for DisambiguationResults.
+// FailedProviders carries the human-readable names of providers whose search
+// failed during the lookup (per ProviderSearchStatus). When non-empty the
+// template renders a warning banner above the results so the user can tell
+// "providers errored, results may be incomplete" apart from the legitimate
+// "providers all succeeded, no matches exist" empty state.
+type DisambiguationResultsData struct {
+	ArtistID        string
+	Candidates      []DisambiguationCandidate
+	FailedProviders []string
+}
+
+// DisambiguationResults renders the list of search result cards for MBID linking.
+func DisambiguationResults(data DisambiguationResultsData) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		if len(data.FailedProviders) > 0 {
+			templ_7745c5c3_Err = disambiguationProviderErrorBanner(data.FailedProviders).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.no_results_found"))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 74, Col: 81}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+		}
+		if len(data.Candidates) == 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<p class=\"text-sm text-gray-500 italic py-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</p>")
+			var templ_7745c5c3_Var13 string
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.no_results_found"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 110, Col: 81}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div class=\"space-y-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div class=\"space-y-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			for _, c := range candidates {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<button type=\"button\" class=\"group/link relative w-full text-left rounded border border-gray-200 dark:border-gray-700 p-3 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:border-blue-300 dark:hover:border-blue-700 transition-colors [&.htmx-request]:border-blue-400 [&.htmx-request]:dark:border-blue-600\" hx-post=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var11 string
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue("/api/v1/artists/" + artistID + "/refresh/link")
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 81, Col: 62}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" hx-vals=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var12 string
-				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.ResolveAttributeValue(disambiguationHxVals(c.Result))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 82, Col: 45}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var12)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\" hx-target=\"#refresh-panel\" hx-swap=\"innerHTML\" hx-disabled-elt=\"this\"><div class=\"hidden group-[.htmx-request]/link:flex absolute inset-0 items-center justify-center rounded bg-white/80 dark:bg-gray-800/80 z-10\"><svg class=\"h-5 w-5 animate-spin text-blue-500 mr-2\" fill=\"none\" viewBox=\"0 0 24 24\" aria-hidden=\"true\"><circle class=\"opacity-25\" cx=\"12\" cy=\"12\" r=\"10\" stroke=\"currentColor\" stroke-width=\"4\"></circle> <path class=\"opacity-75\" fill=\"currentColor\" d=\"M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z\"></path></svg> <span class=\"text-sm font-medium text-blue-600 dark:text-blue-400\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var13 string
-				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.linking_and_refreshing"))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 93, Col: 113}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span></div><div class=\"flex items-center justify-between\"><div class=\"flex-1 min-w-0\"><div class=\"font-medium text-sm\">")
+			for _, c := range data.Candidates {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<button type=\"button\" class=\"group/link relative w-full text-left rounded border border-gray-200 dark:border-gray-700 p-3 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:border-blue-300 dark:hover:border-blue-700 transition-colors [&.htmx-request]:border-blue-400 [&.htmx-request]:dark:border-blue-600\" hx-post=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var14 string
-				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(c.Result.Name)
+				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.ResolveAttributeValue("/api/v1/artists/" + data.ArtistID + "/refresh/link")
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 97, Col: 55}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 117, Col: 67}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var14)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div><div class=\"text-xs text-gray-500 dark:text-gray-400 mt-0.5\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" hx-vals=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var15 string
+				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.ResolveAttributeValue(disambiguationHxVals(c.Result))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 118, Col: 45}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var15)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" hx-target=\"#refresh-panel\" hx-swap=\"innerHTML\" hx-disabled-elt=\"this\"><div class=\"hidden group-[.htmx-request]/link:flex absolute inset-0 items-center justify-center rounded bg-white/80 dark:bg-gray-800/80 z-10\"><svg class=\"h-5 w-5 animate-spin text-blue-500 mr-2\" fill=\"none\" viewBox=\"0 0 24 24\" aria-hidden=\"true\"><circle class=\"opacity-25\" cx=\"12\" cy=\"12\" r=\"10\" stroke=\"currentColor\" stroke-width=\"4\"></circle> <path class=\"opacity-75\" fill=\"currentColor\" d=\"M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z\"></path></svg> <span class=\"text-sm font-medium text-blue-600 dark:text-blue-400\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var16 string
+				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.linking_and_refreshing"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 129, Col: 113}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</span></div><div class=\"flex items-center justify-between\"><div class=\"flex-1 min-w-0\"><div class=\"font-medium text-sm\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var17 string
+				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(c.Result.Name)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 133, Col: 55}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div><div class=\"text-xs text-gray-500 dark:text-gray-400 mt-0.5\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if c.Result.Type != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<span>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var15 string
-					templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(c.Result.Type)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 100, Col: 30}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</span> ")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-				}
-				if c.Result.Origin != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var16 string
-					templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "image.from_country", c.Result.Origin))
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 103, Col: 63}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</span> ")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-				}
-				if c.Result.Disambiguation != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<span class=\"italic\">(")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var17 string
-					templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(c.Result.Disambiguation)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 106, Col: 56}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, ")</span>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				if c.Result.MusicBrainzID != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<div class=\"text-[10px] text-gray-400 font-mono mt-0.5 truncate\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<span>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var18 string
-					templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(c.Result.MusicBrainzID)
+					templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(c.Result.Type)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 110, Col: 97}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 136, Col: 30}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</span> ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				if c.AlbumComparison != nil && c.AlbumComparison.LocalCount > 0 {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"mt-1.5 flex items-center gap-2\">")
+				if c.Result.Origin != "" {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<span>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var19 = []any{"inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium", albumMatchClasses(c.AlbumComparison.MatchPercent)}
-					templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var19...)
+					var templ_7745c5c3_Var19 string
+					templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "image.from_country", c.Result.Origin))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 139, Col: 63}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<span class=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</span> ")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				if c.Result.Disambiguation != "" {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<span class=\"italic\">(")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var20 string
-					templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var19).String())
+					templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(c.Result.Disambiguation)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 1, Col: 0}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 142, Col: 56}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, ")</span>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if c.Result.MusicBrainzID != "" {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<div class=\"text-[10px] text-gray-400 font-mono mt-0.5 truncate\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var21 string
-					templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "image.album_match_count", c.AlbumComparison.MatchCount, c.AlbumComparison.LocalCount))
+					templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(c.Result.MusicBrainzID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 115, Col: 106}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 146, Col: 97}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</span> ")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					if hasMatchedAlbums(c.AlbumComparison) {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<span class=\"text-[10px] text-gray-400 truncate\">")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						var templ_7745c5c3_Var22 string
-						templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(joinMatchedNames(ctx, c.AlbumComparison))
-						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 118, Col: 101}
-						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</span>")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</div><div class=\"flex items-center gap-2 ml-3 shrink-0\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				if c.Result.Score > 0 {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<span class=\"text-xs text-gray-500\">")
+				if c.AlbumComparison != nil && c.AlbumComparison.LocalCount > 0 {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"mt-1.5 flex items-center gap-2\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var22 = []any{"inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium", albumMatchClasses(c.AlbumComparison.MatchPercent)}
+					templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var22...)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<span class=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var23 string
-					templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(c.Result.Score))
+					templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var22).String())
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 125, Col: 74}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 1, Col: 0}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var23)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</span> ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var24 string
+					templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "image.album_match_count", c.AlbumComparison.MatchCount, c.AlbumComparison.LocalCount))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 151, Col: 106}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</span> ")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					if hasMatchedAlbums(c.AlbumComparison) {
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<span class=\"text-[10px] text-gray-400 truncate\">")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var25 string
+						templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(joinMatchedNames(ctx, c.AlbumComparison))
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 154, Col: 101}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</span>")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</div>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</div><div class=\"flex items-center gap-2 ml-3 shrink-0\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if c.Result.Score > 0 {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<span class=\"text-xs text-gray-500\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var26 string
+					templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(c.Result.Score))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 161, Col: 74}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</span> ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
 				if c.Result.Source != "" {
 					if logoSrcSet(c.Result.Source) != "" {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<img src=\"")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						var templ_7745c5c3_Var24 string
-						templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.ResolveAttributeValue(logoSrc(c.Result.Source))
-						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 129, Col: 44}
-						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var24)
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\" srcset=\"")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						var templ_7745c5c3_Var25 string
-						templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(logoSrcSet(c.Result.Source))
-						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 129, Col: 83}
-						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var25)
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\" alt=\"")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						var templ_7745c5c3_Var26 string
-						templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue(c.Result.Source)
-						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 129, Col: 107}
-						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var26)
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\" class=\"h-4 w-4\" title=\"")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<img src=\"")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 						var templ_7745c5c3_Var27 string
-						templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(providerDisplayName(c.Result.Source))
+						templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(logoSrc(c.Result.Source))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 129, Col: 170}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 165, Col: 44}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var27)
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\">")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-					} else {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<img src=\"")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\" srcset=\"")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 						var templ_7745c5c3_Var28 string
-						templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue(logoSrc(c.Result.Source))
+						templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue(logoSrcSet(c.Result.Source))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 131, Col: 44}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 165, Col: 83}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var28)
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\" alt=\"")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\" alt=\"")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 						var templ_7745c5c3_Var29 string
 						templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(c.Result.Source)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 131, Col: 68}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 165, Col: 107}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var29)
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\" class=\"h-4 w-4\" title=\"")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\" class=\"h-4 w-4\" title=\"")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 						var templ_7745c5c3_Var30 string
 						templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(providerDisplayName(c.Result.Source))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 131, Col: 131}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 165, Col: 170}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\">")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+					} else {
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<img src=\"")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var31 string
+						templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(logoSrc(c.Result.Source))
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 167, Col: 44}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var31)
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "\" alt=\"")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var32 string
+						templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(c.Result.Source)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 167, Col: 68}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var32)
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\" class=\"h-4 w-4\" title=\"")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var33 string
+						templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.ResolveAttributeValue(providerDisplayName(c.Result.Source))
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 167, Col: 131}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var33)
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</div></div></button>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</div></div></button>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -574,152 +654,152 @@ func RefreshResultSummary(artistID string, sources []provider.FieldSource) templ
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var31 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var31 == nil {
-			templ_7745c5c3_Var31 = templ.NopComponent
+		templ_7745c5c3_Var34 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var34 == nil {
+			templ_7745c5c3_Var34 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<div class=\"rounded-lg border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-900/20 p-4\"><h3 class=\"font-semibold text-sm mb-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<div class=\"rounded-lg border border-green-300 dark:border-green-700 bg-green-50 dark:bg-green-900/20 p-4\"><h3 class=\"font-semibold text-sm mb-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var32 string
-		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.metadata_refreshed"))
+		var templ_7745c5c3_Var35 string
+		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.metadata_refreshed"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 145, Col: 77}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 181, Col: 77}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</h3>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</h3>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(sources) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<p class=\"text-sm text-gray-500 italic\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<p class=\"text-sm text-gray-500 italic\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var33 string
-			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.no_new_data"))
+			var templ_7745c5c3_Var36 string
+			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.no_new_data"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 147, Col: 72}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 183, Col: 72}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<div class=\"space-y-1 text-sm\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<div class=\"space-y-1 text-sm\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, src := range sources {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<div class=\"flex items-center gap-2\"><span class=\"text-gray-600 dark:text-gray-400\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<div class=\"flex items-center gap-2\"><span class=\"text-gray-600 dark:text-gray-400\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var34 string
-				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(fieldLabel(ctx, src.Field))
+				var templ_7745c5c3_Var37 string
+				templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(fieldLabel(ctx, src.Field))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 152, Col: 81}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 188, Col: 81}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, ":</span> <span class=\"flex items-center gap-1 text-green-600 dark:text-green-400\">")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var35 string
-				templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.updated_from"))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 154, Col: 37}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, ":</span> <span class=\"flex items-center gap-1 text-green-600 dark:text-green-400\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, " ")
+				var templ_7745c5c3_Var38 string
+				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.updated_from"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 190, Col: 37}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				if logoSrcSet(string(src.Provider)) != "" {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<img src=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var36 string
-					templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.ResolveAttributeValue(logoSrc(string(src.Provider)))
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 156, Col: 48}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var36)
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "\" srcset=\"")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var37 string
-					templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.ResolveAttributeValue(logoSrcSet(string(src.Provider)))
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 156, Col: 92}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var37)
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "\" alt=\"\" class=\"h-3.5 w-3.5 inline\" aria-hidden=\"true\"> ")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-				} else {
 					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<img src=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var38 string
-					templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.ResolveAttributeValue(logoSrc(string(src.Provider)))
+					var templ_7745c5c3_Var39 string
+					templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.ResolveAttributeValue(logoSrc(string(src.Provider)))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 158, Col: 48}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 192, Col: 48}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var38)
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var39)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "\" alt=\"\" class=\"h-3.5 w-3.5 inline\" aria-hidden=\"true\"> ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "\" srcset=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var40 string
+					templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.ResolveAttributeValue(logoSrcSet(string(src.Provider)))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 192, Col: 92}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var40)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "\" alt=\"\" class=\"h-3.5 w-3.5 inline\" aria-hidden=\"true\"> ")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				} else {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "<img src=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var41 string
+					templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.ResolveAttributeValue(logoSrc(string(src.Provider)))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 194, Col: 48}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var41)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "\" alt=\"\" class=\"h-3.5 w-3.5 inline\" aria-hidden=\"true\"> ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				var templ_7745c5c3_Var39 string
-				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(src.Provider.DisplayName())
+				var templ_7745c5c3_Var42 string
+				templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(src.Provider.DisplayName())
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 160, Col: 35}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 196, Col: 35}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</span></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</span></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -744,38 +824,38 @@ func RefreshError(message string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var40 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var40 == nil {
-			templ_7745c5c3_Var40 = templ.NopComponent
+		templ_7745c5c3_Var43 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var43 == nil {
+			templ_7745c5c3_Var43 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "<div class=\"rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 p-4\"><h3 class=\"font-semibold text-sm mb-1 text-red-800 dark:text-red-200\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "<div class=\"rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20 p-4\"><h3 class=\"font-semibold text-sm mb-1 text-red-800 dark:text-red-200\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var41 string
-		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.refresh_failed"))
+		var templ_7745c5c3_Var44 string
+		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.refresh_failed"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 172, Col: 104}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 208, Col: 104}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</h3><p class=\"text-sm text-red-600 dark:text-red-400\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var42 string
-		templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(message)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 173, Col: 61}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "</h3><p class=\"text-sm text-red-600 dark:text-red-400\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</p></div>")
+		var templ_7745c5c3_Var45 string
+		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(message)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 209, Col: 61}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "</p></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -801,25 +881,25 @@ func RefreshOOBFragments(data RefreshOOBData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var43 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var43 == nil {
-			templ_7745c5c3_Var43 = templ.NopComponent
+		templ_7745c5c3_Var46 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var46 == nil {
+			templ_7745c5c3_Var46 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "<div hx-swap-oob=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "<div hx-swap-oob=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var44 string
-		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.ResolveAttributeValue("outerHTML:#field-biography-" + data.Artist.ID)
+		var templ_7745c5c3_Var47 string
+		templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.ResolveAttributeValue("outerHTML:#field-biography-" + data.Artist.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 181, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 217, Col: 66}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var44)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var47)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -827,33 +907,33 @@ func RefreshOOBFragments(data RefreshOOBData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "</div><section id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</div><section id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var45 string
-		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.ResolveAttributeValue("artist-tags-" + data.Artist.ID)
+		var templ_7745c5c3_Var48 string
+		templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.ResolveAttributeValue("artist-tags-" + data.Artist.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 185, Col: 46}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 221, Col: 46}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var45)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\" hx-swap-oob=\"outerHTML\" class=\"sw-card rounded-lg bg-white dark:bg-gray-800 p-6 shadow\"><h2 class=\"text-lg font-semibold mb-3\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var48)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var46 string
-		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.tags"))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 186, Col: 64}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "\" hx-swap-oob=\"outerHTML\" class=\"sw-card rounded-lg bg-white dark:bg-gray-800 p-6 shadow\"><h2 class=\"text-lg font-semibold mb-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "</h2>")
+		var templ_7745c5c3_Var49 string
+		templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.tags"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 222, Col: 64}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "</h2>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -869,20 +949,20 @@ func RefreshOOBFragments(data RefreshOOBData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</section><div hx-swap-oob=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "</section><div hx-swap-oob=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var47 string
-		templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.ResolveAttributeValue("outerHTML:#members-section-" + data.Artist.ID)
+		var templ_7745c5c3_Var50 string
+		templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.ResolveAttributeValue("outerHTML:#members-section-" + data.Artist.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 192, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 228, Col: 66}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var47)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var50)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -890,33 +970,33 @@ func RefreshOOBFragments(data RefreshOOBData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "</div><section id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "</div><section id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var48 string
-		templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.ResolveAttributeValue("artist-details-" + data.Artist.ID)
+		var templ_7745c5c3_Var51 string
+		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.ResolveAttributeValue("artist-details-" + data.Artist.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 196, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 232, Col: 49}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var48)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "\" hx-swap-oob=\"outerHTML\" class=\"sw-card rounded-lg bg-white dark:bg-gray-800 p-6 shadow\"><h2 class=\"text-lg font-semibold mb-3\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var51)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var49 string
-		templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.details"))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 197, Col: 67}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "\" hx-swap-oob=\"outerHTML\" class=\"sw-card rounded-lg bg-white dark:bg-gray-800 p-6 shadow\"><h2 class=\"text-lg font-semibold mb-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "</h2><dl class=\"space-y-2 text-sm\">")
+		var templ_7745c5c3_Var52 string
+		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.details"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 233, Col: 67}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "</h2><dl class=\"space-y-2 text-sm\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -936,20 +1016,20 @@ func RefreshOOBFragments(data RefreshOOBData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "<div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "<div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var50 string
-		templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.ResolveAttributeValue("gender-wrap-" + data.Artist.ID)
+		var templ_7745c5c3_Var53 string
+		templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.ResolveAttributeValue("gender-wrap-" + data.Artist.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 203, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 239, Col: 44}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var50)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var53)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -959,7 +1039,7 @@ func RefreshOOBFragments(data RefreshOOBData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -983,33 +1063,33 @@ func RefreshOOBFragments(data RefreshOOBData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "</dl></section><section id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "</dl></section><section id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var51 string
-		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.ResolveAttributeValue("artist-images-" + data.Artist.ID)
+		var templ_7745c5c3_Var54 string
+		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.ResolveAttributeValue("artist-images-" + data.Artist.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 216, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 252, Col: 48}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var51)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "\" hx-swap-oob=\"outerHTML\" class=\"sw-card rounded-lg bg-white dark:bg-gray-800 p-6 shadow\"><h2 class=\"text-lg font-semibold mb-3\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var54)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var52 string
-		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.images"))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 217, Col: 66}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "\" hx-swap-oob=\"outerHTML\" class=\"sw-card rounded-lg bg-white dark:bg-gray-800 p-6 shadow\"><h2 class=\"text-lg font-semibold mb-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "</h2><div class=\"grid grid-cols-2 gap-3\">")
+		var templ_7745c5c3_Var55 string
+		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.images"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 253, Col: 66}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "</h2><div class=\"grid grid-cols-2 gap-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1029,7 +1109,7 @@ func RefreshOOBFragments(data RefreshOOBData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "</div><div class=\"mt-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</div><div class=\"mt-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1037,33 +1117,33 @@ func RefreshOOBFragments(data RefreshOOBData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</div></section><section id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "</div></section><section id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var53 string
-		templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.ResolveAttributeValue("artist-providers-" + data.Artist.ID)
+		var templ_7745c5c3_Var56 string
+		templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.ResolveAttributeValue("artist-providers-" + data.Artist.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 229, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 265, Col: 51}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var53)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "\" hx-swap-oob=\"outerHTML\" class=\"sw-card rounded-lg bg-white dark:bg-gray-800 p-6 shadow\"><h2 class=\"text-lg font-semibold mb-3\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var56)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var54 string
-		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.provider_ids"))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 230, Col: 72}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "\" hx-swap-oob=\"outerHTML\" class=\"sw-card rounded-lg bg-white dark:bg-gray-800 p-6 shadow\"><h2 class=\"text-lg font-semibold mb-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</h2><dl class=\"space-y-2 text-sm\">")
+		var templ_7745c5c3_Var57 string
+		templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "common.provider_ids"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/artist_refresh.templ`, Line: 266, Col: 72}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "</h2><dl class=\"space-y-2 text-sm\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1087,7 +1167,7 @@ func RefreshOOBFragments(data RefreshOOBData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "</dl></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "</dl></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/templates/artist_refresh_test.go
+++ b/web/templates/artist_refresh_test.go
@@ -1,0 +1,122 @@
+package templates
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestDisambiguationResults_RendersProviderUnreachableBanner pins the
+// banner-on-failure contract added for issue #1663. When SearchForLinking
+// reports a provider error via ProviderSearchStatus, the handler forwards
+// the failed-provider display names through DisambiguationResultsData and the
+// template renders a visible warning above the candidate list so the user
+// can tell "providers unreachable" apart from "no matches found".
+func TestDisambiguationResults_RendersProviderUnreachableBanner(t *testing.T) {
+	t.Parallel()
+
+	data := DisambiguationResultsData{
+		ArtistID: "artist-1",
+		Candidates: []DisambiguationCandidate{{
+			Result: provider.ArtistSearchResult{
+				Name:          "Hiromi",
+				MusicBrainzID: "mbid-abc",
+				Source:        "musicbrainz",
+				Score:         95,
+			},
+		}},
+		FailedProviders: []string{"Discogs"},
+	}
+
+	var buf bytes.Buffer
+	if err := DisambiguationResults(data).Render(testCtx(t), &buf); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := buf.String()
+
+	// Stable hook for any future test or CSS audit that needs to find the
+	// banner without relying on translated copy.
+	if !strings.Contains(body, `data-testid="providers-unreachable-banner"`) {
+		t.Errorf("expected providers-unreachable-banner data-testid in rendered output, body:\n%s", body)
+	}
+
+	// Title and body copy must come through the i18n helpers; the en.json
+	// strings live at artist.disambiguation.providers_unreachable.*.
+	if !strings.Contains(body, "Some providers could not be reached") {
+		t.Errorf("expected banner title text in body:\n%s", body)
+	}
+	if !strings.Contains(body, "Discogs") {
+		t.Errorf("expected failed provider name (Discogs) interpolated into banner, body:\n%s", body)
+	}
+
+	// The candidate row must still render alongside the banner -- partial
+	// failures should not hide the providers that did return results.
+	if !strings.Contains(body, "Hiromi") {
+		t.Errorf("expected candidate name to render alongside banner, body:\n%s", body)
+	}
+}
+
+// TestDisambiguationResults_NoBannerWhenAllProvidersSucceed pins the
+// negative case: with zero failed providers the banner must not render. This
+// keeps the legitimate "no matches found" empty state distinct from the
+// new "providers unreachable" warning -- conflating them would defeat the
+// purpose of issue #1663.
+func TestDisambiguationResults_NoBannerWhenAllProvidersSucceed(t *testing.T) {
+	t.Parallel()
+
+	data := DisambiguationResultsData{
+		ArtistID:        "artist-1",
+		Candidates:      nil, // genuine empty-result state
+		FailedProviders: nil,
+	}
+
+	var buf bytes.Buffer
+	if err := DisambiguationResults(data).Render(testCtx(t), &buf); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := buf.String()
+
+	if strings.Contains(body, "providers-unreachable-banner") {
+		t.Errorf("banner should not render when no providers failed; body:\n%s", body)
+	}
+	// The legitimate "no results" message should appear instead.
+	if !strings.Contains(body, "No results found") {
+		t.Errorf("expected the empty-state no-results message; body:\n%s", body)
+	}
+}
+
+// TestDisambiguationResults_BannerWhenProvidersFailAndNoCandidates pins the
+// exact ambiguous state issue #1663 fixes: providers errored AND zero
+// candidates came back. The banner must render so the operator sees a
+// reason for the empty list; the legitimate "no results found" copy still
+// renders alongside it (the template does not suppress the empty-state when
+// the banner is present, and that combined presentation is intentional --
+// the banner explains *why* the list might be empty without lying that the
+// search itself succeeded).
+func TestDisambiguationResults_BannerWhenProvidersFailAndNoCandidates(t *testing.T) {
+	t.Parallel()
+
+	data := DisambiguationResultsData{
+		ArtistID:        "artist-1",
+		Candidates:      nil,
+		FailedProviders: []string{"Discogs"},
+	}
+
+	var buf bytes.Buffer
+	if err := DisambiguationResults(data).Render(testCtx(t), &buf); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := buf.String()
+
+	if !strings.Contains(body, `data-testid="providers-unreachable-banner"`) {
+		t.Errorf("expected providers-unreachable banner when providers fail with zero candidates, body:\n%s", body)
+	}
+	if !strings.Contains(body, "Discogs") {
+		t.Errorf("expected failed provider name (Discogs) interpolated into banner, body:\n%s", body)
+	}
+	if !strings.Contains(body, "No results found") {
+		t.Errorf("expected no-results text to remain visible alongside the failure banner, body:\n%s", body)
+	}
+}

--- a/web/templates/reidentify_wizard.templ
+++ b/web/templates/reidentify_wizard.templ
@@ -33,6 +33,15 @@ type ReIdentifyWizardStepData struct {
 	// when the user lands on the wizard and does not persist across HTMX
 	// step swaps.
 	SkippedAtStart []SkippedArtistView
+	// FailedProviders lists the human-readable names of any providers
+	// that returned an error during this step's candidate lookup but did
+	// not fail the entire step (i.e. at least one other provider still
+	// succeeded). Populated from ProviderSearchStatus on the orchestrator
+	// surface; when non-empty the step renders an in-line warning banner
+	// above the candidate list so the user can distinguish "MB returned
+	// no matches" from "Discogs errored, results incomplete". A full
+	// lookup failure routes through Errored instead. Issue #1663.
+	FailedProviders []string
 }
 
 // SkippedArtistView is the flat view of a dropped artist exposed to the
@@ -132,6 +141,9 @@ templ ReIdentifyWizardStep(data ReIdentifyWizardStepData) {
 			<progress class="w-32" value={ strconv.Itoa(data.Index + 1) } max={ strconv.Itoa(data.Total) }></progress>
 		</header>
 		<div class="border-t border-gray-200 dark:border-gray-700 pt-4">
+			if len(data.FailedProviders) > 0 {
+				@disambiguationProviderErrorBanner(data.FailedProviders)
+			}
 			@reIdentifyWizardCandidates(data)
 		</div>
 		<footer class="flex flex-wrap items-center gap-2 pt-2 border-t border-gray-200 dark:border-gray-700">

--- a/web/templates/reidentify_wizard_templ.go
+++ b/web/templates/reidentify_wizard_templ.go
@@ -41,6 +41,15 @@ type ReIdentifyWizardStepData struct {
 	// when the user lands on the wizard and does not persist across HTMX
 	// step swaps.
 	SkippedAtStart []SkippedArtistView
+	// FailedProviders lists the human-readable names of any providers
+	// that returned an error during this step's candidate lookup but did
+	// not fail the entire step (i.e. at least one other provider still
+	// succeeded). Populated from ProviderSearchStatus on the orchestrator
+	// surface; when non-empty the step renders an in-line warning banner
+	// above the candidate list so the user can distinguish "MB returned
+	// no matches" from "Discogs errored, results incomplete". A full
+	// lookup failure routes through Errored instead. Issue #1663.
+	FailedProviders []string
 }
 
 // SkippedArtistView is the flat view of a dropped artist exposed to the
@@ -104,7 +113,7 @@ func ReIdentifyWizardPage(assets AssetPaths, data ReIdentifyWizardStepData) temp
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.wizard.title"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 63, Col: 83}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 72, Col: 83}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -182,7 +191,7 @@ func reIdentifyWizardSkippedBanner(skipped []SkippedArtistView) templ.Component 
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(tn(ctx, "artists.bulk.reidentify.wizard.skipped_banner", len(skipped)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 86, Col: 75}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 95, Col: 75}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -200,7 +209,7 @@ func reIdentifyWizardSkippedBanner(skipped []SkippedArtistView) templ.Component 
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(s.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 91, Col: 11}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 100, Col: 11}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -213,7 +222,7 @@ func reIdentifyWizardSkippedBanner(skipped []SkippedArtistView) templ.Component 
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(wizardSkippedReasonLabel(ctx, s.Reason))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 93, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 102, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -274,7 +283,7 @@ func ReIdentifyWizardPageDone(assets AssetPaths, data ReIdentifyWizardDoneData) 
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.wizard.title"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 107, Col: 83}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 116, Col: 83}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -341,7 +350,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.ResolveAttributeValue(data.SessionID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 122, Col: 34}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 131, Col: 34}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var12)
 		if templ_7745c5c3_Err != nil {
@@ -354,7 +363,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(data.Index))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 123, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 132, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var13)
 		if templ_7745c5c3_Err != nil {
@@ -367,7 +376,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "artists.bulk.reidentify.wizard.step_of", data.Index+1, data.Total))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 128, Col: 82}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 137, Col: 82}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
@@ -380,7 +389,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(data.ArtistName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 130, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 139, Col: 55}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
@@ -393,7 +402,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(data.Index + 1))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 132, Col: 62}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 141, Col: 62}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
 		if templ_7745c5c3_Err != nil {
@@ -406,7 +415,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(data.Total))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 132, Col: 95}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 141, Col: 95}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var17)
 		if templ_7745c5c3_Err != nil {
@@ -415,6 +424,12 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\"></progress></header><div class=\"border-t border-gray-200 dark:border-gray-700 pt-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
+		}
+		if len(data.FailedProviders) > 0 {
+			templ_7745c5c3_Err = disambiguationProviderErrorBanner(data.FailedProviders).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
 		templ_7745c5c3_Err = reIdentifyWizardCandidates(data).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
@@ -436,7 +451,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(wizardStepURL(data.SessionID, data.Index-1))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 143, Col: 57}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 155, Col: 57}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
 			if templ_7745c5c3_Err != nil {
@@ -449,7 +464,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 			var templ_7745c5c3_Var19 string
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.wizard.back"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 152, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 164, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
@@ -467,7 +482,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(wizardActionURL(data.SessionID, data.Index, "skip"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 158, Col: 65}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 170, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
 		if templ_7745c5c3_Err != nil {
@@ -480,7 +495,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.wizard.skip"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 167, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 179, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
@@ -493,7 +508,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		var templ_7745c5c3_Var22 string
 		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue(wizardActionURL(data.SessionID, data.Index, "decline"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 172, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 184, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var22)
 		if templ_7745c5c3_Err != nil {
@@ -506,7 +521,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.wizard.decline"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 181, Col: 54}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 193, Col: 54}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
@@ -519,7 +534,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		var templ_7745c5c3_Var24 string
 		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.ResolveAttributeValue(wizardSaveExitURL(data.SessionID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 187, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 199, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var24)
 		if templ_7745c5c3_Err != nil {
@@ -532,7 +547,7 @@ func ReIdentifyWizardStep(data ReIdentifyWizardStepData) templ.Component {
 		var templ_7745c5c3_Var25 string
 		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.wizard.save_exit"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 196, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 208, Col: 57}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 		if templ_7745c5c3_Err != nil {
@@ -586,7 +601,7 @@ func reIdentifyWizardCandidates(data ReIdentifyWizardStepData) templ.Component {
 			var templ_7745c5c3_Var27 string
 			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(wizardStepURL(data.SessionID, data.Index))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 215, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 227, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var27)
 			if templ_7745c5c3_Err != nil {
@@ -603,7 +618,7 @@ func reIdentifyWizardCandidates(data ReIdentifyWizardStepData) templ.Component {
 			var templ_7745c5c3_Var28 string
 			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.wizard.loading"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 221, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 233, Col: 53}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
@@ -621,7 +636,7 @@ func reIdentifyWizardCandidates(data ReIdentifyWizardStepData) templ.Component {
 			var templ_7745c5c3_Var29 string
 			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.wizard.no_candidates"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 224, Col: 98}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 236, Col: 98}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 			if templ_7745c5c3_Err != nil {
@@ -644,7 +659,7 @@ func reIdentifyWizardCandidates(data ReIdentifyWizardStepData) templ.Component {
 				var templ_7745c5c3_Var30 string
 				templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(wizardActionURL(data.SessionID, data.Index, "accept"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 232, Col: 69}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 244, Col: 69}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
 				if templ_7745c5c3_Err != nil {
@@ -657,7 +672,7 @@ func reIdentifyWizardCandidates(data ReIdentifyWizardStepData) templ.Component {
 				var templ_7745c5c3_Var31 string
 				templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(wizardAcceptVals(c.MBID))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 233, Col: 40}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 245, Col: 40}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var31)
 				if templ_7745c5c3_Err != nil {
@@ -670,7 +685,7 @@ func reIdentifyWizardCandidates(data ReIdentifyWizardStepData) templ.Component {
 				var templ_7745c5c3_Var32 string
 				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "image.linking_and_refreshing"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 244, Col: 114}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 256, Col: 114}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 				if templ_7745c5c3_Err != nil {
@@ -683,7 +698,7 @@ func reIdentifyWizardCandidates(data ReIdentifyWizardStepData) templ.Component {
 				var templ_7745c5c3_Var33 string
 				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(c.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 248, Col: 49}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 260, Col: 49}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 				if templ_7745c5c3_Err != nil {
@@ -701,7 +716,7 @@ func reIdentifyWizardCandidates(data ReIdentifyWizardStepData) templ.Component {
 					var templ_7745c5c3_Var34 string
 					templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(c.Disambiguation)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 251, Col: 50}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 263, Col: 50}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 					if templ_7745c5c3_Err != nil {
@@ -720,7 +735,7 @@ func reIdentifyWizardCandidates(data ReIdentifyWizardStepData) templ.Component {
 					var templ_7745c5c3_Var35 string
 					templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(c.Origin)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 254, Col: 39}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 266, Col: 39}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 					if templ_7745c5c3_Err != nil {
@@ -743,7 +758,7 @@ func reIdentifyWizardCandidates(data ReIdentifyWizardStepData) templ.Component {
 					var templ_7745c5c3_Var36 string
 					templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(c.MBID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 258, Col: 82}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 270, Col: 82}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 					if templ_7745c5c3_Err != nil {
@@ -766,7 +781,7 @@ func reIdentifyWizardCandidates(data ReIdentifyWizardStepData) templ.Component {
 					var templ_7745c5c3_Var37 string
 					templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(c.ConfidencePct))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 263, Col: 46}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 275, Col: 46}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 					if templ_7745c5c3_Err != nil {
@@ -825,7 +840,7 @@ func reIdentifyWizardErrorBanner(data ReIdentifyWizardStepData) templ.Component 
 		var templ_7745c5c3_Var39 string
 		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.wizard.error.heading"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 285, Col: 83}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 297, Col: 83}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 		if templ_7745c5c3_Err != nil {
@@ -843,7 +858,7 @@ func reIdentifyWizardErrorBanner(data ReIdentifyWizardStepData) templ.Component 
 			var templ_7745c5c3_Var40 string
 			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(data.ErrMsg)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 287, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 299, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 			if templ_7745c5c3_Err != nil {
@@ -861,7 +876,7 @@ func reIdentifyWizardErrorBanner(data ReIdentifyWizardStepData) templ.Component 
 		var templ_7745c5c3_Var41 string
 		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.ResolveAttributeValue(wizardRetryURL(data.SessionID, data.Index))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 292, Col: 55}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 304, Col: 55}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var41)
 		if templ_7745c5c3_Err != nil {
@@ -874,7 +889,7 @@ func reIdentifyWizardErrorBanner(data ReIdentifyWizardStepData) templ.Component 
 		var templ_7745c5c3_Var42 string
 		templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.wizard.error.retry"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 301, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 313, Col: 57}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 		if templ_7745c5c3_Err != nil {
@@ -917,7 +932,7 @@ func ReIdentifyWizardDone(data ReIdentifyWizardDoneData) templ.Component {
 		var templ_7745c5c3_Var44 string
 		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.wizard.done.title"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 309, Col: 89}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 321, Col: 89}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 		if templ_7745c5c3_Err != nil {
@@ -930,7 +945,7 @@ func ReIdentifyWizardDone(data ReIdentifyWizardDoneData) templ.Component {
 		var templ_7745c5c3_Var45 string
 		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(tf(ctx, "artists.bulk.reidentify.wizard.done.summary", data.Accepted, data.Skipped, data.Declined, data.Total))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 311, Col: 115}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 323, Col: 115}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 		if templ_7745c5c3_Err != nil {
@@ -943,7 +958,7 @@ func ReIdentifyWizardDone(data ReIdentifyWizardDoneData) templ.Component {
 		var templ_7745c5c3_Var46 templ.SafeURL
 		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(basePath() + "/artists"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 315, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 327, Col: 49}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 		if templ_7745c5c3_Err != nil {
@@ -956,7 +971,7 @@ func ReIdentifyWizardDone(data ReIdentifyWizardDoneData) templ.Component {
 		var templ_7745c5c3_Var47 string
 		templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(t(ctx, "artists.bulk.reidentify.wizard.done.back_to_artists"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 318, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/reidentify_wizard.templ`, Line: 330, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

- Surfaces a warning banner when one or more providers fail during disambiguation search, instead of returning silent empty results that look identical to "no matches found". Users previously misread an all-providers-errored state as "(Re-)Identify is broken" and went debugging Stillwater code when the real issue was provider configuration.
- Threads per-provider status through `SearchForLinking` -> `handleRefreshSearch` -> `DisambiguationResults`, and through the re-identify wizard's per-step search renderer. Adds i18n keys for the banner copy and unit + render tests for the new error-path shape.
- Out of scope per #1663: `executeRefresh` / `FetchMetadata` swallow and image-search swallow. Same pattern, separate surfaces; track in follow-up issues if desired.

## Linked issue

Closes #1663

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`), or run via `/prep-pr` / `/pr-review-toolkit:review-pr` which invokes it.
- [x] Code review pass complete (`/prep-pr` or `/pr-review-toolkit:review-pr`); critical and important findings fixed before pushing.
- [x] Commits squashed into clean, logical commits before the first push (Copilot reviews the diff at PR open).
- [x] At least one label set on `gh pr create --label ...` (the CI label gate fails without one).
- [x] Docs label decision made: `needs-docs-review` for user-visible changes, `docs: not-required` for test, CI, or refactor PRs with no user-visible behavioral change.
- [ ] Screenshot attached for any UI change. (Captured locally as `uat-1663-disambig.png` and `uat-1663-wizard.png`; `uat-*.png` is gitignored in this repo so the screenshots cannot be committed without a `.gitignore` change. The disambig screenshot shows the new amber "Some providers could not be reached" banner above the 12 Stones candidate list with Discogs revoked.)
- [x] UAT performed for user-visible changes (run the binary, not just the test suite). Reproduced against the running localhost:1973 instance with a deliberately revoked Discogs key; banner rendered with `Discogs` listed and MusicBrainz results still shown.
- [x] OpenAPI spec updated if any request or response shape changed (`make check-openapi`). Added `failed_providers` to the `refreshSearch` 200-response schema.
- [x] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed.

## Test plan

- [x] `go test -race ./...` passes locally.
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] Manual UAT steps (list the specific flows exercised):
  - [x] Re-identified 12 Stones via the artist detail page with Discogs key revoked; banner appeared above the MusicBrainz candidate list naming "Discogs" as unreachable.
  - [x] Restored the Discogs key, re-ran the same search; banner did not render (legitimate "all providers succeeded" state stays distinct).
  - [x] Started the re-identify wizard on the same artist; step rendered the candidate list without the partial-failure banner (wizard only queries MusicBrainz, so any failure routes through the existing Failed-state Retry banner; the new banner field is wired in for future multi-provider wizard queries).
- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
  - [ ] Patch coverage was measured at 95% locally with `PATCH_COVERAGE_EXCLUDE="web/templates/*_templ.go"` (codecov.yml already ignores generated templ files). Without that exclude the local script reports 31% because it includes regenerated `_templ.go` blocks. CI codecov should match the 95% figure.
  - [ ] Wizard banner branch is reachable but currently unused (wizard queries one provider only). The field is plumbed end-to-end and rendered when non-empty so a future change adding Discogs to the wizard query lights it up without an extra patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disambiguation search now shows a visible warning banner when one or more metadata providers are unreachable; the re-identify wizard also surfaces this banner per step.
  * API responses optionally include a failed_providers list to distinguish provider errors from empty results.

* **Documentation**
  * OpenAPI updated to document the optional failed_providers response field.

* **Tests**
  * Added end-to-end and template tests covering provider-failure handling and banner rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->