### PR TITLE
fix(tooling): harden make hooks against worktree config drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-shuffle test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks worktree check-openapi hadolint scan bruno-ci
+.PHONY: build run test test-shuffle test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks doctor worktree check-openapi hadolint scan bruno-ci
 
 # Binary name
 BINARY=stillwater
@@ -117,10 +117,13 @@ check-openapi:
 ## hooks: Install git hooks (pre-commit lint, pre-push gate)
 hooks:
 	chmod +x .githooks/pre-commit .githooks/pre-push
+	@git config --unset core.hooksPath 2>/dev/null || true
 	git config core.hooksPath .githooks
-	@echo "Hooks installed via core.hooksPath=.githooks (covers worktrees)."
-	@echo "  pre-commit: lint, gofmt, templ freshness, build, golangci-lint, govulncheck, hadolint"
-	@echo "  pre-push:   runs scripts/pre-push-gate.sh (tests, OpenAPI, generated, patch coverage >= 70%)"
+	@./scripts/check-hooks.sh
+
+## doctor: Verify hook wiring without modifying anything
+doctor:
+	@./scripts/check-hooks.sh
 
 ## worktree: Create a sibling worktree with hooks wired and tracker entry appended
 ##   Usage: make worktree NAME=<slug> BRANCH=<branch> [ISSUE=<number>]
@@ -130,6 +133,7 @@ worktree:
 	@test -n "$(NAME)"   || (echo "error: NAME is required (e.g. make worktree NAME=my-feature BRANCH=feat/my-feature)"; exit 1)
 	@test -n "$(BRANCH)" || (echo "error: BRANCH is required (e.g. make worktree NAME=my-feature BRANCH=feat/my-feature)"; exit 1)
 	git worktree add ../stillwater-$(NAME) -b $(BRANCH)
+	@git -C ../stillwater-$(NAME) config --unset core.hooksPath 2>/dev/null || true
 	git -C ../stillwater-$(NAME) config core.hooksPath .githooks
 	@mkdir -p "$(dir $(WORKTREES_MD))"
 	@printf "| stillwater-$(NAME) | $(BRANCH) | $(if $(ISSUE),#$(ISSUE),--) | In Progress |\n" >> "$(WORKTREES_MD)"

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -28,6 +28,15 @@ git worktree add -b feat/320-short-desc ../stillwater-m17-320 feat/m17-umbrella
 
 Active worktrees are tracked in `memory/worktrees.md` inside `~/.claude/projects/<project>/memory/`. Update it whenever a worktree is created or removed.
 
+## Hook installation per worktree
+
+`git worktree add` does not copy or re-apply hook configuration. Each worktree starts with
+whatever `core.hooksPath` value its local config inherits from the shared repository config,
+which may be stale or absolute if the original install used an older pattern.
+
+After creating a worktree, run `make hooks` inside it before the first push. `make doctor`
+confirms the wiring without modifying anything.
+
 ## Docker UAT in worktrees
 
 `setupdocker.sh` lives in the main repo root only. To run UAT from a worktree, copy it in or run from main repo.

--- a/scripts/check-hooks.sh
+++ b/scripts/check-hooks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Verify the pre-push gate is actually wired up.
+# Exits 0 when configuration is correct, non-zero otherwise.
+
+set -euo pipefail
+
+hooks_path=$(git config --get core.hooksPath 2>/dev/null || true)
+
+if [ "$hooks_path" != ".githooks" ]; then
+    echo "FAIL: core.hooksPath is '$hooks_path', expected '.githooks'" >&2
+    echo "Fix: run 'make hooks' from this worktree" >&2
+    exit 1
+fi
+
+for h in pre-commit pre-push; do
+    if [ ! -x ".githooks/$h" ]; then
+        echo "FAIL: .githooks/$h missing or not executable" >&2
+        echo "Fix: run 'make hooks' from this worktree" >&2
+        exit 1
+    fi
+done
+
+echo "OK: hooks configured -- core.hooksPath=.githooks, pre-commit + pre-push executable"


### PR DESCRIPTION
## Summary

- `make hooks` now runs `git config --unset core.hooksPath` before setting the canonical relative value, clearing any stale absolute override left by an older install pattern. Same fix applied to the `make worktree` target which had the same gap.
- Adds `make doctor` backed by `scripts/check-hooks.sh` to verify hook wiring (core.hooksPath + executable bits) without modifying anything. `make hooks` calls it at the end for confirmation output.
- Documents in `docs/worktrees.md` that `make hooks` must be re-run in each worktree after `git worktree add` because worktrees do not inherit hook config automatically.

## Linked issue

None -- this is a tooling fix for a drift condition observed on 2026-05-25 where at least one worktree had `core.hooksPath` pointing at the main worktree's `.git/hooks/` (no `pre-push` there), silently bypassing `scripts/pre-push-gate.sh`.

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`), or run via `/prep-pr` / `/pr-review-toolkit:review-pr` which invokes it.
- [x] Code review pass complete (`/prep-pr` or `/pr-review-toolkit:review-pr`); critical and important findings fixed before pushing.
- [x] Commits squashed into clean, logical commits before the first push (Copilot reviews the diff at PR open).
- [x] At least one label set on `gh pr create --label ...` (the CI label gate fails without one).
- [x] Docs label decision made: `docs: not-required` -- the `docs/worktrees.md` addition is internal dev guidance, not user-visible behavior.
- [ ] Screenshot attached for any UI change. -- N/A
- [ ] UAT performed for user-visible changes (run the binary, not just the test suite). -- N/A (tooling only)
- [x] OpenAPI spec updated if any request or response shape changed (`make check-openapi`). -- no API change
- [x] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed. -- no .templ change

## Test plan

- [x] `go test -race ./...` passes locally (run by pre-push gate).
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] `make doctor` exits 0 with "OK" line on a correctly-wired worktree.
- [x] `make doctor` exits non-zero with FAIL message when `core.hooksPath` is set to `/tmp/bogus`.
- [x] `make hooks` with a corrupted `core.hooksPath=/tmp/bogus` restores it to `.githooks` (drift recovery verified).
- [x] `scripts/check-hooks.sh` is shellcheck-clean.
- [ ] Reviewer follow-ups:
  - [ ] Verify `make worktree` unset+set works correctly in a fresh worktree context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on configuring git hooks when using git worktrees.

* **Chores**
  * Added a verification script to check git hook configuration and executability.
  * Updated Makefile `hooks` and `worktree` targets with enhanced hook path management.
  * Added `make doctor` command to validate hook setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

No additional feedback.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge.

No new findings.

None.
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tooling): harden make hooks against ..."](https://github.com/sydlexius/stillwater/commit/d68a9fb9c941e67ee3fe4ad2a1f42d577552a9ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33863304)</sub>

<!-- /greptile_comment -->