### PR TITLE
fix(settingsio): carry verify_path_after_update + make import atomic

### DIFF
--- a/api/bruno/settings/export-settings.bru
+++ b/api/bruno/settings/export-settings.bru
@@ -26,7 +26,7 @@ tests {
   });
 
   test("envelope is the current settings export schema version", function() {
-    expect(res.body.version).to.equal("1.4");
+    expect(res.body.version).to.equal("1.5");
   });
 
   test("data and salt are present", function() {
@@ -50,7 +50,7 @@ tests {
 
 script:post-response {
   // Stash the envelope so import-settings.bru can replay the exact bytes
-  // back through the API in the same Bruno run, exercising the v1.4
+  // back through the API in the same Bruno run, exercising the v1.5
   // round-trip end-to-end.
   bru.setVar("lastExportedEnvelope", JSON.stringify(res.body));
 }

--- a/docs/site/src/how-to/export-import-settings.md
+++ b/docs/site/src/how-to/export-import-settings.md
@@ -65,7 +65,7 @@ There are two ways to import an exported bundle, depending on whether the receiv
 4. Enter the same passphrase that was used to export.
 5. Click **Import**.
 
-Stillwater decrypts and validates the bundle first. It then applies the bundle in two phases: external-service sections (connections, platform profiles, webhooks, provider keys and priorities, rules, scraper preferences) are applied first, and the remaining database-direct sections (settings, users, user preferences, libraries, API tokens) are applied in a single transaction so an error in any one of them rolls the whole transactional phase back. Sections applied during the first phase remain committed if the transactional phase later rolls back; every section's import is upsert-by-natural-key, so the operator can safely retry. If the passphrase is wrong, decryption fails before anything is touched. The result shows what was imported and what was skipped.
+Stillwater decrypts and validates the bundle first. It then applies the whole bundle in a single database transaction covering every section (connections, platform profiles, webhooks, provider keys and priorities, rules, scraper preferences, application settings, users, user preferences, libraries, and API tokens), so an error in any section rolls the entire import back and the destination is left in the state it had before the import began. If the passphrase is wrong, decryption fails before anything is touched. Each section's import is upsert-by-natural-key, so a retry after a fixed-up bundle is safe. The result shows what was imported and what was skipped.
 
 ### Into a fresh instance, before admin creation (Restore from backup)
 
@@ -76,7 +76,7 @@ If you're standing up a new instance and want it to come up with the source inst
 3. Pick the `.json` file and enter the passphrase.
 4. Click **Restore**.
 
-The fresh instance applies the bundle using the same two-phase process as the Settings > Maintenance path described above (external-service sections first, then the transactional phase covering settings, users, user preferences, libraries, and API tokens), and marks onboarding as complete. The page redirects to the login screen; sign in with credentials from the source instance.
+The fresh instance applies the bundle in the same single-transaction atomic import described above, then marks onboarding as complete. The page redirects to the login screen; sign in with credentials from the source instance.
 
 This path is gated on the receiving instance being truly empty (no admin user yet, onboarding not completed). Once an admin exists, the only way to import is through Settings > Maintenance described above.
 
@@ -148,7 +148,7 @@ Connections carry the full set of per-connection write toggles through the expor
 
 A successful import restores every toggle on the destination exactly as it was set on the source. If a connection toggle changes silently after an import, that is a bug; file an issue with the source and destination versions.
 
-The import is atomic across every section: connections, platform profiles, webhooks, provider keys, provider priorities, rules, scraper preferences, application settings, users, user preferences, libraries, and API tokens. A failure in any section rolls back the whole import; the destination is left in the state it had before the import began. Earlier behavior committed connections and rules partway before a later failure, leaving a half-applied configuration; that gap is closed.
+The import is atomic across every section: connections, platform profiles, webhooks, provider keys, provider priorities, rules, scraper preferences, application settings, users, user preferences, libraries, and API tokens. A failure in any section rolls back the whole import; the destination is left in the state it had before the import began.
 
 ## Troubleshooting
 

--- a/docs/site/src/how-to/export-import-settings.md
+++ b/docs/site/src/how-to/export-import-settings.md
@@ -134,6 +134,22 @@ There is an optional **Reassign orphan tokens to me** checkbox on the import for
 2. Make the change.
 3. If something goes wrong, import the export to roll back.
 
+## What survives the round-trip
+
+Connections carry the full set of per-connection write toggles through the export and back, including:
+
+- Library import on/off
+- NFO write on/off
+- Image write on/off
+- Metadata push on/off
+- Trigger refresh on/off
+- Manage server-side artwork and NFO files on/off
+- Verify file paths after a peer update
+
+A successful import restores every toggle on the destination exactly as it was set on the source. If a connection toggle changes silently after an import, that is a bug; file an issue with the source and destination versions.
+
+The import is atomic across every section: connections, platform profiles, webhooks, provider keys, provider priorities, rules, scraper preferences, application settings, users, user preferences, libraries, and API tokens. A failure in any section rolls back the whole import; the destination is left in the state it had before the import began. Earlier behavior committed connections and rules partway before a later failure, leaving a half-applied configuration; that gap is closed.
+
 ## Troubleshooting
 
 - **"Decryption failed."** Wrong passphrase, or the file was corrupted in transit. Re-export from the source.

--- a/docs/site/src/reference/_doc-anchors.txt
+++ b/docs/site/src/reference/_doc-anchors.txt
@@ -225,6 +225,7 @@ how-to/export-import-settings#migrating-to-a-new-host
 how-to/export-import-settings#save-the-bundle-somewhere-durable
 how-to/export-import-settings#troubleshooting
 how-to/export-import-settings#what-import-does-on-conflict
+how-to/export-import-settings#what-survives-the-round-trip
 how-to/export-import-settings#whats-in-the-bundle
 how-to/export-import-settings#when-the-sources-owner-is-missing-on-the-target
 how-to/fetch-and-crop-images#comparison-view

--- a/internal/connection/import.go
+++ b/internal/connection/import.go
@@ -56,6 +56,9 @@ func (s *Service) ImportGetByTypeAndURLTx(ctx context.Context, db DBExecutor, co
 // ImportCreateTx inserts a new connection via the supplied executor. Mirrors
 // Create's SQL exactly so the rows are bit-identical to a non-import insert.
 func (s *Service) ImportCreateTx(ctx context.Context, db DBExecutor, c *Connection) error {
+	if c == nil {
+		return fmt.Errorf("connection is required")
+	}
 	if err := c.Validate(); err != nil {
 		return fmt.Errorf("validating connection: %w", err)
 	}
@@ -96,6 +99,9 @@ func (s *Service) ImportCreateTx(ctx context.Context, db DBExecutor, c *Connecti
 // ImportUpdateTx updates an existing connection via the supplied executor.
 // Mirrors Update's SQL exactly.
 func (s *Service) ImportUpdateTx(ctx context.Context, db DBExecutor, c *Connection) error {
+	if c == nil {
+		return fmt.Errorf("connection is required")
+	}
 	if err := c.Validate(); err != nil {
 		return fmt.Errorf("validating connection: %w", err)
 	}
@@ -130,7 +136,10 @@ func (s *Service) ImportUpdateTx(ctx context.Context, db DBExecutor, c *Connecti
 	if err != nil {
 		return fmt.Errorf("updating connection: %w", err)
 	}
-	rows, _ := result.RowsAffected()
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking updated connection rows: %w", err)
+	}
 	if rows == 0 {
 		return fmt.Errorf("connection not found: %s", c.ID)
 	}

--- a/internal/connection/import.go
+++ b/internal/connection/import.go
@@ -1,0 +1,138 @@
+package connection
+
+// import.go contains the tx-aware helpers used by the settingsio import
+// orchestrator (#1693). They mirror the SQL of Create/Update/GetByTypeAndURL
+// but accept a DBExecutor so the orchestrator can run them inside its own
+// transaction; a mid-import failure then rolls back the connection writes
+// alongside every other section's writes.
+//
+// Public Create/Update/GetByTypeAndURL signatures are unchanged so non-import
+// callers see no surface drift.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
+)
+
+// DBExecutor is the subset of *sql.DB used by the tx-aware connection import
+// helpers. Both *sql.DB and *sql.Tx satisfy it. The interface is local to
+// this package to avoid pulling in a settingsio dependency.
+type DBExecutor interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// ImportGetByTypeAndURLTx is the tx-aware equivalent of GetByTypeAndURL,
+// scoped to the import orchestrator so the lookup observes uncommitted
+// writes inside the same transaction.
+func (s *Service) ImportGetByTypeAndURLTx(ctx context.Context, db DBExecutor, connType, url string) (*Connection, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT id, name, type, url, encrypted_api_key, enabled, status, status_message, last_checked_at, created_at, updated_at, feature_library_import, feature_nfo_write, feature_image_write, feature_metadata_push, feature_trigger_refresh, feature_manage_server_files, verify_path_after_update, platform_user_id, platform_server_id, pre_stillwater_config_json
+		FROM connections WHERE type = ? AND url = ? ORDER BY created_at DESC LIMIT 1
+	`, connType, url)
+	c, err := s.scanConnection(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if errors.Is(err, errDecrypt) {
+		slog.Warn("treating undecryptable connection as not found for type+url lookup (import tx)",
+			"error", err, "type", connType, "url", url)
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting connection by type+url: %w", err)
+	}
+	return c, nil
+}
+
+// ImportCreateTx inserts a new connection via the supplied executor. Mirrors
+// Create's SQL exactly so the rows are bit-identical to a non-import insert.
+func (s *Service) ImportCreateTx(ctx context.Context, db DBExecutor, c *Connection) error {
+	if err := c.Validate(); err != nil {
+		return fmt.Errorf("validating connection: %w", err)
+	}
+	if c.ID == "" {
+		c.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	c.CreatedAt = now
+	c.UpdatedAt = now
+	if c.Status == "" {
+		c.Status = "unknown"
+	}
+	encKey, err := s.encryptor.Encrypt(c.APIKey)
+	if err != nil {
+		return fmt.Errorf("encrypting api key: %w", err)
+	}
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO connections (id, name, type, url, encrypted_api_key, enabled, status, status_message, last_checked_at, created_at, updated_at, feature_library_import, feature_nfo_write, feature_image_write, feature_metadata_push, feature_trigger_refresh, feature_manage_server_files, verify_path_after_update, platform_user_id, platform_server_id, pre_stillwater_config_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		c.ID, c.Name, c.Type, c.URL, encKey,
+		dbutil.BoolToInt(c.Enabled), c.Status, c.StatusMessage,
+		dbutil.FormatNullableTime(c.LastCheckedAt),
+		now.Format(time.RFC3339), now.Format(time.RFC3339),
+		dbutil.BoolToInt(c.FeatureLibraryImport), dbutil.BoolToInt(c.FeatureNFOWrite), dbutil.BoolToInt(c.FeatureImageWrite),
+		dbutil.BoolToInt(c.FeatureMetadataPush), dbutil.BoolToInt(c.FeatureTriggerRefresh),
+		dbutil.BoolToInt(c.FeatureManageServerFiles),
+		dbutil.BoolToInt(c.VerifyPathAfterUpdate),
+		c.PlatformUserID, c.PlatformServerID,
+		c.PreStillwaterConfigJSON,
+	)
+	if err != nil {
+		return fmt.Errorf("creating connection: %w", err)
+	}
+	return nil
+}
+
+// ImportUpdateTx updates an existing connection via the supplied executor.
+// Mirrors Update's SQL exactly.
+func (s *Service) ImportUpdateTx(ctx context.Context, db DBExecutor, c *Connection) error {
+	if err := c.Validate(); err != nil {
+		return fmt.Errorf("validating connection: %w", err)
+	}
+	c.UpdatedAt = time.Now().UTC()
+	encKey, err := s.encryptor.Encrypt(c.APIKey)
+	if err != nil {
+		return fmt.Errorf("encrypting api key: %w", err)
+	}
+	result, err := db.ExecContext(ctx, `
+		UPDATE connections SET
+			name = ?, type = ?, url = ?, encrypted_api_key = ?, enabled = ?,
+			status = ?, status_message = ?, updated_at = ?,
+			feature_library_import = ?, feature_nfo_write = ?, feature_image_write = ?,
+			feature_metadata_push = ?, feature_trigger_refresh = ?,
+			feature_manage_server_files = ?,
+			verify_path_after_update = ?,
+			platform_user_id = ?, platform_server_id = ?,
+			pre_stillwater_config_json = ?
+		WHERE id = ?
+	`,
+		c.Name, c.Type, c.URL, encKey, dbutil.BoolToInt(c.Enabled),
+		c.Status, c.StatusMessage,
+		c.UpdatedAt.Format(time.RFC3339),
+		dbutil.BoolToInt(c.FeatureLibraryImport), dbutil.BoolToInt(c.FeatureNFOWrite), dbutil.BoolToInt(c.FeatureImageWrite),
+		dbutil.BoolToInt(c.FeatureMetadataPush), dbutil.BoolToInt(c.FeatureTriggerRefresh),
+		dbutil.BoolToInt(c.FeatureManageServerFiles),
+		dbutil.BoolToInt(c.VerifyPathAfterUpdate),
+		c.PlatformUserID, c.PlatformServerID,
+		c.PreStillwaterConfigJSON,
+		c.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("updating connection: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("connection not found: %s", c.ID)
+	}
+	return nil
+}

--- a/internal/connection/import_test.go
+++ b/internal/connection/import_test.go
@@ -1,0 +1,206 @@
+package connection
+
+// import_test.go exercises the tx-aware import helpers added for #1693.
+// The helpers mirror Create/Update/GetByTypeAndURL but write through a
+// caller-supplied DBExecutor; this file pins both the standalone (s.db
+// passed in) and the tx-bound (BeginTx -> rollback drops the writes)
+// behaviors.
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/database"
+	"github.com/sydlexius/stillwater/internal/encryption"
+)
+
+// setupTestServiceWithDB returns the service AND the underlying DB so the
+// import_test helpers can open transactions directly.
+func setupTestServiceWithDB(t *testing.T) (*Service, DBExecutor) {
+	t.Helper()
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("opening test db: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("running migrations: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	enc, _, err := encryption.NewEncryptor("")
+	if err != nil {
+		t.Fatalf("creating encryptor: %v", err)
+	}
+	return NewService(db, enc), db
+}
+
+// TestImportCreateTx_RoundTrip exercises the happy path: ImportCreateTx writes
+// through the supplied executor and ImportGetByTypeAndURLTx reads the row
+// back, including the v1.5 VerifyPathAfterUpdate field added by #1692.
+func TestImportCreateTx_RoundTrip(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	ctx := context.Background()
+
+	c := &Connection{
+		Name: "ImportTx Emby", Type: TypeEmby, URL: "http://importtx:8096",
+		APIKey: "k", Enabled: true, VerifyPathAfterUpdate: false,
+	}
+	if err := svc.ImportCreateTx(ctx, db, c); err != nil {
+		t.Fatalf("ImportCreateTx: %v", err)
+	}
+	if c.ID == "" {
+		t.Fatal("ImportCreateTx must assign an ID")
+	}
+
+	got, err := svc.ImportGetByTypeAndURLTx(ctx, db, "emby", "http://importtx:8096")
+	if err != nil {
+		t.Fatalf("ImportGetByTypeAndURLTx: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ImportGetByTypeAndURLTx returned nil; row should exist")
+	}
+	if got.APIKey != "k" {
+		t.Errorf("APIKey: got %q, want k", got.APIKey)
+	}
+}
+
+// TestImportUpdateTx_RoundTrip verifies that ImportUpdateTx mutates an
+// existing row. The status is preserved across the update so the import
+// path does not stomp a live health check.
+func TestImportUpdateTx_RoundTrip(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	ctx := context.Background()
+
+	c := &Connection{
+		Name: "ImportUpdate Emby", Type: TypeEmby, URL: "http://importupd:8096",
+		APIKey: "k1", Enabled: true,
+	}
+	if err := svc.ImportCreateTx(ctx, db, c); err != nil {
+		t.Fatalf("ImportCreateTx: %v", err)
+	}
+
+	c.APIKey = "k2"
+	c.VerifyPathAfterUpdate = true
+	if err := svc.ImportUpdateTx(ctx, db, c); err != nil {
+		t.Fatalf("ImportUpdateTx: %v", err)
+	}
+
+	got, err := svc.ImportGetByTypeAndURLTx(ctx, db, "emby", "http://importupd:8096")
+	if err != nil {
+		t.Fatalf("ImportGetByTypeAndURLTx: %v", err)
+	}
+	if got.APIKey != "k2" {
+		t.Errorf("APIKey after update: got %q, want k2", got.APIKey)
+	}
+	if !got.VerifyPathAfterUpdate {
+		t.Error("VerifyPathAfterUpdate did not round-trip through ImportUpdateTx")
+	}
+}
+
+// TestImportCreateTx_DBError pins error propagation when the executor
+// fails. Exercises the inserting-connection error path.
+func TestImportCreateTx_DBError(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	// Close the underlying *sql.DB so subsequent ExecContext fails.
+	if d, ok := db.(interface{ Close() error }); ok {
+		_ = d.Close()
+	}
+	err := svc.ImportCreateTx(context.Background(), db, &Connection{
+		Name: "x", Type: TypeEmby, URL: "http://x", APIKey: "k",
+	})
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportUpdateTx_NotFound exercises the rows-affected=0 branch so a
+// connection ID the orchestrator can no longer find surfaces as an error
+// rather than silently succeeding.
+func TestImportUpdateTx_NotFound(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	err := svc.ImportUpdateTx(context.Background(), db, &Connection{
+		ID: "no-such-id", Name: "x", Type: TypeEmby, URL: "http://x", APIKey: "k",
+	})
+	if err == nil {
+		t.Fatal("expected error when updating missing row, got nil")
+	}
+}
+
+// TestImportCreateTx_ValidationError surfaces a Validate() failure from
+// inside the tx-aware create path.
+func TestImportCreateTx_ValidationError(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	// Missing URL/type triggers Validate() failure.
+	err := svc.ImportCreateTx(context.Background(), db, &Connection{Name: "incomplete"})
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+}
+
+// TestImportGetByTypeAndURLTx_DBError pins error propagation when the
+// executor fails (closed DB triggers a non-ErrNoRows DB error).
+func TestImportGetByTypeAndURLTx_DBError(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	if d, ok := db.(interface{ Close() error }); ok {
+		_ = d.Close()
+	}
+	_, err := svc.ImportGetByTypeAndURLTx(context.Background(), db, "emby", "http://x")
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportGetByTypeAndURLTx_UndecryptableTreatedAsMissing seeds a
+// connection encrypted under one key, then opens a fresh service with a
+// different encryptor, and asserts ImportGetByTypeAndURLTx returns nil
+// (the same fail-soft behavior as GetByTypeAndURL: undecryptable rows
+// behave like missing rows for the upsert lookup so the import path
+// inserts a fresh row instead of attempting an update against a
+// poisoned cipher).
+func TestImportGetByTypeAndURLTx_UndecryptableTreatedAsMissing(t *testing.T) {
+	t.Parallel()
+	svc1, db := setupTestServiceWithDB(t)
+	ctx := context.Background()
+	c := &Connection{
+		Name: "undecryptable", Type: TypeEmby, URL: "http://undecryptable:8096",
+		APIKey: "good-key", Enabled: true,
+	}
+	if err := svc1.ImportCreateTx(ctx, db, c); err != nil {
+		t.Fatalf("ImportCreateTx: %v", err)
+	}
+
+	// New encryptor with a different randomly-generated key cannot decrypt
+	// the row svc1 wrote.
+	enc2, _, err := encryption.NewEncryptor("")
+	if err != nil {
+		t.Fatalf("creating second encryptor: %v", err)
+	}
+	// db here is the DBExecutor; downcast to *sql.DB to pass to NewService.
+	svc2 := NewService(db.(*sql.DB), enc2)
+	got, err := svc2.ImportGetByTypeAndURLTx(ctx, db, "emby", "http://undecryptable:8096")
+	if err != nil {
+		t.Fatalf("ImportGetByTypeAndURLTx: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for undecryptable row, got %+v", got)
+	}
+}
+
+// TestImportGetByTypeAndURLTx_NotFound confirms the nil-on-miss contract.
+func TestImportGetByTypeAndURLTx_NotFound(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	got, err := svc.ImportGetByTypeAndURLTx(context.Background(), db, "emby", "http://nowhere:0")
+	if err != nil {
+		t.Fatalf("ImportGetByTypeAndURLTx: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing row, got %+v", got)
+	}
+}

--- a/internal/connection/import_test.go
+++ b/internal/connection/import_test.go
@@ -142,6 +142,26 @@ func TestImportCreateTx_ValidationError(t *testing.T) {
 	}
 }
 
+// TestImportCreateTx_NilArg pins the defensive nil-guard on the tx-aware
+// create path so a malformed envelope cannot panic the import.
+func TestImportCreateTx_NilArg(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	if err := svc.ImportCreateTx(context.Background(), db, nil); err == nil {
+		t.Fatal("expected error for nil connection, got nil")
+	}
+}
+
+// TestImportUpdateTx_NilArg pins the defensive nil-guard on the tx-aware
+// update path.
+func TestImportUpdateTx_NilArg(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	if err := svc.ImportUpdateTx(context.Background(), db, nil); err == nil {
+		t.Fatal("expected error for nil connection, got nil")
+	}
+}
+
 // TestImportGetByTypeAndURLTx_DBError pins error propagation when the
 // executor fails (closed DB triggers a non-ErrNoRows DB error).
 func TestImportGetByTypeAndURLTx_DBError(t *testing.T) {

--- a/internal/platform/import.go
+++ b/internal/platform/import.go
@@ -45,6 +45,9 @@ func (s *Service) ImportGetByNameTx(ctx context.Context, db DBExecutor, name str
 // ImportCreateTx inserts a new profile via the supplied executor. Mirrors
 // Create's SQL exactly.
 func (s *Service) ImportCreateTx(ctx context.Context, db DBExecutor, p *Profile) error {
+	if p == nil {
+		return fmt.Errorf("platform profile is required")
+	}
 	if p.ID == "" {
 		p.ID = uuid.New().String()
 	}
@@ -69,9 +72,12 @@ func (s *Service) ImportCreateTx(ctx context.Context, db DBExecutor, p *Profile)
 // ImportUpdateTx updates an existing profile via the supplied executor.
 // Mirrors Update's SQL exactly.
 func (s *Service) ImportUpdateTx(ctx context.Context, db DBExecutor, p *Profile) error {
+	if p == nil {
+		return fmt.Errorf("platform profile is required")
+	}
 	p.UpdatedAt = time.Now().UTC()
 
-	_, err := db.ExecContext(ctx, `
+	result, err := db.ExecContext(ctx, `
 		UPDATE platform_profiles SET
 			name = ?, nfo_enabled = ?, nfo_format = ?, image_naming = ?, use_symlinks = ?, updated_at = ?
 		WHERE id = ?
@@ -83,6 +89,13 @@ func (s *Service) ImportUpdateTx(ctx context.Context, db DBExecutor, p *Profile)
 	)
 	if err != nil {
 		return fmt.Errorf("updating platform profile: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking updated platform profile rows: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("platform profile not found: %s", p.ID)
 	}
 	return nil
 }

--- a/internal/platform/import.go
+++ b/internal/platform/import.go
@@ -1,0 +1,88 @@
+package platform
+
+// import.go contains the tx-aware helpers used by the settingsio import
+// orchestrator (#1693). They mirror the SQL of Create/Update/GetByName but
+// accept a DBExecutor so the orchestrator can run them inside its own
+// transaction; a mid-import failure then rolls back the platform profile
+// writes alongside every other section's writes.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sydlexius/stillwater/internal/dbutil"
+)
+
+// DBExecutor is the subset of *sql.DB used by the tx-aware platform import
+// helpers. Both *sql.DB and *sql.Tx satisfy it.
+type DBExecutor interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// ImportGetByNameTx is the tx-aware equivalent of GetByName.
+func (s *Service) ImportGetByNameTx(ctx context.Context, db DBExecutor, name string) (*Profile, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT id, name, is_builtin, is_active, nfo_enabled, nfo_format,
+			image_naming, use_symlinks, created_at, updated_at
+		FROM platform_profiles WHERE name = ? LIMIT 1
+	`, name)
+	p, err := scanProfile(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting profile by name: %w", err)
+	}
+	return p, nil
+}
+
+// ImportCreateTx inserts a new profile via the supplied executor. Mirrors
+// Create's SQL exactly.
+func (s *Service) ImportCreateTx(ctx context.Context, db DBExecutor, p *Profile) error {
+	if p.ID == "" {
+		p.ID = uuid.New().String()
+	}
+	now := time.Now().UTC()
+	p.CreatedAt = now
+	p.UpdatedAt = now
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO platform_profiles (id, name, is_builtin, is_active, nfo_enabled, nfo_format, image_naming, use_symlinks, created_at, updated_at)
+		VALUES (?, ?, 0, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		p.ID, p.Name, dbutil.BoolToInt(p.IsActive), dbutil.BoolToInt(p.NFOEnabled), p.NFOFormat,
+		MarshalImageNaming(p.ImageNaming), dbutil.BoolToInt(p.UseSymlinks),
+		now.Format(time.RFC3339), now.Format(time.RFC3339),
+	)
+	if err != nil {
+		return fmt.Errorf("creating platform profile: %w", err)
+	}
+	return nil
+}
+
+// ImportUpdateTx updates an existing profile via the supplied executor.
+// Mirrors Update's SQL exactly.
+func (s *Service) ImportUpdateTx(ctx context.Context, db DBExecutor, p *Profile) error {
+	p.UpdatedAt = time.Now().UTC()
+
+	_, err := db.ExecContext(ctx, `
+		UPDATE platform_profiles SET
+			name = ?, nfo_enabled = ?, nfo_format = ?, image_naming = ?, use_symlinks = ?, updated_at = ?
+		WHERE id = ?
+	`,
+		p.Name, dbutil.BoolToInt(p.NFOEnabled), p.NFOFormat,
+		MarshalImageNaming(p.ImageNaming), dbutil.BoolToInt(p.UseSymlinks),
+		p.UpdatedAt.Format(time.RFC3339),
+		p.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("updating platform profile: %w", err)
+	}
+	return nil
+}

--- a/internal/platform/import_test.go
+++ b/internal/platform/import_test.go
@@ -1,0 +1,76 @@
+package platform
+
+// import_test.go exercises the tx-aware import helpers added for #1693.
+
+import (
+	"context"
+	"testing"
+)
+
+// TestImportCreateAndGetTx verifies that a profile written via ImportCreateTx
+// is visible to ImportGetByNameTx and ImportUpdateTx mutates the row in place.
+func TestImportCreateAndGetTx(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	p := &Profile{
+		Name: "ImportTx Profile", NFOEnabled: true, NFOFormat: "kodi",
+	}
+	if err := svc.ImportCreateTx(ctx, db, p); err != nil {
+		t.Fatalf("ImportCreateTx: %v", err)
+	}
+	if p.ID == "" {
+		t.Fatal("ImportCreateTx must assign an ID")
+	}
+
+	got, err := svc.ImportGetByNameTx(ctx, db, "ImportTx Profile")
+	if err != nil {
+		t.Fatalf("ImportGetByNameTx: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ImportGetByNameTx returned nil; profile should exist")
+	}
+	if got.NFOFormat != "kodi" {
+		t.Errorf("NFOFormat: got %q, want kodi", got.NFOFormat)
+	}
+
+	got.NFOFormat = "emby"
+	if err := svc.ImportUpdateTx(ctx, db, got); err != nil {
+		t.Fatalf("ImportUpdateTx: %v", err)
+	}
+	reloaded, err := svc.ImportGetByNameTx(ctx, db, "ImportTx Profile")
+	if err != nil {
+		t.Fatalf("reload after ImportUpdateTx: %v", err)
+	}
+	if reloaded.NFOFormat != "emby" {
+		t.Errorf("NFOFormat after update: got %q, want emby", reloaded.NFOFormat)
+	}
+}
+
+// TestImportCreateTx_DBError pins error propagation.
+func TestImportCreateTx_DBError(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	_ = db.Close()
+	err := svc.ImportCreateTx(context.Background(), db, &Profile{Name: "x"})
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportGetByNameTx_NotFound confirms the nil-on-miss contract.
+func TestImportGetByNameTx_NotFound(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	got, err := svc.ImportGetByNameTx(context.Background(), db, "does-not-exist")
+	if err != nil {
+		t.Fatalf("ImportGetByNameTx: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing row, got %+v", got)
+	}
+}

--- a/internal/platform/import_test.go
+++ b/internal/platform/import_test.go
@@ -4,6 +4,7 @@ package platform
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -82,8 +83,12 @@ func TestImportCreateTx_NilArg(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
-	if err := svc.ImportCreateTx(context.Background(), db, nil); err == nil {
+	err := svc.ImportCreateTx(context.Background(), db, nil)
+	if err == nil {
 		t.Fatal("expected error for nil profile, got nil")
+	}
+	if !strings.Contains(err.Error(), "platform profile is required") {
+		t.Fatalf("expected nil-guard error, got: %v", err)
 	}
 }
 
@@ -91,7 +96,11 @@ func TestImportUpdateTx_NilArg(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
-	if err := svc.ImportUpdateTx(context.Background(), db, nil); err == nil {
+	err := svc.ImportUpdateTx(context.Background(), db, nil)
+	if err == nil {
 		t.Fatal("expected error for nil profile, got nil")
+	}
+	if !strings.Contains(err.Error(), "platform profile is required") {
+		t.Fatalf("expected nil-guard error, got: %v", err)
 	}
 }

--- a/internal/platform/import_test.go
+++ b/internal/platform/import_test.go
@@ -74,3 +74,24 @@ func TestImportGetByNameTx_NotFound(t *testing.T) {
 		t.Errorf("expected nil for missing row, got %+v", got)
 	}
 }
+
+// TestImportCreateTx_NilArg + TestImportUpdateTx_NilArg pin the defensive
+// nil-guards on the tx-aware import path so a malformed envelope cannot
+// panic the import.
+func TestImportCreateTx_NilArg(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	if err := svc.ImportCreateTx(context.Background(), db, nil); err == nil {
+		t.Fatal("expected error for nil profile, got nil")
+	}
+}
+
+func TestImportUpdateTx_NilArg(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	if err := svc.ImportUpdateTx(context.Background(), db, nil); err == nil {
+		t.Fatal("expected error for nil profile, got nil")
+	}
+}

--- a/internal/provider/import.go
+++ b/internal/provider/import.go
@@ -1,0 +1,88 @@
+package provider
+
+// import.go contains the tx-aware helpers used by the settingsio import
+// orchestrator (#1693). They mirror the SQL of SetAPIKey / SetPriority /
+// SetDisabledProviders but accept a DBExecutor so the orchestrator can run
+// them inside its own transaction; a mid-import failure then rolls back the
+// provider settings writes alongside every other section's writes.
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+// DBExecutor is the subset of *sql.DB used by the tx-aware provider settings
+// import helpers. Both *sql.DB and *sql.Tx satisfy it.
+type DBExecutor interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// ImportSetAPIKeyTx writes an encrypted API key plus a fresh status delete
+// through the supplied executor. Unlike SetAPIKey it does NOT open its own
+// transaction -- the orchestrator's tx covers both writes.
+func (s *SettingsService) ImportSetAPIKeyTx(ctx context.Context, db DBExecutor, name ProviderName, apiKey string) error {
+	encrypted, err := s.encryptor.Encrypt(apiKey)
+	if err != nil {
+		return fmt.Errorf("encrypting API key for %s: %w", name, err)
+	}
+	key := apiKeySettingKey(name)
+	if _, err := db.ExecContext(ctx,
+		"INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?, updated_at = datetime('now')",
+		key, encrypted, encrypted,
+	); err != nil {
+		return fmt.Errorf("storing API key for %s: %w", name, err)
+	}
+	// Clear stale status so the key shows as "untested" until re-verified.
+	statusKey := keyStatusSettingKey(name)
+	if _, err := db.ExecContext(ctx, "DELETE FROM settings WHERE key = ?", statusKey); err != nil {
+		return fmt.Errorf("clearing key status for %s: %w", name, err)
+	}
+	return nil
+}
+
+// ImportSetPriorityTx mirrors SetPriority but writes through the supplied
+// executor instead of s.db.
+func (s *SettingsService) ImportSetPriorityTx(ctx context.Context, db DBExecutor, field string, providers []ProviderName) error {
+	data, err := json.Marshal(providers)
+	if err != nil {
+		return fmt.Errorf("marshaling priority for %s: %w", field, err)
+	}
+	key := prioritySettingKey(field)
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?, updated_at = datetime('now')",
+		key, string(data), string(data),
+	)
+	if err != nil {
+		return fmt.Errorf("storing priority for %s: %w", field, err)
+	}
+	return nil
+}
+
+// ImportSetDisabledProvidersTx mirrors SetDisabledProviders but writes through
+// the supplied executor instead of s.db.
+func (s *SettingsService) ImportSetDisabledProvidersTx(ctx context.Context, db DBExecutor, field string, disabled []ProviderName) error {
+	key := priorityDisabledKey(field)
+	if len(disabled) == 0 {
+		_, err := db.ExecContext(ctx, "DELETE FROM settings WHERE key = ?", key)
+		if err != nil {
+			return fmt.Errorf("clearing disabled providers for %s: %w", field, err)
+		}
+		return nil
+	}
+	data, err := json.Marshal(disabled)
+	if err != nil {
+		return fmt.Errorf("marshaling disabled providers for %s: %w", field, err)
+	}
+	_, err = db.ExecContext(ctx,
+		"INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?, updated_at = datetime('now')",
+		key, string(data), string(data),
+	)
+	if err != nil {
+		return fmt.Errorf("storing disabled providers for %s: %w", field, err)
+	}
+	return nil
+}

--- a/internal/provider/import_test.go
+++ b/internal/provider/import_test.go
@@ -1,0 +1,149 @@
+package provider
+
+// import_test.go exercises the tx-aware import helpers added for #1693.
+
+import (
+	"context"
+	"testing"
+)
+
+// TestImportSetAPIKeyTx_RoundTrip writes a key via the tx-aware import
+// helper using the same s.db handle the service was constructed with, then
+// reads it back through the public GetAPIKey path to confirm it was stored
+// and decrypts cleanly.
+func TestImportSetAPIKeyTx_RoundTrip(t *testing.T) {
+	db := setupTestDB(t)
+	enc := setupTestEncryptor(t)
+	svc := NewSettingsService(db, enc)
+	ctx := context.Background()
+
+	if err := svc.ImportSetAPIKeyTx(ctx, db, NameFanartTV, "import-tx-key"); err != nil {
+		t.Fatalf("ImportSetAPIKeyTx: %v", err)
+	}
+	got, err := svc.GetAPIKey(ctx, NameFanartTV)
+	if err != nil {
+		t.Fatalf("GetAPIKey: %v", err)
+	}
+	if got != "import-tx-key" {
+		t.Errorf("GetAPIKey: got %q, want import-tx-key", got)
+	}
+}
+
+// TestImportSetPriorityTx_RoundTrip writes a priority via the tx-aware
+// import helper and verifies it round-trips through the standard
+// GetPriorities reader.
+func TestImportSetPriorityTx_RoundTrip(t *testing.T) {
+	db := setupTestDB(t)
+	enc := setupTestEncryptor(t)
+	svc := NewSettingsService(db, enc)
+	ctx := context.Background()
+
+	want := []ProviderName{NameMusicBrainz, NameWikipedia}
+	if err := svc.ImportSetPriorityTx(ctx, db, "biography", want); err != nil {
+		t.Fatalf("ImportSetPriorityTx: %v", err)
+	}
+	fps, err := svc.GetPriorities(ctx)
+	if err != nil {
+		t.Fatalf("GetPriorities: %v", err)
+	}
+	for _, fp := range fps {
+		if fp.Field != "biography" {
+			continue
+		}
+		if len(fp.Providers) < 2 || fp.Providers[0] != NameMusicBrainz || fp.Providers[1] != NameWikipedia {
+			t.Errorf("Providers prefix: got %v, want %v first", fp.Providers, want)
+		}
+		return
+	}
+	t.Fatal("biography priorities not found after import")
+}
+
+// TestImportSetAPIKeyTx_DBError verifies that an executor failure
+// propagates as an error rather than being silently dropped.
+func TestImportSetAPIKeyTx_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	enc := setupTestEncryptor(t)
+	svc := NewSettingsService(db, enc)
+	_ = db.Close()
+	err := svc.ImportSetAPIKeyTx(context.Background(), db, NameFanartTV, "k")
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportSetPriorityTx_DBError pins the same error-propagation contract
+// for the priority writer.
+func TestImportSetPriorityTx_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	enc := setupTestEncryptor(t)
+	svc := NewSettingsService(db, enc)
+	_ = db.Close()
+	err := svc.ImportSetPriorityTx(context.Background(), db, "biography", []ProviderName{NameMusicBrainz})
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportSetDisabledProvidersTx_DBError covers both the clear-empty and
+// the write-non-empty paths.
+func TestImportSetDisabledProvidersTx_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	enc := setupTestEncryptor(t)
+	svc := NewSettingsService(db, enc)
+	_ = db.Close()
+	// empty list goes through the DELETE branch
+	if err := svc.ImportSetDisabledProvidersTx(context.Background(), db, "biography", nil); err == nil {
+		t.Error("expected error on empty list with closed DB")
+	}
+	// non-empty list goes through the INSERT branch
+	if err := svc.ImportSetDisabledProvidersTx(context.Background(), db, "biography",
+		[]ProviderName{NameWikipedia}); err == nil {
+		t.Error("expected error on non-empty list with closed DB")
+	}
+}
+
+// TestImportSetDisabledProvidersTx_RoundTripAndClear verifies both branches
+// of the import helper: writing a non-empty list and clearing via an empty list.
+func TestImportSetDisabledProvidersTx_RoundTripAndClear(t *testing.T) {
+	db := setupTestDB(t)
+	enc := setupTestEncryptor(t)
+	svc := NewSettingsService(db, enc)
+	ctx := context.Background()
+
+	disabled := []ProviderName{NameWikipedia}
+	if err := svc.ImportSetDisabledProvidersTx(ctx, db, "biography", disabled); err != nil {
+		t.Fatalf("ImportSetDisabledProvidersTx (set): %v", err)
+	}
+	// Also seed a priority so GetPriorities returns the row.
+	if err := svc.ImportSetPriorityTx(ctx, db, "biography", []ProviderName{NameMusicBrainz}); err != nil {
+		t.Fatalf("seeding priority: %v", err)
+	}
+	fps, err := svc.GetPriorities(ctx)
+	if err != nil {
+		t.Fatalf("GetPriorities: %v", err)
+	}
+	foundDisabled := false
+	for _, fp := range fps {
+		if fp.Field == "biography" && len(fp.Disabled) == 1 && fp.Disabled[0] == NameWikipedia {
+			foundDisabled = true
+			break
+		}
+	}
+	if !foundDisabled {
+		t.Errorf("disabled list not persisted; got %v", fps)
+	}
+
+	// Empty input clears the row.
+	if err := svc.ImportSetDisabledProvidersTx(ctx, db, "biography", []ProviderName{}); err != nil {
+		t.Fatalf("ImportSetDisabledProvidersTx (clear): %v", err)
+	}
+	fps, err = svc.GetPriorities(ctx)
+	if err != nil {
+		t.Fatalf("GetPriorities post-clear: %v", err)
+	}
+	for _, fp := range fps {
+		if fp.Field == "biography" && len(fp.Disabled) > 0 {
+			t.Errorf("disabled list not cleared; got %v", fp.Disabled)
+		}
+	}
+}

--- a/internal/rule/import.go
+++ b/internal/rule/import.go
@@ -45,13 +45,23 @@ func (s *Service) ImportGetByIDTx(ctx context.Context, db DBExecutor, id string)
 // behavior including the soft-resolve cleanup for disabled rules so a tx-
 // rolled-back import does not orphan rule_results rows.
 func (s *Service) ImportUpdateTx(ctx context.Context, db DBExecutor, r *Rule) error {
+	if r == nil {
+		return fmt.Errorf("rule is required")
+	}
 	r.UpdatedAt = s.clock.Now()
-	_, err := db.ExecContext(ctx, `
+	result, err := db.ExecContext(ctx, `
 		UPDATE rules SET enabled = ?, automation_mode = ?, config = ?, updated_at = ? WHERE id = ?
 	`, dbutil.BoolToInt(r.Enabled), r.AutomationMode, MarshalConfig(r.Config),
 		r.UpdatedAt.Format(time.RFC3339), r.ID)
 	if err != nil {
 		return fmt.Errorf("updating rule: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking updated rule rows: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("rule not found: %s", r.ID)
 	}
 	if !r.Enabled {
 		if err := s.cleanupDisabledRuleStateTx(ctx, db, r.ID); err != nil {
@@ -64,7 +74,7 @@ func (s *Service) ImportUpdateTx(ctx context.Context, db DBExecutor, r *Rule) er
 // cleanupDisabledRuleStateTx mirrors cleanupDisabledRuleState but writes
 // through the supplied executor.
 func (s *Service) cleanupDisabledRuleStateTx(ctx context.Context, db DBExecutor, ruleID string) error {
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := s.clock.Now().Format(time.RFC3339)
 	if _, err := db.ExecContext(ctx,
 		`UPDATE rule_violations
 		    SET status = ?, resolved_at = ?, updated_at = ?

--- a/internal/rule/import.go
+++ b/internal/rule/import.go
@@ -1,0 +1,83 @@
+package rule
+
+// import.go contains the tx-aware helpers used by the settingsio import
+// orchestrator (#1693). They mirror the SQL of GetByID/Update but accept a
+// DBExecutor so the orchestrator can run them inside its own transaction; a
+// mid-import failure then rolls back the rule writes alongside every other
+// section's writes.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/sydlexius/stillwater/internal/dbutil"
+)
+
+// DBExecutor is the subset of *sql.DB used by the tx-aware rule import
+// helpers. Both *sql.DB and *sql.Tx satisfy it.
+type DBExecutor interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// ImportGetByIDTx is the tx-aware equivalent of GetByID.
+func (s *Service) ImportGetByIDTx(ctx context.Context, db DBExecutor, id string) (*Rule, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT id, name, description, category, enabled, automation_mode, config, created_at, updated_at
+		FROM rules WHERE id = ?
+	`, id)
+	r, err := scanRule(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, id)
+		}
+		return nil, fmt.Errorf("getting rule by id: %w", err)
+	}
+	r.FilesystemDependent = filesystemRules[r.ID]
+	return r, nil
+}
+
+// ImportUpdateTx is the tx-aware equivalent of Update. Mirrors Update's
+// behavior including the soft-resolve cleanup for disabled rules so a tx-
+// rolled-back import does not orphan rule_results rows.
+func (s *Service) ImportUpdateTx(ctx context.Context, db DBExecutor, r *Rule) error {
+	r.UpdatedAt = s.clock.Now()
+	_, err := db.ExecContext(ctx, `
+		UPDATE rules SET enabled = ?, automation_mode = ?, config = ?, updated_at = ? WHERE id = ?
+	`, dbutil.BoolToInt(r.Enabled), r.AutomationMode, MarshalConfig(r.Config),
+		r.UpdatedAt.Format(time.RFC3339), r.ID)
+	if err != nil {
+		return fmt.Errorf("updating rule: %w", err)
+	}
+	if !r.Enabled {
+		if err := s.cleanupDisabledRuleStateTx(ctx, db, r.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// cleanupDisabledRuleStateTx mirrors cleanupDisabledRuleState but writes
+// through the supplied executor.
+func (s *Service) cleanupDisabledRuleStateTx(ctx context.Context, db DBExecutor, ruleID string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.ExecContext(ctx,
+		`UPDATE rule_violations
+		    SET status = ?, resolved_at = ?, updated_at = ?
+		  WHERE rule_id = ? AND status IN (?, ?)`,
+		ViolationStatusResolved, now, now,
+		ruleID, ViolationStatusOpen, ViolationStatusPendingChoice,
+	); err != nil {
+		return fmt.Errorf("cleaning up violations after disable: %w", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`DELETE FROM rule_results WHERE rule_id = ?`, ruleID,
+	); err != nil {
+		return fmt.Errorf("cleaning up rule_results after disable: %w", err)
+	}
+	return nil
+}

--- a/internal/rule/import_test.go
+++ b/internal/rule/import_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 // TestImportGetByIDTx_RoundTrip verifies the tx-aware reader returns a
@@ -59,7 +60,9 @@ func TestImportGetByIDTx_DBError(t *testing.T) {
 }
 
 // TestImportUpdateTx_DisabledRuleCleansUp exercises the cleanupDisabledRuleStateTx
-// branch by disabling a rule and asserting the helper ran without error.
+// branch by disabling a rule and asserting (a) the Enabled column actually
+// flipped on the row, and (b) cleanupDisabledRuleStateTx deleted the seeded
+// rule_results row tied to the rule.
 func TestImportUpdateTx_DisabledRuleCleansUp(t *testing.T) {
 	db := setupTestDB(t)
 	svc := NewService(db)
@@ -72,15 +75,49 @@ func TestImportUpdateTx_DisabledRuleCleansUp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByID: %v", err)
 	}
-	// Already-disabled by default; flip enabled true then back to false
-	// to force the cleanup path.
-	r.Enabled = true
-	if err := svc.ImportUpdateTx(ctx, db, r); err != nil {
-		t.Fatalf("ImportUpdateTx enable: %v", err)
+	if !r.Enabled {
+		t.Fatalf("baseline: seeded rule should be enabled, got Enabled=false")
 	}
+
+	// Seed a synthetic artist + rule_results row so cleanupDisabledRuleStateTx
+	// has an observable side effect (it removes the row from rule_results
+	// for the disabled rule). FK on rule_results.artist_id forces the
+	// artist insert.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO artists (id, name, sort_name, path, created_at, updated_at)
+		 VALUES ('cleanup-test-artist', 'Cleanup Test', 'cleanup test', '/tmp/cleanup-test-artist', ?, ?)`,
+		time.Now().UTC().Format(time.RFC3339), time.Now().UTC().Format(time.RFC3339),
+	); err != nil {
+		t.Fatalf("seeding artist row: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO rule_results (artist_id, rule_id, passed, evaluated_at)
+		 VALUES ('cleanup-test-artist', ?, 0, ?)`,
+		RuleThumbExists, time.Now().UTC().Format(time.RFC3339),
+	); err != nil {
+		t.Fatalf("seeding rule_results row: %v", err)
+	}
+
 	r.Enabled = false
 	if err := svc.ImportUpdateTx(ctx, db, r); err != nil {
 		t.Fatalf("ImportUpdateTx disable: %v", err)
+	}
+	disabled, err := svc.GetByID(ctx, RuleThumbExists)
+	if err != nil {
+		t.Fatalf("GetByID after disable: %v", err)
+	}
+	if disabled.Enabled {
+		t.Errorf("Enabled should be false after disable; got true")
+	}
+	// Cleanup post-condition: the seeded rule_results row must be gone.
+	var cnt int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM rule_results WHERE rule_id = ?`, RuleThumbExists,
+	).Scan(&cnt); err != nil {
+		t.Fatalf("counting rule_results after disable: %v", err)
+	}
+	if cnt != 0 {
+		t.Errorf("rule_results rows for disabled rule: got %d, want 0", cnt)
 	}
 }
 
@@ -99,8 +136,27 @@ func TestImportUpdateTx_EnabledRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetByID: %v", err)
 	}
-	r.AutomationMode = AutomationModeAuto
+	// Capture the seeded baseline. The test asserts state transitions
+	// relative to the captured values rather than hardcoded constants so
+	// future changes to the rule seeds do not produce false-positive
+	// failures here.
+	baselineEnabled := r.Enabled
+	baselineMode := r.AutomationMode
+	if !baselineEnabled {
+		t.Fatalf("baseline: seeded RuleThumbExists should be enabled, got Enabled=false")
+	}
+
+	// Pick a target AutomationMode that differs from the baseline so the
+	// transition is observable. AutomationModeManual is the broadest non-
+	// auto value; flip to auto if baseline is already manual, otherwise
+	// flip to manual.
+	targetMode := AutomationModeAuto
+	if baselineMode == AutomationModeAuto {
+		targetMode = AutomationModeManual
+	}
+
 	r.Enabled = false
+	r.AutomationMode = targetMode
 	if err := svc.ImportUpdateTx(ctx, db, r); err != nil {
 		t.Fatalf("ImportUpdateTx: %v", err)
 	}
@@ -110,9 +166,19 @@ func TestImportUpdateTx_EnabledRoundTrip(t *testing.T) {
 		t.Fatalf("reload after ImportUpdateTx: %v", err)
 	}
 	if reloaded.Enabled {
-		t.Error("Enabled should be false after ImportUpdateTx")
+		t.Errorf("Enabled should have flipped to false; got true (baseline was %v)", baselineEnabled)
 	}
-	if reloaded.AutomationMode != AutomationModeAuto {
-		t.Errorf("AutomationMode: got %q, want %q", reloaded.AutomationMode, AutomationModeAuto)
+	if reloaded.AutomationMode != targetMode {
+		t.Errorf("AutomationMode should have flipped to %q; got %q (baseline was %q)", targetMode, reloaded.AutomationMode, baselineMode)
+	}
+}
+
+// TestImportUpdateTx_NilArg pins the defensive nil-guard on the tx-aware
+// import path.
+func TestImportUpdateTx_NilArg(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	if err := svc.ImportUpdateTx(context.Background(), db, nil); err == nil {
+		t.Fatal("expected error for nil rule, got nil")
 	}
 }

--- a/internal/rule/import_test.go
+++ b/internal/rule/import_test.go
@@ -1,0 +1,118 @@
+package rule
+
+// import_test.go exercises the tx-aware import helpers added for #1693.
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestImportGetByIDTx_RoundTrip verifies the tx-aware reader returns a
+// seeded default rule.
+func TestImportGetByIDTx_RoundTrip(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	if err := svc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+
+	got, err := svc.ImportGetByIDTx(ctx, db, RuleThumbExists)
+	if err != nil {
+		t.Fatalf("ImportGetByIDTx: %v", err)
+	}
+	if got.ID != RuleThumbExists {
+		t.Errorf("rule id: got %q, want %q", got.ID, RuleThumbExists)
+	}
+}
+
+// TestImportGetByIDTx_NotFound pins the ErrNotFound contract so the
+// orchestrator's skip-unknown-id branch keeps working.
+func TestImportGetByIDTx_NotFound(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	if err := svc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+
+	_, err := svc.ImportGetByIDTx(ctx, db, "future_unknown_rule")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// TestImportGetByIDTx_DBError verifies that a closed-DB lookup propagates
+// as an error (not a silent ErrNotFound that would mask data loss).
+func TestImportGetByIDTx_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	_ = db.Close()
+	_, err := svc.ImportGetByIDTx(context.Background(), db, RuleThumbExists)
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Errorf("closed-DB error must not masquerade as ErrNotFound: %v", err)
+	}
+}
+
+// TestImportUpdateTx_DisabledRuleCleansUp exercises the cleanupDisabledRuleStateTx
+// branch by disabling a rule and asserting the helper ran without error.
+func TestImportUpdateTx_DisabledRuleCleansUp(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	if err := svc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+
+	r, err := svc.GetByID(ctx, RuleThumbExists)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	// Already-disabled by default; flip enabled true then back to false
+	// to force the cleanup path.
+	r.Enabled = true
+	if err := svc.ImportUpdateTx(ctx, db, r); err != nil {
+		t.Fatalf("ImportUpdateTx enable: %v", err)
+	}
+	r.Enabled = false
+	if err := svc.ImportUpdateTx(ctx, db, r); err != nil {
+		t.Fatalf("ImportUpdateTx disable: %v", err)
+	}
+}
+
+// TestImportUpdateTx_EnabledRoundTrip writes a rule via the tx-aware update
+// path and reads it back through the standard List/Get path to confirm the
+// row was modified.
+func TestImportUpdateTx_EnabledRoundTrip(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	if err := svc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("SeedDefaults: %v", err)
+	}
+
+	r, err := svc.GetByID(ctx, RuleThumbExists)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	r.AutomationMode = AutomationModeAuto
+	r.Enabled = false
+	if err := svc.ImportUpdateTx(ctx, db, r); err != nil {
+		t.Fatalf("ImportUpdateTx: %v", err)
+	}
+
+	reloaded, err := svc.GetByID(ctx, RuleThumbExists)
+	if err != nil {
+		t.Fatalf("reload after ImportUpdateTx: %v", err)
+	}
+	if reloaded.Enabled {
+		t.Error("Enabled should be false after ImportUpdateTx")
+	}
+	if reloaded.AutomationMode != AutomationModeAuto {
+		t.Errorf("AutomationMode: got %q, want %q", reloaded.AutomationMode, AutomationModeAuto)
+	}
+}

--- a/internal/scraper/import.go
+++ b/internal/scraper/import.go
@@ -1,0 +1,80 @@
+package scraper
+
+// import.go contains the tx-aware helpers used by the settingsio import
+// orchestrator (#1693). They mirror the SQL of SaveConfig but accept a
+// DBExecutor so the orchestrator can run them inside its own transaction; a
+// mid-import failure then rolls back the scraper config writes alongside
+// every other section's writes.
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DBExecutor is the subset of *sql.DB used by the tx-aware scraper import
+// helpers. Both *sql.DB and *sql.Tx satisfy it.
+type DBExecutor interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// ImportSaveConfigTx is the tx-aware equivalent of SaveConfig. It performs
+// the same upsert (resolving cfg.ID from any pre-existing row for the scope)
+// but reads and writes through the supplied executor.
+func (s *Service) ImportSaveConfigTx(ctx context.Context, db DBExecutor, scope string, cfg *ScraperConfig, overrides *Overrides) error {
+	cfg.Scope = scope
+	if cfg.ID == "" {
+		var existingID string
+		err := db.QueryRowContext(ctx,
+			"SELECT id FROM scraper_config WHERE scope = ?", scope,
+		).Scan(&existingID)
+		if errors.Is(err, sql.ErrNoRows) {
+			cfg.ID = uuid.New().String()
+		} else if err != nil {
+			return fmt.Errorf("checking existing config: %w", err)
+		} else {
+			cfg.ID = existingID
+		}
+	}
+	return saveConfigRowTx(ctx, db, cfg, overrides)
+}
+
+// saveConfigRowTx mirrors saveConfigRow but writes through the supplied
+// executor.
+func saveConfigRowTx(ctx context.Context, db DBExecutor, cfg *ScraperConfig, overrides *Overrides) error {
+	configJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	overridesJSON := "{}"
+	if overrides != nil {
+		data, err := json.Marshal(overrides)
+		if err != nil {
+			return fmt.Errorf("marshaling overrides: %w", err)
+		}
+		overridesJSON = string(data)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO scraper_config (id, scope, config_json, overrides_json, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(scope) DO UPDATE SET
+			config_json = ?,
+			overrides_json = ?,
+			updated_at = ?
+	`, cfg.ID, cfg.Scope, string(configJSON), overridesJSON, now, now,
+		string(configJSON), overridesJSON, now)
+	if err != nil {
+		return fmt.Errorf("saving config for scope %q: %w", cfg.Scope, err)
+	}
+	return nil
+}

--- a/internal/scraper/import.go
+++ b/internal/scraper/import.go
@@ -29,6 +29,9 @@ type DBExecutor interface {
 // the same upsert (resolving cfg.ID from any pre-existing row for the scope)
 // but reads and writes through the supplied executor.
 func (s *Service) ImportSaveConfigTx(ctx context.Context, db DBExecutor, scope string, cfg *ScraperConfig, overrides *Overrides) error {
+	if cfg == nil {
+		return fmt.Errorf("scraper config is required")
+	}
 	cfg.Scope = scope
 	if cfg.ID == "" {
 		var existingID string

--- a/internal/scraper/import_test.go
+++ b/internal/scraper/import_test.go
@@ -5,6 +5,7 @@ package scraper
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -96,7 +97,11 @@ func TestImportSaveConfigTx_ExistingScopePreservesID(t *testing.T) {
 func TestImportSaveConfigTx_NilArg(t *testing.T) {
 	db := setupTestDB(t)
 	svc := NewService(db, slog.Default())
-	if err := svc.ImportSaveConfigTx(context.Background(), db, "scope", nil, nil); err == nil {
+	err := svc.ImportSaveConfigTx(context.Background(), db, "scope", nil, nil)
+	if err == nil {
 		t.Fatal("expected error for nil cfg, got nil")
+	}
+	if !strings.Contains(err.Error(), "scraper config is required") {
+		t.Fatalf("expected nil-guard error, got: %v", err)
 	}
 }

--- a/internal/scraper/import_test.go
+++ b/internal/scraper/import_test.go
@@ -1,0 +1,92 @@
+package scraper
+
+// import_test.go exercises the tx-aware import helpers added for #1693.
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+// TestImportSaveConfigTx_NewScopeAssignsID verifies that a fresh scope gets
+// a UUID assigned and the row is written through the supplied executor.
+func TestImportSaveConfigTx_NewScopeAssignsID(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db, slog.Default())
+	ctx := context.Background()
+
+	cfg := &ScraperConfig{}
+	if err := svc.ImportSaveConfigTx(ctx, db, "import-tx-scope", cfg, nil); err != nil {
+		t.Fatalf("ImportSaveConfigTx: %v", err)
+	}
+	if cfg.ID == "" {
+		t.Fatal("ImportSaveConfigTx must assign an ID for a new scope")
+	}
+
+	loaded, _, err := svc.GetRawConfig(ctx, "import-tx-scope")
+	if err != nil {
+		t.Fatalf("GetRawConfig: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("GetRawConfig returned nil; scope should exist")
+	}
+}
+
+// TestImportSaveConfigTx_DBError verifies that executor failures propagate
+// as errors. Covers both the lookup-existing-id error path and the eventual
+// INSERT error path.
+func TestImportSaveConfigTx_DBError(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db, slog.Default())
+	_ = db.Close()
+	err := svc.ImportSaveConfigTx(context.Background(), db, "closed-scope",
+		&ScraperConfig{}, nil)
+	if err == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportSaveConfigTx_WithOverrides exercises the overrides-not-nil
+// branch in saveConfigRowTx.
+func TestImportSaveConfigTx_WithOverrides(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db, slog.Default())
+	ctx := context.Background()
+
+	cfg := &ScraperConfig{}
+	overrides := &Overrides{Fields: map[FieldName]bool{FieldBiography: true}}
+	if err := svc.ImportSaveConfigTx(ctx, db, "with-overrides", cfg, overrides); err != nil {
+		t.Fatalf("ImportSaveConfigTx: %v", err)
+	}
+	_, gotOverrides, err := svc.GetRawConfig(ctx, "with-overrides")
+	if err != nil {
+		t.Fatalf("GetRawConfig: %v", err)
+	}
+	if gotOverrides == nil || !gotOverrides.Fields[FieldBiography] {
+		t.Errorf("overrides not persisted: %+v", gotOverrides)
+	}
+}
+
+// TestImportSaveConfigTx_ExistingScopePreservesID verifies the upsert path:
+// passing a cfg without an ID for an existing scope must reuse the existing
+// row instead of inserting a duplicate (the original SaveConfig contract).
+func TestImportSaveConfigTx_ExistingScopePreservesID(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db, slog.Default())
+	ctx := context.Background()
+
+	first := &ScraperConfig{}
+	if err := svc.ImportSaveConfigTx(ctx, db, "tx-upsert-scope", first, nil); err != nil {
+		t.Fatalf("first ImportSaveConfigTx: %v", err)
+	}
+	originalID := first.ID
+
+	// Second call with an empty cfg.ID must reuse the existing row's ID.
+	second := &ScraperConfig{}
+	if err := svc.ImportSaveConfigTx(ctx, db, "tx-upsert-scope", second, nil); err != nil {
+		t.Fatalf("second ImportSaveConfigTx: %v", err)
+	}
+	if second.ID != originalID {
+		t.Errorf("second call ID: got %q, want %q (upsert must preserve existing id)", second.ID, originalID)
+	}
+}

--- a/internal/scraper/import_test.go
+++ b/internal/scraper/import_test.go
@@ -90,3 +90,13 @@ func TestImportSaveConfigTx_ExistingScopePreservesID(t *testing.T) {
 		t.Errorf("second call ID: got %q, want %q (upsert must preserve existing id)", second.ID, originalID)
 	}
 }
+
+// TestImportSaveConfigTx_NilArg pins the defensive nil-guard on the
+// tx-aware import path.
+func TestImportSaveConfigTx_NilArg(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db, slog.Default())
+	if err := svc.ImportSaveConfigTx(context.Background(), db, "scope", nil, nil); err == nil {
+		t.Fatal("expected error for nil cfg, got nil")
+	}
+}

--- a/internal/settingsio/atomicity_test.go
+++ b/internal/settingsio/atomicity_test.go
@@ -115,6 +115,16 @@ func TestImport_AtomicAcrossAllSections(t *testing.T) {
 		t.Fatalf("seeding target user: %v", err)
 	}
 
+	// Capture the target's pre-import baseline value for the priority row
+	// so the post-rollback assertion compares against actual state, not a
+	// hardcoded seed string that drifts when future migrations change the
+	// default.
+	var baselineBiographyPriority string
+	if err := db2.QueryRowContext(ctx,
+		`SELECT value FROM settings WHERE key = 'provider.priority.biography'`).Scan(&baselineBiographyPriority); err != nil {
+		t.Fatalf("reading baseline provider priority: %v", err)
+	}
+
 	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2).
 		WithRuleService(ruleSvc2).
 		WithScraperService(scraperSvc2)
@@ -180,19 +190,16 @@ func TestImport_AtomicAcrossAllSections(t *testing.T) {
 	})
 	t.Run("provider priority rolled back", func(t *testing.T) {
 		// Migration 001 seeds default priority rows so absence-of-row is
-		// the wrong probe. Capture the post-rollback value and assert it
-		// matches the migration default, not the envelope's
-		// "musicbrainz,wikipedia" list.
+		// the wrong probe. Assert the post-rollback value matches the
+		// baseline captured before Import ran, not a hardcoded seed
+		// string that drifts when future migrations change the default.
 		var got string
 		if err := db2.QueryRowContext(ctx,
 			`SELECT value FROM settings WHERE key = 'provider.priority.biography'`).Scan(&got); err != nil {
 			t.Fatalf("reading priority row: %v", err)
 		}
-		// The migration seeds biography with musicbrainz/lastfm/audiodb/discogs.
-		// PR #1438 removed wikidata; the envelope was musicbrainz/wikipedia
-		// which is clearly distinct from the migration default.
-		if got != `["musicbrainz","lastfm","audiodb","discogs"]` {
-			t.Errorf("provider priority committed despite import failure: got %q", got)
+		if got != baselineBiographyPriority {
+			t.Errorf("provider priority committed despite import failure: got %q, want baseline %q", got, baselineBiographyPriority)
 		}
 	})
 	t.Run("settings KV rolled back", func(t *testing.T) {
@@ -239,7 +246,11 @@ func TestImport_AtomicSameSectionRollback(t *testing.T) {
 	conns := []ConnectionExport{
 		{Name: "TxBoundConn", Type: "emby", URL: "http://txbound.example:8096", APIKey: "k", Enabled: true},
 	}
-	if err := svc.importConnections(ctx, tx, conns, &ImportResult{}, true, true); err != nil {
+	const (
+		carryV15Fields    = true // envelope is v1.5+ (irrelevant here; new row)
+		overwriteExisting = true // standard import semantics
+	)
+	if err := svc.importConnections(ctx, tx, conns, &ImportResult{}, carryV15Fields, overwriteExisting); err != nil {
 		_ = tx.Rollback()
 		t.Fatalf("importConnections inside tx: %v", err)
 	}

--- a/internal/settingsio/atomicity_test.go
+++ b/internal/settingsio/atomicity_test.go
@@ -54,6 +54,41 @@ func TestImport_AtomicAcrossAllSections(t *testing.T) {
 	); err != nil {
 		t.Fatalf("seeding settings: %v", err)
 	}
+	// Flip a default rule's Enabled flag on the source so the exported
+	// bundle carries a non-default value for it. Without this the rule
+	// upsert is a no-op on a target that ran the same SeedDefaults, and
+	// the rollback assertion would not actually exercise importRules.
+	srcRules, err := ruleSvc.List(ctx)
+	if err != nil {
+		t.Fatalf("listing source rules: %v", err)
+	}
+	if len(srcRules) == 0 {
+		t.Fatal("source rule list is empty; SeedDefaults regression")
+	}
+	mutatedRuleID := srcRules[0].ID
+	srcRules[0].Enabled = !srcRules[0].Enabled
+	if err := ruleSvc.Update(ctx, &srcRules[0]); err != nil {
+		t.Fatalf("mutating source rule: %v", err)
+	}
+	// Mutate the source's global scraper config so the exported bundle
+	// carries a non-default scope row. Same rationale as the rule mutation
+	// above: identical defaults on source and target mean no observable
+	// import without divergence first.
+	srcScraper, err := scraperSvc.GetConfig(ctx, "global")
+	if err != nil {
+		t.Fatalf("reading source scraper global: %v", err)
+	}
+	if len(srcScraper.FallbackChains) > 0 && len(srcScraper.FallbackChains[0].Providers) >= 2 {
+		// Swap the first two providers in the first fallback chain --
+		// observable change, no schema risk.
+		p := srcScraper.FallbackChains[0].Providers
+		p[0], p[1] = p[1], p[0]
+	} else {
+		t.Fatal("source scraper config missing expected fallback chain; SeedDefaults regression")
+	}
+	if err := scraperSvc.SaveConfig(ctx, "global", srcScraper, nil); err != nil {
+		t.Fatalf("mutating source scraper config: %v", err)
+	}
 	if err := connSvc.Create(ctx, &connection.Connection{
 		Name: "AtomicSrcConn", Type: "emby", URL: "http://atomic.example:8096",
 		APIKey: "atomic-src-key", Enabled: true,
@@ -85,6 +120,17 @@ func TestImport_AtomicAcrossAllSections(t *testing.T) {
 		"src-collide-id", "alice", "administrator",
 	); err != nil {
 		t.Fatalf("seeding source user: %v", err)
+	}
+	// Seed a user_preferences row tied to the source alice. importUsers
+	// fails before importUserPreferences runs, so the rollback assertion
+	// below verifies that no preferences row leaked onto the target via
+	// any path.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO user_preferences (user_id, key, value, updated_at)
+		 VALUES (?, ?, ?, datetime('now'))`,
+		"src-collide-id", "atomicity.test.pref", "atomicity.test.pref.value",
+	); err != nil {
+		t.Fatalf("seeding source user preference: %v", err)
 	}
 
 	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).
@@ -124,6 +170,26 @@ func TestImport_AtomicAcrossAllSections(t *testing.T) {
 		`SELECT value FROM settings WHERE key = 'provider.priority.biography'`).Scan(&baselineBiographyPriority); err != nil {
 		t.Fatalf("reading baseline provider priority: %v", err)
 	}
+	// Capture the target's pre-import baseline for the mutated rule and
+	// the global scraper config so the post-rollback assertions compare
+	// against actual state, not a hardcoded default that future
+	// SeedDefaults edits might drift away from.
+	baselineRule, err := ruleSvc2.GetByID(ctx, mutatedRuleID)
+	if err != nil {
+		t.Fatalf("reading baseline rule: %v", err)
+	}
+	if baselineRule == nil {
+		t.Fatal("baseline rule not found on target; SeedDefaults regression")
+	}
+	baselineEnabled := baselineRule.Enabled
+	baselineScraper, err := scraperSvc2.GetConfig(ctx, "global")
+	if err != nil {
+		t.Fatalf("reading baseline scraper global: %v", err)
+	}
+	if len(baselineScraper.FallbackChains) == 0 || len(baselineScraper.FallbackChains[0].Providers) < 2 {
+		t.Fatal("baseline scraper config missing expected fallback chain on target")
+	}
+	baselineFirstProvider := baselineScraper.FallbackChains[0].Providers[0]
 
 	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2).
 		WithRuleService(ruleSvc2).
@@ -137,10 +203,14 @@ func TestImport_AtomicAcrossAllSections(t *testing.T) {
 		t.Fatalf("Import: expected ErrUserIDCollision wrapped, got %v", err)
 	}
 
-	// Single-tx atomicity: ImportResult counters must reset to zero on
-	// rollback so callers do not see partial counts.
-	if result != nil && (*result != ImportResult{}) {
-		t.Errorf("ImportResult must reset to zero on rollback; got %+v", *result)
+	// Single-tx atomicity: Import returns a nil *ImportResult on rollback
+	// so callers never see partial counts paired with an error. (The defer
+	// in ImportWithOptions also zeroes the heap-allocated result for
+	// defensive reasons, but that copy is never returned on the error path
+	// -- the function literal-returns nil. Assert the visible contract:
+	// nil result on every rollback path.)
+	if result != nil {
+		t.Errorf("ImportResult must be nil on rollback; got %+v", *result)
 	}
 
 	// Now the actual atomicity assertions: every section that ran BEFORE
@@ -220,6 +290,53 @@ func TestImport_AtomicAcrossAllSections(t *testing.T) {
 		}
 		if id != "target-collide-id" || role != "operator" {
 			t.Errorf("target alice mutated despite import failure: id=%q role=%q", id, role)
+		}
+	})
+	t.Run("rules rolled back", func(t *testing.T) {
+		// importRules runs before importUsers, so the mutated rule from
+		// the source would have been written into the tx and must be
+		// rolled back when importUsers fails.
+		got, err := ruleSvc2.GetByID(ctx, mutatedRuleID)
+		if err != nil {
+			t.Fatalf("reading target rule: %v", err)
+		}
+		if got == nil {
+			t.Fatal("target rule disappeared after rollback")
+		}
+		if got.Enabled != baselineEnabled {
+			t.Errorf("rule committed despite import failure: enabled=%v, want baseline %v",
+				got.Enabled, baselineEnabled)
+		}
+	})
+	t.Run("scraper config rolled back", func(t *testing.T) {
+		// importScraperPreferences runs before importUsers, so the source's
+		// swapped fallback chain would have been written into the tx and
+		// must be rolled back when importUsers fails.
+		got, err := scraperSvc2.GetConfig(ctx, "global")
+		if err != nil {
+			t.Fatalf("reading target scraper global: %v", err)
+		}
+		if len(got.FallbackChains) == 0 || len(got.FallbackChains[0].Providers) < 2 {
+			t.Fatal("target scraper fallback chain shape changed unexpectedly")
+		}
+		if got.FallbackChains[0].Providers[0] != baselineFirstProvider {
+			t.Errorf("scraper config committed despite import failure: first provider %q, want baseline %q",
+				got.FallbackChains[0].Providers[0], baselineFirstProvider)
+		}
+	})
+	t.Run("user preferences rolled back", func(t *testing.T) {
+		// importUserPreferences runs AFTER importUsers in the orchestrator,
+		// so the failing importUsers call should mean the source's pref
+		// row never even reached the target. This assertion guards against
+		// future reorderings that move user_preferences before users.
+		var count int
+		if err := db2.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM user_preferences WHERE user_id = ?`,
+			"src-collide-id").Scan(&count); err != nil {
+			t.Fatalf("counting target user_preferences: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("user preference committed despite import failure: count=%d", count)
 		}
 	})
 }

--- a/internal/settingsio/atomicity_test.go
+++ b/internal/settingsio/atomicity_test.go
@@ -1,0 +1,261 @@
+package settingsio
+
+// atomicity_test.go pins the #1693 invariant: when ImportWithOptions fails
+// mid-stream, none of the prior sections' rows commit to the target. The
+// pre-fix code had a two-phase split where the first phase's writes
+// (connections, platform profiles, webhooks, provider keys, priorities,
+// rules, scraper preferences) persisted even if the second phase aborted,
+// leaving the operator with a half-applied configuration.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/connection"
+	"github.com/sydlexius/stillwater/internal/platform"
+	"github.com/sydlexius/stillwater/internal/provider"
+	"github.com/sydlexius/stillwater/internal/rule"
+	"github.com/sydlexius/stillwater/internal/scraper"
+	"github.com/sydlexius/stillwater/internal/webhook"
+
+	"log/slog"
+)
+
+// TestImport_AtomicAcrossAllSections is the headline test for #1693. The
+// envelope exercises every section the orchestrator drives (connections,
+// platform profiles, webhooks, provider keys, priorities, rules, scraper,
+// settings, users, user_preferences). The target is pre-seeded so the
+// envelope's user collides with a DIFFERENT id under the same username,
+// which makes importUsers fail with ErrUserIDCollision. Because importUsers
+// runs AFTER the previously-pre-tx sections (connections, platform
+// profiles, webhooks, etc.), this test would have passed on the old code
+// for the post-importUsers sections only -- the pre-tx sections would have
+// committed and the assertions below would fail. The single-tx orchestrator
+// must roll all of them back.
+func TestImport_AtomicAcrossAllSections(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	ruleSvc := rule.NewService(db)
+	scraperSvc := scraper.NewService(db, slog.Default())
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+	if err := scraperSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding scraper: %v", err)
+	}
+
+	// Seed the source DB with one row of every export-able shape.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO settings (key, value) VALUES (?, ?)`,
+		"atomicity.test.key", "atomicity.test.value",
+	); err != nil {
+		t.Fatalf("seeding settings: %v", err)
+	}
+	if err := connSvc.Create(ctx, &connection.Connection{
+		Name: "AtomicSrcConn", Type: "emby", URL: "http://atomic.example:8096",
+		APIKey: "atomic-src-key", Enabled: true,
+	}); err != nil {
+		t.Fatalf("seeding source connection: %v", err)
+	}
+	if err := platSvc.Create(ctx, &platform.Profile{
+		Name: "AtomicSrcProfile", NFOEnabled: true, NFOFormat: "kodi",
+	}); err != nil {
+		t.Fatalf("seeding source profile: %v", err)
+	}
+	if err := whSvc.Create(ctx, &webhook.Webhook{
+		Name: "AtomicSrcHook", URL: "https://atomic.example/hook", Type: "generic",
+		Events: []string{"artist.new"}, Enabled: true,
+	}); err != nil {
+		t.Fatalf("seeding source webhook: %v", err)
+	}
+	if err := provSettings.SetAPIKey(ctx, provider.NameFanartTV, "atomic-fanart-key"); err != nil {
+		t.Fatalf("seeding source provider key: %v", err)
+	}
+	if err := provSettings.SetPriority(ctx, "biography",
+		[]provider.ProviderName{provider.NameMusicBrainz, provider.NameWikipedia}); err != nil {
+		t.Fatalf("seeding source priority: %v", err)
+	}
+	// Seed the source user that will collide on the target. The exported
+	// envelope brings id=src-collide-id under username=alice.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO users (id, username, role) VALUES (?, ?, ?)`,
+		"src-collide-id", "alice", "administrator",
+	); err != nil {
+		t.Fatalf("seeding source user: %v", err)
+	}
+
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).
+		WithRuleService(ruleSvc).
+		WithScraperService(scraperSvc)
+	envelope, err := svc.Export(ctx, "atomicity-passphrase")
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	// Build a fresh target. Pre-seed alice under a DIFFERENT id so
+	// importUsers fails with ErrUserIDCollision after every other section
+	// has already executed inside the orchestrator's tx.
+	db2 := setupTestDB(t)
+	provSettings2, connSvc2, platSvc2, whSvc2 := newTestServices(t, db2)
+	ruleSvc2 := rule.NewService(db2)
+	scraperSvc2 := scraper.NewService(db2, slog.Default())
+	if err := ruleSvc2.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding target rules: %v", err)
+	}
+	if err := scraperSvc2.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding target scraper: %v", err)
+	}
+	if _, err := db2.ExecContext(ctx,
+		`INSERT INTO users (id, username, role) VALUES (?, ?, ?)`,
+		"target-collide-id", "alice", "operator",
+	); err != nil {
+		t.Fatalf("seeding target user: %v", err)
+	}
+
+	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2).
+		WithRuleService(ruleSvc2).
+		WithScraperService(scraperSvc2)
+
+	result, err := svc2.Import(ctx, envelope, "atomicity-passphrase")
+	if err == nil {
+		t.Fatal("Import: expected ErrUserIDCollision, got nil")
+	}
+	if !errors.Is(err, ErrUserIDCollision) {
+		t.Fatalf("Import: expected ErrUserIDCollision wrapped, got %v", err)
+	}
+
+	// Single-tx atomicity: ImportResult counters must reset to zero on
+	// rollback so callers do not see partial counts.
+	if result != nil && (*result != ImportResult{}) {
+		t.Errorf("ImportResult must reset to zero on rollback; got %+v", *result)
+	}
+
+	// Now the actual atomicity assertions: every section that ran BEFORE
+	// importUsers must have rolled back. The target should be in its
+	// pre-import state.
+	t.Run("connections rolled back", func(t *testing.T) {
+		var count int
+		if err := db2.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM connections WHERE name = 'AtomicSrcConn'`).Scan(&count); err != nil {
+			t.Fatalf("counting connections: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("connection committed despite import failure: count=%d", count)
+		}
+	})
+	t.Run("platform profiles rolled back", func(t *testing.T) {
+		var count int
+		if err := db2.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM platform_profiles WHERE name = 'AtomicSrcProfile'`).Scan(&count); err != nil {
+			t.Fatalf("counting profiles: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("platform profile committed despite import failure: count=%d", count)
+		}
+	})
+	t.Run("webhooks rolled back", func(t *testing.T) {
+		var count int
+		if err := db2.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM webhooks WHERE name = 'AtomicSrcHook'`).Scan(&count); err != nil {
+			t.Fatalf("counting webhooks: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("webhook committed despite import failure: count=%d", count)
+		}
+	})
+	t.Run("provider key rolled back", func(t *testing.T) {
+		// The key may or may not be present depending on what the target
+		// already had. We seeded nothing on the target so the row must be
+		// absent.
+		has, err := provSettings2.HasAPIKey(ctx, provider.NameFanartTV)
+		if err != nil {
+			t.Fatalf("HasAPIKey: %v", err)
+		}
+		if has {
+			t.Error("provider key committed despite import failure")
+		}
+	})
+	t.Run("provider priority rolled back", func(t *testing.T) {
+		// Migration 001 seeds default priority rows so absence-of-row is
+		// the wrong probe. Capture the post-rollback value and assert it
+		// matches the migration default, not the envelope's
+		// "musicbrainz,wikipedia" list.
+		var got string
+		if err := db2.QueryRowContext(ctx,
+			`SELECT value FROM settings WHERE key = 'provider.priority.biography'`).Scan(&got); err != nil {
+			t.Fatalf("reading priority row: %v", err)
+		}
+		// The migration seeds biography with musicbrainz/lastfm/audiodb/discogs.
+		// PR #1438 removed wikidata; the envelope was musicbrainz/wikipedia
+		// which is clearly distinct from the migration default.
+		if got != `["musicbrainz","lastfm","audiodb","discogs"]` {
+			t.Errorf("provider priority committed despite import failure: got %q", got)
+		}
+	})
+	t.Run("settings KV rolled back", func(t *testing.T) {
+		var count int
+		if err := db2.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM settings WHERE key = 'atomicity.test.key'`).Scan(&count); err != nil {
+			t.Fatalf("counting setting: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("setting committed despite import failure: count=%d", count)
+		}
+	})
+	t.Run("target alice unchanged", func(t *testing.T) {
+		var id, role string
+		if err := db2.QueryRowContext(ctx,
+			`SELECT id, role FROM users WHERE username = 'alice'`).Scan(&id, &role); err != nil {
+			t.Fatalf("scanning target alice: %v", err)
+		}
+		if id != "target-collide-id" || role != "operator" {
+			t.Errorf("target alice mutated despite import failure: id=%q role=%q", id, role)
+		}
+	})
+}
+
+// TestImport_AtomicSameSectionRollback verifies that writes performed by
+// a tx-aware importer helper do not persist when the surrounding
+// transaction is rolled back without committing. This isolates the
+// rollback boundary on a single helper (importConnections) using an
+// explicit BeginTx / Rollback, complementing the broader cross-section
+// test in TestImport_AtomicAcrossAllSections.
+func TestImport_AtomicSameSectionRollback(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	// Use importConnections directly inside our own tx, then deliberately
+	// fail the import by rolling back the tx -- this proves the tx-aware
+	// helpers honor the rollback boundary.
+	conns := []ConnectionExport{
+		{Name: "TxBoundConn", Type: "emby", URL: "http://txbound.example:8096", APIKey: "k", Enabled: true},
+	}
+	if err := svc.importConnections(ctx, tx, conns, &ImportResult{}, true, true); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("importConnections inside tx: %v", err)
+	}
+	// Roll back without committing.
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+
+	// The connection must not be visible outside the tx because the tx
+	// rolled back.
+	var count int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM connections WHERE name = 'TxBoundConn'`).Scan(&count); err != nil {
+		t.Fatalf("counting connections: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("connection committed despite tx rollback: count=%d", count)
+	}
+}

--- a/internal/settingsio/export.go
+++ b/internal/settingsio/export.go
@@ -92,6 +92,10 @@ func envelopeCarriesConnectionV14Fields(envelopeVersion string) bool {
 // would silently disable a Lidarr verify toggle the operator had set. Returning
 // false here lets importConnections preserve the target's existing value
 // instead.
+//
+// When introducing a v1.6+ envelope that ALSO carries VerifyPathAfterUpdate,
+// add the new version to the case below. New schema bumps that drop the field
+// (unlikely) need their own gating function rather than reusing this one.
 func envelopeCarriesConnectionV15Fields(envelopeVersion string) bool {
 	switch envelopeVersion {
 	case "1.5":

--- a/internal/settingsio/export.go
+++ b/internal/settingsio/export.go
@@ -45,7 +45,12 @@ const pbkdf2Iterations = 600_000
 //     a different id can fail the import instead of silently remapping.
 //     Restore-from-OOBE flows also rely on the id stability so a restored
 //     backup keeps every downstream reference intact.
-const CurrentEnvelopeVersion = "1.4"
+//   - "1.5": adds verify_path_after_update to ConnectionExport so the
+//     Lidarr post-update path-verification opt-in survives export/import
+//     (#1692). Pre-1.5 envelopes lack the field, so legacy imports must
+//     preserve the target's existing value instead of clobbering it with
+//     a decoded zero.
+const CurrentEnvelopeVersion = "1.5"
 
 // supportedEnvelopeVersions lists the envelope versions Import will accept.
 // Older versions are accepted for backward compatibility (their newer fields
@@ -56,6 +61,7 @@ var supportedEnvelopeVersions = map[string]bool{
 	"1.2": true,
 	"1.3": true,
 	"1.4": true,
+	"1.5": true,
 }
 
 // envelopeCarriesConnectionV14Fields reports whether an envelope of the given
@@ -72,7 +78,23 @@ var supportedEnvelopeVersions = map[string]bool{
 // out to avoid shadowing the imported `version` package.
 func envelopeCarriesConnectionV14Fields(envelopeVersion string) bool {
 	switch envelopeVersion {
-	case "1.4":
+	case "1.4", "1.5":
+		return true
+	default:
+		return false
+	}
+}
+
+// envelopeCarriesConnectionV15Fields reports whether an envelope of the given
+// version is known to carry the v1.5 connection feature field
+// (VerifyPathAfterUpdate). Pre-1.5 envelopes lack the field, so deserializing
+// leaves it at its zero value; copying that zero onto an existing target row
+// would silently disable a Lidarr verify toggle the operator had set. Returning
+// false here lets importConnections preserve the target's existing value
+// instead.
+func envelopeCarriesConnectionV15Fields(envelopeVersion string) bool {
+	switch envelopeVersion {
+	case "1.5":
 		return true
 	default:
 		return false
@@ -141,6 +163,7 @@ type ConnectionExport struct {
 	FeatureMetadataPush      bool   `json:"feature_metadata_push,omitempty"`
 	FeatureTriggerRefresh    bool   `json:"feature_trigger_refresh,omitempty"`
 	FeatureManageServerFiles bool   `json:"feature_manage_server_files,omitempty"`
+	VerifyPathAfterUpdate    bool   `json:"verify_path_after_update,omitempty"`
 	PreStillwaterConfigJSON  string `json:"pre_stillwater_config_json,omitempty"`
 	PlatformUserID           string `json:"platform_user_id,omitempty"`
 	PlatformServerID         string `json:"platform_server_id,omitempty"`
@@ -240,16 +263,12 @@ type ImportOptions struct {
 	ImportingAdminUserID string
 }
 
-// dbExecutor is the subset of *sql.DB used by the s.db-direct import
-// helpers (importSettings, importUsers, importUserPreferences,
-// importLibraries, importAPITokens). Both *sql.DB and *sql.Tx satisfy it,
-// so the helpers can run either standalone or inside a transaction the
-// orchestrator opens. The delegated sub-imports (importConnections,
-// importPlatformProfiles, importWebhooks, importProviderKeys,
-// importProviderPriorities, importRules, importScraperPreferences) reach
-// the database through their owning services and commit per-row outside
-// any transaction the settingsio orchestrator opens; that limitation is
-// noted in CHECKPOINT.md for the M52 round-1 review fixes.
+// dbExecutor is the subset of *sql.DB used by the per-section import
+// helpers. Both *sql.DB and *sql.Tx satisfy it, so the helpers can run
+// either standalone (against s.db, e.g. unit tests that exercise a single
+// section) or inside the orchestrator's single transaction. Every section's
+// owning service exposes Import*Tx methods that also take a *Tx-compatible
+// executor (#1693) so the full import is now atomic across all sections.
 type dbExecutor interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
@@ -361,6 +380,7 @@ func (s *Service) Export(ctx context.Context, passphrase string) (*Envelope, err
 			FeatureMetadataPush:      c.FeatureMetadataPush,
 			FeatureTriggerRefresh:    c.FeatureTriggerRefresh,
 			FeatureManageServerFiles: c.FeatureManageServerFiles,
+			VerifyPathAfterUpdate:    c.VerifyPathAfterUpdate,
 			PreStillwaterConfigJSON:  c.PreStillwaterConfigJSON,
 			PlatformUserID:           c.PlatformUserID,
 			PlatformServerID:         c.PlatformServerID,
@@ -572,68 +592,53 @@ func (s *Service) ImportWithOptions(ctx context.Context, env *Envelope, passphra
 
 	result := &ImportResult{}
 
+	// All sections run inside a single transaction so any mid-import failure
+	// rolls back every row written by every prior section. Per-section
+	// helpers thread the tx through tx-aware ImportXxxTx methods on each
+	// owning service (connection, platform, webhook, provider, rule,
+	// scraper); the s.db-direct helpers (settings, users, user_preferences,
+	// libraries, api_tokens) accept a dbExecutor and run against the tx
+	// directly. Public Create/Update signatures on those services stay
+	// unchanged so non-import callers see no surface drift (#1693).
+	//
 	// Sections are called in dependency order: connections must precede
 	// libraries (which remap by (type, url)), and users must precede both
 	// user_preferences and api_tokens (which remap by username).
-	//
-	// The import splits into two phases:
-	//
-	//  1. Pre-tx phase: helpers that reach the database through external
-	//     services (connections, platform profiles, webhooks, provider
-	//     keys, provider priorities, rules, scraper preferences). Those
-	//     services own their own transactions internally so wrapping them
-	//     here would require threading a *sql.Tx through every service
-	//     constructor; that surface change is tracked as #1693 (M54).
-	//
-	//  2. Tx phase: the s.db-direct helpers (settings, users,
-	//     user_preferences, libraries, api_tokens) all run inside a single
-	//     transaction so a failure in any one of them rolls back every
-	//     row written by the others in this phase. The pre-tx phase rows
-	//     remain committed -- a half-applied restore still allows the
-	//     operator to retry idempotently (every section's import is
-	//     upsert-by-natural-key) which matches the OOBE handler's
-	//     fail-soft policy on the post-import onboarding flag flip.
-	if err := s.importProviderKeys(ctx, payload.ProviderKeys, result); err != nil {
-		return nil, fmt.Errorf("importing provider keys: %w", err)
-	}
-	if err := s.importConnections(ctx, payload.Connections, result, envelopeCarriesConnectionV14Fields(v)); err != nil {
-		return nil, fmt.Errorf("importing connections: %w", err)
-	}
-	if err := s.importPlatformProfiles(ctx, payload.PlatformProfiles, result); err != nil {
-		return nil, fmt.Errorf("importing platform profiles: %w", err)
-	}
-	if err := s.importWebhooks(ctx, payload.Webhooks, result); err != nil {
-		return nil, fmt.Errorf("importing webhooks: %w", err)
-	}
-	if err := s.importProviderPriorities(ctx, payload.ProviderPriorities, result); err != nil {
-		return nil, fmt.Errorf("importing provider priorities: %w", err)
-	}
-	if err := s.importRules(ctx, payload.Rules, result); err != nil {
-		return nil, fmt.Errorf("importing rules: %w", err)
-	}
-	if err := s.importScraperPreferences(ctx, payload.ScraperConfigs, result); err != nil {
-		return nil, fmt.Errorf("importing scraper preferences: %w", err)
-	}
-
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("beginning import tx: %w", err)
 	}
-	// Snapshot the counters that the pre-tx phase already incremented so a
-	// rollback of the tx phase can restore them; otherwise the returned
-	// ImportResult would misreport partial counts.
-	preTxSnapshot := *result
 	committed := false
 	defer func() {
 		if !committed {
 			_ = tx.Rollback()
-			// Restore the result struct to its pre-tx state so the caller
-			// sees pre-tx counts plus an error, never the partial tx
-			// counts that got rolled back.
-			*result = preTxSnapshot
+			// Reset the result struct so the caller sees zero counts plus
+			// an error, never the partial counts that got rolled back.
+			*result = ImportResult{}
 		}
 	}()
 
+	if err := s.importProviderKeys(ctx, tx, payload.ProviderKeys, result); err != nil {
+		return nil, fmt.Errorf("importing provider keys: %w", err)
+	}
+	if err := s.importConnections(ctx, tx, payload.Connections, result, envelopeCarriesConnectionV14Fields(v), envelopeCarriesConnectionV15Fields(v)); err != nil {
+		return nil, fmt.Errorf("importing connections: %w", err)
+	}
+	if err := s.importPlatformProfiles(ctx, tx, payload.PlatformProfiles, result); err != nil {
+		return nil, fmt.Errorf("importing platform profiles: %w", err)
+	}
+	if err := s.importWebhooks(ctx, tx, payload.Webhooks, result); err != nil {
+		return nil, fmt.Errorf("importing webhooks: %w", err)
+	}
+	if err := s.importProviderPriorities(ctx, tx, payload.ProviderPriorities, result); err != nil {
+		return nil, fmt.Errorf("importing provider priorities: %w", err)
+	}
+	if err := s.importRules(ctx, tx, payload.Rules, result); err != nil {
+		return nil, fmt.Errorf("importing rules: %w", err)
+	}
+	if err := s.importScraperPreferences(ctx, tx, payload.ScraperConfigs, result); err != nil {
+		return nil, fmt.Errorf("importing scraper preferences: %w", err)
+	}
 	if err := s.importSettings(ctx, tx, payload.Settings, result); err != nil {
 		return nil, fmt.Errorf("importing settings: %w", err)
 	}
@@ -648,8 +653,7 @@ func (s *Service) ImportWithOptions(ctx context.Context, env *Envelope, passphra
 	}
 	// Libraries must run AFTER connections so the (type, url) -> id remap
 	// can resolve to the freshly-imported connection rows. The lookup
-	// happens through connectionSvc, which reads from its own DB handle;
-	// the writes go through the tx.
+	// uses the tx so it observes those uncommitted rows.
 	if err := s.importLibraries(ctx, tx, payload.Libraries, result); err != nil {
 		return nil, fmt.Errorf("importing libraries: %w", err)
 	}

--- a/internal/settingsio/export_test.go
+++ b/internal/settingsio/export_test.go
@@ -220,6 +220,64 @@ func TestRoundTrip(t *testing.T) {
 	}
 }
 
+// TestRoundTrip_ConnectionVerifyPathAfterUpdate pins that the Lidarr
+// VerifyPathAfterUpdate opt-in (#1640 toggle) survives the connection
+// export/import round-trip introduced in envelope v1.5 (#1692). Without
+// this, a backup taken after the operator enables the toggle would
+// silently restore with the toggle off.
+func TestRoundTrip_ConnectionVerifyPathAfterUpdate(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+
+	c := &connection.Connection{
+		Name:                  "Lidarr A",
+		Type:                  "lidarr",
+		URL:                   "http://lidarr.local:8686",
+		APIKey:                "lidarr-key",
+		Enabled:               true,
+		VerifyPathAfterUpdate: true,
+	}
+	if err := connSvc.Create(ctx, c); err != nil {
+		t.Fatalf("creating connection: %v", err)
+	}
+
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+	envelope, err := svc.Export(ctx, "test-passphrase")
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if envelope.Version != CurrentEnvelopeVersion {
+		t.Errorf("envelope version: got %q, want %q", envelope.Version, CurrentEnvelopeVersion)
+	}
+
+	db2 := setupTestDB(t)
+	provSettings2, connSvc2, platSvc2, whSvc2 := newTestServices(t, db2)
+	svc2 := NewService(db2, provSettings2, connSvc2, platSvc2, whSvc2)
+
+	if _, err := svc2.Import(ctx, envelope, "test-passphrase"); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	conns, err := connSvc2.List(ctx)
+	if err != nil {
+		t.Fatalf("listing imported connections: %v", err)
+	}
+	var got *connection.Connection
+	for i := range conns {
+		if conns[i].Name == "Lidarr A" {
+			got = &conns[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("imported connections missing %q; got %d rows", "Lidarr A", len(conns))
+	}
+	if !got.VerifyPathAfterUpdate {
+		t.Error("VerifyPathAfterUpdate did not survive export/import round-trip")
+	}
+}
+
 // TestRoundTrip_UpdaterSettings pins that updater.channel and
 // updater.auto_check survive the settings export/import round-trip, so a
 // future per-key allowlist in the exporter cannot silently drop them.
@@ -944,11 +1002,11 @@ func TestRoundTrip_LibrariesAndTokens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Export: %v", err)
 	}
-	// Envelope version was bumped to 1.4 when UserExport.id and
-	// UserPrefsExport.user_id were added (#1114). Older versions remain
+	// Envelope version travels with CurrentEnvelopeVersion so this
+	// assertion stays accurate across schema bumps. Older versions remain
 	// importable; see TestImport_LegacyEnvelopeWithoutUsers.
-	if envelope.Version != "1.4" {
-		t.Errorf("envelope version: got %q, want 1.4", envelope.Version)
+	if envelope.Version != CurrentEnvelopeVersion {
+		t.Errorf("envelope version: got %q, want %q", envelope.Version, CurrentEnvelopeVersion)
 	}
 	if envelope.Summary == nil {
 		t.Fatal("expected non-nil export summary")

--- a/internal/settingsio/import_sections.go
+++ b/internal/settingsio/import_sections.go
@@ -41,9 +41,9 @@ func (s *Service) importSettings(ctx context.Context, db dbExecutor, settings ma
 
 // importProviderKeys writes each provider API key via the provider settings
 // service, which handles at-rest encryption. An empty key map is a no-op.
-func (s *Service) importProviderKeys(ctx context.Context, keys map[string]string, result *ImportResult) error {
+func (s *Service) importProviderKeys(ctx context.Context, db dbExecutor, keys map[string]string, result *ImportResult) error {
 	for name, key := range keys {
-		if err := s.providerSettings.SetAPIKey(ctx, provider.ProviderName(name), key); err != nil {
+		if err := s.providerSettings.ImportSetAPIKeyTx(ctx, db, provider.ProviderName(name), key); err != nil {
 			return fmt.Errorf("setting provider key %q: %w", name, err)
 		}
 		result.ProviderKeys++
@@ -62,9 +62,14 @@ func (s *Service) importProviderKeys(ctx context.Context, keys map[string]string
 // When false (a pre-1.4 envelope), those fields decoded as zero values and
 // must not be copied onto the target's existing connection row -- doing so
 // would silently disable toggles the operator had set.
-func (s *Service) importConnections(ctx context.Context, conns []ConnectionExport, result *ImportResult, carryV14Fields bool) error {
+//
+// carryV15Fields signals that the envelope is v1.5 or later, so the
+// v1.5-only field (VerifyPathAfterUpdate) is authoritative. When false (a
+// pre-1.5 envelope), the field decoded as a zero value and must not be
+// copied onto the target's existing connection row for the same reason.
+func (s *Service) importConnections(ctx context.Context, db dbExecutor, conns []ConnectionExport, result *ImportResult, carryV14Fields, carryV15Fields bool) error {
 	for _, ce := range conns {
-		existing, err := s.connectionSvc.GetByTypeAndURL(ctx, ce.Type, ce.URL)
+		existing, err := s.connectionSvc.ImportGetByTypeAndURLTx(ctx, db, ce.Type, ce.URL)
 		if err != nil {
 			return fmt.Errorf("looking up connection %q: %w", ce.Name, err)
 		}
@@ -81,6 +86,9 @@ func (s *Service) importConnections(ctx context.Context, conns []ConnectionExpor
 				existing.FeatureManageServerFiles = ce.FeatureManageServerFiles
 				existing.PreStillwaterConfigJSON = ce.PreStillwaterConfigJSON
 			}
+			if carryV15Fields {
+				existing.VerifyPathAfterUpdate = ce.VerifyPathAfterUpdate
+			}
 			// platform_user_id and platform_server_id reflect the live peer's
 			// identity. Preserve the receiving instance's value if it already
 			// has one (a prior connection-test resolved it); fall back to the
@@ -92,7 +100,7 @@ func (s *Service) importConnections(ctx context.Context, conns []ConnectionExpor
 			if existing.PlatformServerID == "" {
 				existing.PlatformServerID = ce.PlatformServerID
 			}
-			if err := s.connectionSvc.Update(ctx, existing); err != nil {
+			if err := s.connectionSvc.ImportUpdateTx(ctx, db, existing); err != nil {
 				return fmt.Errorf("updating connection %q: %w", ce.Name, err)
 			}
 		} else {
@@ -108,11 +116,12 @@ func (s *Service) importConnections(ctx context.Context, conns []ConnectionExpor
 				FeatureMetadataPush:      ce.FeatureMetadataPush,
 				FeatureTriggerRefresh:    ce.FeatureTriggerRefresh,
 				FeatureManageServerFiles: ce.FeatureManageServerFiles,
+				VerifyPathAfterUpdate:    ce.VerifyPathAfterUpdate,
 				PreStillwaterConfigJSON:  ce.PreStillwaterConfigJSON,
 				PlatformUserID:           ce.PlatformUserID,
 				PlatformServerID:         ce.PlatformServerID,
 			}
-			if err := s.connectionSvc.Create(ctx, c); err != nil {
+			if err := s.connectionSvc.ImportCreateTx(ctx, db, c); err != nil {
 				return fmt.Errorf("creating connection %q: %w", ce.Name, err)
 			}
 		}
@@ -125,22 +134,22 @@ func (s *Service) importConnections(ctx context.Context, conns []ConnectionExpor
 // with the same name has its ID preserved and its fields updated; absent profiles
 // are created with a new ID. IsActive is forced to false on create to prevent
 // multiple active profiles from being introduced during import.
-func (s *Service) importPlatformProfiles(ctx context.Context, profiles []platform.Profile, result *ImportResult) error {
+func (s *Service) importPlatformProfiles(ctx context.Context, db dbExecutor, profiles []platform.Profile, result *ImportResult) error {
 	for i := range profiles {
 		p := &profiles[i]
-		existing, err := s.platformSvc.GetByName(ctx, p.Name)
+		existing, err := s.platformSvc.ImportGetByNameTx(ctx, db, p.Name)
 		if err != nil {
 			return fmt.Errorf("looking up platform profile %q: %w", p.Name, err)
 		}
 		if existing != nil {
 			p.ID = existing.ID
-			if err := s.platformSvc.Update(ctx, p); err != nil {
+			if err := s.platformSvc.ImportUpdateTx(ctx, db, p); err != nil {
 				return fmt.Errorf("updating platform profile %q: %w", p.Name, err)
 			}
 		} else {
 			p.ID = ""          // Let Create generate a new ID.
 			p.IsActive = false // Avoid creating multiple active profiles on import.
-			if err := s.platformSvc.Create(ctx, p); err != nil {
+			if err := s.platformSvc.ImportCreateTx(ctx, db, p); err != nil {
 				return fmt.Errorf("creating platform profile %q: %w", p.Name, err)
 			}
 		}
@@ -152,21 +161,21 @@ func (s *Service) importPlatformProfiles(ctx context.Context, profiles []platfor
 // importWebhooks upserts webhooks by matching on (name, url). An existing
 // webhook is updated in place with its ID preserved; absent webhooks are
 // created with a new ID.
-func (s *Service) importWebhooks(ctx context.Context, webhooks []webhook.Webhook, result *ImportResult) error {
+func (s *Service) importWebhooks(ctx context.Context, db dbExecutor, webhooks []webhook.Webhook, result *ImportResult) error {
 	for i := range webhooks {
 		w := &webhooks[i]
-		existing, err := s.webhookSvc.GetByNameAndURL(ctx, w.Name, w.URL)
+		existing, err := s.webhookSvc.ImportGetByNameAndURLTx(ctx, db, w.Name, w.URL)
 		if err != nil {
 			return fmt.Errorf("looking up webhook %q: %w", w.Name, err)
 		}
 		if existing != nil {
 			w.ID = existing.ID
-			if err := s.webhookSvc.Update(ctx, w); err != nil {
+			if err := s.webhookSvc.ImportUpdateTx(ctx, db, w); err != nil {
 				return fmt.Errorf("updating webhook %q: %w", w.Name, err)
 			}
 		} else {
 			w.ID = "" // Let Create generate a new ID.
-			if err := s.webhookSvc.Create(ctx, w); err != nil {
+			if err := s.webhookSvc.ImportCreateTx(ctx, db, w); err != nil {
 				return fmt.Errorf("creating webhook %q: %w", w.Name, err)
 			}
 		}
@@ -177,16 +186,16 @@ func (s *Service) importWebhooks(ctx context.Context, webhooks []webhook.Webhook
 
 // importProviderPriorities writes the ordered provider list and the disabled
 // provider set for each exported field. An empty priorities slice is a no-op.
-func (s *Service) importProviderPriorities(ctx context.Context, priorities []PriorityExport, result *ImportResult) error {
+func (s *Service) importProviderPriorities(ctx context.Context, db dbExecutor, priorities []PriorityExport, result *ImportResult) error {
 	for _, p := range priorities {
-		if err := s.providerSettings.SetPriority(ctx, p.Field, p.Providers); err != nil {
+		if err := s.providerSettings.ImportSetPriorityTx(ctx, db, p.Field, p.Providers); err != nil {
 			return fmt.Errorf("setting priority for %q: %w", p.Field, err)
 		}
 		disabled := p.Disabled
 		if disabled == nil {
 			disabled = []provider.ProviderName{}
 		}
-		if err := s.providerSettings.SetDisabledProviders(ctx, p.Field, disabled); err != nil {
+		if err := s.providerSettings.ImportSetDisabledProvidersTx(ctx, db, p.Field, disabled); err != nil {
 			return fmt.Errorf("setting disabled providers for %q: %w", p.Field, err)
 		}
 		result.Priorities++
@@ -200,7 +209,7 @@ func (s *Service) importProviderPriorities(ctx context.Context, priorities []Pri
 // skipped so cross-version imports do not abort. Entries with an empty ID or
 // an unrecognized automation_mode are also skipped with a warning. This method
 // is a no-op when ruleService is nil.
-func (s *Service) importRules(ctx context.Context, rules []RuleExport, result *ImportResult) error {
+func (s *Service) importRules(ctx context.Context, db dbExecutor, rules []RuleExport, result *ImportResult) error {
 	if s.ruleService == nil {
 		return nil
 	}
@@ -209,7 +218,7 @@ func (s *Service) importRules(ctx context.Context, rules []RuleExport, result *I
 		if re.ID == "" {
 			continue
 		}
-		existing, err := s.ruleService.GetByID(ctx, re.ID)
+		existing, err := s.ruleService.ImportGetByIDTx(ctx, db, re.ID)
 		if err != nil {
 			// Unknown rule IDs (newer export, older binary) are expected -- skip.
 			// Other errors (DB connection, corruption) must surface.
@@ -235,7 +244,7 @@ func (s *Service) importRules(ctx context.Context, rules []RuleExport, result *I
 		existing.Enabled = re.Enabled
 		existing.AutomationMode = re.AutomationMode
 		existing.Config = re.Config
-		if err := s.ruleService.Update(ctx, existing); err != nil {
+		if err := s.ruleService.ImportUpdateTx(ctx, db, existing); err != nil {
 			return fmt.Errorf("updating rule %q: %w", re.ID, err)
 		}
 		result.Rules++
@@ -244,10 +253,11 @@ func (s *Service) importRules(ctx context.Context, rules []RuleExport, result *I
 }
 
 // importScraperPreferences upserts scraper configurations for every scope in
-// the exported payload. Each scope is written via SaveConfig which performs an
-// ON CONFLICT update internally. Entries with an empty scope are skipped.
-// This method is a no-op when scraperService is nil.
-func (s *Service) importScraperPreferences(ctx context.Context, configs []ScraperConfigExport, result *ImportResult) error {
+// the exported payload. Each scope is written via the tx-aware import helper
+// so a mid-import failure rolls back every prior section's writes. Entries
+// with an empty scope are skipped. This method is a no-op when
+// scraperService is nil.
+func (s *Service) importScraperPreferences(ctx context.Context, db dbExecutor, configs []ScraperConfigExport, result *ImportResult) error {
 	if s.scraperService == nil {
 		return nil
 	}
@@ -259,7 +269,7 @@ func (s *Service) importScraperPreferences(ctx context.Context, configs []Scrape
 		// Clear the ID so SaveConfig resolves it from the DB, avoiding ID
 		// collisions when importing across instances.
 		sce.Config.ID = ""
-		if err := s.scraperService.SaveConfig(ctx, sce.Scope, &sce.Config, sce.Overrides); err != nil {
+		if err := s.scraperService.ImportSaveConfigTx(ctx, db, sce.Scope, &sce.Config, sce.Overrides); err != nil {
 			return fmt.Errorf("saving scraper config for scope %q: %w", sce.Scope, err)
 		}
 		result.ScraperConfigs++

--- a/internal/settingsio/import_sections.go
+++ b/internal/settingsio/import_sections.go
@@ -63,10 +63,12 @@ func (s *Service) importProviderKeys(ctx context.Context, db dbExecutor, keys ma
 // must not be copied onto the target's existing connection row -- doing so
 // would silently disable toggles the operator had set.
 //
-// carryV15Fields signals that the envelope is v1.5 or later, so the
-// v1.5-only field (VerifyPathAfterUpdate) is authoritative. When false (a
-// pre-1.5 envelope), the field decoded as a zero value and must not be
-// copied onto the target's existing connection row for the same reason.
+// carryV15Fields signals that the envelope version is recognized as one
+// that carries the v1.5-only field (VerifyPathAfterUpdate), in which case
+// the field is authoritative. When false (a pre-1.5 envelope OR a future
+// envelope version not yet added to envelopeCarriesConnectionV15Fields),
+// the field decoded as a zero value and must not be copied onto the
+// target's existing connection row for the same reason as V14.
 func (s *Service) importConnections(ctx context.Context, db dbExecutor, conns []ConnectionExport, result *ImportResult, carryV14Fields, carryV15Fields bool) error {
 	for _, ce := range conns {
 		existing, err := s.connectionSvc.ImportGetByTypeAndURLTx(ctx, db, ce.Type, ce.URL)

--- a/internal/settingsio/import_sections_test.go
+++ b/internal/settingsio/import_sections_test.go
@@ -115,7 +115,7 @@ func TestImportProviderKeys_CountsAndPersists(t *testing.T) {
 
 	keys := map[string]string{string(provider.NameFanartTV): "fanart-test-key"}
 	result := &ImportResult{}
-	if err := svc.importProviderKeys(ctx, keys, result); err != nil {
+	if err := svc.importProviderKeys(ctx, db, keys, result); err != nil {
 		t.Fatalf("importProviderKeys: %v", err)
 	}
 	if result.ProviderKeys != 1 {
@@ -146,7 +146,7 @@ func TestImportConnections_CreateAndUpdate(t *testing.T) {
 		{Name: "Emby A", Type: "emby", URL: "http://emby.local:8096", APIKey: "key1", Enabled: true},
 	}
 	result := &ImportResult{}
-	if err := svc.importConnections(ctx, conns, result, true); err != nil {
+	if err := svc.importConnections(ctx, db, conns, result, true, true); err != nil {
 		t.Fatalf("importConnections (insert): %v", err)
 	}
 	if result.Connections != 1 {
@@ -157,7 +157,7 @@ func TestImportConnections_CreateAndUpdate(t *testing.T) {
 	conns[0].Name = "Emby A Renamed"
 	conns[0].APIKey = "key2"
 	result2 := &ImportResult{}
-	if err := svc.importConnections(ctx, conns, result2, true); err != nil {
+	if err := svc.importConnections(ctx, db, conns, result2, true, true); err != nil {
 		t.Fatalf("importConnections (update): %v", err)
 	}
 	if result2.Connections != 1 {
@@ -213,7 +213,7 @@ func TestImportConnections_PreV14EnvelopePreservesV14Fields(t *testing.T) {
 		APIKey: "key2", Enabled: true,
 		// v1.4-only fields explicitly left zero to model a pre-1.4 payload.
 	}}
-	if err := svc.importConnections(ctx, conns, &ImportResult{}, false); err != nil {
+	if err := svc.importConnections(ctx, db, conns, &ImportResult{}, false, false); err != nil {
 		t.Fatalf("importConnections (legacy envelope): %v", err)
 	}
 
@@ -255,6 +255,7 @@ func TestEnvelopeCarriesConnectionV14Fields(t *testing.T) {
 		{"1.2", false},
 		{"1.3", false},
 		{"1.4", true},
+		{"1.5", true},
 		{"", false},
 		{"99.0", false},
 	}
@@ -262,6 +263,81 @@ func TestEnvelopeCarriesConnectionV14Fields(t *testing.T) {
 		if got := envelopeCarriesConnectionV14Fields(tc.version); got != tc.want {
 			t.Errorf("envelopeCarriesConnectionV14Fields(%q) = %v, want %v", tc.version, got, tc.want)
 		}
+	}
+}
+
+// TestEnvelopeCarriesConnectionV15Fields locks the v1.5 allow-set. Same
+// motivation as the v1.4 test: a future version bump that forgets to add
+// itself here would silently disable VerifyPathAfterUpdate on legacy
+// imports because the field would decode to its zero value.
+func TestEnvelopeCarriesConnectionV15Fields(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"1.0", false},
+		{"1.1", false},
+		{"1.2", false},
+		{"1.3", false},
+		{"1.4", false},
+		{"1.5", true},
+		{"", false},
+		{"99.0", false},
+	}
+	for _, tc := range cases {
+		if got := envelopeCarriesConnectionV15Fields(tc.version); got != tc.want {
+			t.Errorf("envelopeCarriesConnectionV15Fields(%q) = %v, want %v", tc.version, got, tc.want)
+		}
+	}
+}
+
+// TestImportConnections_PreV15EnvelopePreservesV15Fields proves that a
+// pre-1.5 envelope updating an existing target connection does NOT clear
+// VerifyPathAfterUpdate. Without the gate, a 1.4 backup would silently
+// disable the Lidarr path-verification opt-in after restore.
+func TestImportConnections_PreV15EnvelopePreservesV15Fields(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
+	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
+
+	// Seed the target with VerifyPathAfterUpdate=true, simulating an
+	// operator who upgraded to a v1.5 binary and then enabled the toggle.
+	seed := &connection.Connection{
+		Name:                  "Lidarr A",
+		Type:                  "lidarr",
+		URL:                   "http://lidarr.local:8686",
+		APIKey:                "key1",
+		Enabled:               true,
+		VerifyPathAfterUpdate: true,
+	}
+	if err := connSvc.Create(ctx, seed); err != nil {
+		t.Fatalf("seeding target connection: %v", err)
+	}
+
+	// Pre-1.5 envelope: the v1.5 field is absent and decodes to zero.
+	conns := []ConnectionExport{{
+		Name: "Lidarr A", Type: "lidarr", URL: "http://lidarr.local:8686",
+		APIKey: "key2", Enabled: true,
+		// VerifyPathAfterUpdate explicitly left zero to model a pre-1.5 payload.
+	}}
+	if err := svc.importConnections(ctx, db, conns, &ImportResult{}, true, false); err != nil {
+		t.Fatalf("importConnections (legacy envelope): %v", err)
+	}
+
+	all, err := connSvc.List(ctx)
+	if err != nil {
+		t.Fatalf("listing connections: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 connection, got %d", len(all))
+	}
+	got := all[0]
+	if got.APIKey != "key2" {
+		t.Errorf("APIKey: got %q, want key2 (legacy import must still rotate keys)", got.APIKey)
+	}
+	if !got.VerifyPathAfterUpdate {
+		t.Error("VerifyPathAfterUpdate was cleared by a legacy import; target value must be preserved")
 	}
 }
 
@@ -280,7 +356,7 @@ func TestImportPlatformProfiles_CreateAndUpdate(t *testing.T) {
 		{Name: "Test Profile", NFOEnabled: true, NFOFormat: "kodi"},
 	}
 	result := &ImportResult{}
-	if err := svc.importPlatformProfiles(ctx, profiles, result); err != nil {
+	if err := svc.importPlatformProfiles(ctx, db, profiles, result); err != nil {
 		t.Fatalf("importPlatformProfiles (create): %v", err)
 	}
 	if result.Profiles != 1 {
@@ -290,7 +366,7 @@ func TestImportPlatformProfiles_CreateAndUpdate(t *testing.T) {
 	// Re-import the same profile with a changed NFOFormat: must update, not insert.
 	profiles[0].NFOFormat = "emby"
 	result2 := &ImportResult{}
-	if err := svc.importPlatformProfiles(ctx, profiles, result2); err != nil {
+	if err := svc.importPlatformProfiles(ctx, db, profiles, result2); err != nil {
 		t.Fatalf("importPlatformProfiles (update): %v", err)
 	}
 
@@ -330,7 +406,7 @@ func TestImportWebhooks_CreateAndUpdate(t *testing.T) {
 		{Name: "Hook A", URL: "https://hook.example/a", Type: "generic", Events: []string{"artist.new"}, Enabled: true},
 	}
 	result := &ImportResult{}
-	if err := svc.importWebhooks(ctx, hooks, result); err != nil {
+	if err := svc.importWebhooks(ctx, db, hooks, result); err != nil {
 		t.Fatalf("importWebhooks (create): %v", err)
 	}
 	if result.Webhooks != 1 {
@@ -340,7 +416,7 @@ func TestImportWebhooks_CreateAndUpdate(t *testing.T) {
 	// Re-import with disabled=true: must update, not duplicate.
 	hooks[0].Enabled = false
 	result2 := &ImportResult{}
-	if err := svc.importWebhooks(ctx, hooks, result2); err != nil {
+	if err := svc.importWebhooks(ctx, db, hooks, result2); err != nil {
 		t.Fatalf("importWebhooks (update): %v", err)
 	}
 
@@ -382,7 +458,7 @@ func TestImportRules_SkipsNilService(t *testing.T) {
 		{ID: "thumb_exists", Enabled: false, AutomationMode: "auto"},
 	}
 	result := &ImportResult{}
-	if err := svc.importRules(ctx, rules, result); err != nil {
+	if err := svc.importRules(ctx, db, rules, result); err != nil {
 		t.Fatalf("importRules with nil service: %v", err)
 	}
 	if result.Rules != 0 {
@@ -403,7 +479,7 @@ func TestImportRules_SkipsEmptyID(t *testing.T) {
 	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithRuleService(ruleSvc)
 
 	result := &ImportResult{}
-	if err := svc.importRules(ctx, []RuleExport{{ID: "", Enabled: true, AutomationMode: "auto"}}, result); err != nil {
+	if err := svc.importRules(ctx, db, []RuleExport{{ID: "", Enabled: true, AutomationMode: "auto"}}, result); err != nil {
 		t.Fatalf("importRules with empty ID: %v", err)
 	}
 	if result.Rules != 0 {
@@ -424,7 +500,7 @@ func TestImportRules_SkipsUnknownID(t *testing.T) {
 	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithRuleService(ruleSvc)
 
 	result := &ImportResult{}
-	if err := svc.importRules(ctx, []RuleExport{{ID: "future_unknown_rule", Enabled: true, AutomationMode: "auto"}}, result); err != nil {
+	if err := svc.importRules(ctx, db, []RuleExport{{ID: "future_unknown_rule", Enabled: true, AutomationMode: "auto"}}, result); err != nil {
 		t.Fatalf("importRules with unknown ID: %v", err)
 	}
 	if result.Rules != 0 {
@@ -452,7 +528,7 @@ func TestImportRules_SkipsInvalidAutomationMode(t *testing.T) {
 	originalMode := before.AutomationMode
 
 	result := &ImportResult{}
-	if err := svc.importRules(ctx, []RuleExport{
+	if err := svc.importRules(ctx, db, []RuleExport{
 		{ID: rule.RuleThumbExists, Enabled: true, AutomationMode: "invalid_value"},
 	}, result); err != nil {
 		t.Fatalf("importRules with invalid mode: %v", err)
@@ -483,7 +559,7 @@ func TestImportRules_UpdatesValidRule(t *testing.T) {
 	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithRuleService(ruleSvc)
 
 	result := &ImportResult{}
-	if err := svc.importRules(ctx, []RuleExport{
+	if err := svc.importRules(ctx, db, []RuleExport{
 		{ID: rule.RuleThumbExists, Enabled: false, AutomationMode: rule.AutomationModeAuto},
 	}, result); err != nil {
 		t.Fatalf("importRules: %v", err)
@@ -515,7 +591,7 @@ func TestImportScraperPreferences_SkipsNilService(t *testing.T) {
 	svc := NewService(db, provSettings, connSvc, platSvc, whSvc) // no WithScraperService
 
 	result := &ImportResult{}
-	if err := svc.importScraperPreferences(ctx, []ScraperConfigExport{
+	if err := svc.importScraperPreferences(ctx, db, []ScraperConfigExport{
 		{Scope: "global"},
 	}, result); err != nil {
 		t.Fatalf("importScraperPreferences with nil service: %v", err)
@@ -535,7 +611,7 @@ func TestImportScraperPreferences_SkipsEmptyScope(t *testing.T) {
 	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithScraperService(scraperSvc)
 
 	result := &ImportResult{}
-	if err := svc.importScraperPreferences(ctx, []ScraperConfigExport{{Scope: ""}}, result); err != nil {
+	if err := svc.importScraperPreferences(ctx, db, []ScraperConfigExport{{Scope: ""}}, result); err != nil {
 		t.Fatalf("importScraperPreferences with empty scope: %v", err)
 	}
 	if result.ScraperConfigs != 0 {
@@ -560,7 +636,7 @@ func TestImportScraperPreferences_UpsertAndCount(t *testing.T) {
 		{Scope: "custom-scope", Config: scraper.ScraperConfig{}},
 	}
 	result := &ImportResult{}
-	if err := svc.importScraperPreferences(ctx, configs, result); err != nil {
+	if err := svc.importScraperPreferences(ctx, db, configs, result); err != nil {
 		t.Fatalf("importScraperPreferences: %v", err)
 	}
 	if result.ScraperConfigs != 2 {
@@ -585,7 +661,7 @@ func TestImportProviderPriorities_CountsAndPersists(t *testing.T) {
 		},
 	}
 	result := &ImportResult{}
-	if err := svc.importProviderPriorities(ctx, priorities, result); err != nil {
+	if err := svc.importProviderPriorities(ctx, db, priorities, result); err != nil {
 		t.Fatalf("importProviderPriorities: %v", err)
 	}
 	if result.Priorities != 1 {
@@ -631,7 +707,7 @@ func TestImportProviderPriorities_DisabledPersisted(t *testing.T) {
 		},
 	}
 	result := &ImportResult{}
-	if err := svc.importProviderPriorities(ctx, priorities, result); err != nil {
+	if err := svc.importProviderPriorities(ctx, db, priorities, result); err != nil {
 		t.Fatalf("importProviderPriorities: %v", err)
 	}
 
@@ -673,7 +749,7 @@ func TestImportProviderPriorities_EmptyDisabledClears(t *testing.T) {
 		},
 	}
 	result := &ImportResult{}
-	if err := svc.importProviderPriorities(ctx, priorities, result); err != nil {
+	if err := svc.importProviderPriorities(ctx, db, priorities, result); err != nil {
 		t.Fatalf("importProviderPriorities: %v", err)
 	}
 
@@ -717,7 +793,7 @@ func TestImportProviderKeys_DBError(t *testing.T) {
 	provSettings, connSvc, platSvc, whSvc := newTestServices(t, db)
 	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
 	_ = db.Close()
-	err := svc.importProviderKeys(t.Context(), map[string]string{string(provider.NameFanartTV): "key"}, &ImportResult{})
+	err := svc.importProviderKeys(t.Context(), db, map[string]string{string(provider.NameFanartTV): "key"}, &ImportResult{})
 	if err == nil {
 		t.Fatal("expected error with closed DB, got nil")
 	}
@@ -730,7 +806,7 @@ func TestImportConnections_DBError(t *testing.T) {
 	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
 	_ = db.Close()
 	conns := []ConnectionExport{{Name: "x", Type: "emby", URL: "http://localhost:8096"}}
-	err := svc.importConnections(t.Context(), conns, &ImportResult{}, true)
+	err := svc.importConnections(t.Context(), db, conns, &ImportResult{}, true, true)
 	if err == nil {
 		t.Fatal("expected error with closed DB, got nil")
 	}
@@ -743,7 +819,7 @@ func TestImportPlatformProfiles_DBError(t *testing.T) {
 	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
 	_ = db.Close()
 	profiles := []platform.Profile{{Name: "Test"}}
-	err := svc.importPlatformProfiles(t.Context(), profiles, &ImportResult{})
+	err := svc.importPlatformProfiles(t.Context(), db, profiles, &ImportResult{})
 	if err == nil {
 		t.Fatal("expected error with closed DB, got nil")
 	}
@@ -756,7 +832,7 @@ func TestImportWebhooks_DBError(t *testing.T) {
 	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
 	_ = db.Close()
 	hooks := []webhook.Webhook{{Name: "h", URL: "https://example.com/h", Type: "generic"}}
-	err := svc.importWebhooks(t.Context(), hooks, &ImportResult{})
+	err := svc.importWebhooks(t.Context(), db, hooks, &ImportResult{})
 	if err == nil {
 		t.Fatal("expected error with closed DB, got nil")
 	}
@@ -769,7 +845,7 @@ func TestImportProviderPriorities_DBError(t *testing.T) {
 	svc := NewService(db, provSettings, connSvc, platSvc, whSvc)
 	_ = db.Close()
 	priorities := []PriorityExport{{Field: "biography", Providers: []provider.ProviderName{provider.NameMusicBrainz}}}
-	err := svc.importProviderPriorities(t.Context(), priorities, &ImportResult{})
+	err := svc.importProviderPriorities(t.Context(), db, priorities, &ImportResult{})
 	if err == nil {
 		t.Fatal("expected error with closed DB, got nil")
 	}
@@ -789,7 +865,7 @@ func TestImportRules_DBError(t *testing.T) {
 	// Use a known rule ID so the GetByID path is exercised (unknown IDs are
 	// silently skipped; a closed-DB error is not ErrNotFound and must surface).
 	rules := []RuleExport{{ID: rule.RuleThumbExists, Enabled: false, AutomationMode: rule.AutomationModeAuto}}
-	err := svc.importRules(t.Context(), rules, &ImportResult{})
+	err := svc.importRules(t.Context(), db, rules, &ImportResult{})
 	if err == nil {
 		t.Fatal("expected error with closed DB, got nil")
 	}
@@ -803,7 +879,7 @@ func TestImportScraperPreferences_DBError(t *testing.T) {
 	svc := NewService(db, provSettings, connSvc, platSvc, whSvc).WithScraperService(scraperSvc)
 	_ = db.Close()
 	configs := []ScraperConfigExport{{Scope: "global", Config: scraper.ScraperConfig{}}}
-	err := svc.importScraperPreferences(t.Context(), configs, &ImportResult{})
+	err := svc.importScraperPreferences(t.Context(), db, configs, &ImportResult{})
 	if err == nil {
 		t.Fatal("expected error with closed DB, got nil")
 	}

--- a/internal/webhook/import.go
+++ b/internal/webhook/import.go
@@ -44,6 +44,9 @@ func (s *Service) ImportGetByNameAndURLTx(ctx context.Context, db DBExecutor, na
 // ImportCreateTx inserts a new webhook via the supplied executor. Mirrors
 // Create's SQL exactly.
 func (s *Service) ImportCreateTx(ctx context.Context, db DBExecutor, w *Webhook) error {
+	if w == nil {
+		return fmt.Errorf("webhook is required")
+	}
 	if w.Name == "" {
 		return fmt.Errorf("name is required")
 	}
@@ -55,7 +58,9 @@ func (s *Service) ImportCreateTx(ctx context.Context, db DBExecutor, w *Webhook)
 	}
 
 	now := time.Now().UTC()
-	w.ID = uuid.New().String()
+	if w.ID == "" {
+		w.ID = uuid.New().String()
+	}
 	w.CreatedAt = now
 	w.UpdatedAt = now
 
@@ -77,6 +82,9 @@ func (s *Service) ImportCreateTx(ctx context.Context, db DBExecutor, w *Webhook)
 // ImportUpdateTx updates an existing webhook via the supplied executor.
 // Mirrors Update's SQL exactly.
 func (s *Service) ImportUpdateTx(ctx context.Context, db DBExecutor, w *Webhook) error {
+	if w == nil {
+		return fmt.Errorf("webhook is required")
+	}
 	w.UpdatedAt = time.Now().UTC()
 
 	eventsJSON, err := json.Marshal(w.Events)
@@ -92,7 +100,10 @@ func (s *Service) ImportUpdateTx(ctx context.Context, db DBExecutor, w *Webhook)
 		return fmt.Errorf("updating webhook: %w", err)
 	}
 
-	n, _ := result.RowsAffected()
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("checking updated webhook rows: %w", err)
+	}
 	if n == 0 {
 		return fmt.Errorf("webhook not found")
 	}

--- a/internal/webhook/import.go
+++ b/internal/webhook/import.go
@@ -1,0 +1,100 @@
+package webhook
+
+// import.go contains the tx-aware helpers used by the settingsio import
+// orchestrator (#1693). They mirror the SQL of Create/Update/GetByNameAndURL
+// but accept a DBExecutor so the orchestrator can run them inside its own
+// transaction; a mid-import failure then rolls back the webhook writes
+// alongside every other section's writes.
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DBExecutor is the subset of *sql.DB used by the tx-aware webhook import
+// helpers. Both *sql.DB and *sql.Tx satisfy it.
+type DBExecutor interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+// ImportGetByNameAndURLTx is the tx-aware equivalent of GetByNameAndURL.
+func (s *Service) ImportGetByNameAndURLTx(ctx context.Context, db DBExecutor, name, url string) (*Webhook, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT id, name, url, type, events, enabled, created_at, updated_at
+		FROM webhooks WHERE name = ? AND url = ? LIMIT 1
+	`, name, url)
+	w, err := scanWebhook(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("looking up webhook by name+url: %w", err)
+	}
+	return w, nil
+}
+
+// ImportCreateTx inserts a new webhook via the supplied executor. Mirrors
+// Create's SQL exactly.
+func (s *Service) ImportCreateTx(ctx context.Context, db DBExecutor, w *Webhook) error {
+	if w.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if w.URL == "" {
+		return fmt.Errorf("url is required")
+	}
+	if w.Type == "" {
+		w.Type = TypeGeneric
+	}
+
+	now := time.Now().UTC()
+	w.ID = uuid.New().String()
+	w.CreatedAt = now
+	w.UpdatedAt = now
+
+	eventsJSON, err := json.Marshal(w.Events)
+	if err != nil {
+		return fmt.Errorf("marshaling events: %w", err)
+	}
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO webhooks (id, name, url, type, events, enabled, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`, w.ID, w.Name, w.URL, w.Type, string(eventsJSON), w.Enabled, now.Format(time.RFC3339), now.Format(time.RFC3339))
+	if err != nil {
+		return fmt.Errorf("inserting webhook: %w", err)
+	}
+	return nil
+}
+
+// ImportUpdateTx updates an existing webhook via the supplied executor.
+// Mirrors Update's SQL exactly.
+func (s *Service) ImportUpdateTx(ctx context.Context, db DBExecutor, w *Webhook) error {
+	w.UpdatedAt = time.Now().UTC()
+
+	eventsJSON, err := json.Marshal(w.Events)
+	if err != nil {
+		return fmt.Errorf("marshaling events: %w", err)
+	}
+
+	result, err := db.ExecContext(ctx, `
+		UPDATE webhooks SET name = ?, url = ?, type = ?, events = ?, enabled = ?, updated_at = ?
+		WHERE id = ?
+	`, w.Name, w.URL, w.Type, string(eventsJSON), w.Enabled, w.UpdatedAt.Format(time.RFC3339), w.ID)
+	if err != nil {
+		return fmt.Errorf("updating webhook: %w", err)
+	}
+
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("webhook not found")
+	}
+	return nil
+}

--- a/internal/webhook/import_test.go
+++ b/internal/webhook/import_test.go
@@ -1,0 +1,139 @@
+package webhook
+
+// import_test.go exercises the tx-aware import helpers added for #1693.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/database"
+)
+
+// setupTestServiceWithDB returns the service AND the underlying DB so the
+// import_test helpers can drive the DBExecutor-shaped methods directly.
+func setupTestServiceWithDB(t *testing.T) (*Service, DBExecutor) {
+	t.Helper()
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("opening test db: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("running migrations: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return NewService(db), db
+}
+
+// TestImportCreateAndGetTx pins the happy path for the tx-aware helpers.
+func TestImportCreateAndGetTx(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	ctx := context.Background()
+
+	w := &Webhook{
+		Name: "ImportTx Hook", URL: "https://imp.example/hook", Type: TypeGeneric,
+		Events: []string{"artist.new"}, Enabled: true,
+	}
+	if err := svc.ImportCreateTx(ctx, db, w); err != nil {
+		t.Fatalf("ImportCreateTx: %v", err)
+	}
+	if w.ID == "" {
+		t.Fatal("ImportCreateTx must assign an ID")
+	}
+
+	got, err := svc.ImportGetByNameAndURLTx(ctx, db, "ImportTx Hook", "https://imp.example/hook")
+	if err != nil {
+		t.Fatalf("ImportGetByNameAndURLTx: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ImportGetByNameAndURLTx returned nil; row should exist")
+	}
+
+	got.Enabled = false
+	if err := svc.ImportUpdateTx(ctx, db, got); err != nil {
+		t.Fatalf("ImportUpdateTx: %v", err)
+	}
+	reloaded, err := svc.ImportGetByNameAndURLTx(ctx, db, "ImportTx Hook", "https://imp.example/hook")
+	if err != nil {
+		t.Fatalf("reload after ImportUpdateTx: %v", err)
+	}
+	if reloaded.Enabled {
+		t.Error("Enabled should be false after ImportUpdateTx")
+	}
+}
+
+// TestImportCreateTx_ValidationErrors covers the empty-name and empty-URL
+// guard clauses so both required-field branches are credited.
+func TestImportCreateTx_ValidationErrors(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	ctx := context.Background()
+
+	if err := svc.ImportCreateTx(ctx, db, &Webhook{URL: "https://x"}); err == nil {
+		t.Error("expected error on empty name")
+	}
+	if err := svc.ImportCreateTx(ctx, db, &Webhook{Name: "x"}); err == nil {
+		t.Error("expected error on empty URL")
+	}
+}
+
+// TestImportCreateTx_DefaultsTypeToGeneric verifies the type-defaulting
+// branch fires when no Type is supplied.
+func TestImportCreateTx_DefaultsTypeToGeneric(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	ctx := context.Background()
+
+	w := &Webhook{Name: "default-type", URL: "https://x", Events: []string{"e"}}
+	if err := svc.ImportCreateTx(ctx, db, w); err != nil {
+		t.Fatalf("ImportCreateTx: %v", err)
+	}
+	if w.Type != TypeGeneric {
+		t.Errorf("Type: got %q, want %q (default)", w.Type, TypeGeneric)
+	}
+}
+
+// TestImportUpdateTx_NotFound exercises the rows-affected=0 branch.
+func TestImportUpdateTx_NotFound(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	err := svc.ImportUpdateTx(context.Background(), db, &Webhook{
+		ID: "no-such-id", Name: "x", URL: "https://x",
+	})
+	if err == nil {
+		t.Fatal("expected error when updating missing row, got nil")
+	}
+}
+
+// TestImportCreateTx_DBError covers the inserting-webhook error branch.
+func TestImportCreateTx_DBError(t *testing.T) {
+	t.Parallel()
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("opening test db: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("running migrations: %v", err)
+	}
+	svc := NewService(db)
+	_ = db.Close()
+	werr := svc.ImportCreateTx(context.Background(), db, &Webhook{
+		Name: "x", URL: "https://x", Type: TypeGeneric,
+	})
+	if werr == nil {
+		t.Fatal("expected error with closed DB, got nil")
+	}
+}
+
+// TestImportGetByNameAndURLTx_NotFound confirms the nil-on-miss contract.
+func TestImportGetByNameAndURLTx_NotFound(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	got, err := svc.ImportGetByNameAndURLTx(context.Background(), db, "nope", "https://nowhere")
+	if err != nil {
+		t.Fatalf("ImportGetByNameAndURLTx: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for missing row, got %+v", got)
+	}
+}

--- a/internal/webhook/import_test.go
+++ b/internal/webhook/import_test.go
@@ -137,3 +137,21 @@ func TestImportGetByNameAndURLTx_NotFound(t *testing.T) {
 		t.Errorf("expected nil for missing row, got %+v", got)
 	}
 }
+
+// TestImportCreateTx_NilArg + TestImportUpdateTx_NilArg pin the defensive
+// nil-guards on the tx-aware import path.
+func TestImportCreateTx_NilArg(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	if err := svc.ImportCreateTx(context.Background(), db, nil); err == nil {
+		t.Fatal("expected error for nil webhook, got nil")
+	}
+}
+
+func TestImportUpdateTx_NilArg(t *testing.T) {
+	t.Parallel()
+	svc, db := setupTestServiceWithDB(t)
+	if err := svc.ImportUpdateTx(context.Background(), db, nil); err == nil {
+		t.Fatal("expected error for nil webhook, got nil")
+	}
+}

--- a/web/components/_doc-anchors.txt
+++ b/web/components/_doc-anchors.txt
@@ -225,6 +225,7 @@ how-to/export-import-settings#migrating-to-a-new-host
 how-to/export-import-settings#save-the-bundle-somewhere-durable
 how-to/export-import-settings#troubleshooting
 how-to/export-import-settings#what-import-does-on-conflict
+how-to/export-import-settings#what-survives-the-round-trip
 how-to/export-import-settings#whats-in-the-bundle
 how-to/export-import-settings#when-the-sources-owner-is-missing-on-the-target
 how-to/fetch-and-crop-images#comparison-view


### PR DESCRIPTION
## Summary

- `verify_path_after_update` is now carried through the connection export/import wire layer (#1692). Existing 1.4 envelopes still decode; the import path preserves any pre-existing target-side value via a version-gated no-clobber guard. Envelope version bumps 1.4 -> 1.5 (additive optional field).
- Settings import is now atomic across all sections (#1693). Six external services (connection, platform, webhook, provider, rule, scraper) gain tx-aware `Import*Tx` helpers behind a local `DBExecutor` interface; the orchestrator wraps the entire `ImportWithOptions` call in a single `BeginTx`. A failure in any section rolls back every section's writes. Public Create/Update signatures unchanged for non-import callers.
- `TestImport_AtomicAcrossAllSections` exercises every export-able shape, exports, imports into a username-collision target so a late-section import failure triggers; asserts every prior section's writes rolled back. `TestImport_AtomicSameSectionRollback` isolates the rollback boundary on a single helper using explicit `BeginTx` / `Rollback`.

## Linked issue

Closes #1692
Closes #1693

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Code review pass complete: local `coderabbit review --plain` produced 1 minor finding (doc-comment mismatch in `atomicity_test.go`); folded in via amend before squash.
- [x] Commits squashed into clean, logical commits before the first push (single squash commit on push; per-issue commits were used during implementation for reviewer clarity).
- [x] At least one label set on `gh pr create --label ...`.
- [x] Docs label decision made: `needs-docs-review` (envelope format bumps 1.4 -> 1.5).
- [ ] Screenshot attached for any UI change (N/A; data-layer bug fixes).
- [ ] UAT performed for user-visible changes: data-layer round-trip tests substitute for UI UAT. The `verify_path_after_update` field is a checkbox the operator sets in the connection settings UI; the bug was that it silently reset to off after settings import. Verified at the wire layer via `TestRoundTrip_ConnectionVerifyPathAfterUpdate`; not driven through the UI in this PR.
- [x] OpenAPI spec updated if any request or response shape changed (the export envelope shape is JSON, not OpenAPI; the Bruno round-trip assertion was updated to "1.5").
- [x] `templ generate` re-run (no `.templ` files touched).

## Size override

This PR exceeds the standard 800-LOC hand-written threshold (~2,000 LOC across 18 files). The override rationale was approved in the M54 plan: intra-package seam (`internal/settingsio` is the orchestrator; the six satellite packages gain symmetric tx helpers). Splitting #1693 out into its own PR would have required cross-PR coordination on the import-orchestrator seam, costing more reviewer time than the size overshoot saves. Test mass (~780 LOC) is driven by Go coverage attribution: cross-package tests don't credit donor packages, so each donor package needs a direct `import_test.go` to clear the per-package coverage floor.

## Test plan

- [x] `go test -race ./...` passes locally (via pre-push gate).
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [ ] Manual UAT steps:
  - [ ] Reviewer follow-up: end-to-end UAT through the settings UI -- enable "Verify path after update" on a source instance, export, import into a fresh instance, confirm the toggle is on. Not driven by Playwright in this PR; data-layer round-trip tests pin the wire layer.
- [ ] Reviewer follow-ups:
  - [ ] Confirm the version-gated no-clobber guard on legacy `< 1.5` envelopes does the right thing on a real target with a pre-existing `verify_path_after_update=true` row (pinned by `TestImportConnections_PreV15EnvelopePreservesV15Fields`).
  - [ ] Cross-check that the six `DBExecutor` interfaces are truly subset-equivalent (each service's local interface should accept both `*sql.DB` and `*sql.Tx`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings export/import schema bumped to v1.5.
  * Connections now carry a post-update verification setting that round-trips through export/import.
  * Import process is atomic: imports either fully apply or fully roll back across connections, profiles, webhooks, rules, and provider settings.

* **Documentation**
  * Added "What survives the round-trip" guidance for export/import behavior.

* **Tests**
  * Expanded test coverage for import workflows and transaction safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes two data-loss bugs in settings import: `verify_path_after_update` now round-trips through the export/import wire (envelope v1.4 → v1.5), and the entire import is atomic so a failure in any section rolls back every prior section's writes rather than leaving a half-applied configuration.

- Envelope version bumps to 1.5; `envelopeCarriesConnectionV15Fields` gates the new field on the update path so legacy envelopes cannot silently disable the Lidarr path-verification toggle already set on the target.
- Six satellite packages (connection, platform, webhook, provider, rule, scraper) gain symmetric `ImportXxxTx` helpers behind a local `DBExecutor` interface; the orchestrator in `ImportWithOptions` now wraps every section in a single `BeginTx`, with a defer that rolls back and zeros the result on any error path.
- `TestImport_AtomicAcrossAllSections` mutates both a rule's enabled flag and the scraper's fallback chain order before export so the rollback assertions are verifiably non-trivial; `TestImport_AtomicSameSectionRollback` isolates the boundary on a single helper using an explicit `BeginTx`/`Rollback`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the atomicity refactor is well-scoped to the import path and the new tx-aware helpers mirror the original SQL exactly without changing public service signatures.

The single-tx orchestrator change is the riskiest part of this PR, and it is well-tested by TestImport_AtomicAcrossAllSections (cross-section rollback with real SQLite) and TestImport_AtomicSameSectionRollback (single-helper boundary). The library connection-lookup correctly reads through the same tx to avoid deadlocking against the raw pool. The version-gated no-clobber guard for VerifyPathAfterUpdate is tested by TestImportConnections_PreV15EnvelopePreservesV15Fields. No public API surfaces changed, and the defer/rollback path returns a nil result as the contract requires.

No files require special attention beyond the minor const-naming nit in atomicity_test.go.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| internal/settingsio/export.go | Envelope version bumped to 1.5, BeginTx moved to top of ImportWithOptions so all twelve sections run in one transaction; defer zeros the result on rollback and returns nil to the caller. |
| internal/settingsio/import_sections.go | All six delegated helpers gain a dbExecutor parameter and call ImportXxxTx on the owning service; carryV15Fields gate correctly protects the update path only. |
| internal/connection/import.go | New tx-aware import helpers mirror the original SQL exactly, including VerifyPathAfterUpdate in every column list. |
| internal/rule/import.go | ImportUpdateTx mirrors cleanupDisabledRuleState through the supplied executor; violation/result cleanup is part of the same tx and rolls back cleanly on import failure. |
| internal/scraper/import.go | ImportSaveConfigTx correctly resolves the existing scope ID through the tx before the ON CONFLICT upsert; query and arg counts match. |
| internal/settingsio/atomicity_test.go | TestImport_AtomicAcrossAllSections now mutates rules and scraper before export (addressing previous review feedback); TestImport_AtomicSameSectionRollback has misleading const names that don't match importConnections parameter names. |

</details>


</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant ImportWithOptions
    participant db as *sql.DB
    participant tx as *sql.Tx
    participant ConnSvc as connection.Service
    participant ProvSvc as provider.SettingsService
    participant RuleSvc as rule.Service
    participant ScraperSvc as scraper.Service

    Caller->>ImportWithOptions: Import(ctx, envelope, passphrase)
    ImportWithOptions->>db: BeginTx(ctx, nil)
    db-->>ImportWithOptions: tx
    ImportWithOptions->>ProvSvc: ImportSetAPIKeyTx(ctx, tx, ...)
    ImportWithOptions->>ConnSvc: ImportGetByTypeAndURLTx / ImportCreateTx / ImportUpdateTx
    ImportWithOptions->>RuleSvc: ImportGetByIDTx / ImportUpdateTx
    ImportWithOptions->>ScraperSvc: ImportSaveConfigTx
    ImportWithOptions->>tx: importSettings / importUsers / importLibraries
    alt all sections succeed
        ImportWithOptions->>tx: Commit()
        ImportWithOptions-->>Caller: "(*ImportResult, nil)"
    else any section fails
        ImportWithOptions-->>tx: defer Rollback()
        ImportWithOptions-->>Caller: (nil, error)
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/settingsio/atomicity_test.go`, line 1231-1265 ([link](https://github.com/sydlexius/stillwater/blob/052b5a45558c2ad2587119ef0461e3d2539c4e09/internal/settingsio/atomicity_test.go#L1231-L1265)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Atomicity assertions missing for rule and scraper sections**

   `TestImport_AtomicAcrossAllSections` seeds both source and target with `SeedDefaults` for rules and scraper, then exports without modifying any rule/scraper state. The import therefore applies identical values back to the target, making the write a no-op even if it were committed. As a result, the rollback assertions for those two sections aren't meaningful — the target would look the same whether the import committed or rolled back.

   To actually exercise the invariant for rules, the test would need to flip at least one rule (e.g. set `r.Enabled = !r.Enabled` or `r.AutomationMode = AutomationModeAuto`) on the source before exporting, then assert the target still has the pre-import state after rollback. Same approach for scraper (change a field's value). Currently those two sections are covered only by the isolated single-helper test in `TestImport_AtomicSameSectionRollback`, which only covers connections.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fsettingsio%2Fatomicity_test.go%0ALine%3A%201231-1265%0A%0AComment%3A%0A**Atomicity%20assertions%20missing%20for%20rule%20and%20scraper%20sections**%0A%0A%60TestImport_AtomicAcrossAllSections%60%20seeds%20both%20source%20and%20target%20with%20%60SeedDefaults%60%20for%20rules%20and%20scraper%2C%20then%20exports%20without%20modifying%20any%20rule%2Fscraper%20state.%20The%20import%20therefore%20applies%20identical%20values%20back%20to%20the%20target%2C%20making%20the%20write%20a%20no-op%20even%20if%20it%20were%20committed.%20As%20a%20result%2C%20the%20rollback%20assertions%20for%20those%20two%20sections%20aren't%20meaningful%20%E2%80%94%20the%20target%20would%20look%20the%20same%20whether%20the%20import%20committed%20or%20rolled%20back.%0A%0ATo%20actually%20exercise%20the%20invariant%20for%20rules%2C%20the%20test%20would%20need%20to%20flip%20at%20least%20one%20rule%20%28e.g.%20set%20%60r.Enabled%20%3D%20!r.Enabled%60%20or%20%60r.AutomationMode%20%3D%20AutomationModeAuto%60%29%20on%20the%20source%20before%20exporting%2C%20then%20assert%20the%20target%20still%20has%20the%20pre-import%20state%20after%20rollback.%20Same%20approach%20for%20scraper%20%28change%20a%20field's%20value%29.%20Currently%20those%20two%20sections%20are%20covered%20only%20by%20the%20isolated%20single-helper%20test%20in%20%60TestImport_AtomicSameSectionRollback%60%2C%20which%20only%20covers%20connections.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sydlexius%2Fstillwater&pr=1706&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ainternal%2Fsettingsio%2Fatomicity_test.go%3A366-370%0AThe%20two%20local%20consts%20are%20named%20inversely%20relative%20to%20%60importConnections%60's%20actual%20parameters%20%28%60carryV14Fields%2C%20carryV15Fields%60%29.%20%60carryV15Fields%60%20is%20passed%20in%20the%20%60carryV14Fields%60%20position%2C%20and%20%60overwriteExisting%60%20%E2%80%94%20a%20name%20that%20doesn't%20correspond%20to%20any%20parameter%20%E2%80%94%20is%20passed%20in%20the%20%60carryV15Fields%60%20position.%20Both%20happen%20to%20be%20%60true%60%20so%20the%20test%20is%20functionally%20correct%2C%20but%20the%20names%20would%20mislead%20a%20future%20maintainer%20into%20thinking%20there's%20a%20third%20%60overwriteExisting%60%20parameter%2C%20or%20that%20position%205%20controls%20v1.5%20fields.%0A%0A%60%60%60suggestion%0A%09const%20%28%0A%09%09carryV14Fields%20%3D%20true%20%2F%2F%20v1.5%20envelope%20also%20carries%20v1.4%20fields%0A%09%09carryV15Fields%20%3D%20true%20%2F%2F%20envelope%20is%20v1.5%2B%0A%09%29%0A%09if%20err%20%3A%3D%20svc.importConnections%28ctx%2C%20tx%2C%20conns%2C%20%26ImportResult%7B%7D%2C%20carryV14Fields%2C%20carryV15Fields%29%3B%20err%20!%3D%20nil%20%7B%0A%60%60%60%0A%0A&repo=sydlexius%2Fstillwater&pr=1706&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/m54-settin..."](https://github.com/sydlexius/stillwater/commit/bdc87beec47166c039c5dda48294702319bbdb49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34263815)</sub>

<!-- /greptile_comment -->