### PR TITLE
feat(testing): fault-injection smoke harness for provider failures (#1666)

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -232,3 +232,60 @@ jobs:
       - name: Skip (no relevant changes)
         if: steps.filter.outputs.relevant != 'true'
         run: echo "No Go source or fuzz workflow changes; drift check skipped."
+
+  # ---------------------------------------------------------------------------
+  # Provider failure smoke test
+  #
+  # Replicates the '=== Provider failure smoke test ===' step in
+  # scripts/pre-push-gate.sh.  Builds the binary, starts a temporary instance
+  # with SW_FORCE_PROVIDER_ERROR set to all known providers, and asserts that
+  # every covered handler surface communicates the failure explicitly.
+  #
+  # Uses dorny/paths-filter to skip on PRs that touch no Go source or smoke
+  # scripts; the job itself always runs and always emits a terminal status.
+  # ---------------------------------------------------------------------------
+  provider-failure-smoke:
+    name: Provider Failure Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - '**/*.go'
+              - 'scripts/smoke-provider-failure.sh'
+              - 'scripts/pre-push-gate.sh'
+              - '.github/workflows/gate.yml'
+              - 'go.mod'
+              - 'go.sum'
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        if: steps.filter.outputs.relevant == 'true'
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Tailwind CSS
+        if: steps.filter.outputs.relevant == 'true'
+        env:
+          TAILWIND_VERSION: v4.2.0
+          TAILWIND_SHA256: 8f65e2d21c675f1e8d265219979d17d10634c1f553a2f583265b7edb28726432
+        run: |
+          curl -fsSLO "https://github.com/tailwindlabs/tailwindcss/releases/download/${TAILWIND_VERSION}/tailwindcss-linux-x64"
+          echo "${TAILWIND_SHA256}  tailwindcss-linux-x64" | sha256sum -c -
+          chmod +x tailwindcss-linux-x64
+          sudo mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss
+
+      - name: Run provider failure smoke test
+        if: steps.filter.outputs.relevant == 'true'
+        run: bash scripts/smoke-provider-failure.sh
+
+      - name: Skip (no relevant changes)
+        if: steps.filter.outputs.relevant != 'true'
+        run: echo "No Go source or smoke script changes; provider failure smoke skipped."

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -46,6 +46,7 @@ builds:
       - -X github.com/sydlexius/stillwater/internal/version.Version={{ .Version }}
       - -X github.com/sydlexius/stillwater/internal/version.Commit={{ .ShortCommit }}
       - -X github.com/sydlexius/stillwater/internal/version.Date={{ .Date }}
+      - -X github.com/sydlexius/stillwater/internal/version.BuildType=release
 
 archives:
   - id: default

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,7 @@ builds:
       - -X github.com/sydlexius/stillwater/internal/version.Version={{ .Version }}
       - -X github.com/sydlexius/stillwater/internal/version.Commit={{ .ShortCommit }}
       - -X github.com/sydlexius/stillwater/internal/version.Date={{ .Date }}
+      - -X github.com/sydlexius/stillwater/internal/version.BuildType=release
 
 archives:
   - id: default

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -209,6 +209,10 @@ func run() error {
 	// A release build with this env var active would silently break every
 	// provider-dependent surface for real users. Refuse to start so the
 	// operator immediately sees what to unset.
+	//
+	// IsReleaseBuild keys off version.BuildType (set to "release" only by the
+	// goreleaser configs), so `make build`, IDE builds, and the provider-failure
+	// smoke harness all report false here and the guard does not fire on them.
 	if os.Getenv("SW_FORCE_PROVIDER_ERROR") != "" && version.IsReleaseBuild() {
 		return fmt.Errorf(
 			"SW_FORCE_PROVIDER_ERROR is set but this is a release build -- " +

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -205,6 +205,17 @@ func newApplication(opts ...Option) *Application {
 func run() error {
 	a := newApplication()
 
+	// Safety: SW_FORCE_PROVIDER_ERROR must never be set in a production binary.
+	// A release build with this env var active would silently break every
+	// provider-dependent surface for real users. Refuse to start so the
+	// operator immediately sees what to unset.
+	if os.Getenv("SW_FORCE_PROVIDER_ERROR") != "" && version.IsReleaseBuild() {
+		return fmt.Errorf(
+			"SW_FORCE_PROVIDER_ERROR is set but this is a release build -- " +
+				"this env var is reserved for smoke testing only; unset it before starting",
+		)
+	}
+
 	if err := a.loadConfig(); err != nil {
 		return err
 	}

--- a/internal/provider/audiodb/audiodb.go
+++ b/internal/provider/audiodb/audiodb.go
@@ -71,6 +71,9 @@ func (a *Adapter) RequiresAuth() bool { return false }
 
 // SearchArtist searches TheAudioDB by artist name.
 func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.ArtistSearchResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	apiKey, err := a.getAPIKey(ctx)
 	if err != nil {
 		return nil, err
@@ -114,6 +117,9 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 // a MusicBrainz UUID (routed to artist-mb.php) or an AudioDB numeric ID
 // (routed to artist.php for direct lookup).
 func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	apiKey, err := a.getAPIKey(ctx)
 	if err != nil {
 		return nil, err
@@ -146,6 +152,9 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 // GetImages fetches available images for an artist. Like GetArtist, the id
 // parameter can be a MusicBrainz UUID or an AudioDB numeric ID.
 func (a *Adapter) GetImages(ctx context.Context, id string) ([]provider.ImageResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	apiKey, err := a.getAPIKey(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/provider/audiodb/injection_test.go
+++ b/internal/provider/audiodb/injection_test.go
@@ -1,0 +1,33 @@
+package audiodb
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestInjection_AudioDB verifies that all outbound methods respect the
+// fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "audiodb".
+func TestInjection_AudioDB(t *testing.T) {
+	provider.SetInjectedProviders([]string{"audiodb"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), nil, logger)
+
+	ctx := context.Background()
+
+	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetArtist(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetImages(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+	}
+}

--- a/internal/provider/deezer/deezer.go
+++ b/internal/provider/deezer/deezer.go
@@ -53,6 +53,9 @@ func (a *Adapter) RequiresAuth() bool { return false }
 
 // SearchArtist searches Deezer for artists matching the given name.
 func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.ArtistSearchResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	if name == "" {
 		return nil, nil
 	}
@@ -107,6 +110,9 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 // Returns ErrNotFound for non-numeric IDs such as MusicBrainz UUIDs, since
 // Deezer does not index by MBID.
 func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	if !isDeezerID(id) {
 		return nil, &provider.ErrNotFound{Provider: provider.NameDeezer, ID: id}
 	}
@@ -143,6 +149,9 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 // GetImages fetches artist thumbnail images by Deezer ID.
 // Returns ErrNotFound for non-numeric IDs such as MusicBrainz UUIDs.
 func (a *Adapter) GetImages(ctx context.Context, id string) ([]provider.ImageResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	if !isDeezerID(id) {
 		return nil, &provider.ErrNotFound{Provider: provider.NameDeezer, ID: id}
 	}

--- a/internal/provider/deezer/injection_test.go
+++ b/internal/provider/deezer/injection_test.go
@@ -1,0 +1,35 @@
+package deezer
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestInjection_Deezer verifies that all outbound methods respect the
+// fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "deezer".
+func TestInjection_Deezer(t *testing.T) {
+	provider.SetInjectedProviders([]string{"deezer"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), logger)
+
+	ctx := context.Background()
+
+	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
+	}
+	// GetArtist with a numeric ID so the isNumericID guard does not trigger first.
+	if _, err := a.GetArtist(ctx, "12345"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
+	}
+	// GetImages with a numeric ID.
+	if _, err := a.GetImages(ctx, "12345"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+	}
+}

--- a/internal/provider/deezer/injection_test.go
+++ b/internal/provider/deezer/injection_test.go
@@ -24,7 +24,7 @@ func TestInjection_Deezer(t *testing.T) {
 	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
 		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
 	}
-	// GetArtist with a numeric ID so the isNumericID guard does not trigger first.
+	// GetArtist with a numeric ID so the isDeezerID guard does not trigger first.
 	if _, err := a.GetArtist(ctx, "12345"); !errors.Is(err, provider.ErrInjectedFailure) {
 		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
 	}

--- a/internal/provider/discogs/discogs.go
+++ b/internal/provider/discogs/discogs.go
@@ -53,6 +53,9 @@ func (a *Adapter) RequiresAuth() bool { return true }
 
 // SearchArtist searches Discogs for artists matching the given name.
 func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.ArtistSearchResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	token, err := a.getToken(ctx)
 	if err != nil {
 		return nil, err
@@ -112,6 +115,9 @@ func (a *Adapter) SupportsNameLookup() bool { return true }
 // GetArtist is called again with the artist name, which routes through
 // getArtistByName for a search-then-fetch flow.
 func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	if !isNumericID(id) {
 		// If the id is not numeric but also not a UUID, treat it as an
 		// artist name and fall back to name-based search.
@@ -187,6 +193,9 @@ func (a *Adapter) getArtistByName(ctx context.Context, name string) (*provider.A
 // Returns ErrNotFound for non-numeric IDs (such as MusicBrainz UUIDs) without
 // making an HTTP request.
 func (a *Adapter) GetImages(ctx context.Context, id string) ([]provider.ImageResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	if !isNumericID(id) {
 		return nil, &provider.ErrNotFound{Provider: provider.NameDiscogs, ID: id}
 	}

--- a/internal/provider/discogs/injection_test.go
+++ b/internal/provider/discogs/injection_test.go
@@ -1,0 +1,33 @@
+package discogs
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestInjection_Discogs verifies that all outbound methods respect the
+// fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "discogs".
+func TestInjection_Discogs(t *testing.T) {
+	provider.SetInjectedProviders([]string{"discogs"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), nil, logger)
+
+	ctx := context.Background()
+
+	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetArtist(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetImages(ctx, "12345"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+	}
+}

--- a/internal/provider/duckduckgo/duckduckgo.go
+++ b/internal/provider/duckduckgo/duckduckgo.go
@@ -72,6 +72,9 @@ func (a *Adapter) RequiresAuth() bool { return false }
 
 // SearchImages queries DuckDuckGo image search for artist images of a specific type.
 func (a *Adapter) SearchImages(ctx context.Context, artistName string, imageType provider.ImageType) ([]provider.ImageResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	if artistName == "" || len(artistName) > maxArtistNameLen {
 		return nil, nil
 	}

--- a/internal/provider/duckduckgo/injection_test.go
+++ b/internal/provider/duckduckgo/injection_test.go
@@ -1,0 +1,27 @@
+package duckduckgo
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestInjection_DuckDuckGo verifies that SearchImages respects the
+// fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "duckduckgo".
+func TestInjection_DuckDuckGo(t *testing.T) {
+	provider.SetInjectedProviders([]string{"duckduckgo"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), logger)
+
+	ctx := context.Background()
+
+	if _, err := a.SearchImages(ctx, "test artist", provider.ImageThumb); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("SearchImages: want ErrInjectedFailure, got %v", err)
+	}
+}

--- a/internal/provider/fanarttv/fanarttv.go
+++ b/internal/provider/fanarttv/fanarttv.go
@@ -51,16 +51,25 @@ func (a *Adapter) RequiresAuth() bool { return true }
 
 // SearchArtist is not supported by Fanart.tv (lookup by MBID only).
 func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	return nil, nil
 }
 
 // GetArtist is not supported by Fanart.tv (images only).
 func (a *Adapter) GetArtist(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	return nil, nil
 }
 
 // GetImages fetches available images for an artist by their MusicBrainz ID.
 func (a *Adapter) GetImages(ctx context.Context, mbid string) ([]provider.ImageResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	apiKey, err := a.settings.GetAPIKey(ctx, provider.NameFanartTV)
 	if err != nil {
 		return nil, fmt.Errorf("getting API key: %w", err)

--- a/internal/provider/fanarttv/fanarttv.go
+++ b/internal/provider/fanarttv/fanarttv.go
@@ -49,19 +49,19 @@ func (a *Adapter) Name() provider.ProviderName { return provider.NameFanartTV }
 // RequiresAuth returns whether this provider needs an API key.
 func (a *Adapter) RequiresAuth() bool { return true }
 
-// SearchArtist is not supported by Fanart.tv (lookup by MBID only).
+// SearchArtist is a documented no-op for Fanart.tv (lookup is by MBID only).
+// Injection is intentionally NOT consulted here: the production contract is
+// (nil, nil), and callers that treat a nil error from a known-no-op as
+// "provider does not support this" would otherwise behave differently under
+// the smoke harness than in prod -- which would test the harness, not the
+// silent-failure surfaces the harness exists to catch.
 func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
-	if provider.ShouldInjectFailure(a.Name()) {
-		return nil, provider.ErrInjectedFailure
-	}
 	return nil, nil
 }
 
-// GetArtist is not supported by Fanart.tv (images only).
+// GetArtist is a documented no-op for Fanart.tv (images only). Injection is
+// intentionally NOT consulted here; see SearchArtist for rationale.
 func (a *Adapter) GetArtist(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
-	if provider.ShouldInjectFailure(a.Name()) {
-		return nil, provider.ErrInjectedFailure
-	}
 	return nil, nil
 }
 

--- a/internal/provider/fanarttv/injection_test.go
+++ b/internal/provider/fanarttv/injection_test.go
@@ -10,8 +10,13 @@ import (
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
-// TestInjection_FanartTV verifies that all outbound methods respect the
+// TestInjection_FanartTV verifies that real outbound methods respect the
 // fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "fanarttv".
+//
+// SearchArtist and GetArtist are documented no-ops here (Fanart.tv only
+// supports image lookup by MBID), so injection is intentionally NOT
+// consulted on them -- exercising injection on a stub would test the
+// harness, not the silent-failure surfaces the harness exists to catch.
 func TestInjection_FanartTV(t *testing.T) {
 	provider.SetInjectedProviders([]string{"fanarttv"})
 	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
@@ -21,13 +26,28 @@ func TestInjection_FanartTV(t *testing.T) {
 
 	ctx := context.Background()
 
-	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
-		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
-	}
-	if _, err := a.GetArtist(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
-		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
-	}
 	if _, err := a.GetImages(ctx, "test-mbid"); !errors.Is(err, provider.ErrInjectedFailure) {
 		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+	}
+}
+
+// TestStubsBypassInjection_FanartTV pins that the documented no-op stubs
+// keep returning (nil, nil) even when injection is active, so a caller
+// that treats a known-no-op as "skip" stays on the same code path under
+// the smoke harness as it does in production.
+func TestStubsBypassInjection_FanartTV(t *testing.T) {
+	provider.SetInjectedProviders([]string{"fanarttv"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), nil, logger)
+
+	ctx := context.Background()
+
+	if got, err := a.SearchArtist(ctx, "test"); err != nil || got != nil {
+		t.Errorf("SearchArtist stub: want (nil, nil), got (%v, %v)", got, err)
+	}
+	if got, err := a.GetArtist(ctx, "test-id"); err != nil || got != nil {
+		t.Errorf("GetArtist stub: want (nil, nil), got (%v, %v)", got, err)
 	}
 }

--- a/internal/provider/fanarttv/injection_test.go
+++ b/internal/provider/fanarttv/injection_test.go
@@ -1,0 +1,33 @@
+package fanarttv
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestInjection_FanartTV verifies that all outbound methods respect the
+// fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "fanarttv".
+func TestInjection_FanartTV(t *testing.T) {
+	provider.SetInjectedProviders([]string{"fanarttv"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), nil, logger)
+
+	ctx := context.Background()
+
+	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetArtist(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetImages(ctx, "test-mbid"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+	}
+}

--- a/internal/provider/genius/genius.go
+++ b/internal/provider/genius/genius.go
@@ -58,6 +58,9 @@ func (a *Adapter) SupportsNameLookup() bool { return true }
 // SearchArtist searches Genius for artists matching the given name.
 // Genius search returns song hits; we extract and deduplicate primary_artist entries.
 func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.ArtistSearchResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	if err := a.limiter.Wait(ctx, provider.NameGenius); err != nil {
 		return nil, &provider.ErrProviderUnavailable{
 			Provider: provider.NameGenius,
@@ -108,6 +111,9 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 // UUIDs (MusicBrainz IDs) are rejected immediately since Genius cannot use them
 // and searching by UUID would always return no results.
 func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	if provider.IsUUID(id) {
 		return nil, &provider.ErrNotFound{Provider: provider.NameGenius, ID: id}
 	}
@@ -119,6 +125,9 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 
 // GetImages returns nil since Genius does not host artist images.
 func (a *Adapter) GetImages(_ context.Context, _ string) ([]provider.ImageResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	return nil, nil
 }
 

--- a/internal/provider/genius/genius.go
+++ b/internal/provider/genius/genius.go
@@ -123,11 +123,11 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 	return a.getArtistByID(ctx, id)
 }
 
-// GetImages returns nil since Genius does not host artist images.
+// GetImages is a documented no-op for Genius (no artist image hosting).
+// Injection is intentionally NOT consulted here; matching the production
+// (nil, nil) contract keeps callers that treat known-no-op providers as
+// "not supported, skip" on the same code path under the smoke harness.
 func (a *Adapter) GetImages(_ context.Context, _ string) ([]provider.ImageResult, error) {
-	if provider.ShouldInjectFailure(a.Name()) {
-		return nil, provider.ErrInjectedFailure
-	}
 	return nil, nil
 }
 

--- a/internal/provider/genius/injection_test.go
+++ b/internal/provider/genius/injection_test.go
@@ -10,8 +10,12 @@ import (
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
-// TestInjection_Genius verifies that all outbound methods respect the
+// TestInjection_Genius verifies that real outbound methods respect the
 // fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "genius".
+//
+// GetImages is a documented no-op (Genius hosts no artist images), so
+// injection is intentionally NOT consulted on it -- exercising injection
+// on a stub would test the harness, not the silent-failure surfaces.
 func TestInjection_Genius(t *testing.T) {
 	provider.SetInjectedProviders([]string{"genius"})
 	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
@@ -29,7 +33,20 @@ func TestInjection_Genius(t *testing.T) {
 	if _, err := a.GetArtist(ctx, "test-artist"); !errors.Is(err, provider.ErrInjectedFailure) {
 		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
 	}
-	if _, err := a.GetImages(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
-		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+}
+
+// TestStubBypassesInjection_Genius pins that GetImages keeps returning
+// (nil, nil) even when injection is active, so a caller that treats a
+// known-no-op as "skip" stays on the same code path under the smoke
+// harness as it does in production.
+func TestStubBypassesInjection_Genius(t *testing.T) {
+	provider.SetInjectedProviders([]string{"genius"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), nil, logger)
+
+	if got, err := a.GetImages(context.Background(), "test-id"); err != nil || got != nil {
+		t.Errorf("GetImages stub: want (nil, nil), got (%v, %v)", got, err)
 	}
 }

--- a/internal/provider/genius/injection_test.go
+++ b/internal/provider/genius/injection_test.go
@@ -1,0 +1,35 @@
+package genius
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestInjection_Genius verifies that all outbound methods respect the
+// fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "genius".
+func TestInjection_Genius(t *testing.T) {
+	provider.SetInjectedProviders([]string{"genius"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), nil, logger)
+
+	ctx := context.Background()
+
+	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
+	}
+	// GetArtist with a non-UUID, non-numeric ID to exercise the by-name path,
+	// but injection fires before the routing decision.
+	if _, err := a.GetArtist(ctx, "test-artist"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetImages(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+	}
+}

--- a/internal/provider/injection.go
+++ b/internal/provider/injection.go
@@ -1,0 +1,93 @@
+package provider
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"sync"
+)
+
+// ErrInjectedFailure is returned by provider methods when the fault-injection
+// hook is active for that provider. The message is intentionally explicit so
+// that any developer who sees it in logs immediately recognizes this as a
+// self-inflicted test condition, not a real provider outage.
+var ErrInjectedFailure = errors.New("provider call rejected by injection (SW_FORCE_PROVIDER_ERROR)")
+
+// injectedSet is the set of provider names that should return ErrInjectedFailure
+// on every outbound call. Initialized from SW_FORCE_PROVIDER_ERROR at process
+// start and may be replaced at any time via SetInjectedProviders. Guarded by
+// injectedMu because provider methods (readers) are invoked concurrently from
+// net/http handlers, while tests may swap the set via SetInjectedProviders.
+var (
+	injectedMu  sync.RWMutex
+	injectedSet = parseInjectedSet(os.Getenv("SW_FORCE_PROVIDER_ERROR"))
+)
+
+// SetInjectedProviders replaces the active injected-failure set.
+// Pass nil or an empty slice to clear all injected failures.
+//
+// This is exported so that test binaries in sibling packages can activate
+// injection without relying on the env var (which is parsed once at init
+// time). Production code must never call this; use SW_FORCE_PROVIDER_ERROR
+// to configure injection at process start instead.
+//
+// Typical usage in a test:
+//
+//	provider.SetInjectedProviders([]string{"musicbrainz", "fanarttv"})
+//	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+func SetInjectedProviders(names []string) {
+	injectedMu.Lock()
+	defer injectedMu.Unlock()
+	if len(names) == 0 {
+		injectedSet = map[string]struct{}{}
+		return
+	}
+	m := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		key := strings.ToLower(strings.TrimSpace(n))
+		if key != "" {
+			m[key] = struct{}{}
+		}
+	}
+	injectedSet = m
+}
+
+// ShouldInjectFailure reports whether calls from the named provider should
+// return ErrInjectedFailure instead of making real network requests.
+//
+// Usage: at the top of every provider outbound method, add:
+//
+//	if provider.ShouldInjectFailure(p.Name()) {
+//	    return nil, provider.ErrInjectedFailure
+//	}
+//
+// The check is a no-op (returns false) when SW_FORCE_PROVIDER_ERROR is unset
+// and SetInjectedProviders has not been called, so normal production behavior
+// is preserved with zero overhead.
+func ShouldInjectFailure(name ProviderName) bool {
+	injectedMu.RLock()
+	defer injectedMu.RUnlock()
+	if len(injectedSet) == 0 {
+		return false
+	}
+	_, ok := injectedSet[strings.ToLower(string(name))]
+	return ok
+}
+
+// parseInjectedSet parses the SW_FORCE_PROVIDER_ERROR environment variable
+// value into a set of lowercase provider name strings. Accepts a
+// comma-separated list; extra whitespace around entries is trimmed.
+// Returns an empty (non-nil) map when raw is empty.
+func parseInjectedSet(raw string) map[string]struct{} {
+	out := make(map[string]struct{})
+	if raw == "" {
+		return out
+	}
+	for _, part := range strings.Split(raw, ",") {
+		name := strings.ToLower(strings.TrimSpace(part))
+		if name != "" {
+			out[name] = struct{}{}
+		}
+	}
+	return out
+}

--- a/internal/provider/injection_test.go
+++ b/internal/provider/injection_test.go
@@ -1,0 +1,117 @@
+package provider
+
+import (
+	"testing"
+)
+
+func TestParseInjectedSet_Unset(t *testing.T) {
+	m := parseInjectedSet("")
+	if len(m) != 0 {
+		t.Errorf("expected empty set for empty input, got %v", m)
+	}
+}
+
+func TestParseInjectedSet_Single(t *testing.T) {
+	m := parseInjectedSet("musicbrainz")
+	if _, ok := m["musicbrainz"]; !ok {
+		t.Error("expected musicbrainz in set")
+	}
+	if len(m) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(m))
+	}
+}
+
+func TestParseInjectedSet_CommaSeparated(t *testing.T) {
+	m := parseInjectedSet("musicbrainz,fanarttv,discogs")
+	for _, name := range []string{"musicbrainz", "fanarttv", "discogs"} {
+		if _, ok := m[name]; !ok {
+			t.Errorf("expected %q in set", name)
+		}
+	}
+	if len(m) != 3 {
+		t.Errorf("expected 3 entries, got %d", len(m))
+	}
+}
+
+func TestParseInjectedSet_Whitespace(t *testing.T) {
+	m := parseInjectedSet(" musicbrainz , fanarttv ")
+	for _, name := range []string{"musicbrainz", "fanarttv"} {
+		if _, ok := m[name]; !ok {
+			t.Errorf("expected %q in set after whitespace trim", name)
+		}
+	}
+}
+
+func TestParseInjectedSet_MixedCase(t *testing.T) {
+	m := parseInjectedSet("MusicBrainz,FanartTV")
+	for _, name := range []string{"musicbrainz", "fanarttv"} {
+		if _, ok := m[name]; !ok {
+			t.Errorf("expected %q (lowercased) in set", name)
+		}
+	}
+}
+
+func TestParseInjectedSet_EmptySegments(t *testing.T) {
+	// Leading/trailing commas and consecutive commas must not produce empty keys.
+	m := parseInjectedSet(",musicbrainz,,fanarttv,")
+	if _, ok := m[""]; ok {
+		t.Error("empty string must not be a valid key in the injected set")
+	}
+	if len(m) != 2 {
+		t.Errorf("expected 2 entries, got %d: %v", len(m), m)
+	}
+}
+
+func TestShouldInjectFailure_EmptySet(t *testing.T) {
+	t.Cleanup(func() { SetInjectedProviders(nil) })
+
+	SetInjectedProviders(nil)
+	if ShouldInjectFailure(NameMusicBrainz) {
+		t.Error("ShouldInjectFailure must return false when injectedSet is empty")
+	}
+}
+
+func TestShouldInjectFailure_Match(t *testing.T) {
+	t.Cleanup(func() { SetInjectedProviders(nil) })
+
+	SetInjectedProviders([]string{"musicbrainz", "fanarttv"})
+
+	if !ShouldInjectFailure(NameMusicBrainz) {
+		t.Error("ShouldInjectFailure should return true for musicbrainz when it is in the set")
+	}
+	if !ShouldInjectFailure(NameFanartTV) {
+		t.Error("ShouldInjectFailure should return true for fanarttv when it is in the set")
+	}
+	if ShouldInjectFailure(NameLastFM) {
+		t.Error("ShouldInjectFailure should return false for lastfm when it is not in the set")
+	}
+}
+
+func TestShouldInjectFailure_CaseInsensitive(t *testing.T) {
+	t.Cleanup(func() { SetInjectedProviders(nil) })
+
+	// Env var value in mixed case maps correctly to the lowercased provider name.
+	SetInjectedProviders([]string{"MusicBrainz"})
+	if !ShouldInjectFailure(NameMusicBrainz) {
+		t.Errorf("ShouldInjectFailure must match case-insensitively; NameMusicBrainz=%q", NameMusicBrainz)
+	}
+}
+
+func TestShouldInjectFailure_AllProviders(t *testing.T) {
+	t.Cleanup(func() { SetInjectedProviders(nil) })
+
+	// Derive the list from AllProviderNames so adding a new provider can't
+	// silently drop it from coverage.
+	allNames := AllProviderNames()
+	all := make([]string, len(allNames))
+	for i, name := range allNames {
+		all[i] = string(name)
+	}
+	SetInjectedProviders(all)
+
+	for _, name := range allNames {
+		if !ShouldInjectFailure(name) {
+			t.Errorf("ShouldInjectFailure should return true for %q when all providers are injected", name)
+		}
+	}
+}

--- a/internal/provider/lastfm/injection_test.go
+++ b/internal/provider/lastfm/injection_test.go
@@ -10,8 +10,13 @@ import (
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
-// TestInjection_LastFM verifies that all outbound methods respect the
+// TestInjection_LastFM verifies that real outbound methods respect the
 // fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "lastfm".
+//
+// GetImages is a documented no-op (Last.fm hosts no high-quality artist
+// images), so injection is intentionally NOT consulted on it -- exercising
+// injection on a stub would test the harness, not the silent-failure
+// surfaces the harness exists to catch.
 func TestInjection_LastFM(t *testing.T) {
 	provider.SetInjectedProviders([]string{"lastfm"})
 	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
@@ -27,7 +32,20 @@ func TestInjection_LastFM(t *testing.T) {
 	if _, err := a.GetArtist(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
 		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
 	}
-	if _, err := a.GetImages(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
-		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+}
+
+// TestStubBypassesInjection_LastFM pins that GetImages keeps returning
+// (nil, nil) even when injection is active, so a caller that treats a
+// known-no-op as "skip" stays on the same code path under the smoke
+// harness as it does in production.
+func TestStubBypassesInjection_LastFM(t *testing.T) {
+	provider.SetInjectedProviders([]string{"lastfm"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), nil, logger)
+
+	if got, err := a.GetImages(context.Background(), "test-id"); err != nil || got != nil {
+		t.Errorf("GetImages stub: want (nil, nil), got (%v, %v)", got, err)
 	}
 }

--- a/internal/provider/lastfm/injection_test.go
+++ b/internal/provider/lastfm/injection_test.go
@@ -1,0 +1,33 @@
+package lastfm
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestInjection_LastFM verifies that all outbound methods respect the
+// fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "lastfm".
+func TestInjection_LastFM(t *testing.T) {
+	provider.SetInjectedProviders([]string{"lastfm"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), nil, logger)
+
+	ctx := context.Background()
+
+	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetArtist(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetImages(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+	}
+}

--- a/internal/provider/lastfm/lastfm.go
+++ b/internal/provider/lastfm/lastfm.go
@@ -186,11 +186,12 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 	return mapArtist(&resp.Artist), nil
 }
 
-// GetImages returns nil since Last.fm does not host high-quality artist images.
+// GetImages is a documented no-op for Last.fm (no high-quality artist
+// images). Injection is intentionally NOT consulted here; matching the
+// production (nil, nil) contract keeps callers that treat known-no-op
+// providers as "not supported, skip" on the same code path under the
+// smoke harness.
 func (a *Adapter) GetImages(_ context.Context, _ string) ([]provider.ImageResult, error) {
-	if provider.ShouldInjectFailure(a.Name()) {
-		return nil, provider.ErrInjectedFailure
-	}
 	return nil, nil
 }
 

--- a/internal/provider/lastfm/lastfm.go
+++ b/internal/provider/lastfm/lastfm.go
@@ -57,6 +57,9 @@ func (a *Adapter) SupportsNameLookup() bool { return true }
 
 // SearchArtist searches Last.fm for artists matching the given name.
 func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.ArtistSearchResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	apiKey, err := a.getAPIKey(ctx)
 	if err != nil {
 		return nil, err
@@ -109,6 +112,9 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 
 // GetArtist fetches full metadata for an artist by name or MBID.
 func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	apiKey, err := a.getAPIKey(ctx)
 	if err != nil {
 		return nil, err
@@ -182,6 +188,9 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 
 // GetImages returns nil since Last.fm does not host high-quality artist images.
 func (a *Adapter) GetImages(_ context.Context, _ string) ([]provider.ImageResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	return nil, nil
 }
 

--- a/internal/provider/musicbrainz/injection_test.go
+++ b/internal/provider/musicbrainz/injection_test.go
@@ -10,8 +10,12 @@ import (
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
-// TestInjection_MusicBrainz verifies that all outbound methods respect the
+// TestInjection_MusicBrainz verifies that real outbound methods respect the
 // fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "musicbrainz".
+//
+// GetImages is a documented no-op for MusicBrainz (no image hosting), so
+// injection is intentionally NOT consulted on it -- exercising injection on
+// a stub would test the harness, not the silent-failure surfaces.
 func TestInjection_MusicBrainz(t *testing.T) {
 	provider.SetInjectedProviders([]string{"musicbrainz"})
 	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
@@ -27,10 +31,23 @@ func TestInjection_MusicBrainz(t *testing.T) {
 	if _, err := a.GetArtist(ctx, "test-mbid"); !errors.Is(err, provider.ErrInjectedFailure) {
 		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
 	}
-	if _, err := a.GetImages(ctx, "test-mbid"); !errors.Is(err, provider.ErrInjectedFailure) {
-		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
-	}
 	if _, err := a.GetReleaseGroups(ctx, "test-mbid"); !errors.Is(err, provider.ErrInjectedFailure) {
 		t.Errorf("GetReleaseGroups: want ErrInjectedFailure, got %v", err)
+	}
+}
+
+// TestStubBypassesInjection_MusicBrainz pins that GetImages keeps returning
+// (nil, nil) even when injection is active, so a caller that treats a
+// known-no-op as "skip" stays on the same code path under the smoke
+// harness as it does in production.
+func TestStubBypassesInjection_MusicBrainz(t *testing.T) {
+	provider.SetInjectedProviders([]string{"musicbrainz"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), logger)
+
+	if got, err := a.GetImages(context.Background(), "test-mbid"); err != nil || got != nil {
+		t.Errorf("GetImages stub: want (nil, nil), got (%v, %v)", got, err)
 	}
 }

--- a/internal/provider/musicbrainz/injection_test.go
+++ b/internal/provider/musicbrainz/injection_test.go
@@ -1,0 +1,36 @@
+package musicbrainz
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestInjection_MusicBrainz verifies that all outbound methods respect the
+// fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "musicbrainz".
+func TestInjection_MusicBrainz(t *testing.T) {
+	provider.SetInjectedProviders([]string{"musicbrainz"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), logger)
+
+	ctx := context.Background()
+
+	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetArtist(ctx, "test-mbid"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetImages(ctx, "test-mbid"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetReleaseGroups(ctx, "test-mbid"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetReleaseGroups: want ErrInjectedFailure, got %v", err)
+	}
+}

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -60,6 +60,9 @@ func (a *Adapter) RequiresAuth() bool { return false }
 
 // SearchArtist searches MusicBrainz for artists matching the given name.
 func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.ArtistSearchResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	params := url.Values{
 		"query": {name},
 		"fmt":   {"json"},
@@ -118,6 +121,9 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 
 // GetArtist fetches full metadata for an artist by their MusicBrainz ID.
 func (a *Adapter) GetArtist(ctx context.Context, mbid string) (*provider.ArtistMetadata, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	params := url.Values{
 		"inc": {"aliases+genres+tags+ratings+url-rels+artist-rels"},
 		"fmt": {"json"},
@@ -418,6 +424,9 @@ func romanizeFromSortName(sortName string) (string, bool) {
 
 // GetImages returns nil since MusicBrainz does not host artist images.
 func (a *Adapter) GetImages(_ context.Context, _ string) ([]provider.ImageResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	return nil, nil
 }
 
@@ -425,6 +434,9 @@ func (a *Adapter) GetImages(_ context.Context, _ string) ([]provider.ImageResult
 // Results are paginated in batches of 100 and capped at 500 total to avoid
 // runaway loops on prolific artists (classical composers, etc.).
 func (a *Adapter) GetReleaseGroups(ctx context.Context, mbid string) ([]provider.ReleaseGroupInfo, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	const (
 		pageSize = 100
 		maxTotal = 500

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -422,11 +422,11 @@ func romanizeFromSortName(sortName string) (string, bool) {
 	return given + " " + family, true
 }
 
-// GetImages returns nil since MusicBrainz does not host artist images.
+// GetImages is a documented no-op for MusicBrainz (no image hosting).
+// Injection is intentionally NOT consulted here; matching the production
+// (nil, nil) contract keeps callers that treat known-no-op providers as
+// "not supported, skip" on the same code path under the smoke harness.
 func (a *Adapter) GetImages(_ context.Context, _ string) ([]provider.ImageResult, error) {
-	if provider.ShouldInjectFailure(a.Name()) {
-		return nil, provider.ErrInjectedFailure
-	}
 	return nil, nil
 }
 

--- a/internal/provider/spotify/injection_test.go
+++ b/internal/provider/spotify/injection_test.go
@@ -1,0 +1,35 @@
+package spotify
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestInjection_Spotify verifies that all outbound methods respect the
+// fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "spotify".
+func TestInjection_Spotify(t *testing.T) {
+	provider.SetInjectedProviders([]string{"spotify"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), nil, logger)
+
+	ctx := context.Background()
+
+	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
+	}
+	// GetArtist with a valid Spotify ID format (22 char base-62) to pass the
+	// IsSpotifyID guard before reaching injection. Injection fires first.
+	if _, err := a.GetArtist(ctx, "4Z8W4fkeB5YxbusRsdQVPb"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetImages(ctx, "4Z8W4fkeB5YxbusRsdQVPb"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+	}
+}

--- a/internal/provider/spotify/spotify.go
+++ b/internal/provider/spotify/spotify.go
@@ -67,6 +67,9 @@ func (a *Adapter) RequiresAuth() bool { return true }
 
 // SearchArtist searches Spotify for artists matching the given name.
 func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.ArtistSearchResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	if name == "" {
 		return nil, nil
 	}
@@ -113,6 +116,9 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 // GetArtist fetches metadata for an artist by their Spotify ID.
 // Returns ErrNotFound for IDs that are not valid Spotify format.
 func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	if !IsSpotifyID(id) {
 		return nil, &provider.ErrNotFound{Provider: provider.NameSpotify, ID: id}
 	}
@@ -148,6 +154,9 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 // GetImages fetches artist images by Spotify ID.
 // Returns ErrNotFound for IDs that are not valid Spotify format.
 func (a *Adapter) GetImages(ctx context.Context, id string) ([]provider.ImageResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	if !IsSpotifyID(id) {
 		return nil, &provider.ErrNotFound{Provider: provider.NameSpotify, ID: id}
 	}

--- a/internal/provider/wikidata/injection_test.go
+++ b/internal/provider/wikidata/injection_test.go
@@ -10,8 +10,13 @@ import (
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
-// TestInjection_Wikidata verifies that all outbound methods respect the
+// TestInjection_Wikidata verifies that real outbound methods respect the
 // fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "wikidata".
+//
+// SearchArtist is a documented no-op (SPARQL lookup requires an MBID --
+// use GetArtist instead), so injection is intentionally NOT consulted on
+// it -- exercising injection on a stub would test the harness, not the
+// silent-failure surfaces.
 func TestInjection_Wikidata(t *testing.T) {
 	provider.SetInjectedProviders([]string{"wikidata"})
 	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
@@ -21,9 +26,6 @@ func TestInjection_Wikidata(t *testing.T) {
 
 	ctx := context.Background()
 
-	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
-		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
-	}
 	// GetArtist requires a UUID or QID; injection fires before the validation check.
 	if _, err := a.GetArtist(ctx, "Q12345"); !errors.Is(err, provider.ErrInjectedFailure) {
 		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
@@ -31,5 +33,21 @@ func TestInjection_Wikidata(t *testing.T) {
 	// GetImages: injection fires before UUID validation; valid format used only for clarity.
 	if _, err := a.GetImages(ctx, "00000000-0000-0000-0000-000000000000"); !errors.Is(err, provider.ErrInjectedFailure) {
 		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+	}
+}
+
+// TestStubBypassesInjection_Wikidata pins that SearchArtist keeps
+// returning (nil, nil) even when injection is active, so a caller that
+// treats a known-no-op as "skip" stays on the same code path under the
+// smoke harness as it does in production.
+func TestStubBypassesInjection_Wikidata(t *testing.T) {
+	provider.SetInjectedProviders([]string{"wikidata"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), logger)
+
+	if got, err := a.SearchArtist(context.Background(), "test"); err != nil || got != nil {
+		t.Errorf("SearchArtist stub: want (nil, nil), got (%v, %v)", got, err)
 	}
 }

--- a/internal/provider/wikidata/injection_test.go
+++ b/internal/provider/wikidata/injection_test.go
@@ -1,0 +1,35 @@
+package wikidata
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestInjection_Wikidata verifies that all outbound methods respect the
+// fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "wikidata".
+func TestInjection_Wikidata(t *testing.T) {
+	provider.SetInjectedProviders([]string{"wikidata"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), logger)
+
+	ctx := context.Background()
+
+	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
+	}
+	// GetArtist requires a UUID or QID; injection fires before the validation check.
+	if _, err := a.GetArtist(ctx, "Q12345"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
+	}
+	// GetImages: injection fires before UUID validation; valid format used only for clarity.
+	if _, err := a.GetImages(ctx, "00000000-0000-0000-0000-000000000000"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+	}
+}

--- a/internal/provider/wikidata/wikidata.go
+++ b/internal/provider/wikidata/wikidata.go
@@ -72,6 +72,9 @@ func (a *Adapter) RequiresAuth() bool { return false }
 
 // SearchArtist is not directly supported by Wikidata SPARQL (use GetArtist with MBID instead).
 func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	return nil, nil
 }
 
@@ -89,6 +92,9 @@ func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSe
 // (artist name, country name, genre name) are returned in the user's preferred
 // language.
 func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	// Validate the input as either a UUID or a QID before interpolating into
 	// the SPARQL query. This guards against injection regardless of which
 	// branch buildArtistQuery takes below.
@@ -128,6 +134,9 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 // P18 (image/photo) and P154 (logo). The SPARQL query returns Commons filenames
 // which are then resolved to direct URLs via the Wikimedia Commons API.
 func (a *Adapter) GetImages(ctx context.Context, mbid string) ([]provider.ImageResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	// Validate MBID format before interpolating into SPARQL query to prevent injection.
 	if !provider.IsUUID(mbid) {
 		return nil, &provider.ErrNotFound{Provider: provider.NameWikidata, ID: mbid}

--- a/internal/provider/wikidata/wikidata.go
+++ b/internal/provider/wikidata/wikidata.go
@@ -70,11 +70,12 @@ func (a *Adapter) Name() provider.ProviderName { return provider.NameWikidata }
 // RequiresAuth returns whether this provider needs an API key.
 func (a *Adapter) RequiresAuth() bool { return false }
 
-// SearchArtist is not directly supported by Wikidata SPARQL (use GetArtist with MBID instead).
+// SearchArtist is a documented no-op for Wikidata (SPARQL lookup requires
+// an MBID -- use GetArtist instead). Injection is intentionally NOT
+// consulted here; matching the production (nil, nil) contract keeps
+// callers that treat known-no-op providers as "not supported, skip" on
+// the same code path under the smoke harness.
 func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
-	if provider.ShouldInjectFailure(a.Name()) {
-		return nil, provider.ErrInjectedFailure
-	}
 	return nil, nil
 }
 

--- a/internal/provider/wikipedia/injection_test.go
+++ b/internal/provider/wikipedia/injection_test.go
@@ -10,8 +10,14 @@ import (
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
-// TestInjection_Wikipedia verifies that all outbound methods respect the
+// TestInjection_Wikipedia verifies that real outbound methods respect the
 // fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "wikipedia".
+//
+// SearchArtist and GetImages are documented no-ops here (lookup requires
+// an MBID resolved through Wikidata; Wikipedia is not used for artist
+// images), so injection is intentionally NOT consulted on them --
+// exercising injection on a stub would test the harness, not the
+// silent-failure surfaces.
 func TestInjection_Wikipedia(t *testing.T) {
 	provider.SetInjectedProviders([]string{"wikipedia"})
 	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
@@ -21,13 +27,28 @@ func TestInjection_Wikipedia(t *testing.T) {
 
 	ctx := context.Background()
 
-	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
-		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
-	}
 	if _, err := a.GetArtist(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
 		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
 	}
-	if _, err := a.GetImages(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
-		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+}
+
+// TestStubsBypassInjection_Wikipedia pins that the documented no-op stubs
+// keep returning (nil, nil) even when injection is active, so a caller
+// that treats a known-no-op as "skip" stays on the same code path under
+// the smoke harness as it does in production.
+func TestStubsBypassInjection_Wikipedia(t *testing.T) {
+	provider.SetInjectedProviders([]string{"wikipedia"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), nil, logger)
+
+	ctx := context.Background()
+
+	if got, err := a.SearchArtist(ctx, "test"); err != nil || got != nil {
+		t.Errorf("SearchArtist stub: want (nil, nil), got (%v, %v)", got, err)
+	}
+	if got, err := a.GetImages(ctx, "test-id"); err != nil || got != nil {
+		t.Errorf("GetImages stub: want (nil, nil), got (%v, %v)", got, err)
 	}
 }

--- a/internal/provider/wikipedia/injection_test.go
+++ b/internal/provider/wikipedia/injection_test.go
@@ -1,0 +1,33 @@
+package wikipedia
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// TestInjection_Wikipedia verifies that all outbound methods respect the
+// fault-injection hook when SW_FORCE_PROVIDER_ERROR includes "wikipedia".
+func TestInjection_Wikipedia(t *testing.T) {
+	provider.SetInjectedProviders([]string{"wikipedia"})
+	t.Cleanup(func() { provider.SetInjectedProviders(nil) })
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := New(provider.NewRateLimiterMap(), nil, logger)
+
+	ctx := context.Background()
+
+	if _, err := a.SearchArtist(ctx, "test"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("SearchArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetArtist(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetArtist: want ErrInjectedFailure, got %v", err)
+	}
+	if _, err := a.GetImages(ctx, "test-id"); !errors.Is(err, provider.ErrInjectedFailure) {
+		t.Errorf("GetImages: want ErrInjectedFailure, got %v", err)
+	}
+}

--- a/internal/provider/wikipedia/wikipedia.go
+++ b/internal/provider/wikipedia/wikipedia.go
@@ -85,12 +85,12 @@ func (a *Adapter) RequiresAuth() bool { return false }
 // Only the MBID-to-Wikidata-to-article path is reliable.
 func (a *Adapter) SupportsNameLookup() bool { return false }
 
-// SearchArtist is not supported; Wikipedia lookup requires a MusicBrainz ID
-// resolved through Wikidata to ensure the correct article is matched.
+// SearchArtist is a documented no-op for Wikipedia (lookup requires an
+// MBID resolved through Wikidata so the correct article is matched).
+// Injection is intentionally NOT consulted here; matching the production
+// (nil, nil) contract keeps callers that treat known-no-op providers as
+// "not supported, skip" on the same code path under the smoke harness.
 func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
-	if provider.ShouldInjectFailure(a.Name()) {
-		return nil, provider.ErrInjectedFailure
-	}
 	return nil, nil
 }
 
@@ -333,11 +333,12 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 	return meta, nil
 }
 
-// GetImages returns nil; Wikipedia is not used for artist images.
+// GetImages is a documented no-op for Wikipedia (not used for artist
+// images). Injection is intentionally NOT consulted here; matching the
+// production (nil, nil) contract keeps callers that treat known-no-op
+// providers as "not supported, skip" on the same code path under the
+// smoke harness.
 func (a *Adapter) GetImages(_ context.Context, _ string) ([]provider.ImageResult, error) {
-	if provider.ShouldInjectFailure(a.Name()) {
-		return nil, provider.ErrInjectedFailure
-	}
 	return nil, nil
 }
 

--- a/internal/provider/wikipedia/wikipedia.go
+++ b/internal/provider/wikipedia/wikipedia.go
@@ -88,6 +88,9 @@ func (a *Adapter) SupportsNameLookup() bool { return false }
 // SearchArtist is not supported; Wikipedia lookup requires a MusicBrainz ID
 // resolved through Wikidata to ensure the correct article is matched.
 func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	return nil, nil
 }
 
@@ -111,6 +114,9 @@ func (a *Adapter) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSe
 //
 //nolint:gocognit // Resolves an ID to (title, QID), iterates user language preferences with English fallback, and at each language probes extracts, sitelinks, infobox, image, and disambiguation handling; the per-language fallthrough on empty content keeps the policy in one place rather than scattered helpers.
 func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMetadata, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return nil, &provider.ErrNotFound{Provider: provider.NameWikipedia, ID: id}
@@ -329,6 +335,9 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 
 // GetImages returns nil; Wikipedia is not used for artist images.
 func (a *Adapter) GetImages(_ context.Context, _ string) ([]provider.ImageResult, error) {
+	if provider.ShouldInjectFailure(a.Name()) {
+		return nil, provider.ErrInjectedFailure
+	}
 	return nil, nil
 }
 

--- a/internal/version/format.go
+++ b/internal/version/format.go
@@ -63,15 +63,18 @@ func IsDevBuild() bool {
 }
 
 // IsReleaseBuild reports whether the binary was produced by the release
-// pipeline (goreleaser). It is the logical negation of IsDevBuild: both
-// Commit and Date must be non-"unknown" for the binary to be considered
-// a release build.
+// pipeline (goreleaser, stable or nightly). It checks BuildType rather
+// than negating IsDevBuild because both `make build` and goreleaser
+// inject non-"unknown" Commit and Date values, so the two cannot be
+// distinguished by those fields alone. Only the goreleaser configs set
+// `-X .../version.BuildType=release`; everything else (make build,
+// `go build`, IDE builds, CI test builds) leaves it as the zero value.
 //
 // Used by the startup check for SW_FORCE_PROVIDER_ERROR: the env var is
-// allowed in dev/CI builds and blocked in release builds so the hook
-// cannot survive an accidental config copy into production.
+// allowed in dev/CI/smoke builds and blocked in release builds so the
+// hook cannot survive an accidental config copy into production.
 func IsReleaseBuild() bool {
-	return !IsDevBuild()
+	return BuildType == "release"
 }
 
 // UserAgent returns an HTTP User-Agent header value for outbound requests.

--- a/internal/version/format.go
+++ b/internal/version/format.go
@@ -62,6 +62,18 @@ func IsDevBuild() bool {
 	return Commit == "unknown" || Date == "unknown"
 }
 
+// IsReleaseBuild reports whether the binary was produced by the release
+// pipeline (goreleaser). It is the logical negation of IsDevBuild: both
+// Commit and Date must be non-"unknown" for the binary to be considered
+// a release build.
+//
+// Used by the startup check for SW_FORCE_PROVIDER_ERROR: the env var is
+// allowed in dev/CI builds and blocked in release builds so the hook
+// cannot survive an accidental config copy into production.
+func IsReleaseBuild() bool {
+	return !IsDevBuild()
+}
+
 // UserAgent returns an HTTP User-Agent header value for outbound requests.
 //
 // prefix is the application/subsystem identifier (e.g., "Stillwater",

--- a/internal/version/format_test.go
+++ b/internal/version/format_test.go
@@ -27,6 +27,18 @@ func withVersion(t *testing.T, v, commit, date string) {
 	})
 }
 
+// withBuildType swaps version.BuildType for the duration of a test. Use
+// alongside withVersion when a test cares about IsReleaseBuild semantics,
+// which now key off BuildType rather than Commit/Date presence.
+func withBuildType(t *testing.T, bt string) {
+	t.Helper()
+	orig := version.BuildType
+	version.BuildType = bt
+	t.Cleanup(func() {
+		version.BuildType = orig
+	})
+}
+
 // ---- IsDevBuild ----
 
 func TestIsDevBuild_CommitUnknown(t *testing.T) {
@@ -58,18 +70,53 @@ func TestIsDevBuild_ReleaseBuild(t *testing.T) {
 }
 
 // ---- IsReleaseBuild ----
+//
+// IsReleaseBuild keys off BuildType, NOT IsDevBuild's Commit/Date check.
+// `make build` produces non-"unknown" Commit and Date via the Makefile's
+// git/date probes, which is indistinguishable from a goreleaser-produced
+// binary by those fields alone. Only the goreleaser configs inject
+// BuildType=release, so anything else (make build, IDE go build, CI test
+// builds, the provider-failure smoke harness) reports IsReleaseBuild=false
+// and the SW_FORCE_PROVIDER_ERROR boot guard does not fire.
 
-func TestIsReleaseBuild_DevBuild(t *testing.T) {
-	withVersion(t, "1.0.6", "unknown", "unknown")
+func TestIsReleaseBuild_BuildTypeUnset(t *testing.T) {
+	withVersion(t, "1.0.6", "abc1234", "2026-05-08")
+	withBuildType(t, "")
 	if version.IsReleaseBuild() {
-		t.Error("expected IsReleaseBuild() == false for a dev build")
+		t.Error("expected IsReleaseBuild() == false when BuildType is unset (make build / IDE)")
 	}
 }
 
-func TestIsReleaseBuild_ReleaseBuild(t *testing.T) {
+func TestIsReleaseBuild_BuildTypeRelease(t *testing.T) {
 	withVersion(t, "1.0.6", "abc1234", "2026-05-08")
+	withBuildType(t, "release")
 	if !version.IsReleaseBuild() {
-		t.Error("expected IsReleaseBuild() == true for a release build")
+		t.Error("expected IsReleaseBuild() == true when BuildType is 'release'")
+	}
+}
+
+func TestIsReleaseBuild_BuildTypeArbitrary(t *testing.T) {
+	// Anything other than the exact string "release" is non-release, so a
+	// future "nightly" or "dirty" marker (or a typo) does not silently
+	// inherit release semantics.
+	withVersion(t, "1.0.6", "abc1234", "2026-05-08")
+	for _, bt := range []string{"nightly", "dev", "smoke", "Release", " release "} {
+		withBuildType(t, bt)
+		if version.IsReleaseBuild() {
+			t.Errorf("expected IsReleaseBuild() == false for BuildType=%q", bt)
+		}
+	}
+}
+
+func TestIsReleaseBuild_DevBuildRegardlessOfBuildType(t *testing.T) {
+	// Belt-and-suspenders: even if BuildType were somehow set to "release"
+	// on a binary whose Commit/Date came back "unknown", that combination
+	// represents a build pipeline bug -- IsDevBuild is unaffected by
+	// BuildType and continues to surface the "(dev build)" formatting.
+	withVersion(t, "1.0.6", "unknown", "unknown")
+	withBuildType(t, "release")
+	if !version.IsDevBuild() {
+		t.Error("expected IsDevBuild() == true regardless of BuildType when Commit/Date are 'unknown'")
 	}
 }
 

--- a/internal/version/format_test.go
+++ b/internal/version/format_test.go
@@ -57,6 +57,22 @@ func TestIsDevBuild_ReleaseBuild(t *testing.T) {
 	}
 }
 
+// ---- IsReleaseBuild ----
+
+func TestIsReleaseBuild_DevBuild(t *testing.T) {
+	withVersion(t, "1.0.6", "unknown", "unknown")
+	if version.IsReleaseBuild() {
+		t.Error("expected IsReleaseBuild() == false for a dev build")
+	}
+}
+
+func TestIsReleaseBuild_ReleaseBuild(t *testing.T) {
+	withVersion(t, "1.0.6", "abc1234", "2026-05-08")
+	if !version.IsReleaseBuild() {
+		t.Error("expected IsReleaseBuild() == true for a release build")
+	}
+}
+
 // ---- Validate ----
 
 func TestValidate_Success(t *testing.T) {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,15 @@
 package version
 
 // These variables are set at build time via -ldflags.
+//
+// BuildType is the release-pipeline marker: goreleaser (both stable and
+// nightly configs) injects "release"; nothing else does. IsReleaseBuild
+// reads this explicitly because Commit/Date alone cannot distinguish a
+// real release artifact from a developer's `make build` output (both get
+// non-"unknown" values via the Makefile's git/date probes).
 var (
-	Version = "1.4.0"
-	Commit  = "unknown"
-	Date    = "unknown"
+	Version   = "1.4.0"
+	Commit    = "unknown"
+	Date      = "unknown"
+	BuildType = ""
 )

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 // These variables are set at build time via -ldflags.
 var (
-	Version = "1.3.0"
+	Version = "1.4.0"
 	Commit  = "unknown"
 	Date    = "unknown"
 )

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -334,4 +334,22 @@ fi
 echo "OK: $(wc -l < "$live_fuzz_file" | tr -d ' ') fuzz targets, matrix set matches."
 
 echo ""
+echo "=== Provider failure smoke test ==="
+# Builds the binary (re-uses cached build if present), starts a temporary
+# injected instance, drives the coverage matrix, and asserts that every
+# covered surface communicates provider failures instead of silently
+# returning empty data.  Hard-fail on non-zero exit from the script.
+SMOKE_FAILURE_SCRIPT="$SCRIPT_DIR/smoke-provider-failure.sh"
+if [ ! -x "$SMOKE_FAILURE_SCRIPT" ]; then
+  echo "pre-push-gate: smoke-provider-failure.sh not found or not executable in scripts/" >&2
+  exit 1
+fi
+if ! bash "$SMOKE_FAILURE_SCRIPT" 2>&1; then
+  echo ""
+  echo "FAIL: provider failure smoke test reported failures (see output above)."
+  exit 1
+fi
+echo "OK"
+
+echo ""
 echo "All hard checks passed. Proceed with /pr-review-toolkit:review-pr."

--- a/scripts/smoke-provider-failure.sh
+++ b/scripts/smoke-provider-failure.sh
@@ -52,6 +52,17 @@ SW_BASE="${SW_BASE:-http://localhost:19730}"
 SW_USER="${SW_USER:-admin}"
 SW_PASS="${SW_PASS:-testpassword123testpassword123}"
 
+# Derive the listen port from SW_BASE so a non-default SW_BASE (e.g. a
+# different port for parallel smoke runs) launches the binary on the
+# matching port instead of the hard-coded 19730 the health check then
+# fails to reach. The sed regex matches "http(s)://<host>:<port>" and
+# returns empty for URLs without an explicit port (e.g. "http://localhost")
+# or IPv6 bracketed hosts ("http://[::1]:..."), both of which fall back to
+# the 19730 default on the next line -- safe for the smoke use case where
+# the operator overriding SW_BASE controls the port either way.
+SW_PORT="${SW_PORT:-$(printf '%s' "$SW_BASE" | sed -nE 's#^https?://[^:/]+:([0-9]+).*$#\1#p')}"
+SW_PORT="${SW_PORT:-19730}"
+
 # All real providers -- must match provider.NameXxx constants in provider.go.
 ALL_PROVIDERS="musicbrainz,fanarttv,audiodb,discogs,lastfm,wikidata,duckduckgo,deezer,genius,wikipedia,spotify"
 
@@ -128,7 +139,14 @@ cleanup() {
       sleep 0.3
       i=$((i + 1))
     done
-    kill -9 "$SWPID" 2>/dev/null || true
+    # Only SIGKILL if the PID still refers to a live process. The wait
+    # loop exits either because the child is gone (and the kernel may
+    # have already recycled the PID) or because the 3 s cap fired; the
+    # unconditional kill -9 in the second case could otherwise terminate
+    # an unrelated process that happened to inherit the recycled PID.
+    if kill -0 "$SWPID" 2>/dev/null; then
+      kill -9 "$SWPID" 2>/dev/null || true
+    fi
   fi
   if [[ -n "${_SPF_TMPDIR:-}" && -d "$_SPF_TMPDIR" ]]; then
     rm -rf "$_SPF_TMPDIR"
@@ -170,13 +188,22 @@ SPF_LOG="$SW_RUN_DIR/spf-server.log"
 # env-var defaults are sufficient for a smoke instance.
 SW_FORCE_PROVIDER_ERROR="$ALL_PROVIDERS" \
   SW_DB_PATH="$_SPF_TMPDIR/stillwater.db" \
-  SW_PORT=19730 \
+  SW_PORT="$SW_PORT" \
   "$SW_BINARY" >"$SPF_LOG" 2>&1 &
 SWPID=$!
 
-# Wait for the server to become healthy (up to 20 s).
+# Wait for the server to become healthy (up to 20 s). Bail out early if
+# the child process already exited so the operator sees the boot error
+# rather than 20 s of silence followed by a "did not become healthy" message.
 healthy=0
 for i in $(seq 1 40); do
+  if ! kill -0 "$SWPID" 2>/dev/null; then
+    echo "FATAL: injected instance exited before becoming healthy." >&2
+    echo "  PID: $SWPID"
+    echo "  Server log (last 40 lines):"
+    tail -40 "$SPF_LOG" >&2 || true
+    exit 2
+  fi
   if curl -s "$SW_BASE/api/v1/health" | grep -q '"status":"ok"'; then
     healthy=1
     break
@@ -218,13 +245,19 @@ setup_resp=$(curl -s -w "\n%{http_code}" \
   -d "$setup_payload")
 setup_code=$(echo "$setup_resp" | tail -n 1)
 # 201 = created; 409 = already exists (acceptable if DB was somehow reused).
+# Branch the PASS message so the 409 case (admin already present) does not
+# get reported as a failure by assert_status's strict "got != expected" path.
 if [[ "$setup_code" != "201" && "$setup_code" != "409" ]]; then
   setup_body=$(echo "$setup_resp" | sed '$d')
   echo "FATAL: POST /api/v1/auth/setup returned HTTP $setup_code" >&2
   echo "  body: ${setup_body:0:400}" >&2
   exit 2
 fi
-assert_status "POST /api/v1/auth/setup (create admin)" "201" "$setup_code"
+if [[ "$setup_code" == "201" ]]; then
+  assert_pass "POST /api/v1/auth/setup (create admin)"
+else
+  assert_pass "POST /api/v1/auth/setup (admin already exists, HTTP 409)"
+fi
 
 login_payload=$(jq -nc --arg u "$SW_USER" --arg p "$SW_PASS" '{username: $u, password: $p}')
 login_resp=$(printf '%s' "$login_payload" | curl -s -c "$COOKIE_JAR" -b "$COOKIE_JAR" -w "\n%{http_code}" \

--- a/scripts/smoke-provider-failure.sh
+++ b/scripts/smoke-provider-failure.sh
@@ -204,7 +204,13 @@ for i in $(seq 1 40); do
     tail -40 "$SPF_LOG" >&2 || true
     exit 2
   fi
-  if curl -s "$SW_BASE/api/v1/health" | grep -q '"status":"ok"'; then
+  # Bound each probe so a stalled connect or hung socket cannot blow past
+  # the 20 s loop budget (40 iterations * 0.5 s) and leave the gate
+  # non-deterministic. --connect-timeout caps the TCP handshake; --max-time
+  # caps the whole request -- both are well above the in-process health
+  # handler's expected latency (single-digit ms) while still surfacing
+  # genuine stalls fast enough to fail the budget cleanly.
+  if curl -s --connect-timeout 1 --max-time 2 "$SW_BASE/api/v1/health" | grep -q '"status":"ok"'; then
     healthy=1
     break
   fi
@@ -414,8 +420,14 @@ if [[ "$wizard_start_code" == "200" || "$wizard_start_code" == "201" ]]; then
       "Could not load candidates" \
       "$step_resp"
   else
-    assert_fail "GET wizard step -- failed to extract session_id from start response" \
-      "start body: ${wizard_start_body:0:200}"
+    # WARN-NOT-FAIL: hitting assert_fail here would contradict the Row 2
+    # declaration in the else branch below -- an unexpected 2xx-without-
+    # session_id under full injection (e.g. an error envelope shaped
+    # differently than the wizard contract expects) is exactly the kind
+    # of surface-fix-pending behavior the WARN tier exists to capture
+    # without breaking the gate.
+    echo "[WARN] GET wizard step -- could not extract session_id from 2xx response (non-fatal; see TODO below)"
+    echo "  body: ${wizard_start_body:0:200}"
   fi
 else
   # Row 2 is WARN-NOT-FAIL until the wizard start + session flow is stabilized

--- a/scripts/smoke-provider-failure.sh
+++ b/scripts/smoke-provider-failure.sh
@@ -1,0 +1,512 @@
+#!/usr/bin/env bash
+# smoke-provider-failure.sh -- provider-failure injection smoke test
+#
+# Starts a temporary Stillwater instance with SW_FORCE_PROVIDER_ERROR set
+# to all real providers, drives each surface in the coverage matrix, and
+# asserts that every covered handler communicates the failure rather than
+# silently returning empty/incomplete data.
+#
+# Usage:
+#   bash scripts/smoke-provider-failure.sh
+#
+# Environment (all optional):
+#   SW_BINARY     -- path to a pre-built binary (default: ./stillwater)
+#   SW_BASE       -- base URL for the injected instance (default: http://localhost:19730)
+#   SW_USER       -- admin username (default: admin)
+#   SW_PASS       -- admin password (default: testpassword123testpassword123)
+#
+# Exit codes:
+#   0 -- all assertions passed
+#   1 -- one or more assertions failed (see FAILED list in output)
+#   2 -- setup/infrastructure failure (could not start binary, etc.)
+#
+# Output is tee'd to $SW_RUN_DIR/smoke-provider-failure.log per the
+# repo convention in scripts/lib/run-paths.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/lib/run-paths.sh"
+
+LOG_FILE="$SW_RUN_DIR/smoke-provider-failure.log"
+
+# Re-exec with tee so output lands in the log AND on stdout.
+# Guard against infinite re-exec if tee fails to open the log.
+if [[ -z "${_SPF_LOGGED:-}" ]]; then
+  export _SPF_LOGGED=1
+  exec > >(tee "$LOG_FILE") 2>&1
+fi
+
+echo "======================================================="
+echo "  Provider Failure Smoke Test"
+echo "  Log: $LOG_FILE"
+echo "======================================================="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SW_BINARY="${SW_BINARY:-$SCRIPT_DIR/../stillwater}"
+SW_BASE="${SW_BASE:-http://localhost:19730}"
+SW_USER="${SW_USER:-admin}"
+SW_PASS="${SW_PASS:-testpassword123testpassword123}"
+
+# All real providers -- must match provider.NameXxx constants in provider.go.
+ALL_PROVIDERS="musicbrainz,fanarttv,audiodb,discogs,lastfm,wikidata,duckduckgo,deezer,genius,wikipedia,spotify"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+SWPID=""
+COOKIE_JAR=""
+TOKEN=""
+TOKEN_ID=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+assert_pass() {
+  local label="$1"
+  echo "[PASS] $label"
+  PASS=$((PASS + 1))
+}
+
+assert_fail() {
+  local label="$1"
+  local detail="$2"
+  echo "[FAIL] $label -- $detail"
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$label -- $detail")
+}
+
+assert_body_contains() {
+  local label="$1"
+  local needle="$2"
+  local body="$3"
+  if echo "$body" | grep -qF "$needle"; then
+    assert_pass "$label"
+  else
+    assert_fail "$label" "response did not contain: $needle"
+    echo "  (first 400 chars of response:)"
+    echo "  ${body:0:400}"
+  fi
+}
+
+assert_status() {
+  local label="$1"
+  local expected="$2"
+  local got="$3"
+  if [[ "$got" == "$expected" ]]; then
+    echo "[PASS] $label -- HTTP $got"
+    PASS=$((PASS + 1))
+  else
+    echo "[FAIL] $label -- expected HTTP $expected, got $got"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$label -- expected HTTP $expected, got $got")
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup trap
+# ---------------------------------------------------------------------------
+
+cleanup() {
+  if [[ -n "$TOKEN" && -n "$TOKEN_ID" ]]; then
+    curl -s -o /dev/null -X DELETE \
+      -H "Authorization: Bearer $TOKEN" \
+      "$SW_BASE/api/v1/auth/tokens/$TOKEN_ID" || true
+  fi
+  [[ -n "$COOKIE_JAR" ]] && rm -f "$COOKIE_JAR"
+  if [[ -n "$SWPID" ]]; then
+    kill "$SWPID" 2>/dev/null || true
+    # Give the process a moment to exit cleanly.
+    local i=0
+    while kill -0 "$SWPID" 2>/dev/null && [[ $i -lt 10 ]]; do
+      sleep 0.3
+      i=$((i + 1))
+    done
+    kill -9 "$SWPID" 2>/dev/null || true
+  fi
+  if [[ -n "${_SPF_TMPDIR:-}" && -d "$_SPF_TMPDIR" ]]; then
+    rm -rf "$_SPF_TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Build binary (uses cached binary if already present)
+# ---------------------------------------------------------------------------
+
+if [[ ! -x "$SW_BINARY" ]]; then
+  echo "Binary not found at $SW_BINARY -- building..."
+  (cd "$SCRIPT_DIR/.." && make build) || {
+    echo "FATAL: make build failed." >&2
+    exit 2
+  }
+fi
+
+# ---------------------------------------------------------------------------
+# Start injected instance
+# ---------------------------------------------------------------------------
+
+# Spin up a temporary data directory so this run does not touch any real DB.
+_SPF_TMPDIR=$(mktemp -d "$SW_RUN_DIR/spf-data.XXXXXX")
+
+echo "Starting injected instance..."
+echo "  Binary: $SW_BINARY"
+echo "  Base: $SW_BASE"
+echo "  Providers injected: $ALL_PROVIDERS"
+echo "  Data dir: $_SPF_TMPDIR"
+echo ""
+
+SPF_LOG="$SW_RUN_DIR/spf-server.log"
+# SW_DB_PATH: override the in-code default (/config/stillwater.db) so the
+# binary writes its database into our temp directory instead of the
+# container-oriented /config path which is read-only on host systems.
+# SW_CONFIG_PATH is intentionally unset so the scaffold step is skipped;
+# env-var defaults are sufficient for a smoke instance.
+SW_FORCE_PROVIDER_ERROR="$ALL_PROVIDERS" \
+  SW_DB_PATH="$_SPF_TMPDIR/stillwater.db" \
+  SW_PORT=19730 \
+  "$SW_BINARY" >"$SPF_LOG" 2>&1 &
+SWPID=$!
+
+# Wait for the server to become healthy (up to 20 s).
+healthy=0
+for i in $(seq 1 40); do
+  if curl -s "$SW_BASE/api/v1/health" | grep -q '"status":"ok"'; then
+    healthy=1
+    break
+  fi
+  sleep 0.5
+done
+
+if [[ $healthy -eq 0 ]]; then
+  echo "FATAL: injected instance did not become healthy within 20 s." >&2
+  echo "  PID: $SWPID"
+  echo "  Server log (last 40 lines):"
+  tail -40 "$SPF_LOG" >&2
+  exit 2
+fi
+echo "Injected instance is healthy (PID $SWPID)."
+echo ""
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+echo "--- Auth ---"
+echo ""
+
+COOKIE_JAR="$SW_RUN_DIR/spf-cookies.jar"
+: > "$COOKIE_JAR"
+
+resp=$(curl -s -c "$COOKIE_JAR" -w "\n%{http_code}" "$SW_BASE/api/v1/health")
+code=$(echo "$resp" | tail -n 1)
+assert_status "GET /api/v1/health (injected instance)" "200" "$code"
+
+# The injected instance starts with an empty database. Create the admin account
+# via the OOBE setup endpoint (unauthenticated and CSRF-exempt on first run).
+setup_payload=$(jq -nc --arg u "$SW_USER" --arg p "$SW_PASS" \
+  '{auth_method:"local",username:$u,password:$p}')
+setup_resp=$(curl -s -w "\n%{http_code}" \
+  -X POST "$SW_BASE/api/v1/auth/setup" \
+  -H "Content-Type: application/json" \
+  -d "$setup_payload")
+setup_code=$(echo "$setup_resp" | tail -n 1)
+# 201 = created; 409 = already exists (acceptable if DB was somehow reused).
+if [[ "$setup_code" != "201" && "$setup_code" != "409" ]]; then
+  setup_body=$(echo "$setup_resp" | sed '$d')
+  echo "FATAL: POST /api/v1/auth/setup returned HTTP $setup_code" >&2
+  echo "  body: ${setup_body:0:400}" >&2
+  exit 2
+fi
+assert_status "POST /api/v1/auth/setup (create admin)" "201" "$setup_code"
+
+login_payload=$(jq -nc --arg u "$SW_USER" --arg p "$SW_PASS" '{username: $u, password: $p}')
+login_resp=$(printf '%s' "$login_payload" | curl -s -c "$COOKIE_JAR" -b "$COOKIE_JAR" -w "\n%{http_code}" \
+  -X POST "$SW_BASE/api/v1/auth/login" \
+  -H "Content-Type: application/json" \
+  -d @-)
+login_code=$(echo "$login_resp" | tail -n 1)
+assert_status "POST /api/v1/auth/login (injected instance)" "200" "$login_code"
+if [[ "$login_code" != "200" ]]; then
+  echo "FATAL: login failed on injected instance." >&2
+  exit 2
+fi
+
+CSRF_TOKEN=$(grep "csrf_token" "$COOKIE_JAR" | awk '{print $NF}' | tail -1 || true)
+if [[ -z "$CSRF_TOKEN" ]]; then
+  echo "FATAL: csrf_token cookie not found." >&2
+  exit 2
+fi
+
+token_resp=$(curl -s -b "$COOKIE_JAR" -w "\n%{http_code}" \
+  -X POST "$SW_BASE/api/v1/auth/tokens" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-Token: $CSRF_TOKEN" \
+  -d '{"name":"spf-smoke","scopes":"read,write,admin"}')
+token_body=$(echo "$token_resp" | sed '$d')
+token_code=$(echo "$token_resp" | tail -n 1)
+assert_status "POST /api/v1/auth/tokens (mint)" "201" "$token_code"
+
+TOKEN=$(echo "$token_body" | jq -r '.token' 2>/dev/null || echo "")
+TOKEN_ID=$(echo "$token_body" | jq -r '.id' 2>/dev/null || echo "")
+if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+  echo "FATAL: failed to mint API token on injected instance." >&2
+  exit 2
+fi
+echo "  Token minted: ${TOKEN:0:12}... (id=$TOKEN_ID)"
+echo ""
+
+AUTH=(-H "Authorization: Bearer $TOKEN")
+
+# ---------------------------------------------------------------------------
+# Provision a test artist via library scan
+# ---------------------------------------------------------------------------
+
+echo "--- Artist Provisioning ---"
+echo ""
+
+# Artists are created by the library scanner, not directly via the API.
+# Create a minimal music-directory hierarchy, register it as a library,
+# and trigger a scan so the scanner creates a test artist row in the DB.
+MUSIC_DIR="$_SPF_TMPDIR/music"
+ARTIST_DIR="$MUSIC_DIR/Smoke Test Artist"
+mkdir -p "$ARTIST_DIR"
+
+echo "  Music dir: $MUSIC_DIR"
+
+lib_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
+  -X POST "$SW_BASE/api/v1/libraries" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-Token: $CSRF_TOKEN" \
+  -d "{\"name\":\"spf-smoke\",\"path\":\"$MUSIC_DIR\",\"type\":\"regular\"}")
+lib_code=$(echo "$lib_resp" | tail -n 1)
+lib_body=$(echo "$lib_resp" | sed '$d')
+assert_status "POST /api/v1/libraries (smoke library)" "201" "$lib_code"
+if [[ "$lib_code" != "201" ]]; then
+  echo "FATAL: could not create smoke library: ${lib_body:0:300}" >&2
+  exit 2
+fi
+LIB_ID=$(echo "$lib_body" | jq -r '.id // empty' 2>/dev/null || true)
+echo "  Library ID: $LIB_ID"
+
+# Trigger a full scan so the scanner discovers the smoke library and creates
+# the artist row. The scanner/run endpoint takes no body and scans all
+# registered libraries.
+scan_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
+  -X POST "$SW_BASE/api/v1/scanner/run" \
+  -H "X-CSRF-Token: $CSRF_TOKEN")
+scan_code=$(echo "$scan_resp" | tail -n 1)
+# 202 = accepted (async scan started).
+if [[ "$scan_code" != "200" && "$scan_code" != "202" ]]; then
+  scan_body=$(echo "$scan_resp" | sed '$d')
+  echo "FATAL: scanner/run returned HTTP $scan_code: ${scan_body:0:300}" >&2
+  exit 2
+fi
+
+# Poll for the artist to appear (up to 15 s).
+ARTIST_ID=""
+for i in $(seq 1 30); do
+  ARTIST_ID=$(curl -s "${AUTH[@]}" "$SW_BASE/api/v1/artists?page_size=1" \
+    | jq -r '.artists[0].id // empty' 2>/dev/null || true)
+  if [[ -n "$ARTIST_ID" ]]; then
+    break
+  fi
+  sleep 0.5
+done
+
+if [[ -z "$ARTIST_ID" ]]; then
+  echo "FATAL: no artist appeared within 15 s after scan." >&2
+  exit 2
+fi
+echo "  Test artist ID: $ARTIST_ID"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Coverage matrix assertions
+# ---------------------------------------------------------------------------
+
+echo "--- Provider Failure Coverage Matrix ---"
+echo ""
+
+# ---- Row 1: Single-artist Re-identify search --------------------------------
+# POST /api/v1/artists/{id}/refresh/search (HTMX fragment)
+# Asserts: response body contains data-testid="providers-unreachable-banner"
+# (added in PR #1664)
+echo "[ Row 1: Single-artist Re-identify search ]"
+search_resp=$(curl -s "${AUTH[@]}" \
+  -X POST "$SW_BASE/api/v1/artists/$ARTIST_ID/refresh/search" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-Token: $CSRF_TOKEN" \
+  -H "HX-Request: true" \
+  -d '{"query":"Smoke Test Artist"}' || echo "")
+assert_body_contains \
+  "POST /api/v1/artists/$ARTIST_ID/refresh/search -- providers-unreachable-banner present" \
+  'data-testid="providers-unreachable-banner"' \
+  "$search_resp"
+echo ""
+
+# ---- Row 2: Wizard step renderer -------------------------------------------
+# GET /artists/re-identify/wizard/{sid}/step/{idx}
+# Asserts: response body contains wizard error heading
+# ("Could not load candidates" from en.json key
+#  artists.bulk.reidentify.wizard.error.heading)
+#
+# To exercise this we need a wizard session. Start one by POSTing to the
+# wizard start endpoint with our test artist.
+echo "[ Row 2: Wizard step renderer ]"
+wizard_start_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
+  -X POST "$SW_BASE/api/v1/artists/re-identify/wizard" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-Token: $CSRF_TOKEN" \
+  -d "{\"artist_ids\":[\"$ARTIST_ID\"]}")
+wizard_start_code=$(echo "$wizard_start_resp" | tail -n 1)
+wizard_start_body=$(echo "$wizard_start_resp" | sed '$d')
+
+if [[ "$wizard_start_code" == "200" || "$wizard_start_code" == "201" ]]; then
+  SESSION_ID=$(echo "$wizard_start_body" | jq -r '.session_id // empty' 2>/dev/null || true)
+  if [[ -n "$SESSION_ID" ]]; then
+    # Wait briefly for the first step lookup to complete (it runs async).
+    sleep 1
+    # GET the wizard step page (full HTML page -- session cookie required)
+    step_resp=$(curl -s -b "$COOKIE_JAR" \
+      "$SW_BASE/artists/re-identify/wizard/$SESSION_ID/step/0" || echo "")
+    assert_body_contains \
+      "GET /artists/re-identify/wizard/$SESSION_ID/step/0 -- wizard error banner present" \
+      "Could not load candidates" \
+      "$step_resp"
+  else
+    assert_fail "GET wizard step -- failed to extract session_id from start response" \
+      "start body: ${wizard_start_body:0:200}"
+  fi
+else
+  # Row 2 is WARN-NOT-FAIL until the wizard start + session flow is stabilized
+  # under injection. The single-artist search (Row 1) is the primary hard gate.
+  # TODO: harden once session-start error handling in injection mode is verified.
+  # Tracking issue: #1666 follow-up (wizard session start under full injection)
+  echo "[WARN] POST wizard start returned HTTP $wizard_start_code (non-fatal; see TODO above)"
+  echo "  body: ${wizard_start_body:0:200}"
+fi
+echo ""
+
+# ---- Row 3: Single-artist refresh (WARN-NOT-FAIL) --------------------------
+# POST /api/v1/artists/{id}/refresh
+# The response or HTMX fragment must carry a warnings/failed_providers field.
+# Currently SILENT -- this surface has not been fixed yet.
+# TODO: flip to hard-fail once #1666 follow-up surface-fix issue lands.
+echo "[ Row 3: Single-artist refresh (warn-not-fail -- surface fix pending) ]"
+refresh_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
+  -X POST "$SW_BASE/api/v1/artists/$ARTIST_ID/refresh" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-Token: $CSRF_TOKEN" \
+  -d '{}')
+refresh_code=$(echo "$refresh_resp" | tail -n 1)
+refresh_body=$(echo "$refresh_resp" | sed '$d')
+# HTTP 200 is expected; warn if response carries no failure signal.
+if [[ "$refresh_code" == "200" ]]; then
+  if echo "$refresh_body" | grep -qE '"warnings"|"failed_providers"|providers-unreachable-banner'; then
+    assert_pass "POST /api/v1/artists/$ARTIST_ID/refresh -- failure signal present"
+  else
+    echo "[WARN] POST /api/v1/artists/$ARTIST_ID/refresh -- no failure signal in response (silent failure)"
+    echo "       TODO surface-fix: add warnings/failed_providers field (tracked in #1666)"
+  fi
+else
+  echo "[WARN] POST /api/v1/artists/$ARTIST_ID/refresh returned HTTP $refresh_code (non-fatal; surface fix pending)"
+fi
+echo ""
+
+# ---- Row 4: Bulk identify (WARN-NOT-FAIL) ----------------------------------
+# POST /api/v1/artists/bulk/identify
+# Should return per-artist status with error category distinguishing
+# "no match" from "providers down". Currently does not.
+# TODO: flip to hard-fail once follow-up surface-fix issue lands.
+echo "[ Row 4: Bulk identify (warn-not-fail -- surface fix pending) ]"
+bulk_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
+  -X POST "$SW_BASE/api/v1/artists/bulk/identify" \
+  -H "Content-Type: application/json" \
+  -H "X-CSRF-Token: $CSRF_TOKEN" \
+  -d "{\"artist_ids\":[\"$ARTIST_ID\"]}")
+bulk_code=$(echo "$bulk_resp" | tail -n 1)
+bulk_body=$(echo "$bulk_resp" | sed '$d')
+# HTTP 200 accepted; warn if no provider-error category visible.
+if [[ "$bulk_code" == "200" || "$bulk_code" == "202" ]]; then
+  if echo "$bulk_body" | grep -qE '"provider_error"|"providers_unreachable"|"error_category"'; then
+    assert_pass "POST /api/v1/artists/bulk/identify -- provider-error category present"
+  else
+    echo "[WARN] POST /api/v1/artists/bulk/identify -- no provider-error category (silent failure)"
+    echo "       TODO surface-fix: distinguish 'no match' vs 'providers down' (tracked in #1666)"
+  fi
+else
+  echo "[WARN] POST /api/v1/artists/bulk/identify returned HTTP $bulk_code (non-fatal; surface fix pending)"
+fi
+echo ""
+
+# ---- Row 5: Image search (WARN-NOT-FAIL) -----------------------------------
+# GET /api/v1/artists/{id}/images/search
+# Should carry warning when all image providers errored. Currently silent.
+# TODO: flip to hard-fail once follow-up surface-fix issue lands.
+echo "[ Row 5: Image search (warn-not-fail -- surface fix pending) ]"
+img_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
+  "$SW_BASE/api/v1/artists/$ARTIST_ID/images/search")
+img_code=$(echo "$img_resp" | tail -n 1)
+img_body=$(echo "$img_resp" | sed '$d')
+if [[ "$img_code" == "200" ]]; then
+  if echo "$img_body" | grep -qE '"warnings"|"failed_providers"|providers-unreachable'; then
+    assert_pass "GET /api/v1/artists/$ARTIST_ID/images/search -- failure signal present"
+  else
+    echo "[WARN] GET /api/v1/artists/$ARTIST_ID/images/search -- no failure signal (silent failure)"
+    echo "       TODO surface-fix: add warnings field for all-providers-failed (tracked in #1666)"
+  fi
+else
+  echo "[WARN] GET /api/v1/artists/$ARTIST_ID/images/search returned HTTP $img_code (non-fatal; surface fix pending)"
+fi
+echo ""
+
+# ---- Row 6: Per-field provider lookup (partial -- verify) ------------------
+# GET /api/v1/artists/{id}/fields/{field}/providers
+# Should carry per-provider error state.
+echo "[ Row 6: Per-field provider lookup ]"
+field_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
+  "$SW_BASE/api/v1/artists/$ARTIST_ID/fields/biography/providers")
+field_code=$(echo "$field_resp" | tail -n 1)
+field_body=$(echo "$field_resp" | sed '$d')
+if [[ "$field_code" == "200" ]]; then
+  # Each provider should report an error rather than silently return empty data.
+  if echo "$field_body" | grep -qE '"error"|"failed"|"unavailable"'; then
+    assert_pass "GET /api/v1/artists/$ARTIST_ID/fields/biography/providers -- per-provider error state present"
+  else
+    echo "[WARN] GET /api/v1/artists/$ARTIST_ID/fields/biography/providers -- no per-provider error state"
+    echo "       TODO surface-fix: surface per-provider errors in field provider response (tracked in #1666)"
+  fi
+else
+  echo "[WARN] GET /api/v1/artists/$ARTIST_ID/fields/biography/providers returned HTTP $field_code (non-fatal)"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+TOTAL=$((PASS + FAIL))
+echo "======================================================="
+echo "=== RESULTS: $PASS passed, $FAIL failed (of $TOTAL checks) ==="
+echo "======================================================="
+
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+  echo ""
+  echo "FAILED:"
+  for f in "${FAILURES[@]}"; do
+    echo "  $f"
+  done
+  echo ""
+  exit 1
+fi
+
+echo ""
+echo "All provider-failure assertions passed."
+exit 0


### PR DESCRIPTION
## Summary

- Add env-var-gated provider fault-injection hook (`SW_FORCE_PROVIDER_ERROR`) and a smoke phase that drives every covered surface under full provider failure, closing the silent-empty-response class structurally (originated as #1663 prevention).
- Boot-time refusal on release builds so the hook can never be active in production; readers are guarded by a `sync.RWMutex` because handler-driven calls run concurrently with the test-only swap.
- Carries the v1.4.0 RC version bump (Version `1.3.0` -> `1.4.0`).

## Linked issue

Closes #1666

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`) -- 7/7 smoke checks pass; per-package coverage floor green across the board.
- [x] Code review pass complete (`coderabbit review --plain`) -- 5 findings round 1 (1 critical race + 4 trivial), all addressed; round 2 clean.
- [x] Commits squashed into clean, logical commits before the first push (single squashed commit).
- [x] At least one label set on `gh pr create --label ...`.
- [x] Docs label decision made: `docs: not-required` -- testing harness + CI infra, no user-visible behavioral change.
- [ ] Screenshot attached for any UI change -- N/A (no UI).
- [x] UAT performed -- gate run includes a full smoke execution against a temporary instance with all 11 providers injected.
- [x] OpenAPI spec updated if any request or response shape changed -- N/A (no API shape changes).
- [x] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed -- N/A.

## Test plan

- [x] `go test -race ./internal/provider/...` passes locally (all 14 sub-packages green).
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] Manual UAT steps:
  - [x] Temporary instance boots with `SW_FORCE_PROVIDER_ERROR=musicbrainz,fanarttv,...` and serves `/api/v1/health` 200.
  - [x] Row 1 (refresh/search): providers-unreachable banner present in response body.
  - [x] Row 6 (per-field providers): per-provider error state present.
- [ ] Reviewer follow-ups:
  - [ ] Confirm the warn-not-fail rows (single-artist refresh, bulk identify, image search) are the right shape for the eventual surface fixes -- the matrix doubles as the TODO list, follow-up issues to be filed post-merge per the plan-file resume protocol.

## Notes

- The smoke script's coverage matrix splits into hard-fail rows (already wired through PR #1664 + PR #1638) and warn-not-fail rows (surfaces that still silently swallow). The warn rows are documented in the script and intentionally don't break the gate today; they'll flip to PASS as their tracking issues land.
- `SetInjectedProviders` is exported for sibling-package tests; production code paths never call it. Boot-time refusal on release builds is the safety net.
- Worktree's `core.hooksPath` had drifted to the main worktree's empty `.git/hooks/` (same scenario PR #1690 hardened against); healed with `make hooks` mid-session, then the gate caught everything cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI smoke test to verify provider-failure behavior surfaces in app responses.
  * Startup now aborts in release builds if a test-only provider-failure flag is set.

* **Tests**
  * Introduced a provider failure-injection framework and broad unit test coverage across providers.
  * Added an end-to-end smoke script exercising failure handling across UI/API surfaces.

* **Chores**
  * Bumped product version to 1.4.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a fault-injection smoke harness for provider failures: a new `SW_FORCE_PROVIDER_ERROR` env var gates per-provider failure injection, protected at boot time by a release-build guard and at runtime by a `sync.RWMutex`. A comprehensive smoke script (`smoke-provider-failure.sh`) drives the full coverage matrix, and the new `provider-failure-smoke` CI job replicates the gate on every relevant diff.

- `internal/provider/injection.go` introduces the injection core: comma-separated env-var parsing, a mutex-guarded `injectedSet`, `ShouldInjectFailure`, and `SetInjectedProviders` for sibling-package test use. All 11 provider adapters are instrumented; no-op stubs correctly bypass the hook to preserve the `(nil, nil)` production contract.
- `cmd/stillwater/main.go` adds a startup refusal for release builds (`IsReleaseBuild()` keys off the new `BuildType` ldflag injected by both goreleaser configs).
- `scripts/smoke-provider-failure.sh` implements the full coverage matrix: Row 1 is a hard gate, Rows 2–5 are WARN-NOT-FAIL with explicit TODO tracking, and Row 6 checks per-field provider error state.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The injection hook is correctly scoped to non-release builds, mutex-guarded, and thoroughly tested; all previously flagged issues have been addressed.

The injection framework, boot-time guard, and CI job are all implemented correctly. No-op stub bypass was addressed in the previous review cycle and is now pinned by contract tests. The one remaining observation (Row 6 grep breadth) is a quality nit on a WARN-tier check that cannot fail the gate.

scripts/smoke-provider-failure.sh Row 6 grep pattern (lines 800-810) is the only area worth a second look.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/provider/injection.go | New fault-injection hook: parses SW_FORCE_PROVIDER_ERROR at init, exposes ShouldInjectFailure (RLock-guarded) and SetInjectedProviders for test swaps. Mutex usage and init-time parsing are correct. |
| cmd/stillwater/main.go | Startup guard rejects SW_FORCE_PROVIDER_ERROR on release builds via IsReleaseBuild(); fires before any handler is wired up so the window between package init and the guard check is harmless. |
| internal/version/format.go | IsReleaseBuild() checks BuildType == "release" exclusively; tested for the exact string, arbitrary variants, and belt-and-suspenders interaction with IsDevBuild. |
| scripts/smoke-provider-failure.sh | Comprehensive smoke harness; Row 1 is a hard gate, Rows 2-5 are WARN-NOT-FAIL with TODOs, Row 6 uses a grep pattern broad enough to match common JSON boilerplate (see comment). |
| .github/workflows/gate.yml | New provider-failure-smoke job correctly SHA-pins all actions with inline version comments, uses dorny/paths-filter, and verifies the Tailwind SHA256 before installing. |
| internal/provider/fanarttv/fanarttv.go | ShouldInjectFailure added only to GetImages (the real outbound path); SearchArtist/GetArtist no-op stubs correctly bypass injection to preserve the production (nil,nil) contract. |
| internal/provider/musicbrainz/musicbrainz.go | Injection added to SearchArtist, GetArtist, and GetReleaseGroups; GetImages no-op stub correctly bypasses injection. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Process Start] --> B{IsReleaseBuild?}
    B -- yes --> C{SW_FORCE_PROVIDER_ERROR set?}
    C -- yes --> D[Fatal: refuse to start]
    C -- no --> E[Normal startup]
    B -- no --> F{SW_FORCE_PROVIDER_ERROR set?}
    F -- yes --> G[parseInjectedSet at package init\ninjectedSet populated]
    F -- no --> H[injectedSet empty]
    G --> I[Provider method called]
    H --> I
    I --> J{ShouldInjectFailure?}
    J -- yes --> K[return nil, ErrInjectedFailure]
    J -- no --> L[Real outbound HTTP call]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/smoke-provider-failure.sh`, line 1420-1427 ([link](https://github.com/sydlexius/stillwater/blob/fb3e883ecf193e2d402696d01da17797b8da3380/scripts/smoke-provider-failure.sh#L1420-L1427)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`assert_status` contradicts the 409-accepted guard above it**

   The FATAL guard explicitly allows HTTP 409 ("already exists") as a valid outcome, but the `assert_status` call immediately after expects exactly `201`. If the endpoint returns 409, the FATAL check passes without exiting, but `assert_status` then records a `[FAIL]`, increments `FAIL`, and appends to `FAILURES`. The smoke test will exit 1 even though the developer's stated intent is to treat 409 as success. This matters when `SW_BASE` is overridden to point at an existing instance that already has an admin account.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fsmoke-provider-failure.sh%0ALine%3A%201420-1427%0A%0AComment%3A%0A**%60assert_status%60%20contradicts%20the%20409-accepted%20guard%20above%20it**%0A%0AThe%20FATAL%20guard%20explicitly%20allows%20HTTP%20409%20%28%22already%20exists%22%29%20as%20a%20valid%20outcome%2C%20but%20the%20%60assert_status%60%20call%20immediately%20after%20expects%20exactly%20%60201%60.%20If%20the%20endpoint%20returns%20409%2C%20the%20FATAL%20check%20passes%20without%20exiting%2C%20but%20%60assert_status%60%20then%20records%20a%20%60%5BFAIL%5D%60%2C%20increments%20%60FAIL%60%2C%20and%20appends%20to%20%60FAILURES%60.%20The%20smoke%20test%20will%20exit%201%20even%20though%20the%20developer's%20stated%20intent%20is%20to%20treat%20409%20as%20success.%20This%20matters%20when%20%60SW_BASE%60%20is%20overridden%20to%20point%20at%20an%20existing%20instance%20that%20already%20has%20an%20admin%20account.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sydlexius%2Fstillwater&pr=1696&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fsmoke-provider-failure.sh%3A800-810%0A**Row%206%20grep%20is%20too%20broad%20and%20will%20false-positive%20on%20common%20JSON%20fields**%0A%0AThe%20pattern%20%60%22error%22%7C%22failed%22%7C%22unavailable%22%60%20matches%20any%20JSON%20response%20that%20contains%20a%20key%20called%20%60%22error%22%60%20%E2%80%94%20including%20success%20responses%20that%20carry%20%60%22error%22%3A%20null%60%20or%20%60%22error_code%22%3A%200%60%20as%20boilerplate.%20If%20the%20field-providers%20endpoint%20returns%20such%20a%20response%20while%20*not*%20actually%20surfacing%20per-provider%20error%20state%2C%20the%20smoke%20check%20records%20%60assert_pass%60%20even%20though%20providers%20are%20silently%20swallowing%20failures.%20The%20other%20Row%206%20strings%20%28%60%22failed%22%60%2C%20%60%22unavailable%22%60%29%20are%20similarly%20common%20in%20unrelated%20fields%20or%20enum%20values.%20A%20tighter%20anchor%20like%20%60%22provider_error%22%60%20or%20%60%22injection%22%60%20%28matching%20the%20injected%20error%20message%29%20would%20only%20match%20when%20the%20handler%20genuinely%20surfaces%20the%20error.%0A%0A&repo=sydlexius%2Fstillwater&pr=1696&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(m52): bound smoke-script health prob..."](https://github.com/sydlexius/stillwater/commit/8533e018b06862e551b4c97e46eb3d79a5c92465) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34067060)</sub>

<!-- /greptile_comment -->