### PR TITLE
ci(release): fix nightly tag collision with stable v* on same commit

### DIFF
--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -22,13 +22,22 @@ version: 2
 # routes the nightly's artifacts at the existing v1.4.0 GitHub Release and
 # fails the upload with 422 already_exists.
 #
-#   tag_sort: -creatordate picks the most recently created tag on the
-#       same commit, which is always the nightly because it is created at
-#       workflow time, after any stable tag the maintainer pushed earlier.
-#       This drives `.Tag` / `.Version`.
-#   ignore_tags: ["v*"] excludes stable tags from previous-tag walking,
-#       keeping `.PreviousTag` on the prior nightly so the changelog
-#       window stays nightly-to-nightly.
+#   tag_sort: -creatordate picks the most recently created tag on a
+#       multi-tag commit. The nightly tag is always newer than any
+#       same-commit stable tag because the workflow creates it at
+#       runtime, after any stable tag the maintainer pushed earlier.
+#       Drives `.Tag` / `.Version`. (Goreleaser docs imply `ignore_tags`
+#       below also covers current-tag selection, but in v2.16 the
+#       "tag exactly on HEAD" code path does NOT honor `ignore_tags` --
+#       verified empirically against the v1.4.0/nightly-20260527
+#       collision: with `ignore_tags: ["v*"]` alone, goreleaser still
+#       resolved current=v1.4.0. So tag_sort is load-bearing here, not
+#       redundant with ignore_tags.)
+#   ignore_tags: ["v*"] keeps `.PreviousTag` on the prior nightly so the
+#       changelog window stays nightly-to-nightly. Without this, the
+#       previous-tag walk falls through to the next semver below the
+#       current stable (e.g. v1.3.0) and the changelog spans the wrong
+#       window.
 git:
   tag_sort: -creatordate
   ignore_tags:

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -16,6 +16,24 @@ version: 2
 # Keeps cosign keyless signing of the checksums blob to match stable pipeline
 # behavior (checksums.txt.sigstore.json accompanies every release).
 
+# Same-commit tag-collision handling. When a stable v* tag and the nightly
+# tag both point at one commit (e.g. the maintainer cuts v1.4.0, then the
+# 06:00 UTC nightly fires on the same `main` HEAD), the default behavior
+# routes the nightly's artifacts at the existing v1.4.0 GitHub Release and
+# fails the upload with 422 already_exists.
+#
+#   tag_sort: -creatordate picks the most recently created tag on the
+#       same commit, which is always the nightly because it is created at
+#       workflow time, after any stable tag the maintainer pushed earlier.
+#       This drives `.Tag` / `.Version`.
+#   ignore_tags: ["v*"] excludes stable tags from previous-tag walking,
+#       keeping `.PreviousTag` on the prior nightly so the changelog
+#       window stays nightly-to-nightly.
+git:
+  tag_sort: -creatordate
+  ignore_tags:
+    - "v*"
+
 before:
   hooks:
     - go tool templ generate


### PR DESCRIPTION
## Summary

- The 2026-05-27 nightly release job (run 26497207725) failed at the `Run GoReleaser` step with `422 already_exists` on every asset upload. Root cause: that day's `v1.4.0` stable tag and the `nightly-20260527` tag both pointed at the same `main` HEAD commit, and goreleaser's default tag resolution picked `v1.4.0`, so it rendered `.Version=1.4.0` and tried to publish nightly assets onto the existing v1.4.0 Release.
- Fixes the collision declaratively in `.goreleaser.nightly.yml` so the workflow itself is unchanged. Two directives, each covering a separate tag-resolution code path:
  - `git.tag_sort: -creatordate` makes current-tag selection prefer the most recently created tag when multiple tags point at one commit. The nightly tag is always newer than any same-commit stable tag because it is created at workflow time, after any stable tag the maintainer pushed earlier.
  - `git.ignore_tags: ["v*"]` excludes stable tags from previous-tag walking, so `.PreviousTag` stays on the prior nightly (e.g. `nightly-20260526`) instead of falling through to `v1.3.0` and producing a wrong changelog window.

## Linked issue

(No tracking issue filed; this is a direct fix for the failed run referenced above.)

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Code review pass complete (`coderabbit review --plain`); no findings.
- [x] Single commit on the branch; nothing to squash.
- [x] Labels set on PR create (`ci`, `chore`, `scope: small`, `docs: not-required`).
- [x] Docs label decision made: `docs: not-required` -- CI pipeline-internal change, no user-visible behavior.
- [ ] Screenshot attached for any UI change. (n/a)
- [ ] UAT performed for user-visible changes. (n/a)
- [ ] OpenAPI spec updated if any request or response shape changed. (n/a)
- [ ] `templ generate` re-run and `*_templ.go` committed. (n/a)

## Test plan

- [x] `go test -race ./...` passes locally (via pre-push-gate).
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] End-to-end reproduction of the original failure mode, with both `v1.4.0` and `nightly-20260527` synthesized on local HEAD, then `goreleaser release --clean --config .goreleaser.nightly.yml --skip=publish,sign,before,validate`. Output shows `using tags previous=nightly-20260526 current=nightly-20260527` (was `current=v1.4.0` before this change).
- [ ] Manual UAT steps: none -- next scheduled nightly run (06:00 UTC 2026-05-28) is the production validation.
- [ ] Reviewer follow-ups:
  - [ ] Sanity-check the `tag_sort: -creatordate` choice vs `-creatordate` (without the `version:` prefix). Goreleaser's default is `-version:refname`, which is "newest semver wins"; dropping the `version:` prefix means raw git creator-date ordering, which is what we want for non-semver nightly tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nightly releases no longer fail when a stable and nightly tag point to the same commit; the process now correctly prioritizes the nightly tag.

* **Chores**
  * Release configuration updated to improve tag selection and ordering for nightly builds, ensuring stable version tags are ignored during nightly tag resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1700?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a nightly CI failure caused by a same-commit tag collision: when a stable `v*` tag and a `nightly-*` tag both point at HEAD, GoReleaser's default tag resolution picked the stable tag, routing nightly assets to the existing stable GitHub Release and failing with `422 already_exists`. Two directives are added to `.goreleaser.nightly.yml` to resolve this declaratively.

- `git.tag_sort: -creatordate` biases current-tag selection toward the most recently created tag, ensuring the workflow-created nightly tag wins over any same-commit stable tag.
- `git.ignore_tags: [\"v*\"]` keeps the previous-tag walk on the nightly timeline, so the changelog window spans nightly-to-nightly instead of falling back to the prior semver release.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted, additive config block that only affects the nightly pipeline, with no impact on the stable release workflow.

The two-directive fix is minimal and narrowly scoped to `.goreleaser.nightly.yml`. The author empirically verified the fix against a synthesized reproduction of the original failure, and the inline comments accurately document the v2.16 behavior divergence from the GoReleaser docs. `ignore_tags: ["v*"]` cannot affect stable releases since it lives only in the nightly config. The `tag_sort: -creatordate` value is a valid git sort key. No logic paths outside the nightly workflow are touched.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .goreleaser.nightly.yml | Adds a `git:` block with `tag_sort: -creatordate` and `ignore_tags: ["v*"]` to resolve the same-commit stable/nightly tag collision; detailed inline comments explain the empirically-verified v2.16 behavior divergence from docs. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["ci(release): clarify comment on ignore\_t..."](https://github.com/sydlexius/stillwater/commit/98da35a7b12186273696a33f6c53d2afbbbb720f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34225307)</sub>

<!-- /greptile_comment -->