### PR TITLE
chore(tooling): make worktree + remove-worktree maintain the Active table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,9 @@ hooks:
 doctor:
 	@./scripts/check-hooks.sh
 
-## worktree: Create a sibling worktree with hooks wired and tracker entry appended
-##   Usage: make worktree NAME=<slug> BRANCH=<branch> [ISSUE=<number>]
-##   Example: make worktree NAME=m49.5-merge-policy BRANCH=refactor/m49.5-1395-merge-policy ISSUE=1395
+## worktree: Create a sibling worktree with hooks wired and tracker row inserted into the Active table
+##   Usage: make worktree NAME=<slug> BRANCH=<branch> [ISSUE=<number>] [WAVE=<label>]
+##   Example: make worktree NAME=m49.5-merge-policy BRANCH=refactor/m49.5-1395-merge-policy ISSUE=1395 WAVE="M49.5 W1"
 WORKTREES_MD ?= $(HOME)/.claude/projects/-Users-jesse-Developer-stillwater/memory/worktrees.md
 worktree:
 	@test -n "$(NAME)"   || (echo "error: NAME is required (e.g. make worktree NAME=my-feature BRANCH=feat/my-feature)"; exit 1)
@@ -135,8 +135,31 @@ worktree:
 	git worktree add ../stillwater-$(NAME) -b $(BRANCH)
 	@$(MAKE) -C ../stillwater-$(NAME) hooks
 	@mkdir -p "$(dir $(WORKTREES_MD))"
-	@printf "| stillwater-$(NAME) | $(BRANCH) | $(if $(ISSUE),#$(ISSUE),--) | In Progress |\n" >> "$(WORKTREES_MD)"
-	@echo "Worktree ../stillwater-$(NAME) ready on branch $(BRANCH). Hooks wired. Tracker updated."
+	@touch "$(WORKTREES_MD)"
+	@if ! grep -q '^|---' "$(WORKTREES_MD)"; then \
+		printf '# Active Worktrees\n\n## Active\n\n| Worktree | Branch | Issues | Wave | Status |\n|----------|--------|--------|------|--------|\n' >> "$(WORKTREES_MD)"; \
+	fi
+	@row='| stillwater-$(NAME) | $(BRANCH) | $(if $(ISSUE),#$(ISSUE),--) | $(if $(WAVE),$(WAVE),--) | In progress |'; \
+	awk -v row="$$row" 'BEGIN{ins=0} {print} !ins && /^\|---/ {print row; ins=1}' \
+		"$(WORKTREES_MD)" > "$(WORKTREES_MD).tmp" && mv "$(WORKTREES_MD).tmp" "$(WORKTREES_MD)"
+	@echo "Worktree ../stillwater-$(NAME) ready on branch $(BRANCH). Hooks wired. Active table updated."
+
+## remove-worktree: Remove a sibling worktree (via cleanup-worktree.sh) and delete its Active-table row
+##   Usage: make remove-worktree NAME=<slug>
+##   Example: make remove-worktree NAME=m49.5-merge-policy
+remove-worktree:
+	@test -n "$(NAME)" || (echo "error: NAME is required (e.g. make remove-worktree NAME=my-feature)"; exit 1)
+	@$(HOME)/.claude/scripts/cleanup-worktree.sh "$(NAME)" || \
+		echo "warning: cleanup-worktree.sh exited non-zero (worktree or branch may already be gone); continuing with tracker row removal"
+	@if [ -f "$(WORKTREES_MD)" ]; then \
+		if grep -q '^| stillwater-$(NAME) ' "$(WORKTREES_MD)"; then \
+			awk -v prefix='| stillwater-$(NAME) ' 'index($$0, prefix) != 1' \
+				"$(WORKTREES_MD)" > "$(WORKTREES_MD).tmp" && mv "$(WORKTREES_MD).tmp" "$(WORKTREES_MD)"; \
+			echo "Removed stillwater-$(NAME) row from $(WORKTREES_MD)"; \
+		else \
+			echo "no stillwater-$(NAME) row found in $(WORKTREES_MD); nothing to remove"; \
+		fi; \
+	fi
 
 ## clean: Remove build artifacts
 clean:

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -16,17 +16,30 @@ Branch naming:
 
 ## Creating a worktree
 
+Preferred path is `make worktree`, which creates the worktree, runs `make hooks` inside it, and inserts a row into the Active table in `memory/worktrees.md` automatically:
+
 ```bash
 # Single issue:
-git worktree add -b feat/315-musicbrainz-mirror ../stillwater-315 main
+make worktree NAME=315 BRANCH=feat/315-musicbrainz-mirror ISSUE=315
 
-# Milestone sub-issue (branching from umbrella):
+# Milestone sub-issue (with wave label):
+make worktree NAME=m17-320 BRANCH=feat/320-short-desc ISSUE=320 WAVE="M17 W1"
+```
+
+`NAME` is the suffix after `stillwater-`. `BRANCH` is required. `ISSUE` and `WAVE` are optional; both default to `--` in the tracker row.
+
+For cases the Makefile target does not cover (branching off something other than the current `HEAD`, for example a milestone umbrella branch), fall back to raw `git worktree add` and then update the Active table by hand:
+
+```bash
 git worktree add -b feat/320-short-desc ../stillwater-m17-320 feat/m17-umbrella
+make -C ../stillwater-m17-320 hooks
+# then manually add the row to the Active table in memory/worktrees.md
+# row format: | stillwater-<NAME> | <BRANCH> | #<ISSUE> | <WAVE> | In progress |
 ```
 
 ## Tracking
 
-Active worktrees are tracked in `memory/worktrees.md` inside `~/.claude/projects/<project>/memory/`. Update it whenever a worktree is created or removed.
+Active worktrees are tracked in the `## Active` table at the top of `memory/worktrees.md` inside `~/.claude/projects/<project>/memory/`. `make worktree` inserts the row on create and `make remove-worktree` strips it on cleanup, so the table stays current automatically for worktrees managed through those targets. Manual edits are only needed for the fallback `git worktree add` path described above.
 
 ## Hook installation per worktree
 
@@ -52,15 +65,19 @@ Multiple rule PRs conflict on merge (all modify `engine.go`, `service.go`, `chec
 
 ## Cleanup after merge
 
+Preferred path is `make remove-worktree`, which delegates to `cleanup-worktree.sh` (removes worktree + branches + caches, prunes refs) and then strips the matching row from the Active table in `memory/worktrees.md`:
+
 ```bash
-bash $HOME/.claude/scripts/cleanup-worktree.sh <suffix>
+make remove-worktree NAME=1180          # single-issue
+make remove-worktree NAME=m36-639       # milestone sub-issue
+make remove-worktree NAME=fanart-dup    # slug
 ```
 
-`<suffix>` is whatever follows `stillwater-` in the worktree directory name. Examples (one per worktree shape above):
+`NAME` is whatever follows `stillwater-` in the worktree directory name (same value passed to `make worktree`).
 
-- `1180` for `stillwater-1180` (single-issue)
-- `m36` for `stillwater-m36` (milestone umbrella)
-- `m36-639` for `stillwater-m36-639` (milestone sub-issue)
-- `fanart-dup` for `stillwater-fanart-dup` (slug)
+For repos other than Stillwater, or for invocations from outside the main checkout, the underlying script can be called directly. It is repo-agnostic (detects the repo prefix from the current main worktree's basename), but it does not know about Stillwater's tracker file, so the Active table row must be removed by hand:
 
-The helper is repo-agnostic: it detects the repo prefix from the current main worktree's basename, so the same script works from any checkout. It removes the worktree, deletes local and remote branches, and prunes stale refs. Then update `memory/worktrees.md`.
+```bash
+bash $HOME/.claude/scripts/cleanup-worktree.sh <suffix>
+# then manually delete the matching row from memory/worktrees.md
+```


### PR DESCRIPTION
## Summary

- `make worktree` now inserts the new tracker row into the `## Active` table at the top of `worktrees.md` (immediately after the `|---` header separator) using `awk`, instead of appending to the end of the file with `>>`. New rows match the existing 5-column schema (`Worktree | Branch | Issues | Wave | Status`) and pick up an optional `WAVE=<label>` argument so milestone work can fill the Wave column at create time.
- New `make remove-worktree NAME=<slug>` target: calls the existing `~/.claude/scripts/cleanup-worktree.sh` (removes worktree + branches + caches, prunes refs) and then strips the matching `| stillwater-<slug> |` row from the Active table. `cleanup-worktree.sh` itself stays repo-agnostic; no Stillwater-specific paths leak into the shared script.
- `docs/worktrees.md` updated to lead with the Makefile targets (preferred path) while retaining the raw `git worktree add` + direct `cleanup-worktree.sh` invocations as documented fallbacks for branching off non-`HEAD` refs or for invocations from other repos.

## Linked issue

Closes #1701

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`, gate output captured to `$SW_RUN_DIR/race.log`-style as part of the gate run).
- [x] Code review pass complete (local `coderabbit review --plain` returned 1 finding on the BSD-only `sed -i ''` form; addressed in the same commit by converting the remove path to `awk` for parity with the insert path, which sidesteps the BSD vs GNU sed question entirely).
- [x] Commits squashed into clean, logical commits before the first push (single commit on push).
- [x] At least one label set on `gh pr create --label ...` (`chore`, `scope: small`, `needs-docs-review`).
- [x] Docs label decision made: the doc IS updated in this PR (`docs/worktrees.md`), so `needs-docs-review` is the honest label.
- [ ] Screenshot attached for any UI change (N/A; tooling change).
- [x] UAT performed for user-visible changes: end-to-end smoke test of `make worktree NAME=... BRANCH=... ISSUE=... WAVE=...` followed by `make remove-worktree NAME=...` against a throwaway `WORKTREES_MD` confirms the row is inserted under the table separator with all 5 columns populated, and that `make remove-worktree` strips the row + invokes `cleanup-worktree.sh` correctly. Second smoke run after the `sed`-to-`awk` swap re-verified identical behavior.
- [x] OpenAPI spec updated if any request or response shape changed (N/A; no API change).
- [x] `templ generate` re-run (N/A; no `.templ` files touched).

## Test plan

- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] End-to-end smoke: `make worktree NAME=smoke-final BRANCH=test/smoke-final ISSUE=9999 WORKTREES_MD=<tmp>` inserts row under the table separator; `make remove-worktree NAME=smoke-final WORKTREES_MD=<tmp>` removes the row and invokes `cleanup-worktree.sh` (which removed the actual git worktree + branch).
- [x] `make help` lists both `worktree` and `remove-worktree` with usage hints (verified post-edit).
- [ ] Reviewer follow-ups:
  - [ ] Confirm `awk -v prefix=... 'index($$0, prefix) != 1'` is the right string-match form vs a regex; the choice was deliberate to avoid escaping the `|` characters in the row prefix.
  - [ ] Confirm the fallback `printf ... >> $(WORKTREES_MD)` branch (when no `|---` separator exists yet) is still desired -- it's there for the first-ever `make worktree` invocation in a fresh repo, but if `WORKTREES_MD` is always pre-seeded with the table that branch is dead code.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR upgrades the `worktree` Makefile target to insert new tracker rows into the `## Active` table (rather than appending to end-of-file) using `awk`, adds a `WAVE` column to the 5-column schema, and introduces a new `remove-worktree` target that delegates to `cleanup-worktree.sh` and then strips the matching row. Documentation is updated to present the Makefile targets as the preferred path while retaining raw `git worktree add` / direct script invocations as documented fallbacks.

- `make worktree` now seeds the table header when absent, then inserts the new row immediately after the `|---` separator using an `awk` pass-and-insert pattern with a guard flag (`ins`) to handle multiple separator lines safely.
- `make remove-worktree` chains `cleanup-worktree.sh` with `||` so a non-zero exit (already-removed worktree/branch) falls through to a warning rather than aborting before the `awk` row-deletion step.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one small fix still outstanding from the previous review pass.

The `awk` logic for both insert and delete is correct and cross-platform (avoids BSD vs GNU `sed`). The `||`-guarded `cleanup-worktree.sh` invocation means a pre-removed worktree no longer blocks row deletion. The one remaining open issue — `remove-worktree` is not declared in `.PHONY` — means Make would silently skip both the script call and the row deletion if a file or directory named `remove-worktree` ever landed in the repo root, with no error surfaced to the user.

Makefile — the `.PHONY` declaration at line 1 still needs `remove-worktree` added alongside `worktree`.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Makefile | Adds `worktree` target overhaul (awk-based row insert into Active table, WAVE column support) and new `remove-worktree` target (cleanup-worktree.sh + awk row deletion with `||`-guarded failure handling). `awk`/`index()` logic is correct; minor mismatch between BRE `grep` check and exact `awk` match for NAMEs containing dots. |
| docs/worktrees.md | Documentation updated to prefer Makefile targets for create/cleanup, with raw git commands retained as documented fallbacks. Row format comment in the fallback section accurately reflects the new 5-column schema. |

</details>


</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([make worktree]) --> B{NAME and BRANCH set?}
    B -- no --> B1[exit 1 with usage hint]
    B -- yes --> C[git worktree add sibling dir]
    C --> D[make hooks in new worktree]
    D --> E[touch WORKTREES_MD]
    E --> F{separator line in file?}
    F -- no --> G[append table header and separator]
    F -- yes --> H
    G --> H[awk: insert row after first separator]
    H --> I[atomic mv .tmp to WORKTREES_MD]
    I --> Z1([done: Active table updated])

    AA([make remove-worktree]) --> AB{NAME set?}
    AB -- no --> AB1[exit 1 with usage hint]
    AB -- yes --> AC[cleanup-worktree.sh NAME]
    AC -- exit 0 --> AD
    AC -- exit non-zero --> AW[warn and continue]
    AW --> AD
    AD{WORKTREES_MD exists?}
    AD -- no --> AZ([done: nothing to do])
    AD -- yes --> AE{row found in file?}
    AE -- no --> AF([echo: nothing to remove])
    AE -- yes --> AG[awk: delete matching row]
    AG --> AH[atomic mv .tmp to WORKTREES_MD]
    AH --> AZ2([done: row removed])
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Makefile`, line 1 ([link](https://github.com/sydlexius/stillwater/blob/f5eccc11e62e51c367187be87b02ada7e1422baf/Makefile#L1)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `remove-worktree` is absent from the `.PHONY` declaration at the top of the file. If a file or directory named `remove-worktree` ever appears in the repo root, Make will consider the target up-to-date and silently do nothing — the worktree won't be cleaned up and the tracker row won't be removed. `worktree` is already in the list, so `remove-worktree` just needs to be added alongside it.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20Makefile%0ALine%3A%201%0A%0AComment%3A%0A%60remove-worktree%60%20is%20absent%20from%20the%20%60.PHONY%60%20declaration%20at%20the%20top%20of%20the%20file.%20If%20a%20file%20or%20directory%20named%20%60remove-worktree%60%20ever%20appears%20in%20the%20repo%20root%2C%20Make%20will%20consider%20the%20target%20up-to-date%20and%20silently%20do%20nothing%20%E2%80%94%20the%20worktree%20won't%20be%20cleaned%20up%20and%20the%20tracker%20row%20won't%20be%20removed.%20%60worktree%60%20is%20already%20in%20the%20list%2C%20so%20%60remove-worktree%60%20just%20needs%20to%20be%20added%20alongside%20it.%0A%0A%60%60%60suggestion%0A.PHONY%3A%20build%20run%20test%20test-shuffle%20test-race%20test-cover%20lint%20fmt%20clean%20docker-build%20docker-run%20dev%20templ%20tailwind%20generate%20generate-docs%20migrate%20favicon%20hooks%20doctor%20worktree%20remove-worktree%20check-openapi%20hadolint%20scan%20bruno-ci%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=sydlexius%2Fstillwater&pr=1713&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AMakefile%3A155%0A**%60grep%60%20regex%20wildcard%20in%20NAME%20can%20produce%20misleading%20%22Removed%22%20message**%0A%0A%60grep%20-q%20'%5E%7C%20stillwater-%24%28NAME%29%20'%60%20treats%20%60NAME%60%20as%20a%20BRE%20pattern%2C%20so%20a%20dot%20in%20names%20like%20%60m49.5%60%20matches%20any%20character.%20If%20the%20file%20contains%20no%20exact%20row%20for%20%60m49.5%60%20but%20does%20contain%20%60m4905%60%20%28or%20similar%29%2C%20the%20grep%20check%20passes%2C%20the%20%60awk%60%20block%20runs%2C%20finds%20nothing%20to%20delete%20%28awk%20uses%20%60index%28%29%60%20%E2%80%94%20an%20exact-string%20match%2C%20so%20the%20file%20is%20correctly%20left%20alone%29%2C%20and%20the%20script%20still%20prints%20%60%22Removed%20stillwater-m49.5%20row%22%60%20even%20though%20nothing%20changed.%20Use%20%60grep%20-qF%60%20to%20make%20the%20check%20a%20literal-string%20search%2C%20consistent%20with%20what%20%60awk%60's%20%60index%28%29%60%20does%20downstream.%0A%0A&repo=sydlexius%2Fstillwater&pr=1713&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["chore(tooling): make worktree + remove-w..."](https://github.com/sydlexius/stillwater/commit/bccc582d2e3ed079c51d85060949a9846f1bef10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34283847)</sub>

<!-- /greptile_comment -->