### PR TITLE
chore(release): add OCI base-image labels via goreleaser v2.16 (#1667)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,6 +56,19 @@ dockers_v2:
       - "{{ if not .Prerelease }}{{ .Major }}.{{ .Minor }}{{ end }}"
       - "{{ if not .Prerelease }}latest{{ end }}"
       - "{{ if .Prerelease }}beta{{ end }}"
+    # Standard OCI labels surfaced by GHCR, Docker Hub, Grype, Scorecard,
+    # and most registry / scanner UIs without further configuration.
+    # .BaseImage / .BaseImageDigest are parsed from the FROM line of the
+    # dockerfile below at release time (goreleaser v2.16+), so the base
+    # layer's digest pin in Dockerfile.goreleaser is the single source of
+    # truth -- no drift risk from duplicating the digest here.
+    labels:
+      org.opencontainers.image.base.name: "{{ .BaseImage }}"
+      org.opencontainers.image.base.digest: "{{ .BaseImageDigest }}"
+      org.opencontainers.image.source: "https://github.com/sydlexius/stillwater"
+      org.opencontainers.image.licenses: "GPL-3.0"
+      org.opencontainers.image.version: "{{ .Version }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
     dockerfile: build/docker/Dockerfile.goreleaser
     platforms:
       - linux/amd64


### PR DESCRIPTION
## Summary

- Adds the standard OCI label set to the `dockers_v2` block in `.goreleaser.yml`, using the new `.BaseImage` / `.BaseImageDigest` template variables introduced in goreleaser v2.16. These read the `FROM` line of `build/docker/Dockerfile.goreleaser` at build time, so the alpine digest pin stays the single source of truth -- no drift risk from duplicating the digest in two places.
- Previously `docker inspect ghcr.io/sydlexius/stillwater` showed an empty `Config.Labels` map. After this change the published image carries `base.name`, `base.digest`, `source`, `licenses`, `version`, and `revision`, which GHCR's UI, Docker Hub, Grype, Scorecard, and most registry / scanner tooling read without further configuration.
- Pairs naturally with the existing cosign-by-digest signing (`.goreleaser.yml:83`): consumers can now see at a glance what base layer underlies the signed image.

## Linked issue

Closes #1667

## Pre-flight checklist

- [x] Pre-push gate green locally -- skipped intentionally; release-config-only change, no Go / .templ / OpenAPI surface touched. `goreleaser check` validated YAML schema.
- [x] Code review pass complete -- self-review against goreleaser v2.16 release notes and `dockers_v2` schema.
- [x] Commits squashed into clean, logical commits before the first push (single commit).
- [x] At least one label set on `gh pr create --label ...`.
- [x] Docs label decision made: `docs: not-required` -- no user-visible behavioral change.
- [ ] Screenshot attached for any UI change -- n/a.
- [x] UAT performed for user-visible changes -- n/a for runtime; validated via local snapshot build (see Test plan).
- [ ] OpenAPI spec updated if any request or response shape changed -- n/a.
- [ ] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed -- n/a.

## Test plan

- [x] `goreleaser check` validates the modified config.
- [x] Local snapshot build with goreleaser v2.16.0 confirms labels render correctly:
  ```
  goreleaser release --snapshot --clean --skip=publish,sign,validate,before
  ```
  `docker inspect ghcr.io/sydlexius/stillwater:nightly-...-arm64 --format '{{ json .Config.Labels }}'` returns all six labels populated, with `base.digest` matching `Dockerfile.goreleaser:1` byte-for-byte (`sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11`).
- Reviewer follow-ups:
  - First real-world verification happens on the next release tag (v1.4.0 or whichever lands first), since the goreleaser-action pulls `version: latest` and v2.16 is already current.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image metadata by adding OCI standard labels, including source repository, license, version, and revision information for improved image documentation and discoverability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->