### PR TITLE
feat(m52): platform write observability -- ErrAuthRequired sentinels, Lidarr verify-after-PUT, PushMetadataAsync notify parity

### DIFF
--- a/internal/connection/emby/client.go
+++ b/internal/connection/emby/client.go
@@ -23,31 +23,32 @@ import (
 // ErrInvalidCredentials is returned when the media server rejects the
 // credentials during the AuthenticateByName handshake. Scoped to the initial
 // username/password exchange; write methods report auth-class failures via
-// ErrAuth (see below).
+// ErrAuthRequired (see below).
 var ErrInvalidCredentials = errors.New("invalid credentials")
 
-// ErrAuth is the sentinel wrapped by write-method failures when the peer
-// returns a 401 or 403. Callers in the publish layer use
-// errors.Is(err, emby.ErrAuth) to surface a per-connection re-auth signal
-// without parsing the formatted error string. Distinct from
-// ErrInvalidCredentials (which is scoped to the username/password handshake)
-// because the API-key write path has its own re-auth UI signal.
-var ErrAuth = errors.New("emby: authentication required")
+// ErrAuthRequired is the sentinel wrapped by write-method failures when the
+// peer returns a 401 or 403. Callers in the publish layer use
+// errors.Is(err, emby.ErrAuthRequired) so publish.classifyPushErr maps the
+// failure to the auth_failed class consumed by the per-connection
+// push-failure toast. Distinct from ErrInvalidCredentials (which is scoped
+// to the username/password handshake) because the API-key write path has
+// its own re-auth UI signal.
+var ErrAuthRequired = errors.New("emby: authentication required")
 
 // wrapAuthIfStatusAuth detects an httpclient.StatusError whose code is 401 or
-// 403 and wraps the original error with ErrAuth. Used by every write method
-// in this package so the publish layer can route auth-class failures to a
-// re-auth UI signal without parsing the formatted error string. The original
-// error is preserved (still %w-wrapped) so the existing classifyPushErr
-// substring contract on err.Error() continues to match the "HTTP 401" /
-// "status 401" surface.
+// 403 and wraps the original error with ErrAuthRequired. Used by every write
+// method in this package so the publish layer can route auth-class failures
+// to a re-auth UI signal without parsing the formatted error string. The
+// original error is preserved (still %w-wrapped) so the existing
+// classifyPushErr substring contract on err.Error() continues to match the
+// "HTTP 401" / "status 401" surface.
 func wrapAuthIfStatusAuth(err error) error {
 	if err == nil {
 		return nil
 	}
 	var se *httpclient.StatusError
 	if errors.As(err, &se) && se.IsAuth() {
-		return fmt.Errorf("%w: %w", ErrAuth, err)
+		return fmt.Errorf("%w: %w", ErrAuthRequired, err)
 	}
 	return err
 }

--- a/internal/connection/emby/client.go
+++ b/internal/connection/emby/client.go
@@ -194,7 +194,7 @@ func (c *Client) GetArtists(ctx context.Context, libraryID string, startIndex, l
 // TriggerLibraryScan triggers a full library scan.
 func (c *Client) TriggerLibraryScan(ctx context.Context) error {
 	if err := c.Post(ctx, "/Library/Refresh", nil); err != nil {
-		return fmt.Errorf("triggering library scan: %w", err)
+		return fmt.Errorf("triggering library scan: %w", wrapAuthIfStatusAuth(err))
 	}
 	return nil
 }
@@ -203,7 +203,7 @@ func (c *Client) TriggerLibraryScan(ctx context.Context) error {
 func (c *Client) TriggerArtistRefresh(ctx context.Context, artistID string) error {
 	path := fmt.Sprintf("/Items/%s/Refresh", artistID)
 	if err := c.Post(ctx, path, nil); err != nil {
-		return fmt.Errorf("triggering artist refresh: %w", err)
+		return fmt.Errorf("triggering artist refresh: %w", wrapAuthIfStatusAuth(err))
 	}
 	return nil
 }
@@ -434,7 +434,7 @@ func (c *Client) DisableConflictingSettings(ctx context.Context, libraryID strin
 	}
 
 	path := fmt.Sprintf("/Library/VirtualFolders/LibraryOptions?Id=%s", libraryID)
-	return c.PostJSON(ctx, path, bytes.NewReader(body), nil)
+	return wrapAuthIfStatusAuth(c.PostJSON(ctx, path, bytes.NewReader(body), nil))
 }
 
 // UpdateArtistLocks persists the given field-level lock list and whole-item lock

--- a/internal/connection/emby/client.go
+++ b/internal/connection/emby/client.go
@@ -20,8 +20,37 @@ import (
 	"github.com/sydlexius/stillwater/internal/version"
 )
 
-// ErrInvalidCredentials is returned when the media server rejects the credentials.
+// ErrInvalidCredentials is returned when the media server rejects the
+// credentials during the AuthenticateByName handshake. Scoped to the initial
+// username/password exchange; write methods report auth-class failures via
+// ErrAuth (see below).
 var ErrInvalidCredentials = errors.New("invalid credentials")
+
+// ErrAuth is the sentinel wrapped by write-method failures when the peer
+// returns a 401 or 403. Callers in the publish layer use
+// errors.Is(err, emby.ErrAuth) to surface a per-connection re-auth signal
+// without parsing the formatted error string. Distinct from
+// ErrInvalidCredentials (which is scoped to the username/password handshake)
+// because the API-key write path has its own re-auth UI signal.
+var ErrAuth = errors.New("emby: authentication required")
+
+// wrapAuthIfStatusAuth detects an httpclient.StatusError whose code is 401 or
+// 403 and wraps the original error with ErrAuth. Used by every write method
+// in this package so the publish layer can route auth-class failures to a
+// re-auth UI signal without parsing the formatted error string. The original
+// error is preserved (still %w-wrapped) so the existing classifyPushErr
+// substring contract on err.Error() continues to match the "HTTP 401" /
+// "status 401" surface.
+func wrapAuthIfStatusAuth(err error) error {
+	if err == nil {
+		return nil
+	}
+	var se *httpclient.StatusError
+	if errors.As(err, &se) && se.IsAuth() {
+		return fmt.Errorf("%w: %w", ErrAuth, err)
+	}
+	return err
+}
 
 // Client communicates with an Emby server.
 type Client struct {
@@ -444,7 +473,7 @@ func (c *Client) UpdateArtistLocks(ctx context.Context, platformArtistID string,
 	}
 	path := fmt.Sprintf("/Items/%s", platformArtistID)
 	if err := c.PostJSON(ctx, path, bytes.NewReader(body), nil); err != nil {
-		return fmt.Errorf("posting artist lock update: %w", err)
+		return fmt.Errorf("posting artist lock update: %w", wrapAuthIfStatusAuth(err))
 	}
 	return nil
 }
@@ -491,7 +520,7 @@ func (c *Client) UpdateArtistPath(ctx context.Context, platformArtistID, newPath
 	}
 	postPath := fmt.Sprintf("/Items/%s", escapedID)
 	if err := c.PostJSON(ctx, postPath, bytes.NewReader(body), nil); err != nil {
-		return fmt.Errorf("posting artist path update: %w", err)
+		return fmt.Errorf("posting artist path update: %w", wrapAuthIfStatusAuth(err))
 	}
 	return nil
 }

--- a/internal/connection/emby/client_test.go
+++ b/internal/connection/emby/client_test.go
@@ -1607,7 +1607,7 @@ func TestUpdateArtistPath_EmptyNewPath(t *testing.T) {
 }
 
 // TestUpdateArtistPath_AuthClass401 verifies that a 401 response on the
-// POST half of UpdateArtistPath is wrapped with the ErrAuth sentinel so
+// POST half of UpdateArtistPath is wrapped with the ErrAuthRequired sentinel so
 // the publish layer can route the failure to a per-connection re-auth UI
 // signal via errors.Is rather than parsing the formatted message string.
 func TestUpdateArtistPath_AuthClass401(t *testing.T) {
@@ -1626,8 +1626,8 @@ func TestUpdateArtistPath_AuthClass401(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on 401")
 	}
-	if !errors.Is(err, ErrAuth) {
-		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
 	}
 }
 
@@ -1649,13 +1649,13 @@ func TestUpdateArtistPath_AuthClass403(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on 403")
 	}
-	if !errors.Is(err, ErrAuth) {
-		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
 	}
 }
 
 // TestUpdateArtistPath_NonAuthErrorNotWrapped verifies that non-auth status
-// codes (5xx) DO NOT wrap with ErrAuth -- those are server-side faults the
+// codes (5xx) DO NOT wrap with ErrAuthRequired -- those are server-side faults the
 // publish layer routes to a different toast class (server_error, retry).
 func TestUpdateArtistPath_NonAuthErrorNotWrapped(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1673,13 +1673,13 @@ func TestUpdateArtistPath_NonAuthErrorNotWrapped(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on 500")
 	}
-	if errors.Is(err, ErrAuth) {
-		t.Errorf("errors.Is(err, ErrAuth) = true on 500; want false")
+	if errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = true on 500; want false")
 	}
 }
 
 // TestPushMetadata_AuthClass401 verifies the PushMetadata write path wraps
-// 401 responses with ErrAuth so the publish layer can detect auth failures
+// 401 responses with ErrAuthRequired so the publish layer can detect auth failures
 // from PushMetadataAsync's notify path (per issue #1639).
 func TestPushMetadata_AuthClass401(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1692,7 +1692,7 @@ func TestPushMetadata_AuthClass401(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on 401")
 	}
-	if !errors.Is(err, ErrAuth) {
-		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
 	}
 }

--- a/internal/connection/emby/client_test.go
+++ b/internal/connection/emby/client_test.go
@@ -1740,3 +1740,30 @@ func TestUploadImage_AuthClass401(t *testing.T) {
 		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
 	}
 }
+
+// TestPushMetadata_AuthClass401_DualContract pins the dual-contract that
+// any future "single-wrap" refactor would break: the same joined error
+// must satisfy BOTH errors.Is(err, ErrAuthRequired) (the typed sentinel
+// consumed by publish.classifyPushErr's auth_failed branch via the
+// errors.Is(_, ErrAuthRequired) fast path that will land alongside the
+// existing string match) AND strings.Contains(err.Error(), "status 401")
+// (the substring contract that classifyPushErr relies on today). Either
+// half going missing breaks the toast taxonomy.
+func TestPushMetadata_AuthClass401_DualContract(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "test-key", "", srv.Client(), testLogger())
+	err := c.PushMetadata(context.Background(), "emby-001", connection.ArtistPushData{Name: "Test"})
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
+	}
+	if !strings.Contains(err.Error(), "status 401") {
+		t.Errorf("err.Error() = %q; want substring \"status 401\"", err.Error())
+	}
+}

--- a/internal/connection/emby/client_test.go
+++ b/internal/connection/emby/client_test.go
@@ -1605,3 +1605,94 @@ func TestUpdateArtistPath_EmptyNewPath(t *testing.T) {
 		t.Fatal("expected error on whitespace-only newPath")
 	}
 }
+
+// TestUpdateArtistPath_AuthClass401 verifies that a 401 response on the
+// POST half of UpdateArtistPath is wrapped with the ErrAuth sentinel so
+// the publish layer can route the failure to a per-connection re-auth UI
+// signal via errors.Is rather than parsing the formatted message string.
+func TestUpdateArtistPath_AuthClass401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Id":"a1","Name":"Test","Path":"/old"}`))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "test-key", "user-1", srv.Client(), testLogger())
+	err := c.UpdateArtistPath(context.Background(), "a1", "/new")
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !errors.Is(err, ErrAuth) {
+		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	}
+}
+
+// TestUpdateArtistPath_AuthClass403 mirrors AuthClass401 for the 403 branch.
+// The publish layer treats both as the same re-auth class so both must wrap.
+func TestUpdateArtistPath_AuthClass403(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Id":"a1","Name":"Test","Path":"/old"}`))
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "test-key", "user-1", srv.Client(), testLogger())
+	err := c.UpdateArtistPath(context.Background(), "a1", "/new")
+	if err == nil {
+		t.Fatal("expected error on 403")
+	}
+	if !errors.Is(err, ErrAuth) {
+		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	}
+}
+
+// TestUpdateArtistPath_NonAuthErrorNotWrapped verifies that non-auth status
+// codes (5xx) DO NOT wrap with ErrAuth -- those are server-side faults the
+// publish layer routes to a different toast class (server_error, retry).
+func TestUpdateArtistPath_NonAuthErrorNotWrapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Id":"a1","Name":"Test","Path":"/old"}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "test-key", "user-1", srv.Client(), testLogger())
+	err := c.UpdateArtistPath(context.Background(), "a1", "/new")
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if errors.Is(err, ErrAuth) {
+		t.Errorf("errors.Is(err, ErrAuth) = true on 500; want false")
+	}
+}
+
+// TestPushMetadata_AuthClass401 verifies the PushMetadata write path wraps
+// 401 responses with ErrAuth so the publish layer can detect auth failures
+// from PushMetadataAsync's notify path (per issue #1639).
+func TestPushMetadata_AuthClass401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "test-key", "", srv.Client(), testLogger())
+	err := c.PushMetadata(context.Background(), "emby-001", connection.ArtistPushData{Name: "Test"})
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !errors.Is(err, ErrAuth) {
+		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	}
+}

--- a/internal/connection/emby/client_test.go
+++ b/internal/connection/emby/client_test.go
@@ -1696,3 +1696,47 @@ func TestPushMetadata_AuthClass401(t *testing.T) {
 		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
 	}
 }
+
+// TestUpdateArtistLocks_AuthClass401 mirrors TestUpdateArtistPath_AuthClass401
+// for the lock-toggle write path. PushLocks runs through UpdateArtistLocks,
+// so a 401 here must wrap with ErrAuthRequired or the lock-toggle toast
+// loses its auth_failed classification.
+func TestUpdateArtistLocks_AuthClass401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Id":"a1","Name":"Test","LockData":false,"LockedFields":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "test-key", "user-1", srv.Client(), testLogger())
+	err := c.UpdateArtistLocks(context.Background(), "a1", true, []string{"name"})
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
+	}
+}
+
+// TestUploadImage_AuthClass401 covers the image-write surface. Image syncs
+// share the per-connection observability path with PushMetadata, so a 401
+// here must wrap with ErrAuthRequired alongside the metadata write methods.
+func TestUploadImage_AuthClass401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "test-key", "", srv.Client(), testLogger())
+	err := c.UploadImage(context.Background(), "emby-001", "thumb", []byte{1, 2, 3}, "image/jpeg")
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
+	}
+}

--- a/internal/connection/emby/push.go
+++ b/internal/connection/emby/push.go
@@ -16,18 +16,6 @@ import (
 	"github.com/sydlexius/stillwater/internal/connection/httpclient"
 )
 
-// readBoundedStatusError builds an httpclient.StatusError from a non-2xx
-// response, capping the body at 1 MB to guard against a misbehaving peer
-// returning a huge HTML error page. Used by every hand-rolled HTTP path in
-// this file so write-method errors carry the typed status code for
-// ErrAuthRequired detection without re-parsing strings.
-func readBoundedStatusError(resp *http.Response) *httpclient.StatusError {
-	const maxErrBody = 1 << 20 // 1 MB
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-	_, _ = io.Copy(io.Discard, resp.Body)
-	return &httpclient.StatusError{StatusCode: resp.StatusCode, Body: string(respBody)}
-}
-
 // tagItem is a named tag for Emby's TagItems field.
 // Emby uses {Name, Id} objects instead of flat strings; only Name is required
 // when writing.
@@ -127,7 +115,7 @@ func (c *Client) PushMetadata(ctx context.Context, platformArtistID string, data
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		statusErr := readBoundedStatusError(resp)
+		statusErr := httpclient.ReadBoundedStatusError(resp)
 		// Historical error wording preserved ("push failed with status N: body")
 		// for test fixtures and operator log familiarity; errors.Join attaches
 		// the typed StatusError as a sibling in the error tree so
@@ -227,7 +215,7 @@ func (c *Client) UploadImage(ctx context.Context, platformArtistID string, image
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		statusErr := readBoundedStatusError(resp)
+		statusErr := httpclient.ReadBoundedStatusError(resp)
 		formatted := fmt.Errorf("image upload failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
 		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
@@ -266,7 +254,7 @@ func (c *Client) UploadImageAtIndex(ctx context.Context, platformArtistID string
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		statusErr := readBoundedStatusError(resp)
+		statusErr := httpclient.ReadBoundedStatusError(resp)
 		formatted := fmt.Errorf("indexed image upload failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
 		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
@@ -298,7 +286,7 @@ func (c *Client) DeleteImage(ctx context.Context, platformArtistID string, image
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		statusErr := readBoundedStatusError(resp)
+		statusErr := httpclient.ReadBoundedStatusError(resp)
 		formatted := fmt.Errorf("image delete failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
 		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}

--- a/internal/connection/emby/push.go
+++ b/internal/connection/emby/push.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,20 @@ import (
 	"strings"
 
 	"github.com/sydlexius/stillwater/internal/connection"
+	"github.com/sydlexius/stillwater/internal/connection/httpclient"
 )
+
+// readBoundedStatusError builds an httpclient.StatusError from a non-2xx
+// response, capping the body at 1 MB to guard against a misbehaving peer
+// returning a huge HTML error page. Used by every hand-rolled HTTP path in
+// this file so write-method errors carry the typed status code for ErrAuth
+// detection without re-parsing strings.
+func readBoundedStatusError(resp *http.Response) *httpclient.StatusError {
+	const maxErrBody = 1 << 20 // 1 MB
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return &httpclient.StatusError{StatusCode: resp.StatusCode, Body: string(respBody)}
+}
 
 // tagItem is a named tag for Emby's TagItems field.
 // Emby uses {Name, Id} objects instead of flat strings; only Name is required
@@ -113,10 +127,14 @@ func (c *Client) PushMetadata(ctx context.Context, platformArtistID string, data
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		const maxErrBody = 1 << 20 // 1 MB
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("push failed with status %d: %s", resp.StatusCode, string(respBody))
+		statusErr := readBoundedStatusError(resp)
+		// Historical error wording preserved ("push failed with status N: body")
+		// for test fixtures and operator log familiarity; errors.Join attaches
+		// the typed StatusError as a sibling in the error tree so
+		// wrapAuthIfStatusAuth (via errors.As) can still detect 401/403 and
+		// route to ErrAuth without duplicating the status string in Error().
+		formatted := fmt.Errorf("push failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
+		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
 
 	_, _ = io.Copy(io.Discard, resp.Body)
@@ -208,10 +226,9 @@ func (c *Client) UploadImage(ctx context.Context, platformArtistID string, image
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		const maxErrBody = 1 << 20 // 1 MB
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("image upload failed with status %d: %s", resp.StatusCode, string(respBody))
+		statusErr := readBoundedStatusError(resp)
+		formatted := fmt.Errorf("image upload failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
+		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
 
 	_, _ = io.Copy(io.Discard, resp.Body)
@@ -248,10 +265,9 @@ func (c *Client) UploadImageAtIndex(ctx context.Context, platformArtistID string
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		const maxErrBody = 1 << 20 // 1 MB
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("indexed image upload failed with status %d: %s", resp.StatusCode, string(respBody))
+		statusErr := readBoundedStatusError(resp)
+		formatted := fmt.Errorf("indexed image upload failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
+		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
 
 	_, _ = io.Copy(io.Discard, resp.Body)
@@ -281,10 +297,9 @@ func (c *Client) DeleteImage(ctx context.Context, platformArtistID string, image
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		const maxErrBody = 1 << 20 // 1 MB
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("image delete failed with status %d: %s", resp.StatusCode, string(respBody))
+		statusErr := readBoundedStatusError(resp)
+		formatted := fmt.Errorf("image delete failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
+		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
 
 	_, _ = io.Copy(io.Discard, resp.Body)

--- a/internal/connection/emby/push.go
+++ b/internal/connection/emby/push.go
@@ -19,8 +19,8 @@ import (
 // readBoundedStatusError builds an httpclient.StatusError from a non-2xx
 // response, capping the body at 1 MB to guard against a misbehaving peer
 // returning a huge HTML error page. Used by every hand-rolled HTTP path in
-// this file so write-method errors carry the typed status code for ErrAuth
-// detection without re-parsing strings.
+// this file so write-method errors carry the typed status code for
+// ErrAuthRequired detection without re-parsing strings.
 func readBoundedStatusError(resp *http.Response) *httpclient.StatusError {
 	const maxErrBody = 1 << 20 // 1 MB
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
@@ -132,7 +132,8 @@ func (c *Client) PushMetadata(ctx context.Context, platformArtistID string, data
 		// for test fixtures and operator log familiarity; errors.Join attaches
 		// the typed StatusError as a sibling in the error tree so
 		// wrapAuthIfStatusAuth (via errors.As) can still detect 401/403 and
-		// route to ErrAuth without duplicating the status string in Error().
+		// route to ErrAuthRequired without duplicating the status string in
+		// Error().
 		formatted := fmt.Errorf("push failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
 		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}

--- a/internal/connection/httpclient/client.go
+++ b/internal/connection/httpclient/client.go
@@ -60,6 +60,22 @@ func readErrorBody(r io.Reader) string {
 	return string(buf)
 }
 
+// ReadBoundedStatusError builds a StatusError from a non-2xx response,
+// capping the body at 1 MB to guard against a misbehaving peer returning a
+// huge HTML error page. Used by the hand-rolled HTTP paths in emby/push.go
+// and jellyfin/push.go so write-method errors carry the typed status code
+// for ErrAuthRequired detection without re-parsing strings. The 1 MB cap
+// is intentionally larger than readErrorBody's 1 KB so write-method errors
+// preserve enough diagnostic body for operators to debug a 4xx/5xx from
+// the peer; the smaller readErrorBody cap stays in place for the
+// BaseClient helpers where errors typically fit in a single sentence.
+func ReadBoundedStatusError(resp *http.Response) *StatusError {
+	const maxErrBody = 1 << 20 // 1 MB
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return &StatusError{StatusCode: resp.StatusCode, Body: string(respBody)}
+}
+
 // BaseClient holds the common fields and HTTP transport methods shared by all platform clients.
 type BaseClient struct {
 	HTTPClient *http.Client

--- a/internal/connection/httpclient/client.go
+++ b/internal/connection/httpclient/client.go
@@ -11,6 +11,36 @@ import (
 	"github.com/sydlexius/stillwater/internal/connection"
 )
 
+// StatusError is returned by the base HTTP helpers when the peer returns a
+// non-2xx response. It exposes the raw status code (and a bounded snippet of
+// the response body) so per-package callers can route auth-class failures
+// (401/403) to a typed sentinel like emby.ErrAuth without re-parsing the
+// formatted error string. The string form preserves the historical
+// "unexpected status N: body" shape so existing callers and tests that
+// substring-match on err.Error() are unaffected.
+type StatusError struct {
+	StatusCode int
+	Body       string
+}
+
+// Error renders the status-error in the historical "unexpected status N: body"
+// shape so callers that grep err.Error() (notably publish.classifyPushErr,
+// which looks for "status 401"/"HTTP 401"/"status 5" substrings) keep
+// working untouched. Per-package write methods that already include their
+// own "X failed with status %d" prefix should %w the StatusError to keep
+// the typed code available without duplicating the status string; see
+// emby/push.go and jellyfin/push.go for the pattern.
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("unexpected status %d: %s", e.StatusCode, e.Body)
+}
+
+// IsAuth reports whether the status code is in the auth-class set (401 or
+// 403). Used by per-package write methods to decide whether to wrap with
+// the package-level ErrAuth sentinel.
+func (e *StatusError) IsAuth() bool {
+	return e.StatusCode == http.StatusUnauthorized || e.StatusCode == http.StatusForbidden
+}
+
 // readErrorBody reads up to 1 KB of body for use in error messages, then
 // drains any remaining bytes so the HTTP transport can reuse the connection.
 func readErrorBody(r io.Reader) string {
@@ -62,7 +92,7 @@ func (b *BaseClient) Get(ctx context.Context, path string, result any) error {
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, readErrorBody(resp.Body))
+		return &StatusError{StatusCode: resp.StatusCode, Body: readErrorBody(resp.Body)}
 	}
 
 	if result != nil {
@@ -89,7 +119,7 @@ func (b *BaseClient) Post(ctx context.Context, path string, body io.Reader) erro
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, readErrorBody(resp.Body))
+		return &StatusError{StatusCode: resp.StatusCode, Body: readErrorBody(resp.Body)}
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
@@ -111,7 +141,7 @@ func (b *BaseClient) GetRaw(ctx context.Context, path string) ([]byte, string, e
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", fmt.Errorf("unexpected status %d: %s", resp.StatusCode, readErrorBody(resp.Body))
+		return nil, "", &StatusError{StatusCode: resp.StatusCode, Body: readErrorBody(resp.Body)}
 	}
 
 	const maxImageSize = 25 << 20 // 25 MB
@@ -143,7 +173,7 @@ func (b *BaseClient) PutJSON(ctx context.Context, path string, body io.Reader, r
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, readErrorBody(resp.Body))
+		return &StatusError{StatusCode: resp.StatusCode, Body: readErrorBody(resp.Body)}
 	}
 
 	if result != nil {
@@ -172,7 +202,7 @@ func (b *BaseClient) PostJSON(ctx context.Context, path string, body io.Reader, 
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, readErrorBody(resp.Body))
+		return &StatusError{StatusCode: resp.StatusCode, Body: readErrorBody(resp.Body)}
 	}
 
 	if result != nil {

--- a/internal/connection/httpclient/client.go
+++ b/internal/connection/httpclient/client.go
@@ -14,8 +14,8 @@ import (
 // StatusError is returned by the base HTTP helpers when the peer returns a
 // non-2xx response. It exposes the raw status code (and a bounded snippet of
 // the response body) so per-package callers can route auth-class failures
-// (401/403) to a typed sentinel like emby.ErrAuth without re-parsing the
-// formatted error string. The string form preserves the historical
+// (401/403) to a typed sentinel like emby.ErrAuthRequired without re-parsing
+// the formatted error string. The string form preserves the historical
 // "unexpected status N: body" shape so existing callers and tests that
 // substring-match on err.Error() are unaffected.
 type StatusError struct {
@@ -23,20 +23,31 @@ type StatusError struct {
 	Body       string
 }
 
+// NewStatusError builds a StatusError for the given status and body, or
+// returns nil for 2xx codes so callers can use it directly in a return
+// statement without re-checking the status. Mirrors the convention used by
+// the BaseClient helpers; the hand-rolled HTTP paths in emby/push.go,
+// jellyfin/push.go, and lidarr/client.go construct StatusError values via
+// this constructor so the 2xx-is-nil contract lives in one place.
+func NewStatusError(statusCode int, body string) *StatusError {
+	if statusCode >= 200 && statusCode < 300 {
+		return nil
+	}
+	return &StatusError{StatusCode: statusCode, Body: body}
+}
+
 // Error renders the status-error in the historical "unexpected status N: body"
 // shape so callers that grep err.Error() (notably publish.classifyPushErr,
 // which looks for "status 401"/"HTTP 401"/"status 5" substrings) keep
 // working untouched. Per-package write methods that already include their
-// own "X failed with status %d" prefix should %w the StatusError to keep
-// the typed code available without duplicating the status string; see
-// emby/push.go and jellyfin/push.go for the pattern.
+// own "X failed with status %d" prefix attach this StatusError via
+// errors.Join so the typed code is reachable through errors.As without
+// duplicating the status string in Error().
 func (e *StatusError) Error() string {
 	return fmt.Sprintf("unexpected status %d: %s", e.StatusCode, e.Body)
 }
 
-// IsAuth reports whether the status code is in the auth-class set (401 or
-// 403). Used by per-package write methods to decide whether to wrap with
-// the package-level ErrAuth sentinel.
+// IsAuth reports whether the status code is 401 or 403.
 func (e *StatusError) IsAuth() bool {
 	return e.StatusCode == http.StatusUnauthorized || e.StatusCode == http.StatusForbidden
 }
@@ -92,7 +103,7 @@ func (b *BaseClient) Get(ctx context.Context, path string, result any) error {
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode != http.StatusOK {
-		return &StatusError{StatusCode: resp.StatusCode, Body: readErrorBody(resp.Body)}
+		return NewStatusError(resp.StatusCode, readErrorBody(resp.Body))
 	}
 
 	if result != nil {
@@ -119,7 +130,7 @@ func (b *BaseClient) Post(ctx context.Context, path string, body io.Reader) erro
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		return &StatusError{StatusCode: resp.StatusCode, Body: readErrorBody(resp.Body)}
+		return NewStatusError(resp.StatusCode, readErrorBody(resp.Body))
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
@@ -173,7 +184,7 @@ func (b *BaseClient) PutJSON(ctx context.Context, path string, body io.Reader, r
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		return &StatusError{StatusCode: resp.StatusCode, Body: readErrorBody(resp.Body)}
+		return NewStatusError(resp.StatusCode, readErrorBody(resp.Body))
 	}
 
 	if result != nil {
@@ -202,7 +213,7 @@ func (b *BaseClient) PostJSON(ctx context.Context, path string, body io.Reader, 
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		return &StatusError{StatusCode: resp.StatusCode, Body: readErrorBody(resp.Body)}
+		return NewStatusError(resp.StatusCode, readErrorBody(resp.Body))
 	}
 
 	if result != nil {

--- a/internal/connection/httpclient/client.go
+++ b/internal/connection/httpclient/client.go
@@ -103,7 +103,12 @@ func (b *BaseClient) Get(ctx context.Context, path string, result any) error {
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode != http.StatusOK {
-		return NewStatusError(resp.StatusCode, readErrorBody(resp.Body))
+		// Construct StatusError directly rather than via NewStatusError:
+		// NewStatusError treats any 2xx as success (nil) to fit the
+		// POST/PUT contract, but Get's documented contract is 200-only,
+		// so a 201/204 here must still surface as an error rather than
+		// silently fall through to JSON-decoding an unexpected body.
+		return &StatusError{StatusCode: resp.StatusCode, Body: readErrorBody(resp.Body)}
 	}
 
 	if result != nil {

--- a/internal/connection/httpclient/client_test.go
+++ b/internal/connection/httpclient/client_test.go
@@ -245,3 +245,30 @@ func TestNewBase_InvalidURL(t *testing.T) {
 		t.Errorf("BaseURL = %q, want empty for invalid URL", bc.BaseURL)
 	}
 }
+
+// TestStatusError_ErrorAndIsAuth pins the substring shape that the publish
+// layer's classifyPushErr depends on, plus the 401/403 IsAuth contract used
+// by per-package ErrAuth wrappers.
+func TestStatusError_ErrorAndIsAuth(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     *StatusError
+		wantSub string
+		isAuth  bool
+	}{
+		{"401", &StatusError{StatusCode: 401, Body: "denied"}, "unexpected status 401: denied", true},
+		{"403", &StatusError{StatusCode: 403, Body: "forbidden"}, "unexpected status 403", true},
+		{"500", &StatusError{StatusCode: 500, Body: "boom"}, "unexpected status 500", false},
+		{"200", &StatusError{StatusCode: 200, Body: ""}, "unexpected status 200", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); !strings.Contains(got, tc.wantSub) {
+				t.Errorf("Error() = %q, want substring %q", got, tc.wantSub)
+			}
+			if got := tc.err.IsAuth(); got != tc.isAuth {
+				t.Errorf("IsAuth() = %v, want %v", got, tc.isAuth)
+			}
+		})
+	}
+}

--- a/internal/connection/httpclient/client_test.go
+++ b/internal/connection/httpclient/client_test.go
@@ -249,6 +249,51 @@ func TestNewBase_InvalidURL(t *testing.T) {
 // TestStatusError_ErrorAndIsAuth pins the substring shape that the publish
 // layer's classifyPushErr depends on, plus the 401/403 IsAuth contract used
 // by per-package ErrAuthRequired wrappers.
+func TestReadBoundedStatusError_BodyAndStatusCaptured(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Body:       io.NopCloser(strings.NewReader("upstream blew up")),
+	}
+	got := ReadBoundedStatusError(resp)
+	if got == nil {
+		t.Fatal("ReadBoundedStatusError returned nil; want non-nil for non-2xx")
+	}
+	if got.StatusCode != http.StatusBadGateway {
+		t.Errorf("StatusCode = %d, want %d", got.StatusCode, http.StatusBadGateway)
+	}
+	if got.Body != "upstream blew up" {
+		t.Errorf("Body = %q, want %q", got.Body, "upstream blew up")
+	}
+}
+
+func TestReadBoundedStatusError_OneMBCap(t *testing.T) {
+	// Build a body just over the 1 MB cap so the limiter must trim and
+	// the drain must consume the overflow. Use a single byte repeated so
+	// the slice grows fast without burning the test on JSON parsing.
+	const cap1MB = 1 << 20
+	bodyBytes := strings.Repeat("x", cap1MB+512)
+	resp := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader(bodyBytes)),
+	}
+	got := ReadBoundedStatusError(resp)
+	if got == nil {
+		t.Fatal("ReadBoundedStatusError returned nil; want non-nil for 5xx")
+	}
+	if got.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want %d", got.StatusCode, http.StatusInternalServerError)
+	}
+	if len(got.Body) != cap1MB {
+		t.Errorf("len(Body) = %d, want exactly 1 MB cap (%d) -- limiter not enforced", len(got.Body), cap1MB)
+	}
+	// Body must be drained so the underlying transport can reuse the
+	// connection -- a subsequent ReadAll on the same body returns nothing.
+	rest, _ := io.ReadAll(resp.Body)
+	if len(rest) != 0 {
+		t.Errorf("Body not drained: %d bytes remain after read", len(rest))
+	}
+}
+
 func TestStatusError_ErrorAndIsAuth(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/connection/httpclient/client_test.go
+++ b/internal/connection/httpclient/client_test.go
@@ -248,7 +248,7 @@ func TestNewBase_InvalidURL(t *testing.T) {
 
 // TestStatusError_ErrorAndIsAuth pins the substring shape that the publish
 // layer's classifyPushErr depends on, plus the 401/403 IsAuth contract used
-// by per-package ErrAuth wrappers.
+// by per-package ErrAuthRequired wrappers.
 func TestStatusError_ErrorAndIsAuth(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/connection/jellyfin/client.go
+++ b/internal/connection/jellyfin/client.go
@@ -19,8 +19,31 @@ import (
 	"github.com/sydlexius/stillwater/internal/version"
 )
 
-// ErrInvalidCredentials is returned when the media server rejects the credentials.
+// ErrInvalidCredentials is returned when the media server rejects the
+// credentials during the AuthenticateByName handshake.
 var ErrInvalidCredentials = errors.New("invalid credentials")
+
+// ErrAuth is the sentinel wrapped by write-method failures when the peer
+// returns a 401 or 403. Callers in the publish layer use
+// errors.Is(err, jellyfin.ErrAuth) to surface a per-connection re-auth
+// signal without parsing the formatted error string. Distinct from
+// ErrInvalidCredentials, which is scoped to the username/password handshake.
+var ErrAuth = errors.New("jellyfin: authentication required")
+
+// wrapAuthIfStatusAuth detects an httpclient.StatusError whose code is 401 or
+// 403 and wraps the original error with ErrAuth. Mirrors emby.wrapAuthIfStatusAuth
+// so consumers can use errors.Is(err, jellyfin.ErrAuth) regardless of which
+// client surfaced the failure.
+func wrapAuthIfStatusAuth(err error) error {
+	if err == nil {
+		return nil
+	}
+	var se *httpclient.StatusError
+	if errors.As(err, &se) && se.IsAuth() {
+		return fmt.Errorf("%w: %w", ErrAuth, err)
+	}
+	return err
+}
 
 // Client communicates with a Jellyfin server.
 type Client struct {

--- a/internal/connection/jellyfin/client.go
+++ b/internal/connection/jellyfin/client.go
@@ -23,24 +23,20 @@ import (
 // credentials during the AuthenticateByName handshake.
 var ErrInvalidCredentials = errors.New("invalid credentials")
 
-// ErrAuth is the sentinel wrapped by write-method failures when the peer
-// returns a 401 or 403. Callers in the publish layer use
-// errors.Is(err, jellyfin.ErrAuth) to surface a per-connection re-auth
-// signal without parsing the formatted error string. Distinct from
-// ErrInvalidCredentials, which is scoped to the username/password handshake.
-var ErrAuth = errors.New("jellyfin: authentication required")
+// ErrAuthRequired is the sentinel wrapped by write-method failures when the
+// peer returns a 401 or 403. Distinct from ErrInvalidCredentials, which is
+// scoped to the username/password handshake.
+var ErrAuthRequired = errors.New("jellyfin: authentication required")
 
-// wrapAuthIfStatusAuth detects an httpclient.StatusError whose code is 401 or
-// 403 and wraps the original error with ErrAuth. Mirrors emby.wrapAuthIfStatusAuth
-// so consumers can use errors.Is(err, jellyfin.ErrAuth) regardless of which
-// client surfaced the failure.
+// wrapAuthIfStatusAuth wraps 401/403 StatusError with ErrAuthRequired; see
+// emby.wrapAuthIfStatusAuth for rationale.
 func wrapAuthIfStatusAuth(err error) error {
 	if err == nil {
 		return nil
 	}
 	var se *httpclient.StatusError
 	if errors.As(err, &se) && se.IsAuth() {
-		return fmt.Errorf("%w: %w", ErrAuth, err)
+		return fmt.Errorf("%w: %w", ErrAuthRequired, err)
 	}
 	return err
 }

--- a/internal/connection/jellyfin/client.go
+++ b/internal/connection/jellyfin/client.go
@@ -186,7 +186,7 @@ func (c *Client) GetArtists(ctx context.Context, libraryID string, startIndex, l
 // TriggerLibraryScan triggers a full library scan.
 func (c *Client) TriggerLibraryScan(ctx context.Context) error {
 	if err := c.Post(ctx, "/Library/Refresh", nil); err != nil {
-		return fmt.Errorf("triggering library scan: %w", err)
+		return fmt.Errorf("triggering library scan: %w", wrapAuthIfStatusAuth(err))
 	}
 	return nil
 }
@@ -195,7 +195,7 @@ func (c *Client) TriggerLibraryScan(ctx context.Context) error {
 func (c *Client) TriggerArtistRefresh(ctx context.Context, artistID string) error {
 	path := fmt.Sprintf("/Items/%s/Refresh", artistID)
 	if err := c.Post(ctx, path, nil); err != nil {
-		return fmt.Errorf("triggering artist refresh: %w", err)
+		return fmt.Errorf("triggering artist refresh: %w", wrapAuthIfStatusAuth(err))
 	}
 	return nil
 }
@@ -430,7 +430,7 @@ func (c *Client) DisableConflictingSettings(ctx context.Context, libraryID strin
 	}
 
 	path := fmt.Sprintf("/Library/VirtualFolders/LibraryOptions?Id=%s", libraryID)
-	return c.PostJSON(ctx, path, bytes.NewReader(body), nil)
+	return wrapAuthIfStatusAuth(c.PostJSON(ctx, path, bytes.NewReader(body), nil))
 }
 
 // CheckImageSaverEnabled reports whether Jellyfin will persist artwork files

--- a/internal/connection/jellyfin/client_test.go
+++ b/internal/connection/jellyfin/client_test.go
@@ -1752,3 +1752,22 @@ func TestUpdateArtistPath_NonAuthErrorNotWrapped(t *testing.T) {
 		t.Errorf("errors.Is(err, ErrAuthRequired) = true on 500; want false")
 	}
 }
+
+// TestUploadImage_AuthClass401 covers the image-write surface. Image syncs
+// share the per-connection observability path with PushMetadata, so a 401
+// here must wrap with ErrAuthRequired alongside the metadata write methods.
+func TestUploadImage_AuthClass401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", "", srv.Client(), testLogger())
+	err := c.UploadImage(context.Background(), "jf-001", "thumb", []byte{1, 2, 3}, "image/jpeg")
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
+	}
+}

--- a/internal/connection/jellyfin/client_test.go
+++ b/internal/connection/jellyfin/client_test.go
@@ -1681,8 +1681,8 @@ func TestDisableConflictingSettings_Jellyfin(t *testing.T) {
 }
 
 // TestUpdateArtistPath_AuthClass401 verifies that a 401 response (auth-class)
-// from the POST half of UpdateArtistPath is wrapped with the ErrAuth sentinel.
-// The publish layer uses errors.Is(err, jellyfin.ErrAuth) to route the
+// from the POST half of UpdateArtistPath is wrapped with the ErrAuthRequired sentinel.
+// The publish layer uses errors.Is(err, jellyfin.ErrAuthRequired) to route the
 // failure to a per-connection re-auth UI signal (per issue #1639).
 func TestUpdateArtistPath_AuthClass401(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1700,13 +1700,13 @@ func TestUpdateArtistPath_AuthClass401(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on 401")
 	}
-	if !errors.Is(err, ErrAuth) {
-		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
 	}
 }
 
 // TestUpdateArtistPath_AuthClass403 mirrors AuthClass401 for the 403 branch
-// so the publish layer can rely on both codes wrapping with ErrAuth.
+// so the publish layer can rely on both codes wrapping with ErrAuthRequired.
 func TestUpdateArtistPath_AuthClass403(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
@@ -1723,13 +1723,13 @@ func TestUpdateArtistPath_AuthClass403(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on 403")
 	}
-	if !errors.Is(err, ErrAuth) {
-		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
 	}
 }
 
 // TestUpdateArtistPath_NonAuthErrorNotWrapped guards the negative branch:
-// non-auth status codes (5xx) must NOT wrap with ErrAuth so the publish
+// non-auth status codes (5xx) must NOT wrap with ErrAuthRequired so the publish
 // layer routes 5xx to its own toast class (server_error) rather than the
 // re-auth signal.
 func TestUpdateArtistPath_NonAuthErrorNotWrapped(t *testing.T) {
@@ -1748,7 +1748,7 @@ func TestUpdateArtistPath_NonAuthErrorNotWrapped(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on 500")
 	}
-	if errors.Is(err, ErrAuth) {
-		t.Errorf("errors.Is(err, ErrAuth) = true on 500; want false")
+	if errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = true on 500; want false")
 	}
 }

--- a/internal/connection/jellyfin/client_test.go
+++ b/internal/connection/jellyfin/client_test.go
@@ -1679,3 +1679,76 @@ func TestDisableConflictingSettings_Jellyfin(t *testing.T) {
 		}
 	}
 }
+
+// TestUpdateArtistPath_AuthClass401 verifies that a 401 response (auth-class)
+// from the POST half of UpdateArtistPath is wrapped with the ErrAuth sentinel.
+// The publish layer uses errors.Is(err, jellyfin.ErrAuth) to route the
+// failure to a per-connection re-auth UI signal (per issue #1639).
+func TestUpdateArtistPath_AuthClass401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Items":[{"Id":"jf-a1","Name":"Test","Path":"/old"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", "", srv.Client(), testLogger())
+	err := c.UpdateArtistPath(context.Background(), "jf-a1", "/new")
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !errors.Is(err, ErrAuth) {
+		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	}
+}
+
+// TestUpdateArtistPath_AuthClass403 mirrors AuthClass401 for the 403 branch
+// so the publish layer can rely on both codes wrapping with ErrAuth.
+func TestUpdateArtistPath_AuthClass403(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Items":[{"Id":"jf-a1","Name":"Test","Path":"/old"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", "", srv.Client(), testLogger())
+	err := c.UpdateArtistPath(context.Background(), "jf-a1", "/new")
+	if err == nil {
+		t.Fatal("expected error on 403")
+	}
+	if !errors.Is(err, ErrAuth) {
+		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	}
+}
+
+// TestUpdateArtistPath_NonAuthErrorNotWrapped guards the negative branch:
+// non-auth status codes (5xx) must NOT wrap with ErrAuth so the publish
+// layer routes 5xx to its own toast class (server_error) rather than the
+// re-auth signal.
+func TestUpdateArtistPath_NonAuthErrorNotWrapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Items":[{"Id":"jf-a1","Name":"Test","Path":"/old"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", "", srv.Client(), testLogger())
+	err := c.UpdateArtistPath(context.Background(), "jf-a1", "/new")
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if errors.Is(err, ErrAuth) {
+		t.Errorf("errors.Is(err, ErrAuth) = true on 500; want false")
+	}
+}

--- a/internal/connection/jellyfin/push.go
+++ b/internal/connection/jellyfin/push.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,19 @@ import (
 	"strings"
 
 	"github.com/sydlexius/stillwater/internal/connection"
+	"github.com/sydlexius/stillwater/internal/connection/httpclient"
 )
+
+// readBoundedStatusError reads a bounded snippet of the peer error body and
+// returns a typed httpclient.StatusError. Used by every hand-rolled HTTP
+// path in this file so write-method errors carry the status code for
+// wrapAuthIfStatusAuth (errors.As + ErrAuth wrap on 401/403).
+func readBoundedStatusError(resp *http.Response) *httpclient.StatusError {
+	const maxErrBody = 1 << 20 // 1 MB
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return &httpclient.StatusError{StatusCode: resp.StatusCode, Body: string(respBody)}
+}
 
 // PushMetadata updates metadata for an artist item on the Jellyfin server.
 //
@@ -237,12 +250,9 @@ func (c *Client) postFullItem(ctx context.Context, platformArtistID string, item
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		// Cap the error body at 1 MB so a misbehaving peer that returns a
-		// huge HTML error page cannot blow up the caller's logger.
-		const maxErrBody = 1 << 20
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("%s failed with status %d: %s", op, resp.StatusCode, string(respBody))
+		statusErr := readBoundedStatusError(resp)
+		formatted := fmt.Errorf("%s failed with status %d: %s", op, statusErr.StatusCode, statusErr.Body)
+		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
 
 	_, _ = io.Copy(io.Discard, resp.Body)
@@ -284,10 +294,9 @@ func (c *Client) fetchItem(ctx context.Context, itemID string) (map[string]any, 
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		const maxErrBody = 1 << 20
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, fmt.Errorf("fetch failed with status %d: %s", resp.StatusCode, string(respBody))
+		statusErr := readBoundedStatusError(resp)
+		formatted := fmt.Errorf("fetch failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
+		return nil, wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
 
 	var result struct {
@@ -337,10 +346,9 @@ func (c *Client) UploadImage(ctx context.Context, platformArtistID string, image
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		const maxErrBody = 1 << 20 // 1 MB
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("image upload failed with status %d: %s", resp.StatusCode, string(respBody))
+		statusErr := readBoundedStatusError(resp)
+		formatted := fmt.Errorf("image upload failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
+		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
 
 	_, _ = io.Copy(io.Discard, resp.Body)
@@ -377,10 +385,9 @@ func (c *Client) UploadImageAtIndex(ctx context.Context, platformArtistID string
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		const maxErrBody = 1 << 20 // 1 MB
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("indexed image upload failed with status %d: %s", resp.StatusCode, string(respBody))
+		statusErr := readBoundedStatusError(resp)
+		formatted := fmt.Errorf("indexed image upload failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
+		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
 
 	_, _ = io.Copy(io.Discard, resp.Body)
@@ -410,10 +417,9 @@ func (c *Client) DeleteImage(ctx context.Context, platformArtistID string, image
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		const maxErrBody = 1 << 20 // 1 MB
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return fmt.Errorf("image delete failed with status %d: %s", resp.StatusCode, string(respBody))
+		statusErr := readBoundedStatusError(resp)
+		formatted := fmt.Errorf("image delete failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
+		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
 
 	_, _ = io.Copy(io.Discard, resp.Body)

--- a/internal/connection/jellyfin/push.go
+++ b/internal/connection/jellyfin/push.go
@@ -19,7 +19,7 @@ import (
 // readBoundedStatusError reads a bounded snippet of the peer error body and
 // returns a typed httpclient.StatusError. Used by every hand-rolled HTTP
 // path in this file so write-method errors carry the status code for
-// wrapAuthIfStatusAuth (errors.As + ErrAuth wrap on 401/403).
+// wrapAuthIfStatusAuth (errors.As + ErrAuthRequired wrap on 401/403).
 func readBoundedStatusError(resp *http.Response) *httpclient.StatusError {
 	const maxErrBody = 1 << 20 // 1 MB
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))

--- a/internal/connection/jellyfin/push.go
+++ b/internal/connection/jellyfin/push.go
@@ -16,17 +16,6 @@ import (
 	"github.com/sydlexius/stillwater/internal/connection/httpclient"
 )
 
-// readBoundedStatusError reads a bounded snippet of the peer error body and
-// returns a typed httpclient.StatusError. Used by every hand-rolled HTTP
-// path in this file so write-method errors carry the status code for
-// wrapAuthIfStatusAuth (errors.As + ErrAuthRequired wrap on 401/403).
-func readBoundedStatusError(resp *http.Response) *httpclient.StatusError {
-	const maxErrBody = 1 << 20 // 1 MB
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
-	_, _ = io.Copy(io.Discard, resp.Body)
-	return &httpclient.StatusError{StatusCode: resp.StatusCode, Body: string(respBody)}
-}
-
 // PushMetadata updates metadata for an artist item on the Jellyfin server.
 //
 // Jellyfin's POST /Items/{id} requires the full item body; partial updates
@@ -250,7 +239,7 @@ func (c *Client) postFullItem(ctx context.Context, platformArtistID string, item
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		statusErr := readBoundedStatusError(resp)
+		statusErr := httpclient.ReadBoundedStatusError(resp)
 		formatted := fmt.Errorf("%s failed with status %d: %s", op, statusErr.StatusCode, statusErr.Body)
 		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
@@ -294,7 +283,7 @@ func (c *Client) fetchItem(ctx context.Context, itemID string) (map[string]any, 
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		statusErr := readBoundedStatusError(resp)
+		statusErr := httpclient.ReadBoundedStatusError(resp)
 		formatted := fmt.Errorf("fetch failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
 		return nil, wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
@@ -346,7 +335,7 @@ func (c *Client) UploadImage(ctx context.Context, platformArtistID string, image
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		statusErr := readBoundedStatusError(resp)
+		statusErr := httpclient.ReadBoundedStatusError(resp)
 		formatted := fmt.Errorf("image upload failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
 		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
@@ -385,7 +374,7 @@ func (c *Client) UploadImageAtIndex(ctx context.Context, platformArtistID string
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		statusErr := readBoundedStatusError(resp)
+		statusErr := httpclient.ReadBoundedStatusError(resp)
 		formatted := fmt.Errorf("indexed image upload failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
 		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}
@@ -417,7 +406,7 @@ func (c *Client) DeleteImage(ctx context.Context, platformArtistID string, image
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
 	if resp.StatusCode >= 300 {
-		statusErr := readBoundedStatusError(resp)
+		statusErr := httpclient.ReadBoundedStatusError(resp)
 		formatted := fmt.Errorf("image delete failed with status %d: %s", statusErr.StatusCode, statusErr.Body)
 		return wrapAuthIfStatusAuth(errors.Join(formatted, statusErr))
 	}

--- a/internal/connection/lidarr/client.go
+++ b/internal/connection/lidarr/client.go
@@ -17,23 +17,19 @@ import (
 	"github.com/sydlexius/stillwater/internal/connection/httpclient"
 )
 
-// ErrAuth is the sentinel wrapped by write-method failures when the peer
-// returns a 401 or 403. Callers in the publish layer use
-// errors.Is(err, lidarr.ErrAuth) to route the failure to a per-connection
-// re-auth UI signal without parsing the formatted error string.
-var ErrAuth = errors.New("lidarr: authentication required")
+// ErrAuthRequired is the sentinel wrapped by write-method failures when the
+// peer returns a 401 or 403.
+var ErrAuthRequired = errors.New("lidarr: authentication required")
 
-// wrapAuthIfStatusAuth detects an httpclient.StatusError whose code is 401 or
-// 403 and wraps the original error with ErrAuth. Mirrors the emby /
-// jellyfin helpers so consumers can use errors.Is(err, lidarr.ErrAuth)
-// regardless of which client surfaced the failure.
+// wrapAuthIfStatusAuth wraps 401/403 StatusError with ErrAuthRequired; see
+// emby.wrapAuthIfStatusAuth for rationale.
 func wrapAuthIfStatusAuth(err error) error {
 	if err == nil {
 		return nil
 	}
 	var se *httpclient.StatusError
 	if errors.As(err, &se) && se.IsAuth() {
-		return fmt.Errorf("%w: %w", ErrAuth, err)
+		return fmt.Errorf("%w: %w", ErrAuthRequired, err)
 	}
 	return err
 }
@@ -226,7 +222,7 @@ func (c *Client) getMetadataProviderConfigs(ctx context.Context) ([]MetadataProv
 		// Read a small prefix for diagnostics and drain the rest so the
 		// transport can reuse the connection. Wrap with the typed
 		// httpclient.StatusError so wrapAuthIfStatusAuth can route 401/403
-		// to ErrAuth even for this hand-rolled HTTP path.
+		// to ErrAuthRequired even for this hand-rolled HTTP path.
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil, wrapAuthIfStatusAuth(&httpclient.StatusError{StatusCode: resp.StatusCode, Body: string(bytes.TrimSpace(snippet))})
@@ -610,7 +606,7 @@ func (c *Client) UpdateArtistPath(ctx context.Context, platformArtistID, newPath
 // confirms the `path` field round-tripped intact. Mismatch returns a
 // caller-friendly error including both sent and got values; the auth-class
 // wrap is applied to any transport / status error so a credentials
-// rotation between PUT and verify still routes to ErrAuth.
+// rotation between PUT and verify still routes to ErrAuthRequired.
 func (c *Client) verifyArtistPath(ctx context.Context, escapedID, sent string) error {
 	getPath := fmt.Sprintf("/api/v1/artist/%s", escapedID)
 	var verifyItem map[string]any

--- a/internal/connection/lidarr/client.go
+++ b/internal/connection/lidarr/client.go
@@ -152,7 +152,7 @@ func (c *Client) TriggerArtistRefresh(ctx context.Context, artistID int) (*Comma
 
 	var resp CommandResponse
 	if err := c.PostJSON(ctx, "/api/v1/command", bytes.NewReader(body), &resp); err != nil {
-		return nil, fmt.Errorf("triggering artist refresh: %w", err)
+		return nil, fmt.Errorf("triggering artist refresh: %w", wrapAuthIfStatusAuth(err))
 	}
 	return &resp, nil
 }
@@ -197,7 +197,7 @@ func (c *Client) DisableMetadataConsumer(ctx context.Context, configID int) erro
 	}
 
 	path := fmt.Sprintf("/api/v1/config/metadataprovider/%d", configID)
-	return c.PutJSON(ctx, path, bytes.NewReader(body), nil)
+	return wrapAuthIfStatusAuth(c.PutJSON(ctx, path, bytes.NewReader(body), nil))
 }
 
 // getMetadataProviderConfigs fetches the metadata provider config from Lidarr,
@@ -455,7 +455,7 @@ func (c *Client) putMetadataConsumer(ctx context.Context, m map[string]any) erro
 		return fmt.Errorf("encoding consumer: %w", err)
 	}
 	path := fmt.Sprintf("/api/v1/metadata/%d", id)
-	return c.PutJSON(ctx, path, bytes.NewReader(body), nil)
+	return wrapAuthIfStatusAuth(c.PutJSON(ctx, path, bytes.NewReader(body), nil))
 }
 
 // consumerID normalizes the "id" field from the raw consumer map. Lidarr

--- a/internal/connection/lidarr/client.go
+++ b/internal/connection/lidarr/client.go
@@ -39,9 +39,9 @@ type Client struct {
 	httpclient.BaseClient
 	// verifyPathAfterUpdate, when true, makes UpdateArtistPath issue a
 	// follow-up GET after the PUT and confirm the returned path field
-	// round-trips intact. Default false (opt-in per #1640): a healthy
-	// Lidarr rarely drifts and the extra request roughly doubles the
-	// per-rename cost.
+	// round-trips intact. Default false (opt-in): a healthy Lidarr
+	// rarely drifts and the extra request roughly doubles the per-rename
+	// cost.
 	verifyPathAfterUpdate bool
 }
 
@@ -67,13 +67,13 @@ func NewWithHTTPClient(baseURL, apiKey string, httpClient *http.Client, logger *
 }
 
 // SetVerifyPathAfterUpdate toggles the per-connection verify-after-PUT
-// behavior described by #1640. When enabled, UpdateArtistPath issues a
-// follow-up GET after a successful PUT and compares the returned `path`
-// field against the value we sent. A mismatch surfaces an error wrapped
-// with enough context (sent vs got) to identify the divergence so the
-// operator knows Lidarr coerced the path against the Root Folder list.
-// Default false: a healthy Lidarr almost never drifts and the extra
-// request roughly doubles per-rename cost.
+// behavior. When enabled, UpdateArtistPath issues a follow-up GET after a
+// successful PUT and compares the returned `path` field against the value
+// we sent. A mismatch surfaces an error wrapped with enough context (sent
+// vs got) to identify the divergence so the operator knows Lidarr coerced
+// the path against the Root Folder list. Default false: a healthy Lidarr
+// almost never drifts and the extra request roughly doubles per-rename
+// cost.
 func (c *Client) SetVerifyPathAfterUpdate(enabled bool) {
 	c.verifyPathAfterUpdate = enabled
 }
@@ -587,10 +587,10 @@ func (c *Client) UpdateArtistPath(ctx context.Context, platformArtistID, newPath
 		return fmt.Errorf("putting artist path update: %w", wrapAuthIfStatusAuth(err))
 	}
 
-	// Optional verify-after-PUT round-trip (per #1640). Older Lidarr
-	// versions sometimes coerce a submitted path against the Root Folder
-	// list and silently store the coerced value, so a 2xx PUT alone is
-	// not authoritative confirmation that the path persisted exactly as
+	// Optional verify-after-PUT round-trip. Older Lidarr versions
+	// sometimes coerce a submitted path against the Root Folder list and
+	// silently store the coerced value, so a 2xx PUT alone is not
+	// authoritative confirmation that the path persisted exactly as
 	// sent. Reuses the caller's context so the verify GET shares the
 	// per-platform rename deadline (publish.renameSyncTimeout); no
 	// additional timeout knob.

--- a/internal/connection/lidarr/client.go
+++ b/internal/connection/lidarr/client.go
@@ -613,8 +613,22 @@ func (c *Client) verifyArtistPath(ctx context.Context, escapedID, sent string) e
 	if err := c.Get(ctx, getPath, &verifyItem); err != nil {
 		return fmt.Errorf("verifying artist path after update: %w", wrapAuthIfStatusAuth(err))
 	}
+	// Distinguish "body decoded to nil" (Lidarr returned literal JSON null,
+	// or the GET succeeded but the artist disappeared between PUT and
+	// verify) from "body decoded to an object with no path field". The
+	// former is a malformed-body class error the operator must triage on
+	// the peer; the latter is a genuine field-level mismatch (sent X, got
+	// "") so we route to the regular mismatch error.
+	if verifyItem == nil {
+		return fmt.Errorf("lidarr path verify: empty response body after update")
+	}
 	got, _ := verifyItem["path"].(string)
 	if got != sent {
+		c.Logger.Warn("lidarr path verify mismatch",
+			slog.String("artist_id_escaped", escapedID),
+			slog.String("sent", sent),
+			slog.String("got", got),
+		)
 		return fmt.Errorf("lidarr path verify mismatch: sent %q, got %q", sent, got)
 	}
 	return nil

--- a/internal/connection/lidarr/client.go
+++ b/internal/connection/lidarr/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,9 +17,36 @@ import (
 	"github.com/sydlexius/stillwater/internal/connection/httpclient"
 )
 
+// ErrAuth is the sentinel wrapped by write-method failures when the peer
+// returns a 401 or 403. Callers in the publish layer use
+// errors.Is(err, lidarr.ErrAuth) to route the failure to a per-connection
+// re-auth UI signal without parsing the formatted error string.
+var ErrAuth = errors.New("lidarr: authentication required")
+
+// wrapAuthIfStatusAuth detects an httpclient.StatusError whose code is 401 or
+// 403 and wraps the original error with ErrAuth. Mirrors the emby /
+// jellyfin helpers so consumers can use errors.Is(err, lidarr.ErrAuth)
+// regardless of which client surfaced the failure.
+func wrapAuthIfStatusAuth(err error) error {
+	if err == nil {
+		return nil
+	}
+	var se *httpclient.StatusError
+	if errors.As(err, &se) && se.IsAuth() {
+		return fmt.Errorf("%w: %w", ErrAuth, err)
+	}
+	return err
+}
+
 // Client communicates with a Lidarr server.
 type Client struct {
 	httpclient.BaseClient
+	// verifyPathAfterUpdate, when true, makes UpdateArtistPath issue a
+	// follow-up GET after the PUT and confirm the returned path field
+	// round-trips intact. Default false (opt-in per #1640): a healthy
+	// Lidarr rarely drifts and the extra request roughly doubles the
+	// per-rename cost.
+	verifyPathAfterUpdate bool
 }
 
 // New creates a Lidarr client with default HTTP settings.
@@ -40,6 +68,18 @@ func NewWithHTTPClient(baseURL, apiKey string, httpClient *http.Client, logger *
 	}
 	c.AuthFunc = c.setAuth
 	return c
+}
+
+// SetVerifyPathAfterUpdate toggles the per-connection verify-after-PUT
+// behavior described by #1640. When enabled, UpdateArtistPath issues a
+// follow-up GET after a successful PUT and compares the returned `path`
+// field against the value we sent. A mismatch surfaces an error wrapped
+// with enough context (sent vs got) to identify the divergence so the
+// operator knows Lidarr coerced the path against the Root Folder list.
+// Default false: a healthy Lidarr almost never drifts and the extra
+// request roughly doubles per-rename cost.
+func (c *Client) SetVerifyPathAfterUpdate(enabled bool) {
+	c.verifyPathAfterUpdate = enabled
 }
 
 // TestConnection verifies connectivity by calling GET /api/v1/system/status.
@@ -184,10 +224,12 @@ func (c *Client) getMetadataProviderConfigs(ctx context.Context) ([]MetadataProv
 
 	if resp.StatusCode != http.StatusOK {
 		// Read a small prefix for diagnostics and drain the rest so the
-		// transport can reuse the connection.
+		// transport can reuse the connection. Wrap with the typed
+		// httpclient.StatusError so wrapAuthIfStatusAuth can route 401/403
+		// to ErrAuth even for this hand-rolled HTTP path.
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, bytes.TrimSpace(snippet))
+		return nil, wrapAuthIfStatusAuth(&httpclient.StatusError{StatusCode: resp.StatusCode, Body: string(bytes.TrimSpace(snippet))})
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // cap at 1 MB
@@ -380,7 +422,8 @@ func (c *Client) getMetadataConsumers(ctx context.Context) ([]map[string]any, er
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 	if resp.StatusCode != http.StatusOK {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, bytes.TrimSpace(snippet))
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, wrapAuthIfStatusAuth(&httpclient.StatusError{StatusCode: resp.StatusCode, Body: string(bytes.TrimSpace(snippet))})
 	}
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
@@ -529,7 +572,7 @@ func (c *Client) UpdateArtistPath(ctx context.Context, platformArtistID, newPath
 	getPath := fmt.Sprintf("/api/v1/artist/%s", escapedID)
 	var item map[string]any
 	if err := c.Get(ctx, getPath, &item); err != nil {
-		return fmt.Errorf("fetching artist for path update: %w", err)
+		return fmt.Errorf("fetching artist for path update: %w", wrapAuthIfStatusAuth(err))
 	}
 	if item == nil {
 		return fmt.Errorf("lidarr returned empty artist body for id %s", platformArtistID)
@@ -545,7 +588,38 @@ func (c *Client) UpdateArtistPath(ctx context.Context, platformArtistID, newPath
 	// to move them would either fail (source gone) or race our own rename.
 	putPath := fmt.Sprintf("/api/v1/artist/%s?moveFiles=false", escapedID)
 	if err := c.PutJSON(ctx, putPath, bytes.NewReader(body), nil); err != nil {
-		return fmt.Errorf("putting artist path update: %w", err)
+		return fmt.Errorf("putting artist path update: %w", wrapAuthIfStatusAuth(err))
+	}
+
+	// Optional verify-after-PUT round-trip (per #1640). Older Lidarr
+	// versions sometimes coerce a submitted path against the Root Folder
+	// list and silently store the coerced value, so a 2xx PUT alone is
+	// not authoritative confirmation that the path persisted exactly as
+	// sent. Reuses the caller's context so the verify GET shares the
+	// per-platform rename deadline (publish.renameSyncTimeout); no
+	// additional timeout knob.
+	if c.verifyPathAfterUpdate {
+		if err := c.verifyArtistPath(ctx, escapedID, newPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// verifyArtistPath issues a follow-up GET on the artist resource and
+// confirms the `path` field round-tripped intact. Mismatch returns a
+// caller-friendly error including both sent and got values; the auth-class
+// wrap is applied to any transport / status error so a credentials
+// rotation between PUT and verify still routes to ErrAuth.
+func (c *Client) verifyArtistPath(ctx context.Context, escapedID, sent string) error {
+	getPath := fmt.Sprintf("/api/v1/artist/%s", escapedID)
+	var verifyItem map[string]any
+	if err := c.Get(ctx, getPath, &verifyItem); err != nil {
+		return fmt.Errorf("verifying artist path after update: %w", wrapAuthIfStatusAuth(err))
+	}
+	got, _ := verifyItem["path"].(string)
+	if got != sent {
+		return fmt.Errorf("lidarr path verify mismatch: sent %q, got %q", sent, got)
 	}
 	return nil
 }

--- a/internal/connection/lidarr/client_test.go
+++ b/internal/connection/lidarr/client_test.go
@@ -451,7 +451,7 @@ func TestUpdateArtistPath_EmptyNewPath(t *testing.T) {
 }
 
 // TestUpdateArtistPath_AuthClass401 verifies that a 401 response on the
-// PUT half wraps with the ErrAuth sentinel (per issue #1639), so the
+// PUT half wraps with the ErrAuthRequired sentinel (per issue #1639), so the
 // publish layer can detect auth failures via errors.Is.
 func TestUpdateArtistPath_AuthClass401(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -469,8 +469,8 @@ func TestUpdateArtistPath_AuthClass401(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on 401")
 	}
-	if !errors.Is(err, ErrAuth) {
-		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
 	}
 }
 
@@ -491,8 +491,8 @@ func TestUpdateArtistPath_AuthClass403(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on 403")
 	}
-	if !errors.Is(err, ErrAuth) {
-		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
 	}
 }
 
@@ -514,8 +514,8 @@ func TestUpdateArtistPath_NonAuthErrorNotWrapped(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on 500")
 	}
-	if errors.Is(err, ErrAuth) {
-		t.Errorf("errors.Is(err, ErrAuth) = true on 500; want false")
+	if errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = true on 500; want false")
 	}
 }
 

--- a/internal/connection/lidarr/client_test.go
+++ b/internal/connection/lidarr/client_test.go
@@ -628,3 +628,90 @@ func TestUpdateArtistPath_VerifyAfterPut_Disabled(t *testing.T) {
 		t.Errorf("expected 1 GET (pre-PUT only), got %d -- verify-after-PUT must be opt-in", getCount)
 	}
 }
+
+// TestGetMetadataProviderConfigs_AuthClass401 covers the hand-rolled GET on
+// /api/v1/config/metadataprovider so a 401 there still routes through the
+// ErrAuthRequired wrap. The function is unexported, so we exercise it
+// through GetMetadataConsumers (its only caller) which forwards the error.
+func TestGetMetadataProviderConfigs_AuthClass401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/config/metadataprovider" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", srv.Client(), testLogger())
+	_, err := c.GetMetadataConsumers(context.Background())
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
+	}
+}
+
+// TestGetMetadataConsumers_AuthClass401 covers the hand-rolled GET on
+// /api/v1/metadata used by the conflict detection and snapshot/restore
+// paths. A 401 here must wrap with ErrAuthRequired so peer-side credential
+// rotation surfaces consistently across every Lidarr touchpoint.
+func TestGetMetadataConsumers_AuthClass401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/metadata" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", srv.Client(), testLogger())
+	// CheckNFOWriterEnabled forwards getMetadataConsumers' error directly.
+	_, _, err := c.CheckNFOWriterEnabled(context.Background())
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
+	}
+}
+
+// TestUpdateArtistPath_VerifyAfterPut_AuthClass401 covers the credentials
+// rotation between PUT and verify case: the pre-PUT GET and the PUT both
+// succeed, but the verify GET returns 401. The error must still wrap with
+// ErrAuthRequired so the toast surface routes to auth_failed rather than a
+// generic verify mismatch class.
+func TestUpdateArtistPath_VerifyAfterPut_AuthClass401(t *testing.T) {
+	var getCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			getCount++
+			if getCount == 1 {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
+				return
+			}
+			// Second GET is the verify call; simulate credentials revoked.
+			w.WriteHeader(http.StatusUnauthorized)
+		case http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", srv.Client(), testLogger())
+	c.SetVerifyPathAfterUpdate(true)
+	err := c.UpdateArtistPath(context.Background(), "42", "/new/X")
+	if err == nil {
+		t.Fatal("expected error on verify 401")
+	}
+	if !errors.Is(err, ErrAuthRequired) {
+		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
+	}
+	if getCount != 2 {
+		t.Errorf("expected 2 GETs (pre-PUT + verify), got %d", getCount)
+	}
+}

--- a/internal/connection/lidarr/client_test.go
+++ b/internal/connection/lidarr/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -524,18 +525,21 @@ func TestUpdateArtistPath_NonAuthErrorNotWrapped(t *testing.T) {
 // sent on the follow-up GET, the call succeeds. The test server tracks
 // each request so we can confirm the verify GET actually fired.
 func TestUpdateArtistPath_VerifyAfterPut_Match(t *testing.T) {
-	var getCount int
+	// atomic.Int32 because the counter is written from the httptest
+	// handler goroutine and read from the test goroutine; a plain int
+	// trips -race under the project's race-test rule.
+	var getCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			getCount++
+			n := getCount.Add(1)
 			w.Header().Set("Content-Type", "application/json")
 			// Both the pre-PUT fetch and the verify-after-PUT GET hit the
 			// same handler; for the verify branch we must echo the new
 			// path so the comparison succeeds. The first GET (pre-PUT)
 			// can return the old path; current path field is overwritten
 			// on the PUT body anyway.
-			if getCount == 1 {
+			if n == 1 {
 				_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
 			} else {
 				_, _ = w.Write([]byte(`{"id":42,"path":"/new/X"}`))
@@ -553,8 +557,8 @@ func TestUpdateArtistPath_VerifyAfterPut_Match(t *testing.T) {
 	if err := c.UpdateArtistPath(context.Background(), "42", "/new/X"); err != nil {
 		t.Fatalf("UpdateArtistPath with verify (match): %v", err)
 	}
-	if getCount != 2 {
-		t.Errorf("expected 2 GET requests (pre-PUT + verify), got %d", getCount)
+	if got := getCount.Load(); got != 2 {
+		t.Errorf("expected 2 GET requests (pre-PUT + verify), got %d", got)
 	}
 }
 
@@ -564,13 +568,14 @@ func TestUpdateArtistPath_VerifyAfterPut_Match(t *testing.T) {
 // an error including both sent and got values so the operator can
 // diagnose the drift.
 func TestUpdateArtistPath_VerifyAfterPut_Mismatch(t *testing.T) {
-	var getCount int
+	// atomic.Int32: see TestUpdateArtistPath_VerifyAfterPut_Match.
+	var getCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			getCount++
+			n := getCount.Add(1)
 			w.Header().Set("Content-Type", "application/json")
-			if getCount == 1 {
+			if n == 1 {
 				_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
 			} else {
 				// Simulate Lidarr coercing the path to a different value
@@ -604,11 +609,12 @@ func TestUpdateArtistPath_VerifyAfterPut_Mismatch(t *testing.T) {
 // SetVerifyPathAfterUpdate(true) the follow-up GET does NOT fire, so the
 // opt-in default keeps the historical per-rename cost (1 GET + 1 PUT).
 func TestUpdateArtistPath_VerifyAfterPut_Disabled(t *testing.T) {
-	var getCount int
+	// atomic.Int32: see TestUpdateArtistPath_VerifyAfterPut_Match.
+	var getCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			getCount++
+			getCount.Add(1)
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
 		case http.MethodPut:
@@ -624,8 +630,8 @@ func TestUpdateArtistPath_VerifyAfterPut_Disabled(t *testing.T) {
 	if err := c.UpdateArtistPath(context.Background(), "42", "/new/X"); err != nil {
 		t.Fatalf("UpdateArtistPath (verify disabled): %v", err)
 	}
-	if getCount != 1 {
-		t.Errorf("expected 1 GET (pre-PUT only), got %d -- verify-after-PUT must be opt-in", getCount)
+	if got := getCount.Load(); got != 1 {
+		t.Errorf("expected 1 GET (pre-PUT only), got %d -- verify-after-PUT must be opt-in", got)
 	}
 }
 
@@ -682,12 +688,13 @@ func TestGetMetadataConsumers_AuthClass401(t *testing.T) {
 // ErrAuthRequired so the toast surface routes to auth_failed rather than a
 // generic verify mismatch class.
 func TestUpdateArtistPath_VerifyAfterPut_AuthClass401(t *testing.T) {
-	var getCount int
+	// atomic.Int32: see TestUpdateArtistPath_VerifyAfterPut_Match.
+	var getCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			getCount++
-			if getCount == 1 {
+			n := getCount.Add(1)
+			if n == 1 {
 				w.Header().Set("Content-Type", "application/json")
 				_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
 				return
@@ -711,7 +718,7 @@ func TestUpdateArtistPath_VerifyAfterPut_AuthClass401(t *testing.T) {
 	if !errors.Is(err, ErrAuthRequired) {
 		t.Errorf("errors.Is(err, ErrAuthRequired) = false; want true. err = %v", err)
 	}
-	if getCount != 2 {
-		t.Errorf("expected 2 GETs (pre-PUT + verify), got %d", getCount)
+	if got := getCount.Load(); got != 2 {
+		t.Errorf("expected 2 GETs (pre-PUT + verify), got %d", got)
 	}
 }

--- a/internal/connection/lidarr/client_test.go
+++ b/internal/connection/lidarr/client_test.go
@@ -3,11 +3,13 @@ package lidarr
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -445,5 +447,184 @@ func TestUpdateArtistPath_EmptyNewPath(t *testing.T) {
 	c := NewWithHTTPClient(srv.URL, "key", srv.Client(), testLogger())
 	if err := c.UpdateArtistPath(context.Background(), "42", ""); err == nil {
 		t.Fatal("expected error on empty newPath")
+	}
+}
+
+// TestUpdateArtistPath_AuthClass401 verifies that a 401 response on the
+// PUT half wraps with the ErrAuth sentinel (per issue #1639), so the
+// publish layer can detect auth failures via errors.Is.
+func TestUpdateArtistPath_AuthClass401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", srv.Client(), testLogger())
+	err := c.UpdateArtistPath(context.Background(), "42", "/new/X")
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !errors.Is(err, ErrAuth) {
+		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	}
+}
+
+// TestUpdateArtistPath_AuthClass403 mirrors AuthClass401 for the 403 branch.
+func TestUpdateArtistPath_AuthClass403(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", srv.Client(), testLogger())
+	err := c.UpdateArtistPath(context.Background(), "42", "/new/X")
+	if err == nil {
+		t.Fatal("expected error on 403")
+	}
+	if !errors.Is(err, ErrAuth) {
+		t.Errorf("errors.Is(err, ErrAuth) = false; want true. err = %v", err)
+	}
+}
+
+// TestUpdateArtistPath_NonAuthErrorNotWrapped guards the negative branch
+// so the publish layer routes 5xx away from the re-auth toast class.
+func TestUpdateArtistPath_NonAuthErrorNotWrapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", srv.Client(), testLogger())
+	err := c.UpdateArtistPath(context.Background(), "42", "/new/X")
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if errors.Is(err, ErrAuth) {
+		t.Errorf("errors.Is(err, ErrAuth) = true on 500; want false")
+	}
+}
+
+// TestUpdateArtistPath_VerifyAfterPut_Match exercises the #1640 happy
+// path: when verify-after-PUT is enabled and Lidarr returns the path we
+// sent on the follow-up GET, the call succeeds. The test server tracks
+// each request so we can confirm the verify GET actually fired.
+func TestUpdateArtistPath_VerifyAfterPut_Match(t *testing.T) {
+	var getCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			getCount++
+			w.Header().Set("Content-Type", "application/json")
+			// Both the pre-PUT fetch and the verify-after-PUT GET hit the
+			// same handler; for the verify branch we must echo the new
+			// path so the comparison succeeds. The first GET (pre-PUT)
+			// can return the old path; current path field is overwritten
+			// on the PUT body anyway.
+			if getCount == 1 {
+				_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
+			} else {
+				_, _ = w.Write([]byte(`{"id":42,"path":"/new/X"}`))
+			}
+		case http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", srv.Client(), testLogger())
+	c.SetVerifyPathAfterUpdate(true)
+	if err := c.UpdateArtistPath(context.Background(), "42", "/new/X"); err != nil {
+		t.Fatalf("UpdateArtistPath with verify (match): %v", err)
+	}
+	if getCount != 2 {
+		t.Errorf("expected 2 GET requests (pre-PUT + verify), got %d", getCount)
+	}
+}
+
+// TestUpdateArtistPath_VerifyAfterPut_Mismatch covers the divergence
+// branch: when Lidarr coerces the path against the Root Folder list, the
+// follow-up GET returns a different value and UpdateArtistPath surfaces
+// an error including both sent and got values so the operator can
+// diagnose the drift.
+func TestUpdateArtistPath_VerifyAfterPut_Mismatch(t *testing.T) {
+	var getCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			getCount++
+			w.Header().Set("Content-Type", "application/json")
+			if getCount == 1 {
+				_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
+			} else {
+				// Simulate Lidarr coercing the path to a different value
+				// (e.g. canonicalizing against the Root Folder).
+				_, _ = w.Write([]byte(`{"id":42,"path":"/lidarr-canonical/X"}`))
+			}
+		case http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", srv.Client(), testLogger())
+	c.SetVerifyPathAfterUpdate(true)
+	err := c.UpdateArtistPath(context.Background(), "42", "/new/X")
+	if err == nil {
+		t.Fatal("expected verify-mismatch error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "verify mismatch") {
+		t.Errorf("error %q does not mention verify mismatch", msg)
+	}
+	if !strings.Contains(msg, "/new/X") || !strings.Contains(msg, "/lidarr-canonical/X") {
+		t.Errorf("error %q must include both sent and got paths for diagnosis", msg)
+	}
+}
+
+// TestUpdateArtistPath_VerifyAfterPut_Disabled confirms that without
+// SetVerifyPathAfterUpdate(true) the follow-up GET does NOT fire, so the
+// opt-in default keeps the historical per-rename cost (1 GET + 1 PUT).
+func TestUpdateArtistPath_VerifyAfterPut_Disabled(t *testing.T) {
+	var getCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			getCount++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
+		case http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewWithHTTPClient(srv.URL, "k", srv.Client(), testLogger())
+	// SetVerifyPathAfterUpdate not called; default is false.
+	if err := c.UpdateArtistPath(context.Background(), "42", "/new/X"); err != nil {
+		t.Fatalf("UpdateArtistPath (verify disabled): %v", err)
+	}
+	if getCount != 1 {
+		t.Errorf("expected 1 GET (pre-PUT only), got %d -- verify-after-PUT must be opt-in", getCount)
 	}
 }

--- a/internal/connection/model.go
+++ b/internal/connection/model.go
@@ -43,7 +43,16 @@ type Connection struct {
 	// options taken when FeatureManageServerFiles was flipped on. Empty
 	// string when the toggle has never been flipped or has been restored.
 	PreStillwaterConfigJSON string `json:"pre_stillwater_config_json,omitempty"`
-	PlatformUserID          string `json:"platform_user_id,omitempty"`
+	// VerifyPathAfterUpdate, for Lidarr connections only, enables a
+	// follow-up GET after UpdateArtistPath PUT that confirms the returned
+	// path field matches what Stillwater sent. Mismatch produces an error
+	// with "sent X, got Y" context so the operator can identify that
+	// Lidarr coerced the path against its Root Folder list. Default false
+	// (opt-in): a healthy Lidarr rarely drifts and the extra request
+	// roughly doubles the per-rename HTTP cost. Ignored for non-Lidarr
+	// types because they do not expose this failure mode.
+	VerifyPathAfterUpdate bool   `json:"verify_path_after_update"`
+	PlatformUserID        string `json:"platform_user_id,omitempty"`
 	// PlatformServerID is the Emby/Jellyfin server identity returned by
 	// /System/Info. Web deep-links must include serverId=<id> so the
 	// platform client loads the correct item view; without it the URL

--- a/internal/connection/service.go
+++ b/internal/connection/service.go
@@ -51,8 +51,8 @@ func (s *Service) Create(ctx context.Context, c *Connection) error {
 	}
 
 	_, err = s.db.ExecContext(ctx, `
-		INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, status_message, last_checked_at, created_at, updated_at, feature_library_import, feature_nfo_write, feature_image_write, feature_metadata_push, feature_trigger_refresh, feature_manage_server_files, platform_user_id, platform_server_id, pre_stillwater_config_json)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, status_message, last_checked_at, created_at, updated_at, feature_library_import, feature_nfo_write, feature_image_write, feature_metadata_push, feature_trigger_refresh, feature_manage_server_files, verify_path_after_update, platform_user_id, platform_server_id, pre_stillwater_config_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`,
 		c.ID, c.Name, c.Type, c.URL, encKey,
 		dbutil.BoolToInt(c.Enabled), c.Status, c.StatusMessage,
@@ -61,6 +61,7 @@ func (s *Service) Create(ctx context.Context, c *Connection) error {
 		dbutil.BoolToInt(c.FeatureLibraryImport), dbutil.BoolToInt(c.FeatureNFOWrite), dbutil.BoolToInt(c.FeatureImageWrite),
 		dbutil.BoolToInt(c.FeatureMetadataPush), dbutil.BoolToInt(c.FeatureTriggerRefresh),
 		dbutil.BoolToInt(c.FeatureManageServerFiles),
+		dbutil.BoolToInt(c.VerifyPathAfterUpdate),
 		c.PlatformUserID, c.PlatformServerID,
 		c.PreStillwaterConfigJSON,
 	)
@@ -73,7 +74,7 @@ func (s *Service) Create(ctx context.Context, c *Connection) error {
 // GetByID retrieves a connection by ID with API key decrypted.
 func (s *Service) GetByID(ctx context.Context, id string) (*Connection, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, name, type, url, encrypted_api_key, enabled, status, status_message, last_checked_at, created_at, updated_at, feature_library_import, feature_nfo_write, feature_image_write, feature_metadata_push, feature_trigger_refresh, feature_manage_server_files, platform_user_id, platform_server_id, pre_stillwater_config_json
+		SELECT id, name, type, url, encrypted_api_key, enabled, status, status_message, last_checked_at, created_at, updated_at, feature_library_import, feature_nfo_write, feature_image_write, feature_metadata_push, feature_trigger_refresh, feature_manage_server_files, verify_path_after_update, platform_user_id, platform_server_id, pre_stillwater_config_json
 		FROM connections WHERE id = ?
 	`, id)
 	c, err := s.scanConnection(row)
@@ -89,7 +90,7 @@ func (s *Service) GetByID(ctx context.Context, id string) (*Connection, error) {
 // List returns all connections with API keys decrypted.
 func (s *Service) List(ctx context.Context) ([]Connection, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, name, type, url, encrypted_api_key, enabled, status, status_message, last_checked_at, created_at, updated_at, feature_library_import, feature_nfo_write, feature_image_write, feature_metadata_push, feature_trigger_refresh, feature_manage_server_files, platform_user_id, platform_server_id, pre_stillwater_config_json
+		SELECT id, name, type, url, encrypted_api_key, enabled, status, status_message, last_checked_at, created_at, updated_at, feature_library_import, feature_nfo_write, feature_image_write, feature_metadata_push, feature_trigger_refresh, feature_manage_server_files, verify_path_after_update, platform_user_id, platform_server_id, pre_stillwater_config_json
 		FROM connections ORDER BY name
 	`)
 	if err != nil {
@@ -115,7 +116,7 @@ func (s *Service) List(ctx context.Context) ([]Connection, error) {
 // ListByType returns connections filtered by type.
 func (s *Service) ListByType(ctx context.Context, connType string) ([]Connection, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, name, type, url, encrypted_api_key, enabled, status, status_message, last_checked_at, created_at, updated_at, feature_library_import, feature_nfo_write, feature_image_write, feature_metadata_push, feature_trigger_refresh, feature_manage_server_files, platform_user_id, platform_server_id, pre_stillwater_config_json
+		SELECT id, name, type, url, encrypted_api_key, enabled, status, status_message, last_checked_at, created_at, updated_at, feature_library_import, feature_nfo_write, feature_image_write, feature_metadata_push, feature_trigger_refresh, feature_manage_server_files, verify_path_after_update, platform_user_id, platform_server_id, pre_stillwater_config_json
 		FROM connections WHERE type = ? ORDER BY name
 	`, connType)
 	if err != nil {
@@ -141,7 +142,7 @@ func (s *Service) ListByType(ctx context.Context, connType string) ([]Connection
 // GetByTypeAndURL returns the most recently created connection matching type and URL, or nil if none.
 func (s *Service) GetByTypeAndURL(ctx context.Context, connType, url string) (*Connection, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, name, type, url, encrypted_api_key, enabled, status, status_message, last_checked_at, created_at, updated_at, feature_library_import, feature_nfo_write, feature_image_write, feature_metadata_push, feature_trigger_refresh, feature_manage_server_files, platform_user_id, platform_server_id, pre_stillwater_config_json
+		SELECT id, name, type, url, encrypted_api_key, enabled, status, status_message, last_checked_at, created_at, updated_at, feature_library_import, feature_nfo_write, feature_image_write, feature_metadata_push, feature_trigger_refresh, feature_manage_server_files, verify_path_after_update, platform_user_id, platform_server_id, pre_stillwater_config_json
 		FROM connections WHERE type = ? AND url = ? ORDER BY created_at DESC LIMIT 1
 	`, connType, url)
 	c, err := s.scanConnection(row)
@@ -196,6 +197,7 @@ func (s *Service) Update(ctx context.Context, c *Connection) error {
 			feature_library_import = ?, feature_nfo_write = ?, feature_image_write = ?,
 			feature_metadata_push = ?, feature_trigger_refresh = ?,
 			feature_manage_server_files = ?,
+			verify_path_after_update = ?,
 			platform_user_id = ?, platform_server_id = ?,
 			pre_stillwater_config_json = ?
 		WHERE id = ?
@@ -206,6 +208,7 @@ func (s *Service) Update(ctx context.Context, c *Connection) error {
 		dbutil.BoolToInt(c.FeatureLibraryImport), dbutil.BoolToInt(c.FeatureNFOWrite), dbutil.BoolToInt(c.FeatureImageWrite),
 		dbutil.BoolToInt(c.FeatureMetadataPush), dbutil.BoolToInt(c.FeatureTriggerRefresh),
 		dbutil.BoolToInt(c.FeatureManageServerFiles),
+		dbutil.BoolToInt(c.VerifyPathAfterUpdate),
 		c.PlatformUserID, c.PlatformServerID,
 		c.PreStillwaterConfigJSON,
 		c.ID,
@@ -365,6 +368,7 @@ func (s *Service) scanConnection(row interface{ Scan(...any) error }) (*Connecti
 	var featLibImport, featNFOWrite, featImageWrite int
 	var featMetadataPush, featTriggerRefresh int
 	var featManageServerFiles int
+	var verifyPathAfterUpdate int
 	var platformUserID sql.NullString
 	var platformServerID sql.NullString
 	var preStillwaterConfigJSON sql.NullString
@@ -377,6 +381,7 @@ func (s *Service) scanConnection(row interface{ Scan(...any) error }) (*Connecti
 		&featLibImport, &featNFOWrite, &featImageWrite,
 		&featMetadataPush, &featTriggerRefresh,
 		&featManageServerFiles,
+		&verifyPathAfterUpdate,
 		&platformUserID, &platformServerID,
 		&preStillwaterConfigJSON,
 	)
@@ -398,6 +403,7 @@ func (s *Service) scanConnection(row interface{ Scan(...any) error }) (*Connecti
 	c.FeatureMetadataPush = featMetadataPush == 1
 	c.FeatureTriggerRefresh = featTriggerRefresh == 1
 	c.FeatureManageServerFiles = featManageServerFiles == 1
+	c.VerifyPathAfterUpdate = verifyPathAfterUpdate == 1
 	c.CreatedAt = dbutil.ParseTime(createdAt)
 	c.UpdatedAt = dbutil.ParseTime(updatedAt)
 	c.PlatformUserID = platformUserID.String

--- a/internal/connection/service_test.go
+++ b/internal/connection/service_test.go
@@ -745,7 +745,7 @@ func TestVerifyPathAfterUpdate_RoundTrip(t *testing.T) {
 // TestVerifyPathAfterUpdate_DefaultsFalse pins the opt-in default required
 // by issue #1640: a connection inserted without setting the field reads
 // back false. Existing rows on upgrade hit the same path via the
-// ensureColumn DEFAULT 0 fallback in migrate.go.
+// ensureConnectionsColumn DEFAULT 0 fallback in migrate.go.
 func TestVerifyPathAfterUpdate_DefaultsFalse(t *testing.T) {
 	t.Parallel()
 	svc := setupTestService(t)

--- a/internal/connection/service_test.go
+++ b/internal/connection/service_test.go
@@ -698,3 +698,74 @@ func TestSetManageServerFiles_ErrorOnUnknownID(t *testing.T) {
 		t.Error("want error on unknown id")
 	}
 }
+
+// TestVerifyPathAfterUpdate_RoundTrip exercises the persistence half of
+// the #1640 toggle: a Lidarr connection inserted with VerifyPathAfterUpdate
+// = true must read back true after a GetByID and stay sticky across an
+// Update() that does not touch the field. Mirrors the
+// FeatureManageServerFiles round-trip pattern.
+func TestVerifyPathAfterUpdate_RoundTrip(t *testing.T) {
+	t.Parallel()
+	svc := setupTestService(t)
+	ctx := context.Background()
+
+	conn := &Connection{
+		Name:                  "Lidarr verify on",
+		Type:                  TypeLidarr,
+		URL:                   "http://localhost:8686",
+		APIKey:                "key",
+		VerifyPathAfterUpdate: true,
+	}
+	if err := svc.Create(ctx, conn); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := svc.GetByID(ctx, conn.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !got.VerifyPathAfterUpdate {
+		t.Error("VerifyPathAfterUpdate should be true after round-trip")
+	}
+
+	// Update without touching the field; it must persist.
+	got.Name = "renamed"
+	if err := svc.Update(ctx, got); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	reloaded, err := svc.GetByID(ctx, conn.ID)
+	if err != nil {
+		t.Fatalf("reload after update: %v", err)
+	}
+	if !reloaded.VerifyPathAfterUpdate {
+		t.Error("VerifyPathAfterUpdate should survive an Update that did not change it")
+	}
+}
+
+// TestVerifyPathAfterUpdate_DefaultsFalse pins the opt-in default required
+// by issue #1640: a connection inserted without setting the field reads
+// back false. Existing rows on upgrade hit the same path via the
+// ensureColumn DEFAULT 0 fallback in migrate.go.
+func TestVerifyPathAfterUpdate_DefaultsFalse(t *testing.T) {
+	t.Parallel()
+	svc := setupTestService(t)
+	ctx := context.Background()
+
+	conn := &Connection{
+		Name:   "Lidarr default",
+		Type:   TypeLidarr,
+		URL:    "http://localhost:8686",
+		APIKey: "key",
+	}
+	if err := svc.Create(ctx, conn); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := svc.GetByID(ctx, conn.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.VerifyPathAfterUpdate {
+		t.Error("VerifyPathAfterUpdate should default to false")
+	}
+}

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -224,7 +224,10 @@ func ensureConnectionColumns(db *sql.DB) error {
 	if err := ensureColumn(db, "connections", "feature_manage_server_files", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
-	return ensureColumn(db, "connections", "pre_stillwater_config_json", "TEXT NOT NULL DEFAULT ''")
+	if err := ensureColumn(db, "connections", "pre_stillwater_config_json", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
+	return ensureColumn(db, "connections", "verify_path_after_update", "INTEGER NOT NULL DEFAULT 0")
 }
 
 // cleanupOrphanArtistPlatformIDs removes rows from artist_platform_ids whose

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -218,16 +218,16 @@ func markPre002Applied(db *sql.DB) error {
 // PRAGMA table_info to avoid the "duplicate column" error SQLite raises
 // when a column already exists.
 func ensureConnectionColumns(db *sql.DB) error {
-	if err := ensureColumn(db, "connections", "platform_server_id", "TEXT NOT NULL DEFAULT ''"); err != nil {
+	if err := ensureConnectionsColumn(db, "platform_server_id", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		return err
 	}
-	if err := ensureColumn(db, "connections", "feature_manage_server_files", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+	if err := ensureConnectionsColumn(db, "feature_manage_server_files", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
-	if err := ensureColumn(db, "connections", "pre_stillwater_config_json", "TEXT NOT NULL DEFAULT ''"); err != nil {
+	if err := ensureConnectionsColumn(db, "pre_stillwater_config_json", "TEXT NOT NULL DEFAULT ''"); err != nil {
 		return err
 	}
-	return ensureColumn(db, "connections", "verify_path_after_update", "INTEGER NOT NULL DEFAULT 0")
+	return ensureConnectionsColumn(db, "verify_path_after_update", "INTEGER NOT NULL DEFAULT 0")
 }
 
 // cleanupOrphanArtistPlatformIDs removes rows from artist_platform_ids whose
@@ -1011,14 +1011,15 @@ func lowercaseASCII(s string) string {
 	return string(b)
 }
 
-// ensureColumn adds a column to a table if it does not already exist.
-// The definition string is concatenated directly into the ALTER TABLE
-// statement, so callers must only pass internal literals.
-func ensureColumn(db *sql.DB, table, column, definition string) error {
+// ensureConnectionsColumn adds a column to the connections table if it
+// does not already exist. The definition string is concatenated directly
+// into the ALTER TABLE statement, so callers must only pass internal
+// literals.
+func ensureConnectionsColumn(db *sql.DB, column, definition string) error {
 	ctx := context.Background()
-	rows, err := db.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table))
+	rows, err := db.QueryContext(ctx, "PRAGMA table_info(connections)")
 	if err != nil {
-		return fmt.Errorf("reading %s schema: %w", table, err)
+		return fmt.Errorf("reading connections schema: %w", err)
 	}
 	defer rows.Close() //nolint:errcheck // Close error not actionable on cleanup
 
@@ -1032,19 +1033,19 @@ func ensureColumn(db *sql.DB, table, column, definition string) error {
 			pk        int
 		)
 		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dfltValue, &pk); err != nil {
-			return fmt.Errorf("scanning %s schema row: %w", table, err)
+			return fmt.Errorf("scanning connections schema row: %w", err)
 		}
 		if name == column {
 			return nil
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterating %s schema: %w", table, err)
+		return fmt.Errorf("iterating connections schema: %w", err)
 	}
 
-	stmt := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", table, column, definition)
+	stmt := fmt.Sprintf("ALTER TABLE connections ADD COLUMN %s %s", column, definition)
 	if _, err := db.ExecContext(ctx, stmt); err != nil {
-		return fmt.Errorf("adding %s.%s: %w", table, column, err)
+		return fmt.Errorf("adding connections.%s: %w", column, err)
 	}
 	return nil
 }

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -224,10 +224,7 @@ func ensureConnectionColumns(db *sql.DB) error {
 	if err := ensureConnectionsColumn(db, "feature_manage_server_files", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return err
 	}
-	if err := ensureConnectionsColumn(db, "pre_stillwater_config_json", "TEXT NOT NULL DEFAULT ''"); err != nil {
-		return err
-	}
-	return ensureConnectionsColumn(db, "verify_path_after_update", "INTEGER NOT NULL DEFAULT 0")
+	return ensureConnectionsColumn(db, "pre_stillwater_config_json", "TEXT NOT NULL DEFAULT ''")
 }
 
 // cleanupOrphanArtistPlatformIDs removes rows from artist_platform_ids whose

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -1762,3 +1762,31 @@ func TestMigration010_NoClassicalRowsAfterMigrate(t *testing.T) {
 		t.Errorf("classical library count on fresh migrated db = %d, want 0", count)
 	}
 }
+
+// TestEnsureConnectionsColumn_AddsAndIsIdempotent covers both branches of
+// the runtime helper used to add forward-compat columns to the connections
+// table on upgrade. The SQL migrations exercise the no-op branch (column
+// already exists); this test exercises the ALTER TABLE branch and the
+// idempotency follow-up call.
+func TestEnsureConnectionsColumn_AddsAndIsIdempotent(t *testing.T) {
+	db := openMigratedDB(t)
+
+	const col = "test_only_dummy"
+	const def = "INTEGER NOT NULL DEFAULT 0"
+
+	if err := ensureConnectionsColumn(db, col, def); err != nil {
+		t.Fatalf("first call (add): %v", err)
+	}
+
+	got, err := columnExists(db, "connections", col)
+	if err != nil {
+		t.Fatalf("columnExists after add: %v", err)
+	}
+	if !got {
+		t.Fatalf("column %q not added after first call", col)
+	}
+
+	if err := ensureConnectionsColumn(db, col, def); err != nil {
+		t.Fatalf("second call (no-op): %v", err)
+	}
+}

--- a/internal/database/migrate_test.go
+++ b/internal/database/migrate_test.go
@@ -1790,3 +1790,18 @@ func TestEnsureConnectionsColumn_AddsAndIsIdempotent(t *testing.T) {
 		t.Fatalf("second call (no-op): %v", err)
 	}
 }
+
+// TestEnsureConnectionsColumn_PropagatesAlterError covers the
+// ExecContext error branch by passing a definition SQLite rejects, and
+// asserts the wrap carries the column name so operators can diagnose
+// an upgrade-time failure from logs alone.
+func TestEnsureConnectionsColumn_PropagatesAlterError(t *testing.T) {
+	db := openMigratedDB(t)
+	err := ensureConnectionsColumn(db, "bad_col", "NOT A VALID TYPE")
+	if err == nil {
+		t.Fatal("expected error from ExecContext with invalid type")
+	}
+	if !strings.Contains(err.Error(), "bad_col") {
+		t.Errorf("error %v does not name the column", err)
+	}
+}

--- a/internal/database/migrations/013_connection_verify_path_after_update.sql
+++ b/internal/database/migrations/013_connection_verify_path_after_update.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- Issue #1640: persistence for the Lidarr verify-after-PUT rename safety toggle.
+--
+-- Adds the verify_path_after_update boolean column to connections. Default 0
+-- (opt-in) so existing rows keep today's single-PUT behavior; operators flip
+-- it on per Lidarr connection when they suspect path coercion against the
+-- Root Folder list. The client-side capability landed in PR16
+-- (lidarr.Client.SetVerifyPathAfterUpdate); this column is the persistence
+-- half that lets the rename pipeline reach the setter from a stored
+-- connection. The matching UI toggle is tracked separately.
+
+-- +goose StatementBegin
+ALTER TABLE connections ADD COLUMN verify_path_after_update INTEGER NOT NULL DEFAULT 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE connections DROP COLUMN verify_path_after_update;
+-- +goose StatementEnd

--- a/internal/database/migrations/013_connection_verify_path_after_update.sql
+++ b/internal/database/migrations/013_connection_verify_path_after_update.sql
@@ -1,13 +1,13 @@
 -- +goose Up
--- Issue #1640: persistence for the Lidarr verify-after-PUT rename safety toggle.
+-- Persistence for the Lidarr verify-after-PUT rename safety toggle.
 --
 -- Adds the verify_path_after_update boolean column to connections. Default 0
 -- (opt-in) so existing rows keep today's single-PUT behavior; operators flip
 -- it on per Lidarr connection when they suspect path coercion against the
--- Root Folder list. The client-side capability landed in PR16
--- (lidarr.Client.SetVerifyPathAfterUpdate); this column is the persistence
--- half that lets the rename pipeline reach the setter from a stored
--- connection. The matching UI toggle is tracked separately.
+-- Root Folder list. The client-side capability (
+-- lidarr.Client.SetVerifyPathAfterUpdate) is reached from a stored
+-- connection via the rename pipeline; the matching UI toggle is tracked
+-- separately.
 
 -- +goose StatementBegin
 ALTER TABLE connections ADD COLUMN verify_path_after_update INTEGER NOT NULL DEFAULT 0;

--- a/internal/publish/publisher.go
+++ b/internal/publish/publisher.go
@@ -31,9 +31,7 @@ const pushOpLockToggle = "lock_toggle"
 
 // pushOpMetadataPush is the operation slug emitted on connection.push_failed
 // events from PushMetadataAsync. Toast subscribers can filter by this slug
-// to distinguish a metadata-write failure from a lock-toggle failure (per
-// issue #1642 -- bringing the metadata push surface into parity with the
-// PushLocks notify path introduced by #1088).
+// to distinguish a metadata-write failure from a lock-toggle failure.
 const pushOpMetadataPush = "metadata_push"
 
 const (

--- a/internal/publish/publisher.go
+++ b/internal/publish/publisher.go
@@ -26,9 +26,15 @@ import (
 )
 
 // pushOpLockToggle is the operation slug emitted on connection.push_failed
-// events from PushLocks. Other push surfaces (PushMetadataAsync) will gain
-// their own slugs as the notifier path is extended to them.
+// events from PushLocks.
 const pushOpLockToggle = "lock_toggle"
+
+// pushOpMetadataPush is the operation slug emitted on connection.push_failed
+// events from PushMetadataAsync. Toast subscribers can filter by this slug
+// to distinguish a metadata-write failure from a lock-toggle failure (per
+// issue #1642 -- bringing the metadata push surface into parity with the
+// PushLocks notify path introduced by #1088).
+const pushOpMetadataPush = "metadata_push"
 
 const (
 	// pushTimeout is the per-connection timeout for async metadata pushes.
@@ -286,6 +292,16 @@ func (p *Publisher) PushMetadataAsync(ctx context.Context, a *artist.Artist) {
 					slog.String("artist_id", a.ID),
 					slog.String("connection_id", pid.ConnectionID),
 					slog.String("error", connErr.Error()))
+				// Mirror the PushLocks lookup-failure notify path (#1088).
+				// shortConnLabel falls back to an 8-char id prefix because the
+				// connection name is unknown when GetByID itself failed.
+				// classifyPushErr keeps the toast error class in the same
+				// stable taxonomy regardless of which surface raised it.
+				class := classifyPushErr(connErr)
+				if class == "" {
+					class = "rejected"
+				}
+				p.notifyPushFailure(shortConnLabel(pid.ConnectionID), class, a.ID, artistDisplayName(a), pushOpMetadataPush, connErr)
 				return
 			}
 			if !conn.Enabled {
@@ -303,6 +319,11 @@ func (p *Publisher) PushMetadataAsync(ctx context.Context, a *artist.Artist) {
 					slog.String("artist_name", a.Name),
 					slog.String("connection", conn.Name),
 					slog.String("error", pushErr.Error()))
+				// Same notify path as PushLocks: classifyPushErr translates
+				// the raw transport / status error into the stable taxonomy
+				// (auth_failed, timeout, server_error, ...) so the toast
+				// tells the operator what kind of intervention is needed.
+				p.notifyPushFailure(conn.Name, classifyPushErr(pushErr), a.ID, artistDisplayName(a), pushOpMetadataPush, pushErr)
 			} else {
 				p.logger.Info("auto-push: metadata pushed",
 					slog.String("artist_id", a.ID),

--- a/internal/publish/publisher.go
+++ b/internal/publish/publisher.go
@@ -292,16 +292,18 @@ func (p *Publisher) PushMetadataAsync(ctx context.Context, a *artist.Artist) {
 					slog.String("artist_id", a.ID),
 					slog.String("connection_id", pid.ConnectionID),
 					slog.String("error", connErr.Error()))
-				// Mirror the PushLocks lookup-failure notify path (#1088).
-				// shortConnLabel falls back to an 8-char id prefix because the
-				// connection name is unknown when GetByID itself failed.
-				// classifyPushErr keeps the toast error class in the same
-				// stable taxonomy regardless of which surface raised it.
-				class := classifyPushErr(connErr)
-				if class == "" {
-					class = "rejected"
-				}
-				p.notifyPushFailure(shortConnLabel(pid.ConnectionID), class, a.ID, artistDisplayName(a), pushOpMetadataPush, connErr)
+				// Mirror the PushLocks lookup-failure notify path so the
+				// metadata push surface emits the same toast taxonomy.
+				// shortConnLabel falls back to an 8-char id prefix the
+				// operator can correlate against the settings page
+				// connection list -- it matches the connection_id prefix
+				// shown in the "auto-push: fetching connection" error log
+				// above, so a toast can be cross-referenced to the log
+				// entry without exposing the full UUID. classifyPushErr
+				// translates the lookup failure into a stable category;
+				// connErr is always non-nil in this branch so the empty
+				// return from classifyPushErr is unreachable here.
+				p.notifyPushFailure(shortConnLabel(pid.ConnectionID), classifyPushErr(connErr), a.ID, artistDisplayName(a), pushOpMetadataPush, connErr)
 				return
 			}
 			if !conn.Enabled {

--- a/internal/publish/publisher_test.go
+++ b/internal/publish/publisher_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -306,12 +307,19 @@ func TestResolveLockNFO(t *testing.T) {
 }
 
 // recordingNotifier captures every NotifyConnectionPushFailed call so
-// PushLocks tests can assert on the (connection, error_class) pair the
-// publisher hands the SSE bridge. Concurrent calls from per-connection
-// goroutines are serialized by mu.
+// PushLocks / PushMetadataAsync tests can assert on the (connection,
+// error_class) pair the publisher hands the SSE bridge. Concurrent calls
+// from per-connection goroutines are serialized by mu.
+//
+// done is an optional non-buffered signal: every call sends a struct{} on
+// it after appending to calls, so a test can block on receive instead of
+// polling for the slice length to grow. Tests that do not care about
+// synchronization (most pre-channel-conversion ones) leave done nil and
+// the send is skipped.
 type recordingNotifier struct {
 	mu    sync.Mutex
 	calls []notifyCall
+	done  chan struct{}
 }
 
 type notifyCall struct {
@@ -325,7 +333,6 @@ type notifyCall struct {
 
 func (r *recordingNotifier) NotifyConnectionPushFailed(connectionName, errorClass, artistID, artistName, operation string, err error) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.calls = append(r.calls, notifyCall{
 		connection: connectionName,
 		errorClass: errorClass,
@@ -334,6 +341,17 @@ func (r *recordingNotifier) NotifyConnectionPushFailed(connectionName, errorClas
 		operation:  operation,
 		err:        err,
 	})
+	ch := r.done
+	r.mu.Unlock()
+	if ch != nil {
+		// Buffered channel so a producer never blocks; tests that wire it
+		// up are responsible for draining when they expect more than one
+		// notify within a single test.
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
 }
 
 func (r *recordingNotifier) snapshot() []notifyCall {
@@ -586,7 +604,7 @@ func TestPushMetadataAsync_NotifierFiresOnPushFailure(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	notifier := &recordingNotifier{}
+	notifier := &recordingNotifier{done: make(chan struct{}, 1)}
 	p := New(Deps{
 		ArtistService: &fakePlatformLister{ids: []artist.PlatformID{
 			{ArtistID: "a1", ConnectionID: "c-emby", PlatformArtistID: "p1"},
@@ -601,15 +619,13 @@ func TestPushMetadataAsync_NotifierFiresOnPushFailure(t *testing.T) {
 	a := &artist.Artist{ID: "a1", Name: "Test Artist"}
 	p.PushMetadataAsync(context.Background(), a)
 
-	// PushMetadataAsync dispatches its work in a goroutine; spin briefly
-	// until the notifier observes the failure. The 401 path is synchronous
-	// inside PushMetadata so a short deadline is sufficient.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(notifier.snapshot()) > 0 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
+	// Block on the channel-backed notify signal instead of polling. The
+	// 401 path is synchronous inside PushMetadata, so the goroutine
+	// completes well within the 2s safety timeout.
+	select {
+	case <-notifier.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("notify did not fire within 2s")
 	}
 
 	got := notifier.snapshot()
@@ -643,7 +659,7 @@ func TestPushMetadataAsync_NotifierFiresOnPushFailure(t *testing.T) {
 // underlying write was never attempted). Connection name falls back to
 // shortConnLabel since GetByID failed before we could read the real name.
 func TestPushMetadataAsync_NotifierFiresOnConnectionLookupFailure(t *testing.T) {
-	notifier := &recordingNotifier{}
+	notifier := &recordingNotifier{done: make(chan struct{}, 1)}
 	p := New(Deps{
 		ArtistService: &fakePlatformLister{ids: []artist.PlatformID{
 			{ArtistID: "a1", ConnectionID: "c-gone", PlatformArtistID: "p1"},
@@ -657,12 +673,10 @@ func TestPushMetadataAsync_NotifierFiresOnConnectionLookupFailure(t *testing.T) 
 	a := &artist.Artist{ID: "a1", Name: "Test Artist"}
 	p.PushMetadataAsync(context.Background(), a)
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(notifier.snapshot()) > 0 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
+	select {
+	case <-notifier.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("notify did not fire within 2s")
 	}
 
 	got := notifier.snapshot()
@@ -687,12 +701,26 @@ func TestPushMetadataAsync_NotifierFiresOnConnectionLookupFailure(t *testing.T) 
 // no notify, no toast. Symmetric with TestPushLocks_NotifierNotCalledOnSuccess
 // so a regression on either surface fails its own test, not the other's.
 func TestPushMetadataAsync_NotifierNotCalledOnSuccess(t *testing.T) {
+	// pushDone fires when the test server has finished handling the
+	// metadata POST (the one PushMetadataAsync's goroutine awaits).
+	// Refresh requests fire after the POST and are not waited on. The
+	// channel-backed barrier replaces a sleep timer so the test does not
+	// race on a slow CI box.
+	pushDone := make(chan struct{}, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/Refresh") {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
+		select {
+		case pushDone <- struct{}{}:
+		default:
+		}
 	}))
 	defer srv.Close()
 
-	notifier := &recordingNotifier{}
+	notifier := &recordingNotifier{done: make(chan struct{}, 1)}
 	p := New(Deps{
 		ArtistService: &fakePlatformLister{ids: []artist.PlatformID{
 			{ArtistID: "a1", ConnectionID: "c-emby", PlatformArtistID: "p1"},
@@ -707,8 +735,22 @@ func TestPushMetadataAsync_NotifierNotCalledOnSuccess(t *testing.T) {
 	a := &artist.Artist{ID: "a1", Name: "Test Artist"}
 	p.PushMetadataAsync(context.Background(), a)
 
-	// Give the goroutine time to complete a successful POST.
-	time.Sleep(200 * time.Millisecond)
+	// Wait for the metadata POST to complete server-side, then assert
+	// the notifier never fired. A spurious notify (regression) would
+	// already have raced into r.calls by the time the POST returned.
+	select {
+	case <-pushDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("metadata POST did not complete within 2s")
+	}
+	// Tiny yield so any spurious notify enqueued from inside the publisher
+	// goroutine has a chance to land before we read the snapshot. This is
+	// not a polling loop; the success path is synchronous post-POST.
+	select {
+	case <-notifier.done:
+		t.Errorf("notifier fired on success path")
+	case <-time.After(50 * time.Millisecond):
+	}
 	if got := notifier.snapshot(); len(got) != 0 {
 		t.Errorf("notifier calls on success = %d, want 0; calls=%+v", len(got), got)
 	}

--- a/internal/publish/publisher_test.go
+++ b/internal/publish/publisher_test.go
@@ -569,3 +569,147 @@ func TestShortConnLabel(t *testing.T) {
 		})
 	}
 }
+
+// TestPushMetadataAsync_NotifierFiresOnPushFailure mirrors
+// TestPushLocks_NotifierFiresOnSyncFailure for the PushMetadataAsync
+// surface (#1642). When the platform write returns 401, the per-connection
+// goroutine must invoke the Notifier exactly once with the operation slug
+// "metadata_push" and a non-empty error class from the classifyPushErr
+// taxonomy (auth_failed for 401). Without this hook the operator gets
+// nothing in the UI while the platform silently rejected the write.
+func TestPushMetadataAsync_NotifierFiresOnPushFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Emby PushMetadata posts directly to /Items/{id}; reject every
+		// write with 401 so the push goroutine surfaces an auth_failed
+		// classification through classifyPushErr.
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	notifier := &recordingNotifier{}
+	p := New(Deps{
+		ArtistService: &fakePlatformLister{ids: []artist.PlatformID{
+			{ArtistID: "a1", ConnectionID: "c-emby", PlatformArtistID: "p1"},
+		}},
+		ConnectionService: &fakeConnectionGetter{conns: map[string]*connection.Connection{
+			"c-emby": {ID: "c-emby", Name: "my-emby", Type: connection.TypeEmby, URL: srv.URL, Enabled: true, PlatformUserID: "u1"},
+		}},
+		Logger:   silentLogger(),
+		Notifier: notifier,
+	})
+
+	a := &artist.Artist{ID: "a1", Name: "Test Artist"}
+	p.PushMetadataAsync(context.Background(), a)
+
+	// PushMetadataAsync dispatches its work in a goroutine; spin briefly
+	// until the notifier observes the failure. The 401 path is synchronous
+	// inside PushMetadata so a short deadline is sufficient.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(notifier.snapshot()) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	got := notifier.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("notifier calls = %d, want 1; calls=%+v", len(got), got)
+	}
+	if got[0].connection != "my-emby" {
+		t.Errorf("connection = %q, want %q", got[0].connection, "my-emby")
+	}
+	if got[0].errorClass != "auth_failed" {
+		t.Errorf("errorClass = %q, want %q (401 should classify as auth_failed)", got[0].errorClass, "auth_failed")
+	}
+	if got[0].artistID != "a1" {
+		t.Errorf("artistID = %q, want %q", got[0].artistID, "a1")
+	}
+	if got[0].artistName != "Test Artist" {
+		t.Errorf("artistName = %q, want %q", got[0].artistName, "Test Artist")
+	}
+	if got[0].operation != "metadata_push" {
+		t.Errorf("operation = %q, want %q (PushMetadataAsync must emit pushOpMetadataPush)", got[0].operation, "metadata_push")
+	}
+	if got[0].err == nil {
+		t.Error("err = nil, want a non-nil error so logs can correlate")
+	}
+}
+
+// TestPushMetadataAsync_NotifierFiresOnConnectionLookupFailure verifies
+// the GetByID lookup-failure branch. When a connection is deleted between
+// platform-ID resolution and metadata push, the goroutine must still
+// surface a toast (operator otherwise sees a green success path while the
+// underlying write was never attempted). Connection name falls back to
+// shortConnLabel since GetByID failed before we could read the real name.
+func TestPushMetadataAsync_NotifierFiresOnConnectionLookupFailure(t *testing.T) {
+	notifier := &recordingNotifier{}
+	p := New(Deps{
+		ArtistService: &fakePlatformLister{ids: []artist.PlatformID{
+			{ArtistID: "a1", ConnectionID: "c-gone", PlatformArtistID: "p1"},
+		}},
+		// Empty conns map -> fakeConnectionGetter.GetByID returns an error.
+		ConnectionService: &fakeConnectionGetter{conns: map[string]*connection.Connection{}},
+		Logger:            silentLogger(),
+		Notifier:          notifier,
+	})
+
+	a := &artist.Artist{ID: "a1", Name: "Test Artist"}
+	p.PushMetadataAsync(context.Background(), a)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(notifier.snapshot()) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	got := notifier.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("notifier calls = %d, want 1; calls=%+v", len(got), got)
+	}
+	if got[0].operation != "metadata_push" {
+		t.Errorf("operation = %q, want %q", got[0].operation, "metadata_push")
+	}
+	if got[0].connection == "" {
+		t.Error("connection label is empty; expected shortConnLabel fallback (id=c-gone)")
+	}
+	if got[0].errorClass == "" {
+		t.Error("errorClass empty; lookup failure must still classify (rejected fallback)")
+	}
+	if got[0].err == nil {
+		t.Error("err = nil, want a non-nil error so logs can correlate")
+	}
+}
+
+// TestPushMetadataAsync_NotifierNotCalledOnSuccess covers the happy path:
+// no notify, no toast. Symmetric with TestPushLocks_NotifierNotCalledOnSuccess
+// so a regression on either surface fails its own test, not the other's.
+func TestPushMetadataAsync_NotifierNotCalledOnSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	notifier := &recordingNotifier{}
+	p := New(Deps{
+		ArtistService: &fakePlatformLister{ids: []artist.PlatformID{
+			{ArtistID: "a1", ConnectionID: "c-emby", PlatformArtistID: "p1"},
+		}},
+		ConnectionService: &fakeConnectionGetter{conns: map[string]*connection.Connection{
+			"c-emby": {ID: "c-emby", Name: "my-emby", Type: connection.TypeEmby, URL: srv.URL, Enabled: true, PlatformUserID: "u1"},
+		}},
+		Logger:   silentLogger(),
+		Notifier: notifier,
+	})
+
+	a := &artist.Artist{ID: "a1", Name: "Test Artist"}
+	p.PushMetadataAsync(context.Background(), a)
+
+	// Give the goroutine time to complete a successful POST.
+	time.Sleep(200 * time.Millisecond)
+	if got := notifier.snapshot(); len(got) != 0 {
+		t.Errorf("notifier calls on success = %d, want 0; calls=%+v", len(got), got)
+	}
+}

--- a/internal/publish/publisher_test.go
+++ b/internal/publish/publisher_test.go
@@ -686,11 +686,19 @@ func TestPushMetadataAsync_NotifierFiresOnConnectionLookupFailure(t *testing.T) 
 	if got[0].operation != "metadata_push" {
 		t.Errorf("operation = %q, want %q", got[0].operation, "metadata_push")
 	}
-	if got[0].connection == "" {
-		t.Error("connection label is empty; expected shortConnLabel fallback (id=c-gone)")
+	// Pin the exact shortConnLabel("c-gone") fallback so a future regression
+	// that changes the label format or drops the prefix-truncation logic
+	// fails here. Asserting non-empty would let an unrelated format change
+	// pass silently.
+	if want := shortConnLabel("c-gone"); got[0].connection != want {
+		t.Errorf("connection = %q, want %q", got[0].connection, want)
 	}
-	if got[0].errorClass == "" {
-		t.Error("errorClass empty; lookup failure must still classify (rejected fallback)")
+	// Pin the exact "rejected" class so the PushMetadataAsync lookup-failure
+	// path stays in parity with PushLocks: classifyPushErr's default
+	// taxonomy bucket for a non-network/non-status error is "rejected", and
+	// this is the contract the surrounding toast surface relies on.
+	if got[0].errorClass != "rejected" {
+		t.Errorf("errorClass = %q, want %q (lookup failure must classify as rejected)", got[0].errorClass, "rejected")
 	}
 	if got[0].err == nil {
 		t.Error("err = nil, want a non-nil error so logs can correlate")

--- a/internal/publish/rename_sync.go
+++ b/internal/publish/rename_sync.go
@@ -43,7 +43,16 @@ var renamePathUpdaterFactory = func(conn *connection.Connection, logger *slog.Lo
 	case connection.TypeJellyfin:
 		return jellyfin.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger), true
 	case connection.TypeLidarr:
-		return lidarr.New(conn.URL, conn.APIKey, logger), true
+		// VerifyPathAfterUpdate is the per-connection opt-in (#1640): when
+		// true, UpdateArtistPath issues a follow-up GET and confirms the
+		// returned path round-trips. Setting it here is the load-bearing
+		// wiring -- without this line the Connection field exists in the
+		// DB but never reaches the client, so the verify capability is
+		// dead code. Default false on the model means existing rows keep
+		// today's single-PUT behavior.
+		client := lidarr.New(conn.URL, conn.APIKey, logger)
+		client.SetVerifyPathAfterUpdate(conn.VerifyPathAfterUpdate)
+		return client, true
 	default:
 		return nil, false
 	}

--- a/internal/publish/rename_sync.go
+++ b/internal/publish/rename_sync.go
@@ -43,8 +43,8 @@ var renamePathUpdaterFactory = func(conn *connection.Connection, logger *slog.Lo
 	case connection.TypeJellyfin:
 		return jellyfin.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger), true
 	case connection.TypeLidarr:
-		// VerifyPathAfterUpdate is the per-connection opt-in (#1640): when
-		// true, UpdateArtistPath issues a follow-up GET and confirms the
+		// VerifyPathAfterUpdate is the per-connection opt-in: when true,
+		// UpdateArtistPath issues a follow-up GET and confirms the
 		// returned path round-trips. Setting it here is the load-bearing
 		// wiring -- without this line the Connection field exists in the
 		// DB but never reaches the client, so the verify capability is

--- a/internal/publish/rename_sync_test.go
+++ b/internal/publish/rename_sync_test.go
@@ -442,3 +442,112 @@ func TestSyncRename_PerPlatformTimeoutFires(t *testing.T) {
 		t.Errorf("Error = %q, want substring \"deadline\" (context.DeadlineExceeded)", results[0].Error)
 	}
 }
+
+// lidarrVerifyServer is a minimal httptest fixture that counts GET vs PUT
+// hits against /api/v1/artist/{id}. Shared by the two wiring tests below so
+// the only delta between them is the Connection.VerifyPathAfterUpdate value.
+// Echoes the requested path on the verify GET so the match branch
+// succeeds without each test needing to script per-request bodies.
+func lidarrVerifyServer(t *testing.T, newPath string) (*httptest.Server, func() int) {
+	t.Helper()
+	var getCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			getCount++
+			w.Header().Set("Content-Type", "application/json")
+			if getCount == 1 {
+				_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
+				return
+			}
+			// Subsequent GET (the verify-after-PUT branch) echoes the new
+			// path so the match check inside lidarr.Client succeeds.
+			_, _ = w.Write([]byte(`{"id":42,"path":"` + newPath + `"}`))
+		case http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func() int { return getCount }
+}
+
+// TestSyncRename_LidarrVerifyWiringEnabled asserts the load-bearing wiring
+// for #1640: when conn.VerifyPathAfterUpdate is true the real
+// renamePathUpdaterFactory must call client.SetVerifyPathAfterUpdate(true)
+// so the rename produces 2 GETs (pre-PUT + verify) against the Lidarr
+// peer. The factory is NOT swapped here so the test exercises the actual
+// production path. Without this coverage the Connection field could be
+// silently dropped on its way to the client and the verify capability
+// would be dead code.
+func TestSyncRename_LidarrVerifyWiringEnabled(t *testing.T) {
+	srv, gets := lidarrVerifyServer(t, "/new/X")
+
+	p := New(Deps{
+		ArtistService: &fakePlatformLister{ids: []artist.PlatformID{
+			{ArtistID: "a1", ConnectionID: "c-lid", PlatformArtistID: "42"},
+		}},
+		ConnectionService: &fakeConnectionGetter{conns: map[string]*connection.Connection{
+			"c-lid": {
+				ID:                    "c-lid",
+				Name:                  "lid",
+				Type:                  connection.TypeLidarr,
+				URL:                   srv.URL,
+				APIKey:                "k",
+				Enabled:               true,
+				VerifyPathAfterUpdate: true,
+			},
+		}},
+		Logger: silentLogger(),
+	})
+
+	results, err := p.SyncRename(context.Background(), "a1", "/old", "/new/X")
+	if err != nil {
+		t.Fatalf("SyncRename: %v", err)
+	}
+	if len(results) != 1 || results[0].Result != artist.PlatformRemapOK {
+		t.Fatalf("results = %+v, want one ok entry", results)
+	}
+	if got := gets(); got != 2 {
+		t.Errorf("GET count = %d, want 2 (pre-PUT + verify); wiring did not reach client", got)
+	}
+}
+
+// TestSyncRename_LidarrVerifyWiringDisabled is the negative-branch twin
+// of the enabled wiring test: when conn.VerifyPathAfterUpdate is false the
+// rename must produce exactly 1 GET (pre-PUT only) so the opt-in default
+// stays cheap. A regression that hard-codes verify=true would surface
+// here as a 2-GET observation.
+func TestSyncRename_LidarrVerifyWiringDisabled(t *testing.T) {
+	srv, gets := lidarrVerifyServer(t, "/new/X")
+
+	p := New(Deps{
+		ArtistService: &fakePlatformLister{ids: []artist.PlatformID{
+			{ArtistID: "a1", ConnectionID: "c-lid", PlatformArtistID: "42"},
+		}},
+		ConnectionService: &fakeConnectionGetter{conns: map[string]*connection.Connection{
+			"c-lid": {
+				ID:      "c-lid",
+				Name:    "lid",
+				Type:    connection.TypeLidarr,
+				URL:     srv.URL,
+				APIKey:  "k",
+				Enabled: true,
+				// VerifyPathAfterUpdate defaults to false.
+			},
+		}},
+		Logger: silentLogger(),
+	})
+
+	results, err := p.SyncRename(context.Background(), "a1", "/old", "/new/X")
+	if err != nil {
+		t.Fatalf("SyncRename: %v", err)
+	}
+	if len(results) != 1 || results[0].Result != artist.PlatformRemapOK {
+		t.Fatalf("results = %+v, want one ok entry", results)
+	}
+	if got := gets(); got != 1 {
+		t.Errorf("GET count = %d, want 1 (verify must remain opt-in)", got)
+	}
+}

--- a/internal/publish/rename_sync_test.go
+++ b/internal/publish/rename_sync_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -450,13 +451,16 @@ func TestSyncRename_PerPlatformTimeoutFires(t *testing.T) {
 // succeeds without each test needing to script per-request bodies.
 func lidarrVerifyServer(t *testing.T, newPath string) (*httptest.Server, func() int) {
 	t.Helper()
-	var getCount int
+	// atomic.Int32 because the counter is written from the httptest
+	// handler goroutine and read from the test goroutine; a plain int
+	// trips -race under the project's race-test rule.
+	var getCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			getCount++
+			n := getCount.Add(1)
 			w.Header().Set("Content-Type", "application/json")
-			if getCount == 1 {
+			if n == 1 {
 				_, _ = w.Write([]byte(`{"id":42,"path":"/old/X"}`))
 				return
 			}
@@ -470,7 +474,7 @@ func lidarrVerifyServer(t *testing.T, newPath string) (*httptest.Server, func() 
 		}
 	}))
 	t.Cleanup(srv.Close)
-	return srv, func() int { return getCount }
+	return srv, func() int { return int(getCount.Load()) }
 }
 
 // TestSyncRename_LidarrVerifyWiringEnabled asserts the load-bearing wiring


### PR DESCRIPTION
## Summary

- Add typed auth-class sentinels (`emby.ErrAuthRequired`, `jellyfin.ErrAuthRequired`, `lidarr.ErrAuthRequired`) wrapping 401/403 on every platform-write method, so consumers route auth-class failures via `errors.Is` instead of substring matching.
- Introduce shared `httpclient.StatusError` type that exposes the status code through `errors.As` while preserving the historical "unexpected status N: body" string shape that `publish.classifyPushErr` depends on.
- Add per-connection opt-in verify-after-PUT for Lidarr rename: new migration 013 column + Connection model field + `rename_sync.go` wiring that calls `client.SetVerifyPathAfterUpdate(conn.VerifyPathAfterUpdate)` before issuing the rename PUT.
- Extend `PushMetadataAsync` to emit per-connection failure toasts via the same Notifier path as `PushLocks` (new `pushOpMetadataPush = "metadata_push"` operation slug).

## Linked issue

Closes #1639
Closes #1640
Closes #1642

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Code review pass complete (`/pr-review-toolkit:review-pr` ran with all 5 reviewers; all 8 Important + 12 of 15 Suggestions fixed; remaining 3 Suggestions filed as follow-ups #1686, #1687, #1688).
- [x] Commits squashed-clean before push (20 commits, intentionally not amended; squash on merge).
- [x] Labels: `enhancement`, `docs: not-required`.
- [x] Docs label decision: `docs: not-required` -- ErrAuthRequired and verify-after-PUT have no UI surface yet (deferred to follow-ups #1684 and #1685); metadata_push toast is a behavioral mirror of PushLocks already documented.
- [x] Screenshot N/A (no UI changes in this PR).
- [x] UAT performed: built binary from this branch, configured Emby UAT connection at closed port + `feature_metadata_push=true`, triggered Refresh Metadata on 12 Stones, confirmed "push failed" toast rendered and `publisher.go:317 auto-push: metadata push failed` log entry fired with the new `metadata_push` operation slug. Reverted connection state after.
- [x] OpenAPI: no shape change. Connection schema toggle for `verify_path_after_update` deferred to UI follow-up #1685.
- [x] No `.templ` files changed.

## Test plan

- [x] `go test -race ./...` passes locally (pre-push-gate).
- [x] `bash scripts/pre-push-gate.sh` passes locally (patch coverage 88.14%).
- [x] Manual UAT steps:
  - [x] Triggered metadata push to a connection at a closed port; observed `push failed` toast + structured log entry from `PushMetadataAsync` with `operation=metadata_push`.
  - [x] Reverted Emby UAT URL + feature_metadata_push after capture.
- [ ] Reviewer follow-ups:
  - [ ] Confirm `errors.Join` ordering preserves the substring-match contract for `classifyPushErr` against future refactors (pinned by new `TestStatusError_ErrorAndIsAuth` + dual-contract test).

## Follow-up issues filed

| Follow-up | Topic | Milestone |
|-----------|-------|-----------|
| #1684 | UI re-authenticate affordance for ErrAuthRequired platform-write failures | M55 |
| #1685 | Per-connection UI toggle for Lidarr verify-after-PUT | M55 |
| #1686 | Connection sub-struct refactor (type-discriminated config) | M55.5 |
| #1687 | Unified image-write observability (notify-path parity) | M55 |
| #1688 | golangci linter rule for missing wrapAuthIfStatusAuth | M55.5 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional path verification for Lidarr updates.
  * Push metadata now emits per-connection failure notifications.

* **Bug Fixes**
  * Consistent detection/handling of authentication failures across Emby, Jellyfin, and Lidarr write operations.
  * Preserve HTTP status and response snippets in error reporting for clearer diagnostics.

* **Tests**
  * Expanded tests for auth classification, Lidarr verify-after-update, notifier behavior, and migration helpers.

* **Database**
  * Migration adds verify_path_after_update column to connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces platform write observability across three interconnected areas: typed auth sentinels, a shared `StatusError` type, a Lidarr verify-after-PUT feature, and `PushMetadataAsync` toast parity with `PushLocks`.

- **`httpclient.StatusError` + per-package `ErrAuthRequired` sentinels**: all BaseClient HTTP helpers now return a typed `*StatusError`; every write method in emby, jellyfin, and lidarr wraps 401/403 responses with `wrapAuthIfStatusAuth`, enabling `errors.Is` detection while preserving the historical `\"status 401\"` substring that `classifyPushErr` depends on via `errors.Join(formatted, statusErr)`. A dual-contract test pins both halves.
- **Lidarr verify-after-PUT**: migration 013 adds `verify_path_after_update` to connections; the model, service (all four query sites), and `renamePathUpdaterFactory` wiring are updated; `verifyArtistPath` issues a follow-up GET and surfaces a \"sent X, got Y\" error on path mismatch, including `ErrAuthRequired` wrap if the verify GET itself gets 401.
- **`PushMetadataAsync` notify parity**: adds `pushOpMetadataPush` slug and calls `notifyPushFailure` on both the `GetByID` lookup-failure path and the platform-write failure path, matching the existing `PushLocks` toast taxonomy.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

All changed code paths are covered by targeted tests; the dual-contract test pins both the typed-sentinel and substring-match contracts simultaneously, and the rename wiring is validated end-to-end by two integration tests against the production factory.

The error-wrapping chain is correct: errors.Join attaches the typed *StatusError as a sibling so errors.As finds it while the formatted string preserves 'status 401' for the existing classifyPushErr switch. Scan column order matches SELECT column list across all four query sites. The migration is additive with DEFAULT 0, existing rows keep prior behavior. The only finding is a doc comment inconsistency in a test helper — the behavior is correct as written.

internal/publish/publisher_test.go — doc comment on the done field of recordingNotifier says 'non-buffered' but the channel is buffered at capacity 1; the inconsistency with the inner 'Buffered channel' comment could mislead future test authors.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/connection/httpclient/client.go | Adds StatusError type, NewStatusError, ReadBoundedStatusError, and IsAuth; all BaseClient HTTP helpers now return typed *StatusError instead of fmt.Errorf strings, enabling errors.As detection of 401/403 without re-parsing strings. |
| internal/connection/emby/client.go | Adds ErrAuthRequired sentinel and wrapAuthIfStatusAuth helper; applies the wrap to all five write methods. |
| internal/connection/lidarr/client.go | Adds ErrAuthRequired + wrapAuthIfStatusAuth, verifyPathAfterUpdate field + SetVerifyPathAfterUpdate setter, and verifyArtistPath follow-up GET; getMetadataConsumers gains the missing body drain on non-200 response. |
| internal/connection/service.go | Adds verify_path_after_update to all SELECT/INSERT/UPDATE queries and scanConnection in correct column position. |
| internal/database/migrations/013_connection_verify_path_after_update.sql | New goose migration adds verify_path_after_update INTEGER NOT NULL DEFAULT 0 to connections with Down migration. |
| internal/publish/publisher.go | Adds pushOpMetadataPush constant; extends PushMetadataAsync to call notifyPushFailure on both the GetByID lookup-failure and platform-write failure branches. |
| internal/publish/rename_sync.go | Adds load-bearing wiring: calls SetVerifyPathAfterUpdate(conn.VerifyPathAfterUpdate) on the lidarr client before returning it. |
| internal/publish/publisher_test.go | Adds done channel to recordingNotifier; adds three PushMetadataAsync tests; minor doc inconsistency between struct comment and channel capacity. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P as Publisher
    participant C as Platform Client
    participant BC as httpclient.BaseClient
    participant N as Notifier
    P->>C: PushMetadata / UpdateArtistPath
    C->>BC: PostJSON / PutJSON / Get
    BC-->>C: "*StatusError (401/403)"
    C->>C: wrapAuthIfStatusAuth
    C-->>P: ErrAuthRequired wrapped error
    P->>P: classifyPushErr
    P->>N: notifyPushFailure
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/publish/rename_sync_test.go`, line 1931 ([link](https://github.com/sydlexius/stillwater/blob/e9de984eeddf16b709ca1be2e59309058e420976/internal/publish/rename_sync_test.go#L1931)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **JSON string concatenation in test fixture** — `lidarrVerifyServer` builds the verify-GET response body via raw string concatenation. If a future test passes a `newPath` containing a double-quote, backslash, or newline, the body is silently malformed JSON and `c.Get` returns a JSON-decode error instead of a path-mismatch assertion, making the failure confusing to diagnose. Using `json.Marshal` removes the fragility at negligible cost.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fpublish%2Frename_sync_test.go%0ALine%3A%201931%0A%0AComment%3A%0A**JSON%20string%20concatenation%20in%20test%20fixture**%20%E2%80%94%20%60lidarrVerifyServer%60%20builds%20the%20verify-GET%20response%20body%20via%20raw%20string%20concatenation.%20If%20a%20future%20test%20passes%20a%20%60newPath%60%20containing%20a%20double-quote%2C%20backslash%2C%20or%20newline%2C%20the%20body%20is%20silently%20malformed%20JSON%20and%20%60c.Get%60%20returns%20a%20JSON-decode%20error%20instead%20of%20a%20path-mismatch%20assertion%2C%20making%20the%20failure%20confusing%20to%20diagnose.%20Using%20%60json.Marshal%60%20removes%20the%20fragility%20at%20negligible%20cost.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sydlexius%2Fstillwater&pr=1689&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ainternal%2Fpublish%2Fpublisher_test.go%3A1700-1702%0A**%60done%60%20channel%20comment%20contradicts%20initialization**%20%E2%80%94%20the%20struct-level%20doc%20says%20%22non-buffered%20signal%22%20but%20every%20test%20wires%20it%20as%20%60make%28chan%20struct%7B%7D%2C%201%29%60%20%28capacity%201%29.%20The%20buffer%20is%20load-bearing%3A%20%60PushMetadataAsync%60%20launches%20goroutines%20that%20may%20fire%20the%20notification%20before%20the%20test%20goroutine%20reaches%20%60select%20%7B%20case%20%3C-notifier.done%3A%20%7D%60.%20With%20an%20unbuffered%20channel%20the%20non-blocking%20send%20in%20%60NotifyConnectionPushFailed%60%20would%20fall%20to%20%60default%60%2C%20the%20test%20would%20timeout%2C%20and%20a%20real%20regression%20would%20go%20undetected.%20The%20inner%20code%20comment%20correctly%20says%20%22Buffered%20channel%22%20%E2%80%94%20the%20struct%20doc%20should%20match.%20Additionally%2C%20the%20inner%20comment%20says%20%22tests%20are%20responsible%20for%20draining%20when%20they%20expect%20more%20than%20one%20notify%22%2C%20but%20the%20non-blocking%20send%20pattern%20makes%20that%20impossible%20at%20capacity%201%3B%20a%20test%20expecting%20two%20signals%20would%20need%20%60make%28chan%20struct%7B%7D%2C%202%29%60%20or%20a%20polling%20loop%20instead.%0A%0A&repo=sydlexius%2Fstillwater&pr=1689&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["test(m52): cover httpclient.ReadBoundedS..."](https://github.com/sydlexius/stillwater/commit/7e17021796eb4db1f55c3c01ae59fd9a040b0245) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33855907)</sub>

<!-- /greptile_comment -->