### PR TITLE
test(smoke): seed provider IDs in smoke-provider-failure fixture

### DIFF
--- a/internal/provider/injection.go
+++ b/internal/provider/injection.go
@@ -32,9 +32,10 @@ var (
 	injectedSet = parseInjectedSet(os.Getenv("SW_FORCE_PROVIDER_ERROR"))
 
 	// injectedFiredCount counts the number of times ShouldInjectFailure
-	// returned true. Exposed via InjectedFailureCount so test harnesses can
-	// assert the injection hook was actually exercised (issue #1697). An
-	// atomic int64 avoids contending with injectedMu on the hot path.
+	// returned true. Exposed via injectedFailureCount so test harnesses in
+	// this package can assert the injection hook was actually exercised
+	// (issue #1697). An atomic int64 avoids contending with injectedMu on
+	// the hot path.
 	injectedFiredCount atomic.Int64
 )
 
@@ -79,7 +80,7 @@ func SetInjectedProviders(names []string) {
 // The check is a no-op (returns false) when SW_FORCE_PROVIDER_ERROR is unset
 // and SetInjectedProviders has not been called, so normal production behavior
 // is preserved with zero overhead. On a true return the function also
-// increments an atomic counter (see InjectedFailureCount) and emits a single
+// increments an atomic counter (see injectedFailureCount) and emits a single
 // Info-level log line carrying the provider name, so smoke harnesses can
 // assert the hook was actually reached by the surfaces they drive.
 func ShouldInjectFailure(name ProviderName) bool {
@@ -97,19 +98,20 @@ func ShouldInjectFailure(name ProviderName) bool {
 	return ok
 }
 
-// InjectedFailureCount returns the number of times ShouldInjectFailure has
-// returned true since process start (or since the last ResetInjectedFailureCount
-// call). Exposed so test harnesses can assert that the injection hook was
-// actually exercised by the surfaces they drive (issue #1697). The counter is
-// process-global and atomic; concurrent provider calls cannot lose increments.
-func InjectedFailureCount() int64 {
+// injectedFailureCount returns the number of times ShouldInjectFailure has
+// returned true since process start (or since the last resetInjectedFailureCount
+// call). Unexported so only same-package test code can read it; exporting it
+// would let unrelated production callers depend on a counter intended only
+// for the smoke harness (issue #1697 finding). The counter is process-global
+// and atomic; concurrent provider calls cannot lose increments.
+func injectedFailureCount() int64 {
 	return injectedFiredCount.Load()
 }
 
-// ResetInjectedFailureCount zeroes the counter. Intended for tests that want
-// to assert "this surface incremented the counter from N to N+M"; production
-// code must never call it.
-func ResetInjectedFailureCount() {
+// resetInjectedFailureCount zeroes the counter. Intended for tests that want
+// to assert "this surface incremented the counter from N to N+M". Unexported
+// for the same reason as injectedFailureCount.
+func resetInjectedFailureCount() {
 	injectedFiredCount.Store(0)
 }
 

--- a/internal/provider/injection.go
+++ b/internal/provider/injection.go
@@ -2,9 +2,11 @@ package provider
 
 import (
 	"errors"
+	"log/slog"
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 // ErrInjectedFailure is returned by provider methods when the fault-injection
@@ -12,6 +14,13 @@ import (
 // that any developer who sees it in logs immediately recognizes this as a
 // self-inflicted test condition, not a real provider outage.
 var ErrInjectedFailure = errors.New("provider call rejected by injection (SW_FORCE_PROVIDER_ERROR)")
+
+// injectionMarker is the log message emitted at Info level every time
+// ShouldInjectFailure returns true. The smoke harness greps the server log
+// for this exact substring to assert that injection was actually exercised
+// by the surfaces it drove (issue #1697). The string is intentionally
+// distinctive so a fuzzy match cannot collide with unrelated log lines.
+const injectionMarker = "provider injection hook fired"
 
 // injectedSet is the set of provider names that should return ErrInjectedFailure
 // on every outbound call. Initialized from SW_FORCE_PROVIDER_ERROR at process
@@ -21,6 +30,12 @@ var ErrInjectedFailure = errors.New("provider call rejected by injection (SW_FOR
 var (
 	injectedMu  sync.RWMutex
 	injectedSet = parseInjectedSet(os.Getenv("SW_FORCE_PROVIDER_ERROR"))
+
+	// injectedFiredCount counts the number of times ShouldInjectFailure
+	// returned true. Exposed via InjectedFailureCount so test harnesses can
+	// assert the injection hook was actually exercised (issue #1697). An
+	// atomic int64 avoids contending with injectedMu on the hot path.
+	injectedFiredCount atomic.Int64
 )
 
 // SetInjectedProviders replaces the active injected-failure set.
@@ -63,15 +78,39 @@ func SetInjectedProviders(names []string) {
 //
 // The check is a no-op (returns false) when SW_FORCE_PROVIDER_ERROR is unset
 // and SetInjectedProviders has not been called, so normal production behavior
-// is preserved with zero overhead.
+// is preserved with zero overhead. On a true return the function also
+// increments an atomic counter (see InjectedFailureCount) and emits a single
+// Info-level log line carrying the provider name, so smoke harnesses can
+// assert the hook was actually reached by the surfaces they drive.
 func ShouldInjectFailure(name ProviderName) bool {
 	injectedMu.RLock()
-	defer injectedMu.RUnlock()
 	if len(injectedSet) == 0 {
+		injectedMu.RUnlock()
 		return false
 	}
 	_, ok := injectedSet[strings.ToLower(string(name))]
+	injectedMu.RUnlock()
+	if ok {
+		injectedFiredCount.Add(1)
+		slog.Info(injectionMarker, slog.String("provider", string(name)))
+	}
 	return ok
+}
+
+// InjectedFailureCount returns the number of times ShouldInjectFailure has
+// returned true since process start (or since the last ResetInjectedFailureCount
+// call). Exposed so test harnesses can assert that the injection hook was
+// actually exercised by the surfaces they drive (issue #1697). The counter is
+// process-global and atomic; concurrent provider calls cannot lose increments.
+func InjectedFailureCount() int64 {
+	return injectedFiredCount.Load()
+}
+
+// ResetInjectedFailureCount zeroes the counter. Intended for tests that want
+// to assert "this surface incremented the counter from N to N+M"; production
+// code must never call it.
+func ResetInjectedFailureCount() {
+	injectedFiredCount.Store(0)
 }
 
 // parseInjectedSet parses the SW_FORCE_PROVIDER_ERROR environment variable

--- a/internal/provider/injection_test.go
+++ b/internal/provider/injection_test.go
@@ -115,3 +115,48 @@ func TestShouldInjectFailure_AllProviders(t *testing.T) {
 		}
 	}
 }
+
+func TestInjectedFailureCount_IncrementsOnHit(t *testing.T) {
+	t.Cleanup(func() {
+		SetInjectedProviders(nil)
+		ResetInjectedFailureCount()
+	})
+
+	ResetInjectedFailureCount()
+	SetInjectedProviders([]string{"musicbrainz"})
+
+	if got := InjectedFailureCount(); got != 0 {
+		t.Fatalf("counter must be 0 after reset, got %d", got)
+	}
+
+	// Hits on injected provider increment the counter.
+	for i := 0; i < 3; i++ {
+		ShouldInjectFailure(NameMusicBrainz)
+	}
+	if got := InjectedFailureCount(); got != 3 {
+		t.Errorf("counter must be 3 after 3 injected hits, got %d", got)
+	}
+
+	// Misses (provider not in the set) do not increment the counter.
+	ShouldInjectFailure(NameFanartTV)
+	if got := InjectedFailureCount(); got != 3 {
+		t.Errorf("counter must remain 3 after miss on non-injected provider, got %d", got)
+	}
+}
+
+func TestInjectedFailureCount_NoIncrementWhenSetEmpty(t *testing.T) {
+	t.Cleanup(func() {
+		SetInjectedProviders(nil)
+		ResetInjectedFailureCount()
+	})
+
+	ResetInjectedFailureCount()
+	SetInjectedProviders(nil)
+
+	for i := 0; i < 5; i++ {
+		ShouldInjectFailure(NameMusicBrainz)
+	}
+	if got := InjectedFailureCount(); got != 0 {
+		t.Errorf("counter must remain 0 when injectedSet is empty, got %d", got)
+	}
+}

--- a/internal/provider/injection_test.go
+++ b/internal/provider/injection_test.go
@@ -1,8 +1,25 @@
 package provider
 
 import (
+	"io"
+	"log/slog"
+	"os"
 	"testing"
 )
+
+// TestMain swaps the default slog handler to discard for this package's test
+// run so ShouldInjectFailure's "provider injection hook fired" Info line does
+// not leak into the test runner's stderr (which bypasses per-test output
+// capture and would noise up `go test ./internal/provider/...` output).
+// The original default is restored on exit so other packages that share the
+// test binary (none today) see no spillover.
+func TestMain(m *testing.M) {
+	orig := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	code := m.Run()
+	slog.SetDefault(orig)
+	os.Exit(code)
+}
 
 func TestParseInjectedSet_Unset(t *testing.T) {
 	m := parseInjectedSet("")
@@ -119,13 +136,13 @@ func TestShouldInjectFailure_AllProviders(t *testing.T) {
 func TestInjectedFailureCount_IncrementsOnHit(t *testing.T) {
 	t.Cleanup(func() {
 		SetInjectedProviders(nil)
-		ResetInjectedFailureCount()
+		resetInjectedFailureCount()
 	})
 
-	ResetInjectedFailureCount()
+	resetInjectedFailureCount()
 	SetInjectedProviders([]string{"musicbrainz"})
 
-	if got := InjectedFailureCount(); got != 0 {
+	if got := injectedFailureCount(); got != 0 {
 		t.Fatalf("counter must be 0 after reset, got %d", got)
 	}
 
@@ -133,13 +150,13 @@ func TestInjectedFailureCount_IncrementsOnHit(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		ShouldInjectFailure(NameMusicBrainz)
 	}
-	if got := InjectedFailureCount(); got != 3 {
+	if got := injectedFailureCount(); got != 3 {
 		t.Errorf("counter must be 3 after 3 injected hits, got %d", got)
 	}
 
 	// Misses (provider not in the set) do not increment the counter.
 	ShouldInjectFailure(NameFanartTV)
-	if got := InjectedFailureCount(); got != 3 {
+	if got := injectedFailureCount(); got != 3 {
 		t.Errorf("counter must remain 3 after miss on non-injected provider, got %d", got)
 	}
 }
@@ -147,16 +164,16 @@ func TestInjectedFailureCount_IncrementsOnHit(t *testing.T) {
 func TestInjectedFailureCount_NoIncrementWhenSetEmpty(t *testing.T) {
 	t.Cleanup(func() {
 		SetInjectedProviders(nil)
-		ResetInjectedFailureCount()
+		resetInjectedFailureCount()
 	})
 
-	ResetInjectedFailureCount()
+	resetInjectedFailureCount()
 	SetInjectedProviders(nil)
 
 	for i := 0; i < 5; i++ {
 		ShouldInjectFailure(NameMusicBrainz)
 	}
-	if got := InjectedFailureCount(); got != 0 {
+	if got := injectedFailureCount(); got != 0 {
 		t.Errorf("counter must remain 0 when injectedSet is empty, got %d", got)
 	}
 }

--- a/scripts/smoke-provider-failure.sh
+++ b/scripts/smoke-provider-failure.sh
@@ -367,6 +367,90 @@ echo "  Test artist ID: $ARTIST_ID"
 echo ""
 
 # ---------------------------------------------------------------------------
+# Seed provider IDs on the fixture artist (#1697)
+# ---------------------------------------------------------------------------
+#
+# The fixture artist created by the bare-folder scan above has no external IDs
+# (no MBID, no Discogs ID, etc.) because the identify path that would
+# populate them is exactly the path being injected against. Several surfaces
+# early-return when the artist lacks an MBID (refresh, image search, etc.),
+# so without seeding the provider-failure handlers downstream of those gates
+# never run and the matrix cannot assert injection actually fired.
+#
+# Seed via the public PATCH /fields/{field} API rather than a direct SQL
+# INSERT so the seeding path stays at the API boundary -- service-layer
+# validation, NFO write-back, and event bus all behave identically to a
+# user-initiated edit. Each call is its own injection-free request.
+#
+# IDs below all reference the canonical UAT artist "12 Stones" (a real,
+# stable, public band) so the smoke harness's fixture artist is shaped like
+# a realistic post-identify record. Sources:
+#   MBID:    https://musicbrainz.org/artist/6f81a7dc-be31-4498-ae95-6d994ffec614
+#   Discogs: https://www.discogs.com/artist/901359  (from MB url-rels)
+#   Wikidata: https://www.wikidata.org/wiki/Q175044 (from MB url-rels)
+#   AudioDB: https://www.theaudiodb.com/api/v1/json/2/search.php?s=12+Stones (idArtist=113824)
+#   Deezer:  https://api.deezer.com/search/artist?q=12+Stones (id=5269)
+echo "--- Seed provider IDs (#1697) ---"
+echo ""
+
+SEED_MBID="6f81a7dc-be31-4498-ae95-6d994ffec614"
+SEED_DISCOGS_ID="901359"
+SEED_WIKIDATA_ID="Q175044"
+SEED_AUDIODB_ID="113824"
+SEED_DEEZER_ID="5269"
+
+seed_field() {
+  local field="$1"
+  local value="$2"
+  local payload
+  payload=$(jq -nc --arg v "$value" '{value:$v}')
+  local resp code
+  resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
+    -X PATCH "$SW_BASE/api/v1/artists/$ARTIST_ID/fields/$field" \
+    -H "Content-Type: application/json" \
+    -H "X-CSRF-Token: $CSRF_TOKEN" \
+    -d "$payload")
+  code=$(echo "$resp" | tail -n 1)
+  if [[ "$code" != "200" ]]; then
+    local body
+    body=$(echo "$resp" | sed '$d')
+    echo "FATAL: seed $field=$value returned HTTP $code: ${body:0:300}" >&2
+    exit 2
+  fi
+  echo "  seeded $field=$value"
+}
+
+seed_field musicbrainz_id "$SEED_MBID"
+seed_field discogs_id     "$SEED_DISCOGS_ID"
+seed_field wikidata_id    "$SEED_WIKIDATA_ID"
+seed_field audiodb_id     "$SEED_AUDIODB_ID"
+seed_field deezer_id      "$SEED_DEEZER_ID"
+echo ""
+
+# Snapshot the injection counter via the server log marker BEFORE driving
+# the matrix. Each ShouldInjectFailure=true emits a single
+# "provider injection hook fired" line at slog.Info; counting occurrences
+# before vs after the matrix lets the new assertion verify that the
+# matrix's call paths actually entered injected adapters (issue #1697).
+INJECTION_MARKER='provider injection hook fired'
+# grep -c prints the count to stdout AND exits 1 on zero matches; route the
+# exit-1 path explicitly so the captured variable holds the literal count
+# (avoids "0\n0" when both the grep output and the fallback echo fire).
+count_marker() {
+  local f="$1"
+  local n
+  if [[ ! -f "$f" ]]; then
+    echo 0
+    return
+  fi
+  n=$(grep -c "$INJECTION_MARKER" "$f" 2>/dev/null) || n=0
+  echo "$n"
+}
+PRE_MATRIX_HITS=$(count_marker "$SPF_LOG")
+echo "  Pre-matrix injection-hook hits in server log: $PRE_MATRIX_HITS"
+echo ""
+
+# ---------------------------------------------------------------------------
 # Coverage matrix assertions
 # ---------------------------------------------------------------------------
 
@@ -491,45 +575,84 @@ else
 fi
 echo ""
 
-# ---- Row 5: Image search (WARN-NOT-FAIL) -----------------------------------
+# ---- Row 5: Image search (flipped to hard-fail post-seed -- #1697) ---------
 # GET /api/v1/artists/{id}/images/search
-# Should carry warning when all image providers errored. Currently silent.
-# TODO: flip to hard-fail once follow-up surface-fix issue lands.
-echo "[ Row 5: Image search (warn-not-fail -- surface fix pending) ]"
+# Pre-seed this row was WARN because the handler 400'd on missing MBID before
+# any adapter was reached (no determinism = no fair hard-fail). Post-seed the
+# MBID-gated path runs through orchestrator.FetchImages, fanart.tv /
+# wikidata / spotify / etc. all hit the injection hook, and the response
+# carries result.Errors populated with "<provider>: image fetch failed". The
+# grep below recognizes both the JSON envelope shape and the historic
+# warnings / failed_providers / providers-unreachable shapes so any future
+# response refactor that keeps one or the other still passes.
+echo "[ Row 5: Image search (hard-fail post-seed) ]"
 img_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
   "$SW_BASE/api/v1/artists/$ARTIST_ID/images/search")
 img_code=$(echo "$img_resp" | tail -n 1)
 img_body=$(echo "$img_resp" | sed '$d')
 if [[ "$img_code" == "200" ]]; then
-  if echo "$img_body" | grep -qE '"warnings"|"failed_providers"|providers-unreachable'; then
+  if echo "$img_body" | grep -qE '"errors":\["|"warnings"|"failed_providers"|providers-unreachable'; then
     assert_pass "GET /api/v1/artists/$ARTIST_ID/images/search -- failure signal present"
   else
-    echo "[WARN] GET /api/v1/artists/$ARTIST_ID/images/search -- no failure signal (silent failure)"
-    echo "       TODO surface-fix: add warnings field for all-providers-failed (tracked in #1666)"
+    assert_fail "GET /api/v1/artists/$ARTIST_ID/images/search -- no failure signal post-seed" \
+      "expected one of: errors[], warnings, failed_providers, providers-unreachable; body[0:300]=${img_body:0:300}"
   fi
 else
-  echo "[WARN] GET /api/v1/artists/$ARTIST_ID/images/search returned HTTP $img_code (non-fatal; surface fix pending)"
+  assert_fail "GET /api/v1/artists/$ARTIST_ID/images/search returned HTTP $img_code" \
+    "expected 200 with seeded MBID; body[0:300]=${img_body:0:300}"
 fi
 echo ""
 
-# ---- Row 6: Per-field provider lookup (partial -- verify) ------------------
+# ---- Row 6: Per-field provider lookup (flipped to hard-fail post-seed) -----
 # GET /api/v1/artists/{id}/fields/{field}/providers
-# Should carry per-provider error state.
-echo "[ Row 6: Per-field provider lookup ]"
+# Pre-seed the bare-folder fixture caused this row to be defensive WARN
+# because the orchestrator's per-provider call path depended on name-
+# fallback behavior that was hard to reason about. Post-seed the orchestrator
+# runs every priority-listed biography provider against the seeded MBID;
+# every injected adapter returns ErrInjectedFailure -> FieldProviderResult
+# carries Error="metadata fetch failed". A response without any per-provider
+# error post-seed would mean either the orchestrator silently dropped the
+# providers (regression) or the field-provider handler is hiding errors
+# (regression). Either case is now in-scope to break the gate.
+echo "[ Row 6: Per-field provider lookup (hard-fail post-seed) ]"
 field_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" \
   "$SW_BASE/api/v1/artists/$ARTIST_ID/fields/biography/providers")
 field_code=$(echo "$field_resp" | tail -n 1)
 field_body=$(echo "$field_resp" | sed '$d')
 if [[ "$field_code" == "200" ]]; then
-  # Each provider should report an error rather than silently return empty data.
   if echo "$field_body" | grep -qE '"error"|"failed"|"unavailable"'; then
     assert_pass "GET /api/v1/artists/$ARTIST_ID/fields/biography/providers -- per-provider error state present"
   else
-    echo "[WARN] GET /api/v1/artists/$ARTIST_ID/fields/biography/providers -- no per-provider error state"
-    echo "       TODO surface-fix: surface per-provider errors in field provider response (tracked in #1666)"
+    assert_fail "GET /api/v1/artists/$ARTIST_ID/fields/biography/providers -- no per-provider error state" \
+      "expected at least one error/failed/unavailable token; body[0:300]=${field_body:0:300}"
   fi
 else
-  echo "[WARN] GET /api/v1/artists/$ARTIST_ID/fields/biography/providers returned HTTP $field_code (non-fatal)"
+  assert_fail "GET /api/v1/artists/$ARTIST_ID/fields/biography/providers returned HTTP $field_code" \
+    "expected 200 with seeded MBID; body[0:300]=${field_body:0:300}"
+fi
+echo ""
+
+# ---- Row 7: Injection hook actually reached (#1697) ------------------------
+# Counts "provider injection hook fired" lines in the server log emitted by
+# ShouldInjectFailure each time the hook returns true. With provider IDs
+# seeded above, the surfaces driven by rows 1-6 enter MBID-gated adapters
+# (fanart.tv, wikidata image search, musicbrainz GetReleaseGroups, etc.)
+# that early-return when the fixture artist lacks the relevant ID. A POST_HITS
+# delta of zero would mean every PASS / WARN in this run was decided BEFORE
+# any injected method was actually called -- the false-positive class that
+# motivated this issue. Hard-fail when no new hits land.
+echo "[ Row 7: Injection hook actually reached ]"
+# Race avoidance: server writes async, give a brief settle window before
+# reading the count.
+sleep 1
+POST_MATRIX_HITS=$(count_marker "$SPF_LOG")
+HITS_DELTA=$((POST_MATRIX_HITS - PRE_MATRIX_HITS))
+echo "  Post-matrix injection-hook hits in server log: $POST_MATRIX_HITS (delta: $HITS_DELTA)"
+if [[ $HITS_DELTA -gt 0 ]]; then
+  assert_pass "Injection hook fired during matrix (delta $HITS_DELTA > 0)"
+else
+  assert_fail "Injection hook never fired during matrix" \
+    "expected delta > 0; got pre=$PRE_MATRIX_HITS post=$POST_MATRIX_HITS"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

- Smoke fixture artist now seeded with five well-known provider IDs (musicbrainz, discogs, wikidata, audiodb, deezer) so provider adapters whose primary call paths are ID-gated actually enter `provider.ShouldInjectFailure`. Without seeding, those adapters early-return and the injection hook was never consulted, so prior PASS/WARN rows were measuring call paths that did not execute.
- New `InjectedFailureCount` / `ResetInjectedFailureCount` counter on `internal/provider/injection.go` plus a `slog.Info("provider injection hook fired", ...)` marker per hit. Matrix gains a new row asserting hook hits go from 0 (pre-matrix) to >0 (post-matrix); two prior WARN-NOT-FAIL rows (image search, field providers) flip to hard-fail now that the post-seed call paths are deterministic.
- Seeding goes through the public `PATCH /api/v1/artists/{id}/fields/{field}` endpoint (same validation + write path a user-initiated edit takes); avoids hardcoding schema knowledge into the harness.

## Linked issue

Closes #1697

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Code review pass complete (local `coderabbit review --plain` returned no findings).
- [x] Commits squashed into clean, logical commits before the first push.
- [x] At least one label set on `gh pr create --label ...`.
- [x] Docs label decision made: `docs: not-required` (test-only change, no user-visible behavior).
- [ ] Screenshot attached for any UI change (N/A).
- [ ] UAT performed for user-visible changes (N/A; smoke harness end-to-end run instead, 0 -> 16 injection hits confirmed).
- [x] OpenAPI spec updated if any request or response shape changed (no API shape change).
- [x] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed (no `.templ` changes).

## Test plan

- [x] `go test -race ./...` passes locally (via pre-push gate).
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] Manual UAT steps:
  - [x] Ran `scripts/smoke-provider-failure.sh` end-to-end against a fresh local Stillwater instance; injection-hook hits jumped from 0 (pre-matrix) to 16 (post-matrix). 9 of 9 checks passed.
- [ ] Reviewer follow-ups:
  - [ ] Confirm the IDs picked (musicbrainz 6f81a7dc-be31-4498-ae95-6d994ffec614, discogs 901359, wikidata Q175044, audiodb 113824, deezer 5269) all point to the band "12 Stones" rather than the song.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive unit tests for provider failure injection counting and verification
  * Enhanced smoke test to validate provider failure scenarios with improved assertions

* **Chores**
  * Improved observability for provider failure handling with enhanced logging and tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a class of false-positive smoke results where provider adapters early-returned before reaching `ShouldInjectFailure` because the fixture artist had no external IDs. It seeds five well-known provider IDs via the public PATCH API, adds an atomic hit counter with two new unit tests, and upgrades two WARN rows plus a new Row 7 (hook-actually-reached) to hard-fail assertions.

- `internal/provider/injection.go`: early-releases the read lock before the atomic increment and `slog.Info` call, adds unexported `injectedFailureCount`/`resetInjectedFailureCount` helpers (no longer exported footguns), and emits a distinctive log marker per hit.
- `internal/provider/injection_test.go`: adds `TestMain` that discards slog output for the whole package run, plus two new counter tests covering increment-on-hit and no-increment-on-empty-set paths.
- `scripts/smoke-provider-failure.sh`: seeds MBID/Discogs/Wikidata/AudioDB/Deezer IDs on the fixture artist, snapshots pre/post-matrix hit counts from the server log, and flips Rows 5 and 6 from WARN to hard-fail, adding Row 7 asserting `delta > 0`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. Changes are test-infrastructure only: a new atomic counter and log marker in an already-unexported injection path, two new unit tests, and a smoke script that seeds provider IDs and tightens two WARN rows to hard-fail.

No production behavior changes. The mutex early-release in ShouldInjectFailure is correct: the lock guards only injectedSet, and the atomic counter plus slog call are independent. The unexported accessor/reset helpers address the previously flagged footgun. The shell script's count_marker handles zero-match grep -c exit code correctly under set -euo pipefail. Unit tests reset both provider set and counter in Cleanup, so execution order cannot corrupt assertions.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/provider/injection.go | Adds atomic hit counter, unexported accessor/reset helpers, early mutex release, and slog marker per injection hit. Lock hygiene and atomic usage are correct; counter and log call happen after the read lock is released, which is safe. |
| internal/provider/injection_test.go | Adds TestMain that redirects slog to io.Discard for the package, plus two counter tests. Cleanup hooks reset both the injected set and the counter. Previous tests that now increment the counter are unaffected because the new tests reset explicitly before asserting. |
| scripts/smoke-provider-failure.sh | Seeds five provider IDs via PATCH API, captures pre/post-matrix injection-hook hit counts from the server log, and flips Rows 5/6 from WARN to hard-fail, adding Row 7. count_marker correctly handles zero-match grep -c exit code under set -euo pipefail. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(provider): unexport injection counte..."](https://github.com/sydlexius/stillwater/commit/98573a404b519522fb25c1a26551b84744c21559) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34259331)</sub>

<!-- /greptile_comment -->