### PR TITLE
perf(rule): intra-artist provider-fetch coalescing (#1133, M54 W2A)

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -758,6 +758,12 @@ func (a *Application) wireRuleEngine(ctx context.Context, logger *slog.Logger) e
 	}
 	a.pipeline = rule.NewPipeline(a.ruleEngine, a.artistService, a.ruleService, fixers, a.publisher, logger)
 	a.pipeline.SetHistoryService(a.historyService)
+	// Wire the provider Orchestrator so the pipeline can build a per-artist
+	// EvaluationContext that coalesces upstream fetches across the rule
+	// fixer chain (M54 #1133). Without this setter the pipeline still
+	// runs -- fixers fall back to direct orchestrator calls -- but every
+	// rule that needs the same provider data triggers its own fetch.
+	a.pipeline.SetOrchestrator(a.orchestrator)
 
 	a.bulkService = rule.NewBulkService(db)
 	a.bulkExecutor = rule.NewBulkExecutor(a.bulkService, a.artistService, a.orchestrator, a.pipeline, a.nfoSnapshotService, a.platformService, a.expectedWrites, a.publisher, logger)

--- a/internal/rule/eval_context.go
+++ b/internal/rule/eval_context.go
@@ -3,6 +3,7 @@ package rule
 import (
 	"context"
 	"log/slog"
+	"sort"
 	"sync"
 	"sync/atomic"
 
@@ -10,13 +11,13 @@ import (
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
-// evalProvider is the union of provider-call surfaces the
+// EvalProvider is the union of provider-call surfaces the
 // EvaluationContext coalesces. Defining it as an interface (rather than
-// holding a *provider.Orchestrator) lets tests inject a stub provider
-// without spinning up the full orchestrator dependency chain, while the
-// production wiring (Pipeline.SetOrchestrator -> NewEvaluationContext)
-// passes the real *provider.Orchestrator which satisfies it.
-type evalProvider interface {
+// holding a *provider.Orchestrator) lets tests drive the production
+// SetOrchestrator wiring with a stub instead of spinning up the full
+// orchestrator dependency chain; the real *provider.Orchestrator
+// satisfies it for production wiring.
+type EvalProvider interface {
 	FetchImages(ctx context.Context, mbid string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error)
 	FetchMetadata(ctx context.Context, mbid, name string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error)
 	FetchFieldFromProviders(ctx context.Context, mbid, name, field string, providerIDs map[provider.ProviderName]string) ([]provider.FieldProviderResult, error)
@@ -57,7 +58,7 @@ type evalProvider interface {
 // does not need to rename anything.
 type EvaluationContext struct {
 	artistID string
-	orch     evalProvider
+	orch     EvalProvider
 	logger   *slog.Logger
 
 	mu    sync.Mutex
@@ -88,12 +89,32 @@ type evalCacheKey struct {
 // evalCacheEntry stores the cached outcome of a coalesced fetch. Errors
 // are cached so a flapping provider does not amplify a single failure
 // into N retries across N rules in the same pass.
+//
+// done is closed once the entry's payload fields are populated. The
+// publishing goroutine inserts the placeholder under the cache lock,
+// releases the lock, runs the actual fetch, populates the fields, and
+// closes done. Late callers that find the placeholder in the cache wait
+// on done before reading the payload -- the singleflight pattern that
+// guarantees one upstream fetch per cache key even under parallel
+// callers (the W4 telemetry decision depends on the counter staying
+// honest under Phase 2 parallel evaluation).
 type evalCacheEntry struct {
 	fetch  *provider.FetchResult
 	search []provider.ArtistSearchResult
 	field  []provider.FieldProviderResult
 	err    error
+	done   chan struct{}
 }
+
+// alreadyDoneCh is a closed channel reused as the done signal for cache
+// entries that are populated synchronously (notably the nil-orchestrator
+// sentinel in dispatch). Sharing one closed channel keeps the hot path
+// from allocating per call when we know the entry is already terminal.
+var alreadyDoneCh = func() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}()
 
 // NewEvaluationContext constructs a fresh per-artist context. orch is the
 // real provider orchestrator; logger is used to emit cache-hit / fetch
@@ -103,7 +124,7 @@ type evalCacheEntry struct {
 // Passing a nil orchestrator is supported for tests that exercise paths
 // not reaching a provider call -- methods will return a sentinel error
 // instead of panicking.
-func NewEvaluationContext(a *artist.Artist, orch evalProvider, logger *slog.Logger) *EvaluationContext {
+func NewEvaluationContext(a *artist.Artist, orch EvalProvider, logger *slog.Logger) *EvaluationContext {
 	id := ""
 	if a != nil {
 		id = a.ID
@@ -136,15 +157,18 @@ func (e *EvaluationContext) Counters() (fetches, dedups uint64) {
 // Two violations that arrive with the same MBID but different provider-ID
 // hints must NOT coalesce, otherwise a re-evaluation triggered after a
 // provider-ID enrichment would silently reuse the pre-enrichment payload.
+//
+// Output layout: the canonical priority-order subset first (the common
+// case from the existing ImageFixer cache key), then every remaining map
+// key sorted alphabetically. The sort over extras keeps the fingerprint
+// stable across Go's randomized map iteration so two equivalent maps
+// produce the same string. Skipping the extras path -- as the first
+// version of this function did -- silently collides any two calls that
+// differ only in an unlisted provider name.
 func providerIDFingerprint(ids map[provider.ProviderName]string) string {
 	if len(ids) == 0 {
 		return ""
 	}
-	// Emit in the canonical priority-order subset the existing
-	// ImageFixer cache key already used, plus any other names that
-	// appear in the map. The fixed prefix keeps the common case
-	// (audiodb/discogs/deezer/spotify) deterministic; the trailing
-	// extras path handles provider IDs added by future enrichment.
 	canonical := []provider.ProviderName{
 		provider.NameAudioDB,
 		provider.NameDiscogs,
@@ -156,12 +180,28 @@ func providerIDFingerprint(ids map[provider.ProviderName]string) string {
 		provider.NameWikidata,
 		provider.NameWikipedia,
 	}
+	seen := make(map[provider.ProviderName]struct{}, len(canonical))
 	var buf []byte
 	for _, n := range canonical {
+		seen[n] = struct{}{}
 		buf = append(buf, byte('|'))
 		buf = append(buf, string(n)...)
 		buf = append(buf, '=')
 		buf = append(buf, ids[n]...)
+	}
+	extras := make([]string, 0, len(ids))
+	for n := range ids {
+		if _, isCanonical := seen[n]; isCanonical {
+			continue
+		}
+		extras = append(extras, string(n))
+	}
+	sort.Strings(extras)
+	for _, raw := range extras {
+		buf = append(buf, byte('|'))
+		buf = append(buf, raw...)
+		buf = append(buf, '=')
+		buf = append(buf, ids[provider.ProviderName(raw)]...)
 	}
 	return string(buf)
 }
@@ -184,6 +224,7 @@ func (e *EvaluationContext) FetchImages(ctx context.Context, mbid string, provid
 	e.mu.Lock()
 	if cached, ok := e.cache[key]; ok {
 		e.mu.Unlock()
+		<-cached.done
 		e.dedupTotal.Add(1)
 		e.logger.Debug("provider fetch dedup",
 			slog.String("method", "images"),
@@ -192,13 +233,12 @@ func (e *EvaluationContext) FetchImages(ctx context.Context, mbid string, provid
 		)
 		return cached.fetch, cached.err
 	}
-	// Unlock before the orchestrator call so unrelated keys can fetch
-	// concurrently. dispatch() performs a second cache check under the
-	// lock to handle the narrow race where another goroutine populated
-	// the entry between our miss and the dispatch call. For Phase 1 the
-	// rule loop is sequential per artist so the race is unlikely;
-	// Phase 2 (#1134) may revisit if duplicate fetches show up in the
-	// telemetry.
+	// Unlock before dispatch so unrelated keys can fetch concurrently.
+	// dispatch publishes a singleflight placeholder under the lock and
+	// closes its done channel after the upstream fetch completes; any
+	// parallel caller that races past this fast-path miss will see the
+	// placeholder under dispatch's own lock check, wait on done, and
+	// dedup-count without re-issuing the upstream call.
 	e.mu.Unlock()
 	result, err := e.dispatch(ctx, key, func() *evalCacheEntry {
 		fr, ferr := e.orch.FetchImages(ctx, mbid, providerIDs)
@@ -221,6 +261,7 @@ func (e *EvaluationContext) FetchMetadata(ctx context.Context, mbid, name string
 	e.mu.Lock()
 	if cached, ok := e.cache[key]; ok {
 		e.mu.Unlock()
+		<-cached.done
 		e.dedupTotal.Add(1)
 		e.logger.Debug("provider fetch dedup",
 			slog.String("method", "metadata"),
@@ -252,6 +293,7 @@ func (e *EvaluationContext) FetchFieldFromProviders(ctx context.Context, mbid, n
 	e.mu.Lock()
 	if cached, ok := e.cache[key]; ok {
 		e.mu.Unlock()
+		<-cached.done
 		e.dedupTotal.Add(1)
 		e.logger.Debug("provider fetch dedup",
 			slog.String("method", "field"),
@@ -284,6 +326,7 @@ func (e *EvaluationContext) Search(ctx context.Context, name string) ([]provider
 	e.mu.Lock()
 	if cached, ok := e.cache[key]; ok {
 		e.mu.Unlock()
+		<-cached.done
 		e.dedupTotal.Add(1)
 		e.logger.Debug("provider fetch dedup",
 			slog.String("method", "search"),
@@ -300,63 +343,71 @@ func (e *EvaluationContext) Search(ctx context.Context, name string) ([]provider
 	return result.search, err
 }
 
-// dispatch runs fetch, stores the resulting entry under key, and bumps the
-// fetch counter. The lock is held only across the map mutation, not across
-// the network call, so unrelated keys can fetch concurrently. The current
-// rule loop is sequential per artist so the lock is effectively
-// uncontended; Phase 2 / #1135 may parallelize.
+// dispatch is the singleflight publisher for a coalesced provider call.
+// It guarantees exactly one fetch() per cache key by inserting an
+// in-flight placeholder entry under the cache lock BEFORE running fetch;
+// any parallel goroutine that arrives between the per-method fast-path
+// miss and this point finds the placeholder under dispatch's own lock
+// check, waits on placeholder.done, and dedup-counts without re-issuing
+// the upstream call. This is the contract change that makes
+// provider_fetch_total stay honest under Phase 2 (#1134) parallel
+// evaluation -- without it, two racers both miss the initial check,
+// both call fetch(), and the second one's increment inflates the
+// telemetry by one with no compensating dedup hit (the Greptile P2
+// finding).
+//
+// nil-orchestrator path: surfaces the typed sentinel instead of a
+// nil-deref panic inside fetch(). The sentinel entry is cached the same
+// way any other failure is, so subsequent rules in the same pass do not
+// retry; it uses the shared alreadyDoneCh so callers waiting on done
+// observe the populated entry immediately.
 func (e *EvaluationContext) dispatch(_ context.Context, key evalCacheKey, fetch func() *evalCacheEntry) (*evalCacheEntry, error) {
-	// Guard nil orchestrator so a misconfigured context surfaces the
-	// typed sentinel instead of a nil-deref panic inside fetch(). This
-	// keeps the doc promise on NewEvaluationContext consistent with the
-	// runtime behavior for tests that construct a context without an
-	// orchestrator. The sentinel entry is cached the same way any other
-	// failure is, so subsequent rules in the same pass do not retry.
 	if e.orch == nil {
-		entry := &evalCacheEntry{err: errNilEvalContext}
+		entry := &evalCacheEntry{err: errNilEvalContext, done: alreadyDoneCh}
 		e.mu.Lock()
 		if existing, ok := e.cache[key]; ok {
 			e.mu.Unlock()
+			<-existing.done
+			e.dedupTotal.Add(1)
 			return existing, existing.err
 		}
 		e.cache[key] = entry
 		e.mu.Unlock()
 		return entry, entry.err
 	}
-	// Re-check under the lock in case another goroutine populated the
-	// key between our initial miss and now. Without this, two concurrent
-	// callers for the same key both miss, both dispatch, and the second
-	// to finish overwrites the first's entry -- benign for correctness
-	// but doubles the fetch count we are trying to eliminate.
+
+	// Singleflight publish: re-check the cache under the lock to absorb
+	// any racer that arrived between the per-method fast-path miss and
+	// this point; if absent, insert a placeholder with an unclosed done
+	// channel so late callers will wait rather than redispatch.
 	e.mu.Lock()
 	if cached, ok := e.cache[key]; ok {
 		e.mu.Unlock()
+		<-cached.done
 		e.dedupTotal.Add(1)
 		return cached, cached.err
 	}
+	placeholder := &evalCacheEntry{done: make(chan struct{})}
+	e.cache[key] = placeholder
 	e.mu.Unlock()
 
-	entry := fetch()
+	// Fetch outside the lock so unrelated keys can fetch concurrently.
+	// The placeholder is already published, so its identity is what
+	// every caller will observe -- copying the populated fields into it
+	// after the fetch is the standard singleflight finish.
+	filled := fetch()
+	placeholder.fetch = filled.fetch
+	placeholder.search = filled.search
+	placeholder.field = filled.field
+	placeholder.err = filled.err
 	e.fetchTotal.Add(1)
-
-	e.mu.Lock()
-	// If a concurrent caller raced ahead and populated the slot while
-	// we were fetching, prefer the earlier entry to keep cache identity
-	// stable for any consumer that compared pointers. Either entry is
-	// correct because the underlying orchestrator call is idempotent on
-	// this layer.
-	if existing, ok := e.cache[key]; ok {
-		e.mu.Unlock()
-		return existing, existing.err
-	}
-	e.cache[key] = entry
-	e.mu.Unlock()
+	close(placeholder.done)
 
 	e.logger.Debug("provider fetch dispatched",
 		slog.String("method", key.method),
 		slog.String("artist_id", key.artistID),
 	)
-	return entry, entry.err
+	return placeholder, placeholder.err
 }
 
 // evalContextKey is the unexported context.Context value key used to

--- a/internal/rule/eval_context.go
+++ b/internal/rule/eval_context.go
@@ -1,0 +1,398 @@
+package rule
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// evalProvider is the union of provider-call surfaces the
+// EvaluationContext coalesces. Defining it as an interface (rather than
+// holding a *provider.Orchestrator) lets tests inject a stub provider
+// without spinning up the full orchestrator dependency chain, while the
+// production wiring (Pipeline.SetOrchestrator -> NewEvaluationContext)
+// passes the real *provider.Orchestrator which satisfies it.
+type evalProvider interface {
+	FetchImages(ctx context.Context, mbid string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error)
+	FetchMetadata(ctx context.Context, mbid, name string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error)
+	FetchFieldFromProviders(ctx context.Context, mbid, name, field string, providerIDs map[provider.ProviderName]string) ([]provider.FieldProviderResult, error)
+	Search(ctx context.Context, name string) ([]provider.ArtistSearchResult, error)
+}
+
+// EvaluationContext coalesces provider fetches that would otherwise run once
+// per rule when several rules on the same artist need the same upstream
+// payload. It sits between the fixer chain and the provider Orchestrator:
+// the first rule that asks for a given (artist, provider-call) pair triggers
+// the real fetch and caches the full result; every subsequent rule in the
+// same evaluation reuses that cached result instead of issuing a fresh
+// network call.
+//
+// Phase 1 lifetime (issue #1133): one EvaluationContext per (artist,
+// evaluation pass). The pipeline constructs it before dispatching
+// violations and lets it fall out of scope once the artist's pass
+// completes. There is no cross-artist leakage.
+//
+// Phase 2 (issue #1134) will widen the lifetime to one context per
+// Run-All-Rules pass so a single artist's payload survives across re-entries
+// inside the same pass. The cache key already includes artist_id so Phase 2
+// can adopt the same struct without renaming counters or restructuring the
+// map.
+//
+// Error caching: failed fetches are cached for the duration of the context
+// per the issue spec, so a flapping provider does not amplify a single
+// failure into N retries across N rules.
+//
+// Concurrency: the cache is guarded by a mutex. Current rule evaluation is
+// serial per artist, but the cost of the lock is negligible compared to a
+// provider call and the safety margin protects future parallel-fixer work
+// (#1135 batch endpoints, scheduler).
+//
+// Counters (provider_fetch_total, provider_fetch_dedup_total) are exposed
+// for the W4 (#1135) telemetry-gated decision. Phase 2 will add a
+// provider_cache_hit_total counter; the names here are chosen so Phase 2
+// does not need to rename anything.
+type EvaluationContext struct {
+	artistID string
+	orch     evalProvider
+	logger   *slog.Logger
+
+	mu    sync.Mutex
+	cache map[evalCacheKey]*evalCacheEntry
+
+	// Atomic counters. fetchTotal increments on every actual provider
+	// call dispatched through this context; dedupTotal increments on
+	// every cache hit (a rule asked for a payload that was already
+	// fetched, including a cached failure).
+	fetchTotal atomic.Uint64
+	dedupTotal atomic.Uint64
+}
+
+// evalCacheKey identifies a single coalesced provider call. method is a
+// stable tag for the orchestrator method ("images", "metadata", "field",
+// "search"); detail carries any method-specific discriminator (the field
+// name for FetchFieldFromProviders, the search query for Search, the
+// concatenated provider-ID fingerprint for the artist-bound calls).
+//
+// artist_id is included even in Phase 1 so the same struct survives the
+// Phase 2 lifetime widening without a key rewrite.
+type evalCacheKey struct {
+	artistID string
+	method   string
+	detail   string
+}
+
+// evalCacheEntry stores the cached outcome of a coalesced fetch. Errors
+// are cached so a flapping provider does not amplify a single failure
+// into N retries across N rules in the same pass.
+type evalCacheEntry struct {
+	fetch  *provider.FetchResult
+	search []provider.ArtistSearchResult
+	field  []provider.FieldProviderResult
+	err    error
+}
+
+// NewEvaluationContext constructs a fresh per-artist context. orch is the
+// real provider orchestrator; logger is used to emit cache-hit / fetch
+// debug records that future telemetry scrapes can pick up via the
+// "evalctx" component tag.
+//
+// Passing a nil orchestrator is supported for tests that exercise paths
+// not reaching a provider call -- methods will return a sentinel error
+// instead of panicking.
+func NewEvaluationContext(a *artist.Artist, orch evalProvider, logger *slog.Logger) *EvaluationContext {
+	id := ""
+	if a != nil {
+		id = a.ID
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &EvaluationContext{
+		artistID: id,
+		orch:     orch,
+		logger:   logger.With(slog.String("component", "rule.evalctx")),
+		cache:    make(map[evalCacheKey]*evalCacheEntry),
+	}
+}
+
+// Counters returns the cumulative fetch and dedup counts for this
+// context. The values are a snapshot taken without acquiring the cache
+// mutex; both counters are atomic. Callers use this for end-of-pass
+// telemetry assertions in tests and may later wire them into a metrics
+// scraper.
+func (e *EvaluationContext) Counters() (fetches, dedups uint64) {
+	if e == nil {
+		return 0, 0
+	}
+	return e.fetchTotal.Load(), e.dedupTotal.Load()
+}
+
+// providerIDFingerprint produces a stable, order-independent string from a
+// providerIDs map so the cache key reflects the actual fetch parameters.
+// Two violations that arrive with the same MBID but different provider-ID
+// hints must NOT coalesce, otherwise a re-evaluation triggered after a
+// provider-ID enrichment would silently reuse the pre-enrichment payload.
+func providerIDFingerprint(ids map[provider.ProviderName]string) string {
+	if len(ids) == 0 {
+		return ""
+	}
+	// Emit in the canonical priority-order subset the existing
+	// ImageFixer cache key already used, plus any other names that
+	// appear in the map. The fixed prefix keeps the common case
+	// (audiodb/discogs/deezer/spotify) deterministic; the trailing
+	// extras path handles provider IDs added by future enrichment.
+	canonical := []provider.ProviderName{
+		provider.NameAudioDB,
+		provider.NameDiscogs,
+		provider.NameDeezer,
+		provider.NameSpotify,
+		provider.NameMusicBrainz,
+		provider.NameLastFM,
+		provider.NameFanartTV,
+		provider.NameWikidata,
+		provider.NameWikipedia,
+	}
+	var buf []byte
+	for _, n := range canonical {
+		buf = append(buf, byte('|'))
+		buf = append(buf, string(n)...)
+		buf = append(buf, '=')
+		buf = append(buf, ids[n]...)
+	}
+	return string(buf)
+}
+
+// FetchImages coalesces calls to provider.Orchestrator.FetchImages keyed by
+// (artist_id, mbid, providerIDs). The first call for a given key dispatches
+// to the orchestrator; every subsequent call in the same context returns
+// the cached *FetchResult and error.
+func (e *EvaluationContext) FetchImages(ctx context.Context, mbid string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error) {
+	if e == nil {
+		// Defensive: fixers should never receive a nil context, but if
+		// they do, surface a typed sentinel instead of nil-deref.
+		return nil, errNilEvalContext
+	}
+	key := evalCacheKey{
+		artistID: e.artistID,
+		method:   "images",
+		detail:   mbid + providerIDFingerprint(providerIDs),
+	}
+	e.mu.Lock()
+	if cached, ok := e.cache[key]; ok {
+		e.mu.Unlock()
+		e.dedupTotal.Add(1)
+		e.logger.Debug("provider fetch dedup",
+			slog.String("method", "images"),
+			slog.String("artist_id", e.artistID),
+			slog.String("mbid", mbid),
+		)
+		return cached.fetch, cached.err
+	}
+	// Unlock before the orchestrator call so unrelated keys can fetch
+	// concurrently. dispatch() performs a second cache check under the
+	// lock to handle the narrow race where another goroutine populated
+	// the entry between our miss and the dispatch call. For Phase 1 the
+	// rule loop is sequential per artist so the race is unlikely;
+	// Phase 2 (#1134) may revisit if duplicate fetches show up in the
+	// telemetry.
+	e.mu.Unlock()
+	result, err := e.dispatch(ctx, key, func() *evalCacheEntry {
+		fr, ferr := e.orch.FetchImages(ctx, mbid, providerIDs)
+		return &evalCacheEntry{fetch: fr, err: ferr}
+	})
+	return result.fetch, err
+}
+
+// FetchMetadata coalesces calls to provider.Orchestrator.FetchMetadata.
+// Cache key is (artist_id, mbid, name, providerIDs).
+func (e *EvaluationContext) FetchMetadata(ctx context.Context, mbid, name string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error) {
+	if e == nil {
+		return nil, errNilEvalContext
+	}
+	key := evalCacheKey{
+		artistID: e.artistID,
+		method:   "metadata",
+		detail:   mbid + "|" + name + providerIDFingerprint(providerIDs),
+	}
+	e.mu.Lock()
+	if cached, ok := e.cache[key]; ok {
+		e.mu.Unlock()
+		e.dedupTotal.Add(1)
+		e.logger.Debug("provider fetch dedup",
+			slog.String("method", "metadata"),
+			slog.String("artist_id", e.artistID),
+			slog.String("name", name),
+		)
+		return cached.fetch, cached.err
+	}
+	e.mu.Unlock()
+	result, err := e.dispatch(ctx, key, func() *evalCacheEntry {
+		fr, ferr := e.orch.FetchMetadata(ctx, mbid, name, providerIDs)
+		return &evalCacheEntry{fetch: fr, err: ferr}
+	})
+	return result.fetch, err
+}
+
+// FetchFieldFromProviders coalesces calls to
+// provider.Orchestrator.FetchFieldFromProviders. Cache key is
+// (artist_id, mbid, name, field, providerIDs).
+func (e *EvaluationContext) FetchFieldFromProviders(ctx context.Context, mbid, name, field string, providerIDs map[provider.ProviderName]string) ([]provider.FieldProviderResult, error) {
+	if e == nil {
+		return nil, errNilEvalContext
+	}
+	key := evalCacheKey{
+		artistID: e.artistID,
+		method:   "field/" + field,
+		detail:   mbid + "|" + name + providerIDFingerprint(providerIDs),
+	}
+	e.mu.Lock()
+	if cached, ok := e.cache[key]; ok {
+		e.mu.Unlock()
+		e.dedupTotal.Add(1)
+		e.logger.Debug("provider fetch dedup",
+			slog.String("method", "field"),
+			slog.String("artist_id", e.artistID),
+			slog.String("field", field),
+		)
+		return cached.field, cached.err
+	}
+	e.mu.Unlock()
+	result, err := e.dispatch(ctx, key, func() *evalCacheEntry {
+		results, ferr := e.orch.FetchFieldFromProviders(ctx, mbid, name, field, providerIDs)
+		return &evalCacheEntry{field: results, err: ferr}
+	})
+	return result.field, err
+}
+
+// Search coalesces calls to provider.Orchestrator.Search. Cache key is
+// (artist_id, name). Search is keyed by name rather than MBID because its
+// purpose is to RESOLVE a missing MBID; a second rule on the same artist
+// that also needs to search would otherwise issue a duplicate call.
+func (e *EvaluationContext) Search(ctx context.Context, name string) ([]provider.ArtistSearchResult, error) {
+	if e == nil {
+		return nil, errNilEvalContext
+	}
+	key := evalCacheKey{
+		artistID: e.artistID,
+		method:   "search",
+		detail:   name,
+	}
+	e.mu.Lock()
+	if cached, ok := e.cache[key]; ok {
+		e.mu.Unlock()
+		e.dedupTotal.Add(1)
+		e.logger.Debug("provider fetch dedup",
+			slog.String("method", "search"),
+			slog.String("artist_id", e.artistID),
+			slog.String("name", name),
+		)
+		return cached.search, cached.err
+	}
+	e.mu.Unlock()
+	result, err := e.dispatch(ctx, key, func() *evalCacheEntry {
+		results, ferr := e.orch.Search(ctx, name)
+		return &evalCacheEntry{search: results, err: ferr}
+	})
+	return result.search, err
+}
+
+// dispatch runs fetch, stores the resulting entry under key, and bumps the
+// fetch counter. The lock is held only across the map mutation, not across
+// the network call, so unrelated keys can fetch concurrently. The current
+// rule loop is sequential per artist so the lock is effectively
+// uncontended; Phase 2 / #1135 may parallelize.
+func (e *EvaluationContext) dispatch(_ context.Context, key evalCacheKey, fetch func() *evalCacheEntry) (*evalCacheEntry, error) {
+	// Guard nil orchestrator so a misconfigured context surfaces the
+	// typed sentinel instead of a nil-deref panic inside fetch(). This
+	// keeps the doc promise on NewEvaluationContext consistent with the
+	// runtime behavior for tests that construct a context without an
+	// orchestrator. The sentinel entry is cached the same way any other
+	// failure is, so subsequent rules in the same pass do not retry.
+	if e.orch == nil {
+		entry := &evalCacheEntry{err: errNilEvalContext}
+		e.mu.Lock()
+		if existing, ok := e.cache[key]; ok {
+			e.mu.Unlock()
+			return existing, existing.err
+		}
+		e.cache[key] = entry
+		e.mu.Unlock()
+		return entry, entry.err
+	}
+	// Re-check under the lock in case another goroutine populated the
+	// key between our initial miss and now. Without this, two concurrent
+	// callers for the same key both miss, both dispatch, and the second
+	// to finish overwrites the first's entry -- benign for correctness
+	// but doubles the fetch count we are trying to eliminate.
+	e.mu.Lock()
+	if cached, ok := e.cache[key]; ok {
+		e.mu.Unlock()
+		e.dedupTotal.Add(1)
+		return cached, cached.err
+	}
+	e.mu.Unlock()
+
+	entry := fetch()
+	e.fetchTotal.Add(1)
+
+	e.mu.Lock()
+	// If a concurrent caller raced ahead and populated the slot while
+	// we were fetching, prefer the earlier entry to keep cache identity
+	// stable for any consumer that compared pointers. Either entry is
+	// correct because the underlying orchestrator call is idempotent on
+	// this layer.
+	if existing, ok := e.cache[key]; ok {
+		e.mu.Unlock()
+		return existing, existing.err
+	}
+	e.cache[key] = entry
+	e.mu.Unlock()
+
+	e.logger.Debug("provider fetch dispatched",
+		slog.String("method", key.method),
+		slog.String("artist_id", key.artistID),
+	)
+	return entry, entry.err
+}
+
+// evalContextKey is the unexported context.Context value key used to
+// thread an EvaluationContext through the rule pipeline -> fixer chain
+// without altering the Fixer interface. A typed key avoids collision with
+// any other package's context values.
+type evalContextKeyType struct{}
+
+var evalContextKey = evalContextKeyType{}
+
+// WithEvaluationContext returns a derived context.Context carrying ec.
+// Fixers retrieve it via EvaluationContextFromContext.
+func WithEvaluationContext(parent context.Context, ec *EvaluationContext) context.Context {
+	if ec == nil {
+		return parent
+	}
+	return context.WithValue(parent, evalContextKey, ec)
+}
+
+// EvaluationContextFromContext returns the EvaluationContext threaded onto
+// ctx, or nil when ctx carries none. Fixers fall back to the bare
+// orchestrator in that case so single-violation paths like FixViolation
+// (or any code path the pipeline did not seed) keep working unchanged.
+func EvaluationContextFromContext(ctx context.Context) *EvaluationContext {
+	if ctx == nil {
+		return nil
+	}
+	ec, _ := ctx.Value(evalContextKey).(*EvaluationContext)
+	return ec
+}
+
+// errNilEvalContext signals that a method was called on a nil
+// *EvaluationContext. Callers should treat it the same as an orchestrator
+// failure: warn-log and surface the fix as not-applied.
+var errNilEvalContext = &evalCtxError{msg: "nil EvaluationContext"}
+
+type evalCtxError struct{ msg string }
+
+func (e *evalCtxError) Error() string { return e.msg }

--- a/internal/rule/eval_context_test.go
+++ b/internal/rule/eval_context_test.go
@@ -160,6 +160,70 @@ func TestEvaluationContext_DistinctKeysDoNotCoalesce(t *testing.T) {
 	}
 }
 
+// TestEvaluationContext_NonCanonicalProviderIDsDifferentiate verifies the
+// open reviewer concern from PR #1718 round 1 (Greptile P1 / CR Major):
+// providerIDFingerprint must include non-canonical provider IDs so two
+// calls that differ only in an unlisted provider produce distinct cache
+// keys. Without this, a Phase 2 enrichment that adds a new provider hint
+// would silently reuse the pre-enrichment payload.
+func TestEvaluationContext_NonCanonicalProviderIDsDifferentiate(t *testing.T) {
+	count := &countingEvalProvider{
+		imagesResult: &provider.FetchResult{},
+	}
+	a := &artist.Artist{ID: "artist-fp", Name: "Test"}
+	ec := NewEvaluationContext(a, count, testLogger())
+
+	// Two calls that share an MBID and ALL canonical provider IDs but
+	// differ only in a non-canonical provider name's value. Pre-fix
+	// behavior was to drop the non-canonical entry from the fingerprint
+	// so these would collide; the post-fix fingerprint must include
+	// every key.
+	canonicalIDs := map[provider.ProviderName]string{
+		provider.NameAudioDB:  "audio-1",
+		provider.NameDiscogs:  "disc-1",
+		provider.NameDeezer:   "deez-1",
+		provider.NameSpotify:  "spot-1",
+		provider.NameLastFM:   "lfm-1",
+		provider.NameFanartTV: "fan-1",
+	}
+	nonCanonical := provider.ProviderName("hypothetical-future-provider")
+
+	a1 := make(map[provider.ProviderName]string, len(canonicalIDs)+1)
+	for k, v := range canonicalIDs {
+		a1[k] = v
+	}
+	a1[nonCanonical] = "v1"
+
+	a2 := make(map[provider.ProviderName]string, len(canonicalIDs)+1)
+	for k, v := range canonicalIDs {
+		a2[k] = v
+	}
+	a2[nonCanonical] = "v2"
+
+	if _, err := ec.FetchImages(context.Background(), "mbid-fp", a1); err != nil {
+		t.Fatalf("FetchImages a1: %v", err)
+	}
+	if _, err := ec.FetchImages(context.Background(), "mbid-fp", a2); err != nil {
+		t.Fatalf("FetchImages a2: %v", err)
+	}
+	if got := count.fetchImagesCalls.Load(); got != 2 {
+		t.Errorf("FetchImages dispatched %d times; want 2 (non-canonical IDs must differentiate)", got)
+	}
+
+	// Sanity: two calls with identical non-canonical IDs DO coalesce.
+	a3 := make(map[provider.ProviderName]string, len(canonicalIDs)+1)
+	for k, v := range canonicalIDs {
+		a3[k] = v
+	}
+	a3[nonCanonical] = "v2"
+	if _, err := ec.FetchImages(context.Background(), "mbid-fp", a3); err != nil {
+		t.Fatalf("FetchImages a3: %v", err)
+	}
+	if got := count.fetchImagesCalls.Load(); got != 2 {
+		t.Errorf("FetchImages dispatched %d times after duplicate-keys call; want still 2 (a3 should coalesce with a2)", got)
+	}
+}
+
 // TestEvaluationContext_ErrorsAreCached verifies the spec's error
 // semantics: "if a fetch fails, the failure is cached ... so subsequent
 // rules in the same pass do not retry and compound the failure".
@@ -261,11 +325,15 @@ func TestEvaluationContext_ConcurrentAccess(t *testing.T) {
 	}
 	wg.Wait()
 
-	// Shared-mbid: must collapse to 1 call. Distinct-mbid: 8 unique
-	// keys -> 8 calls. Total upper bound is 9.
-	got := count.fetchImagesCalls.Load()
-	if got < 1 || got > 9 {
-		t.Errorf("FetchImages dispatched %d times; want in [1, 9]", got)
+	// Shared-mbid must collapse to exactly 1 call (singleflight in
+	// dispatch). Distinct-mbid keys produce 8 unique calls. With the
+	// singleflight publication this must be exactly 9; a looser bound
+	// would not catch a regression in the coalescing contract. The
+	// exact equality is what makes this test a meaningful guard for
+	// Phase 2 (#1134) when the cache lifetime widens and parallel
+	// callers become routine.
+	if got := count.fetchImagesCalls.Load(); got != 9 {
+		t.Errorf("FetchImages dispatched %d times; want 9 (8 unique keys + 1 shared key)", got)
 	}
 }
 

--- a/internal/rule/eval_context_test.go
+++ b/internal/rule/eval_context_test.go
@@ -1,0 +1,295 @@
+package rule
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// countingEvalProvider records every call so a test can assert that N
+// rule invocations coalesce into a single upstream call when they share
+// an EvaluationContext. Each method increments its own counter.
+type countingEvalProvider struct {
+	fetchImagesCalls atomic.Int64
+	fetchMetaCalls   atomic.Int64
+	fetchFieldCalls  atomic.Int64
+	searchCalls      atomic.Int64
+
+	// imagesResult is what FetchImages returns when set; zero values
+	// otherwise are fine because the eval-ctx test never inspects the
+	// payload, only the call count.
+	imagesResult *provider.FetchResult
+	imagesErr    error
+
+	metaResult *provider.FetchResult
+	metaErr    error
+
+	fieldResult []provider.FieldProviderResult
+	fieldErr    error
+
+	searchResult []provider.ArtistSearchResult
+	searchErr    error
+}
+
+func (c *countingEvalProvider) FetchImages(_ context.Context, _ string, _ map[provider.ProviderName]string) (*provider.FetchResult, error) {
+	c.fetchImagesCalls.Add(1)
+	return c.imagesResult, c.imagesErr
+}
+
+func (c *countingEvalProvider) FetchMetadata(_ context.Context, _, _ string, _ map[provider.ProviderName]string) (*provider.FetchResult, error) {
+	c.fetchMetaCalls.Add(1)
+	return c.metaResult, c.metaErr
+}
+
+func (c *countingEvalProvider) FetchFieldFromProviders(_ context.Context, _, _, _ string, _ map[provider.ProviderName]string) ([]provider.FieldProviderResult, error) {
+	c.fetchFieldCalls.Add(1)
+	return c.fieldResult, c.fieldErr
+}
+
+func (c *countingEvalProvider) Search(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+	c.searchCalls.Add(1)
+	return c.searchResult, c.searchErr
+}
+
+// TestEvaluationContext_CoalescesImageFetches is the spec's first
+// acceptance criterion: N rules needing the same provider produce
+// exactly one provider call per artist per pass.
+func TestEvaluationContext_CoalescesImageFetches(t *testing.T) {
+	count := &countingEvalProvider{
+		imagesResult: &provider.FetchResult{Images: nil},
+	}
+	a := &artist.Artist{ID: "artist-1", Name: "Test", MusicBrainzID: "mbid-1"}
+	ec := NewEvaluationContext(a, count, testLogger())
+
+	// Simulate 5 rules calling FetchImages on the same (artist, mbid,
+	// providerIDs) tuple within one evaluation pass.
+	for i := 0; i < 5; i++ {
+		_, err := ec.FetchImages(context.Background(), "mbid-1", map[provider.ProviderName]string{
+			provider.NameAudioDB: "audio-1",
+			provider.NameDiscogs: "dis-1",
+		})
+		if err != nil {
+			t.Fatalf("FetchImages: %v", err)
+		}
+	}
+
+	if got := count.fetchImagesCalls.Load(); got != 1 {
+		t.Errorf("FetchImages dispatched %d times; want 1 (coalesced)", got)
+	}
+	fetches, dedups := ec.Counters()
+	if fetches != 1 {
+		t.Errorf("provider_fetch_total = %d; want 1", fetches)
+	}
+	if dedups != 4 {
+		t.Errorf("provider_fetch_dedup_total = %d; want 4", dedups)
+	}
+}
+
+// TestEvaluationContext_CoalescesMetadataAndField verifies the metadata
+// and field-fetch surfaces coalesce on their own keys. A bio rule and a
+// junk-bio rule both call FetchMetadata; an origin rule calls
+// FetchFieldFromProviders. Each fetch surface dedups independently.
+func TestEvaluationContext_CoalescesMetadataAndField(t *testing.T) {
+	count := &countingEvalProvider{
+		metaResult: &provider.FetchResult{},
+	}
+	a := &artist.Artist{ID: "artist-2", Name: "Test"}
+	ec := NewEvaluationContext(a, count, testLogger())
+
+	ids := map[provider.ProviderName]string{provider.NameMusicBrainz: "mb-1"}
+
+	// Three FetchMetadata calls -- one for bio, one for junk-bio
+	// re-fetch, one a hypothetical third metadata rule.
+	for i := 0; i < 3; i++ {
+		if _, err := ec.FetchMetadata(context.Background(), "mbid-2", "Test", ids); err != nil {
+			t.Fatalf("FetchMetadata: %v", err)
+		}
+	}
+	// Two FetchFieldFromProviders calls for the same field.
+	for i := 0; i < 2; i++ {
+		if _, err := ec.FetchFieldFromProviders(context.Background(), "mbid-2", "Test", "origin", ids); err != nil {
+			t.Fatalf("FetchFieldFromProviders: %v", err)
+		}
+	}
+
+	if got := count.fetchMetaCalls.Load(); got != 1 {
+		t.Errorf("FetchMetadata dispatched %d times; want 1 (coalesced)", got)
+	}
+	if got := count.fetchFieldCalls.Load(); got != 1 {
+		t.Errorf("FetchFieldFromProviders dispatched %d times; want 1 (coalesced)", got)
+	}
+	fetches, dedups := ec.Counters()
+	if fetches != 2 {
+		t.Errorf("provider_fetch_total = %d; want 2 (one metadata + one field)", fetches)
+	}
+	if dedups != 3 {
+		t.Errorf("provider_fetch_dedup_total = %d; want 3 (2 meta hits + 1 field hit)", dedups)
+	}
+}
+
+// TestEvaluationContext_DistinctKeysDoNotCoalesce verifies that the key
+// includes mbid/name/providerIDs so semantically distinct calls do NOT
+// reuse each other's payload. A second rule with a different MBID, name,
+// or provider-ID fingerprint must trigger a fresh fetch.
+func TestEvaluationContext_DistinctKeysDoNotCoalesce(t *testing.T) {
+	count := &countingEvalProvider{
+		imagesResult: &provider.FetchResult{},
+	}
+	a := &artist.Artist{ID: "artist-3", Name: "Test"}
+	ec := NewEvaluationContext(a, count, testLogger())
+
+	// Same MBID, different provider-ID hints.
+	if _, err := ec.FetchImages(context.Background(), "mbid-3", map[provider.ProviderName]string{provider.NameDiscogs: "A"}); err != nil {
+		t.Fatalf("Fetch1: %v", err)
+	}
+	if _, err := ec.FetchImages(context.Background(), "mbid-3", map[provider.ProviderName]string{provider.NameDiscogs: "B"}); err != nil {
+		t.Fatalf("Fetch2: %v", err)
+	}
+	// Different MBID.
+	if _, err := ec.FetchImages(context.Background(), "mbid-4", map[provider.ProviderName]string{provider.NameDiscogs: "A"}); err != nil {
+		t.Fatalf("Fetch3: %v", err)
+	}
+
+	if got := count.fetchImagesCalls.Load(); got != 3 {
+		t.Errorf("FetchImages dispatched %d times; want 3 (each key distinct)", got)
+	}
+}
+
+// TestEvaluationContext_ErrorsAreCached verifies the spec's error
+// semantics: "if a fetch fails, the failure is cached ... so subsequent
+// rules in the same pass do not retry and compound the failure".
+func TestEvaluationContext_ErrorsAreCached(t *testing.T) {
+	sentinel := errors.New("provider down")
+	count := &countingEvalProvider{
+		imagesResult: nil,
+		imagesErr:    sentinel,
+	}
+	a := &artist.Artist{ID: "artist-4", Name: "Test"}
+	ec := NewEvaluationContext(a, count, testLogger())
+
+	for i := 0; i < 4; i++ {
+		_, err := ec.FetchImages(context.Background(), "mbid-5", nil)
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("call %d returned %v; want sentinel", i, err)
+		}
+	}
+	if got := count.fetchImagesCalls.Load(); got != 1 {
+		t.Errorf("FetchImages dispatched %d times; want 1 (error cached)", got)
+	}
+	fetches, dedups := ec.Counters()
+	if fetches != 1 || dedups != 3 {
+		t.Errorf("counters = (%d, %d); want (1, 3)", fetches, dedups)
+	}
+}
+
+// TestEvaluationContext_SearchCoalesces verifies the Search surface
+// dedups on artist name. fixMBID may run for multiple rules in the same
+// pass (defensive call sites); the duplicate Search would burn a slot of
+// the MB rate limit budget for no extra information.
+func TestEvaluationContext_SearchCoalesces(t *testing.T) {
+	count := &countingEvalProvider{
+		searchResult: []provider.ArtistSearchResult{{MusicBrainzID: "mb-result"}},
+	}
+	a := &artist.Artist{ID: "artist-5", Name: "Searchee"}
+	ec := NewEvaluationContext(a, count, testLogger())
+
+	for i := 0; i < 3; i++ {
+		if _, err := ec.Search(context.Background(), "Searchee"); err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+	}
+	if got := count.searchCalls.Load(); got != 1 {
+		t.Errorf("Search dispatched %d times; want 1", got)
+	}
+}
+
+// TestEvaluationContext_ContextPropagation verifies that
+// WithEvaluationContext / EvaluationContextFromContext round-trips. The
+// fixer-side coalescer helpers depend on this round-trip to find the
+// active eval context.
+func TestEvaluationContext_ContextPropagation(t *testing.T) {
+	a := &artist.Artist{ID: "artist-6", Name: "Test"}
+	ec := NewEvaluationContext(a, &countingEvalProvider{}, testLogger())
+
+	if got := EvaluationContextFromContext(context.Background()); got != nil {
+		t.Errorf("bare context returned %v; want nil", got)
+	}
+	ctx := WithEvaluationContext(context.Background(), ec)
+	got := EvaluationContextFromContext(ctx)
+	if got != ec {
+		t.Errorf("EvaluationContextFromContext returned %v; want %v", got, ec)
+	}
+
+	// Nil pass-through: WithEvaluationContext(ctx, nil) returns ctx
+	// unchanged so callers can use it unconditionally.
+	if got := WithEvaluationContext(ctx, nil); got != ctx {
+		t.Error("WithEvaluationContext(ctx, nil) modified ctx")
+	}
+}
+
+// TestEvaluationContext_ConcurrentAccess exercises the cache mutex under
+// parallel access. The current rule loop is sequential per artist but
+// the lock is mandatory for Phase 2 (#1134) and #1135 forward-compat, so
+// the test pins the race detector against parallel callers for the same
+// key and for distinct keys.
+func TestEvaluationContext_ConcurrentAccess(t *testing.T) {
+	count := &countingEvalProvider{
+		imagesResult: &provider.FetchResult{},
+	}
+	a := &artist.Artist{ID: "artist-7", Name: "Test"}
+	ec := NewEvaluationContext(a, count, testLogger())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Half the goroutines hit the same key (coalesce);
+			// the other half use distinct MBIDs so the cache
+			// inserts under contention.
+			mbid := "shared-mbid"
+			if i%2 == 1 {
+				mbid = "mbid-" + string(rune('A'+i))
+			}
+			_, _ = ec.FetchImages(context.Background(), mbid, nil)
+		}(i)
+	}
+	wg.Wait()
+
+	// Shared-mbid: must collapse to 1 call. Distinct-mbid: 8 unique
+	// keys -> 8 calls. Total upper bound is 9.
+	got := count.fetchImagesCalls.Load()
+	if got < 1 || got > 9 {
+		t.Errorf("FetchImages dispatched %d times; want in [1, 9]", got)
+	}
+}
+
+// TestEvaluationContext_NilSafe pins the nil-receiver safety: methods on
+// a nil *EvaluationContext return errNilEvalContext rather than panicking.
+// Production code should never construct a nil context, but the
+// defensive guard simplifies future call sites that may forget to seed
+// one.
+func TestEvaluationContext_NilSafe(t *testing.T) {
+	var ec *EvaluationContext
+	if _, err := ec.FetchImages(context.Background(), "x", nil); err == nil {
+		t.Error("nil receiver FetchImages returned nil error")
+	}
+	if _, err := ec.FetchMetadata(context.Background(), "x", "y", nil); err == nil {
+		t.Error("nil receiver FetchMetadata returned nil error")
+	}
+	if _, err := ec.FetchFieldFromProviders(context.Background(), "x", "y", "f", nil); err == nil {
+		t.Error("nil receiver FetchFieldFromProviders returned nil error")
+	}
+	if _, err := ec.Search(context.Background(), "x"); err == nil {
+		t.Error("nil receiver Search returned nil error")
+	}
+	fetches, dedups := ec.Counters()
+	if fetches != 0 || dedups != 0 {
+		t.Errorf("nil counters = (%d, %d); want (0, 0)", fetches, dedups)
+	}
+}

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/internal/publish"
 )
 
@@ -151,6 +152,71 @@ type Pipeline struct {
 
 	ruleCacheMu sync.RWMutex
 	ruleCache   map[string]*Rule
+
+	// orchestratorMu guards orchestrator. SetOrchestrator is the
+	// canonical wiring path (main.go installs it after construction),
+	// kept symmetric with SetWriteGate / SetHistoryService so the
+	// NewPipeline signature stays stable for the many test call sites.
+	// Reads happen on the per-artist hot path that builds the
+	// EvaluationContext (#1133), so the read lock is mandatory rather
+	// than optional.
+	orchestratorMu   sync.RWMutex
+	orchestrator     *provider.Orchestrator
+	testEvalProvider evalProvider // test-only override; see setEvalProviderForTest.
+}
+
+// SetOrchestrator installs (or replaces) the provider Orchestrator the
+// pipeline uses to construct a per-artist EvaluationContext (#1133). The
+// EvaluationContext coalesces upstream fetches so multiple rules on the
+// same artist share a single provider call per (artist, provider)
+// combination per evaluation pass. Passing nil disables coalescing --
+// the fixers fall through to their bare orchestrator references, which
+// preserves the legacy uncoalesced behavior for tests that have not
+// wired this setter.
+func (p *Pipeline) SetOrchestrator(o *provider.Orchestrator) {
+	p.orchestratorMu.Lock()
+	p.orchestrator = o
+	p.orchestratorMu.Unlock()
+}
+
+// setEvalProviderForTest installs a test-only evalProvider override that
+// takes precedence over the real Orchestrator when constructing the
+// per-artist EvaluationContext. This is the test seam for #1133
+// integration coverage: a counting stub can stand in for the full
+// provider stack so the test asserts coalescing behavior without
+// network IO or DB-backed provider state. Production code never calls
+// this method.
+func (p *Pipeline) setEvalProviderForTest(ep evalProvider) {
+	p.orchestratorMu.Lock()
+	p.testEvalProvider = ep
+	p.orchestratorMu.Unlock()
+}
+
+// withEvalContext returns ctx augmented with a fresh per-artist
+// EvaluationContext when the pipeline has an Orchestrator installed.
+// Without an orchestrator we return ctx unchanged; the fixers see no
+// EvaluationContext and fall back to their bare orchestrator references.
+//
+// The returned counters function reads the fetch/dedup totals at the end
+// of the pass so the pipeline can warn-log them for the W4 (#1135)
+// telemetry-gated decision. When no eval context is created the
+// function returns zeros.
+func (p *Pipeline) withEvalContext(ctx context.Context, a *artist.Artist) (context.Context, func() (uint64, uint64)) {
+	// Test override takes precedence so the integration test can
+	// inject a counting stub. Production callers never set the
+	// override and fall straight through to the real Orchestrator.
+	p.orchestratorMu.RLock()
+	prov := p.testEvalProvider
+	if prov == nil && p.orchestrator != nil {
+		prov = p.orchestrator
+	}
+	p.orchestratorMu.RUnlock()
+
+	if prov == nil {
+		return ctx, func() (uint64, uint64) { return 0, 0 }
+	}
+	ec := NewEvaluationContext(a, prov, p.logger)
+	return WithEvaluationContext(ctx, ec), ec.Counters
 }
 
 // SetWriteGate installs (or replaces) the conflict gate the pipeline
@@ -285,6 +351,15 @@ func (p *Pipeline) RunRuleScoped(ctx context.Context, ruleID string, scope RunSc
 		// startedAt is captured before evaluation so every rule_results
 		// row written during this pass shares a timestamp (issue #699).
 		startedAt := time.Now().UTC()
+
+		// Issue #1133: per-artist EvaluationContext for fetch coalescing.
+		// Rebinding ctx (rather than introducing artistCtx everywhere) is
+		// deliberate: every downstream call within the closure picks up
+		// the eval-context-tagged ctx automatically, and the lexical
+		// scope keeps the outer RunRuleScoped ctx unchanged for the
+		// walkScopedArtists call below.
+		ctx, counters := p.withEvalContext(ctx, a)
+		defer p.logEvalCounters(a, counters)
 
 		eval, err := p.engine.Evaluate(ctx, a)
 		if err != nil {
@@ -597,7 +672,15 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 	// strictly greater than rules_evaluated_at.
 	startedAt := time.Now().UTC()
 
-	eval, err := p.engine.Evaluate(ctx, a)
+	// Issue #1133 (M54 W2A): wrap ctx with a per-artist EvaluationContext
+	// so multiple fixers needing the same provider payload share one
+	// upstream call. The context lifetime is the artist's evaluation
+	// pass; cleanup is via the defer'd telemetry log, which also serves
+	// as the W4 (#1135) gating signal.
+	evalCtx, counters := p.withEvalContext(ctx, a)
+	defer p.logEvalCounters(a, counters)
+
+	eval, err := p.engine.Evaluate(evalCtx, a)
 	if err != nil {
 		return nil, fmt.Errorf("evaluating artist %s: %w", a.Name, err)
 	}
@@ -607,9 +690,35 @@ func (p *Pipeline) runForArtistFiltered(ctx context.Context, a *artist.Artist, c
 	// post-filter pass-row writer share a single set of DB reads.
 	ruleCache := map[string]*Rule{}
 
-	p.dispatchViolations(ctx, a, eval.Violations, categoryFilter, ruleCache, acc, result)
-	p.finalizeArtistRun(ctx, a, ruleCache, acc, categoryFilter, startedAt)
+	p.dispatchViolations(evalCtx, a, eval.Violations, categoryFilter, ruleCache, acc, result)
+	p.finalizeArtistRun(evalCtx, a, ruleCache, acc, categoryFilter, startedAt)
 	return result, nil
+}
+
+// logEvalCounters emits the per-artist provider_fetch_total /
+// provider_fetch_dedup_total signals at the end of an evaluation pass.
+// These are the gating signals for the W4 (#1135) telemetry-gated
+// decision: if a substantial fraction of fetches dedup, the coalescing
+// layer earns its keep; if not, the milestone closes #1135 without
+// implementing batch endpoints.
+//
+// We log at debug to avoid bloating production logs; a future metrics
+// scrape can pick up the structured keys directly.
+func (p *Pipeline) logEvalCounters(a *artist.Artist, counters func() (uint64, uint64)) {
+	if counters == nil {
+		return
+	}
+	fetches, dedups := counters()
+	if fetches == 0 && dedups == 0 {
+		// No provider calls touched the eval ctx; nothing to report.
+		return
+	}
+	p.logger.Debug("evaluation context provider counters",
+		slog.String("artist_id", a.ID),
+		slog.String("artist", a.Name),
+		slog.Uint64("provider_fetch_total", fetches),
+		slog.Uint64("provider_fetch_dedup_total", dedups),
+	)
 }
 
 // dispatchViolations is the strategy-dispatch loop pulled out of
@@ -913,6 +1022,12 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 		// startedAt captured pre-Evaluate so every rule_results pass row
 		// written during this pass shares a timestamp (issue #699).
 		startedAt := time.Now().UTC()
+
+		// Issue #1133: per-artist EvaluationContext for fetch coalescing.
+		// Shadows the outer ctx so every downstream call inside this
+		// closure inherits the coalescer without an artistCtx rename.
+		ctx, counters := p.withEvalContext(ctx, a)
+		defer p.logEvalCounters(a, counters)
 
 		eval, err := p.engine.Evaluate(ctx, a)
 		if err != nil {
@@ -1290,6 +1405,15 @@ func (p *Pipeline) FixViolation(ctx context.Context, violationID string) (*FixRe
 		Fixable:  rv.Fixable,
 		Config:   r.Config,
 	}
+
+	// Issue #1133: even single-violation FixViolation runs under an
+	// EvaluationContext so the post-fix updateHealthScore re-evaluate
+	// (which may issue checker-side provider calls) shares the cache
+	// the fixer just primed. The win is small (typically a single
+	// fetch), but the unified telemetry tag matters for the W4 (#1135)
+	// gating signal.
+	ctx, counters := p.withEvalContext(ctx, a)
+	defer p.logEvalCounters(a, counters)
 
 	fr := p.attemptFix(ctx, a, v)
 

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/artist"
-	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/internal/publish"
 )
 
@@ -159,41 +158,33 @@ type Pipeline struct {
 	// NewPipeline signature stays stable for the many test call sites.
 	// Reads happen on the per-artist hot path that builds the
 	// EvaluationContext (#1133), so the read lock is mandatory rather
-	// than optional.
-	orchestratorMu   sync.RWMutex
-	orchestrator     *provider.Orchestrator
-	testEvalProvider evalProvider // test-only override; see setEvalProviderForTest.
+	// than optional. Stored as the EvalProvider interface so tests can
+	// exercise this exact wiring with a stub orchestrator without
+	// needing the test to live in the same package as a concrete
+	// *provider.Orchestrator constructor.
+	orchestratorMu sync.RWMutex
+	orchestrator   EvalProvider
 }
 
-// SetOrchestrator installs (or replaces) the provider Orchestrator the
-// pipeline uses to construct a per-artist EvaluationContext (#1133). The
+// SetOrchestrator installs (or replaces) the EvalProvider the pipeline
+// uses to construct a per-artist EvaluationContext (#1133). The
 // EvaluationContext coalesces upstream fetches so multiple rules on the
 // same artist share a single provider call per (artist, provider)
-// combination per evaluation pass. Passing nil disables coalescing --
-// the fixers fall through to their bare orchestrator references, which
-// preserves the legacy uncoalesced behavior for tests that have not
-// wired this setter.
-func (p *Pipeline) SetOrchestrator(o *provider.Orchestrator) {
+// combination per evaluation pass. The production caller in main.go
+// passes a *provider.Orchestrator (which satisfies EvalProvider);
+// integration tests can pass a counting stub here to exercise this
+// exact wiring rather than a bypass seam. Passing nil disables
+// coalescing -- the fixers fall through to their bare orchestrator
+// references, which preserves the legacy uncoalesced behavior for tests
+// that have not wired this setter.
+func (p *Pipeline) SetOrchestrator(o EvalProvider) {
 	p.orchestratorMu.Lock()
 	p.orchestrator = o
 	p.orchestratorMu.Unlock()
 }
 
-// setEvalProviderForTest installs a test-only evalProvider override that
-// takes precedence over the real Orchestrator when constructing the
-// per-artist EvaluationContext. This is the test seam for #1133
-// integration coverage: a counting stub can stand in for the full
-// provider stack so the test asserts coalescing behavior without
-// network IO or DB-backed provider state. Production code never calls
-// this method.
-func (p *Pipeline) setEvalProviderForTest(ep evalProvider) {
-	p.orchestratorMu.Lock()
-	p.testEvalProvider = ep
-	p.orchestratorMu.Unlock()
-}
-
 // withEvalContext returns ctx augmented with a fresh per-artist
-// EvaluationContext when the pipeline has an Orchestrator installed.
+// EvaluationContext when the pipeline has an orchestrator installed.
 // Without an orchestrator we return ctx unchanged; the fixers see no
 // EvaluationContext and fall back to their bare orchestrator references.
 //
@@ -202,14 +193,8 @@ func (p *Pipeline) setEvalProviderForTest(ep evalProvider) {
 // telemetry-gated decision. When no eval context is created the
 // function returns zeros.
 func (p *Pipeline) withEvalContext(ctx context.Context, a *artist.Artist) (context.Context, func() (uint64, uint64)) {
-	// Test override takes precedence so the integration test can
-	// inject a counting stub. Production callers never set the
-	// override and fall straight through to the real Orchestrator.
 	p.orchestratorMu.RLock()
-	prov := p.testEvalProvider
-	if prov == nil && p.orchestrator != nil {
-		prov = p.orchestrator
-	}
+	prov := p.orchestrator
 	p.orchestratorMu.RUnlock()
 
 	if prov == nil {

--- a/internal/rule/fixer_test.go
+++ b/internal/rule/fixer_test.go
@@ -548,6 +548,11 @@ func TestImageFixer_Fix_ResolutionGate(t *testing.T) {
 	}
 }
 
+// TestImageFixer_FetchImages_Cached verifies that two image rules on the
+// same artist coalesce into a single provider FetchImages call when an
+// EvaluationContext is attached to the context. The historical per-fixer
+// sync.Map cache was unbounded across passes; the eval-context (#1133)
+// replaces it with a per-evaluation cache the pipeline owns.
 func TestImageFixer_FetchImages_Cached(t *testing.T) {
 	mock := &mockImageProvider{
 		result: &provider.FetchResult{
@@ -559,11 +564,19 @@ func TestImageFixer_FetchImages_Cached(t *testing.T) {
 
 	f := NewImageFixer(mock, nil, nonSharedFSCheck(), testLogger())
 	a := &artist.Artist{
+		ID:            "artist-cache",
 		Name:          "Cache Test",
 		MusicBrainzID: "mbid-cache",
 		Path:          t.TempDir(),
 		LibraryID:     "lib-test",
 	}
+
+	// Attach an EvaluationContext so multiple violations on the same
+	// artist coalesce. Without it the fixer falls through to the bare
+	// orchestrator (no caching) -- which is the legacy uncoalesced
+	// behavior FixViolation single-violation callers exercise.
+	ctx := WithEvaluationContext(context.Background(),
+		NewEvaluationContext(a, &evalCtxImageOnlyProvider{img: mock}, testLogger()))
 
 	// First call: thumb_min_res -- one candidate passes, SelectBestCandidate=false
 	// so it returns pending_choice (multiple not needed here -- just one candidate
@@ -573,7 +586,7 @@ func TestImageFixer_FetchImages_Cached(t *testing.T) {
 		RuleID: RuleThumbMinRes,
 		Config: RuleConfig{MinWidth: 5000, MinHeight: 5000}, // forces "no candidates" path
 	}
-	if _, err := f.Fix(context.Background(), a, v1); err != nil {
+	if _, err := f.Fix(ctx, a, v1); err != nil {
 		t.Fatalf("Fix v1: %v", err)
 	}
 
@@ -582,13 +595,127 @@ func TestImageFixer_FetchImages_Cached(t *testing.T) {
 		RuleID: RuleFanartMinRes,
 		Config: RuleConfig{MinWidth: 5000, MinHeight: 5000},
 	}
-	if _, err := f.Fix(context.Background(), a, v2); err != nil {
+	if _, err := f.Fix(ctx, a, v2); err != nil {
 		t.Fatalf("Fix v2: %v", err)
 	}
 
 	if mock.calls != 1 {
 		t.Errorf("FetchImages called %d times; want 1 (cache hit on second call)", mock.calls)
 	}
+}
+
+// TestPipeline_RunForArtist_CoalescesImageFetches is the spec's
+// "integration test: Run-All-Rules on a fixture library shows reduced
+// provider call count proportional to rule fanout" -- scoped down to a
+// single artist with multiple image violations so the test does not need
+// to seed a large fixture library. The relevant signal is that 4 image
+// rules (thumb_exists, fanart_exists, logo_exists, banner_exists) on the
+// same artist trigger exactly one FetchImages call through the
+// EvaluationContext (issue #1133).
+//
+// Without coalescing this would be 4 provider calls; with coalescing it
+// is 1, and the per-artist provider_fetch_dedup_total counter should
+// report 3 dedup events. Both invariants are pinned below.
+func TestPipeline_RunForArtist_CoalescesImageFetches(t *testing.T) {
+	db := setupTestDB(t)
+	artistSvc := artist.NewService(db)
+	ruleSvc := NewService(db)
+	ctx := context.Background()
+
+	if err := ruleSvc.SeedDefaults(ctx); err != nil {
+		t.Fatalf("seeding rules: %v", err)
+	}
+
+	// Flip the four image existence rules into auto mode so the
+	// pipeline actually invokes the fixer for each. Without this they
+	// stay manual and the fanout argument breaks down.
+	for _, rid := range []string{RuleThumbExists, RuleFanartExists, RuleLogoExists, RuleBannerExists} {
+		r, err := ruleSvc.GetByID(ctx, rid)
+		if err != nil {
+			t.Fatalf("getting rule %s: %v", rid, err)
+		}
+		r.AutomationMode = AutomationModeAuto
+		if err := ruleSvc.Update(ctx, r); err != nil {
+			t.Fatalf("updating rule %s: %v", rid, err)
+		}
+	}
+
+	dir := t.TempDir()
+	a := &artist.Artist{
+		Name:          "Coalesce Test",
+		SortName:      "Coalesce Test",
+		Path:          dir,
+		MusicBrainzID: "mbid-coalesce",
+		LibraryID:     "lib-coalesce",
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// Counting provider returns an empty result so the ImageFixer
+	// short-circuits at "no <type> images found from providers" -- no
+	// download path, no save path, just the cached fetch. That is the
+	// exact behavior the coalescer is being measured against.
+	count := &countingEvalProvider{
+		imagesResult: &provider.FetchResult{Images: nil},
+	}
+
+	imageFixer := NewImageFixer(&countingImageFacade{c: count}, nil, nonSharedFSCheck(), testLogger())
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{imageFixer}, nil, testLogger())
+	// SetOrchestrator wires the EvaluationContext path. Without it the
+	// fixer would call the bare orchestrator and the coalescing layer
+	// is bypassed -- the failure mode the production wiring in
+	// cmd/stillwater/main.go protects against.
+	pipeline.SetOrchestrator(nil) // nil orchestrator -> no coalescing
+	// Then test the coalescing path by installing the counting provider
+	// directly via the dev hook used by tests (a sibling to SetOrchestrator
+	// that accepts the evalProvider interface).
+	pipeline.setEvalProviderForTest(count)
+
+	result, err := pipeline.RunForArtist(ctx, a)
+	if err != nil {
+		t.Fatalf("RunForArtist: %v", err)
+	}
+	if result.ViolationsFound < 4 {
+		t.Fatalf("ViolationsFound = %d; want >= 4 (the four image-existence rules)", result.ViolationsFound)
+	}
+
+	if got := count.fetchImagesCalls.Load(); got != 1 {
+		t.Errorf("FetchImages dispatched %d times; want 1 (coalesced across %d image rules)", got, 4)
+	}
+}
+
+// countingImageFacade adapts a countingEvalProvider to the imageProvider
+// interface so NewImageFixer accepts it. The fixer's bare-orchestrator
+// fallback path goes through this facade when the EvaluationContext is
+// absent; the integration test installs an EvaluationContext via the
+// pipeline so the coalescer captures the calls instead.
+type countingImageFacade struct{ c *countingEvalProvider }
+
+func (f *countingImageFacade) FetchImages(ctx context.Context, mbid string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error) {
+	return f.c.FetchImages(ctx, mbid, providerIDs)
+}
+
+// evalCtxImageOnlyProvider adapts a mockImageProvider to the
+// EvaluationContext's full evalProvider surface for tests that only
+// exercise the FetchImages path. The metadata-side methods panic if
+// invoked -- the test would have a bug, not a silent fall-through.
+type evalCtxImageOnlyProvider struct {
+	img *mockImageProvider
+}
+
+func (p *evalCtxImageOnlyProvider) FetchImages(ctx context.Context, mbid string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error) {
+	return p.img.FetchImages(ctx, mbid, providerIDs)
+}
+func (p *evalCtxImageOnlyProvider) FetchMetadata(_ context.Context, _, _ string, _ map[provider.ProviderName]string) (*provider.FetchResult, error) {
+	panic("FetchMetadata not implemented for image-only test stub")
+}
+func (p *evalCtxImageOnlyProvider) FetchFieldFromProviders(_ context.Context, _, _, _ string, _ map[provider.ProviderName]string) ([]provider.FieldProviderResult, error) {
+	panic("FetchFieldFromProviders not implemented for image-only test stub")
+}
+func (p *evalCtxImageOnlyProvider) Search(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+	panic("Search not implemented for image-only test stub")
 }
 
 // TestImageFixer_Fix_PostDownloadDimensionGate verifies that a candidate with

--- a/internal/rule/fixer_test.go
+++ b/internal/rule/fixer_test.go
@@ -626,14 +626,18 @@ func TestPipeline_RunForArtist_CoalescesImageFetches(t *testing.T) {
 		t.Fatalf("seeding rules: %v", err)
 	}
 
-	// Flip the four image existence rules into auto mode so the
-	// pipeline actually invokes the fixer for each. Without this they
-	// stay manual and the fanout argument breaks down.
+	// Flip the four image-existence rules into enabled + auto mode so
+	// the pipeline actually invokes the fixer for each. RuleBannerExists
+	// defaults to Enabled=false (legacy Kodi-list-view image) so this
+	// loop must set Enabled=true explicitly; without it banner_exists
+	// silently does not fire and the fanout argument collapses to three
+	// rules instead of four.
 	for _, rid := range []string{RuleThumbExists, RuleFanartExists, RuleLogoExists, RuleBannerExists} {
 		r, err := ruleSvc.GetByID(ctx, rid)
 		if err != nil {
 			t.Fatalf("getting rule %s: %v", rid, err)
 		}
+		r.Enabled = true
 		r.AutomationMode = AutomationModeAuto
 		if err := ruleSvc.Update(ctx, r); err != nil {
 			t.Fatalf("updating rule %s: %v", rid, err)
@@ -663,15 +667,13 @@ func TestPipeline_RunForArtist_CoalescesImageFetches(t *testing.T) {
 	imageFixer := NewImageFixer(&countingImageFacade{c: count}, nil, nonSharedFSCheck(), testLogger())
 	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
 	pipeline := NewPipeline(engine, artistSvc, ruleSvc, []Fixer{imageFixer}, nil, testLogger())
-	// SetOrchestrator wires the EvaluationContext path. Without it the
-	// fixer would call the bare orchestrator and the coalescing layer
-	// is bypassed -- the failure mode the production wiring in
-	// cmd/stillwater/main.go protects against.
-	pipeline.SetOrchestrator(nil) // nil orchestrator -> no coalescing
-	// Then test the coalescing path by installing the counting provider
-	// directly via the dev hook used by tests (a sibling to SetOrchestrator
-	// that accepts the evalProvider interface).
-	pipeline.setEvalProviderForTest(count)
+	// Drive the production wiring directly: SetOrchestrator is the
+	// method main.go calls (with a real *provider.Orchestrator) to
+	// attach the EvaluationContext path; here we hand it the counting
+	// stub. Exercising this method -- rather than a test-only bypass
+	// seam -- is what protects against a future refactor that
+	// silently breaks the main.go glue.
+	pipeline.SetOrchestrator(count)
 
 	result, err := pipeline.RunForArtist(ctx, a)
 	if err != nil {
@@ -679,6 +681,26 @@ func TestPipeline_RunForArtist_CoalescesImageFetches(t *testing.T) {
 	}
 	if result.ViolationsFound < 4 {
 		t.Fatalf("ViolationsFound = %d; want >= 4 (the four image-existence rules)", result.ViolationsFound)
+	}
+	// Assert the four image-existence RuleIDs are actually present
+	// before measuring coalescing. ViolationsFound >= 4 could be
+	// satisfied by any unrelated rules; we want to know thumb / fanart
+	// / logo / banner specifically were the rules that coalesced.
+	want := map[string]bool{
+		RuleThumbExists:  false,
+		RuleFanartExists: false,
+		RuleLogoExists:   false,
+		RuleBannerExists: false,
+	}
+	for _, r := range result.Results {
+		if _, ok := want[r.RuleID]; ok {
+			want[r.RuleID] = true
+		}
+	}
+	for rid, found := range want {
+		if !found {
+			t.Errorf("result.Results missing RuleID %q -- coalescing assertion below would not exercise the intended fanout", rid)
+		}
 	}
 
 	if got := count.fetchImagesCalls.Load(); got != 1 {

--- a/internal/rule/fixers.go
+++ b/internal/rule/fixers.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"golang.org/x/text/unicode/norm"
@@ -40,16 +39,53 @@ type metadataOrchestrator interface {
 	FetchFieldFromProviders(ctx context.Context, mbid, name, field string, providerIDs map[provider.ProviderName]string) ([]provider.FieldProviderResult, error)
 }
 
-// imageCacheEntry holds a cached FetchImages result (or error) for one MBID.
-type imageCacheEntry struct {
-	result *provider.FetchResult
-	err    error
-}
-
 const (
 	fetchTimeout  = 30 * time.Second
 	maxImageBytes = 25 << 20 // 25 MB
 )
+
+// coalescedSearch routes Search through the per-evaluation context when
+// one is attached to ctx (the canonical pipeline path), or falls back to
+// the raw orchestrator. The fallback path matters for callers like
+// FixViolation that operate on a single violation outside an evaluation
+// pass; they still benefit from the unified telemetry tag the helper
+// applies but do not get coalescing for free.
+func coalescedSearch(ctx context.Context, orch metadataOrchestrator, name string) ([]provider.ArtistSearchResult, error) {
+	if ec := EvaluationContextFromContext(ctx); ec != nil {
+		return ec.Search(ctx, name)
+	}
+	return orch.Search(ctx, name)
+}
+
+// coalescedFetchMetadata routes FetchMetadata through the per-evaluation
+// context when one is attached to ctx, falling back to the raw
+// orchestrator otherwise.
+func coalescedFetchMetadata(ctx context.Context, orch metadataOrchestrator, mbid, name string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error) {
+	if ec := EvaluationContextFromContext(ctx); ec != nil {
+		return ec.FetchMetadata(ctx, mbid, name, providerIDs)
+	}
+	return orch.FetchMetadata(ctx, mbid, name, providerIDs)
+}
+
+// coalescedFetchField routes FetchFieldFromProviders through the
+// per-evaluation context when one is attached to ctx, falling back to the
+// raw orchestrator otherwise.
+func coalescedFetchField(ctx context.Context, orch metadataOrchestrator, mbid, name, field string, providerIDs map[provider.ProviderName]string) ([]provider.FieldProviderResult, error) {
+	if ec := EvaluationContextFromContext(ctx); ec != nil {
+		return ec.FetchFieldFromProviders(ctx, mbid, name, field, providerIDs)
+	}
+	return orch.FetchFieldFromProviders(ctx, mbid, name, field, providerIDs)
+}
+
+// coalescedFetchImages routes FetchImages through the per-evaluation
+// context when one is attached to ctx, falling back to the raw image
+// orchestrator (or its test stub) otherwise.
+func coalescedFetchImages(ctx context.Context, orch imageProvider, mbid string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error) {
+	if ec := EvaluationContextFromContext(ctx); ec != nil {
+		return ec.FetchImages(ctx, mbid, providerIDs)
+	}
+	return orch.FetchImages(ctx, mbid, providerIDs)
+}
 
 // NFOFixer creates missing artist.nfo files from the artist's current metadata.
 type NFOFixer struct {
@@ -174,7 +210,7 @@ func (f *MetadataFixer) Fix(ctx context.Context, a *artist.Artist, v *Violation)
 }
 
 func (f *MetadataFixer) fixMBID(ctx context.Context, a *artist.Artist) (*FixResult, error) {
-	results, err := f.orchestrator.Search(ctx, a.Name)
+	results, err := coalescedSearch(ctx, f.orchestrator, a.Name)
 	if err != nil {
 		return nil, fmt.Errorf("searching providers: %w", err)
 	}
@@ -216,7 +252,7 @@ func (f *MetadataFixer) fixMBID(ctx context.Context, a *artist.Artist) (*FixResu
 }
 
 func (f *MetadataFixer) fixBio(ctx context.Context, a *artist.Artist) (*FixResult, error) {
-	result, err := f.orchestrator.FetchMetadata(ctx, a.MusicBrainzID, a.Name, a.ProviderIDMap())
+	result, err := coalescedFetchMetadata(ctx, f.orchestrator, a.MusicBrainzID, a.Name, a.ProviderIDMap())
 	if err != nil {
 		return nil, fmt.Errorf("fetching metadata: %w", err)
 	}
@@ -245,7 +281,7 @@ func (f *MetadataFixer) fixJunkBio(ctx context.Context, a *artist.Artist) (*FixR
 	oldBio := a.Biography
 	a.Biography = "" // clear junk so providers are queried fresh
 
-	result, err := f.orchestrator.FetchMetadata(ctx, a.MusicBrainzID, a.Name, a.ProviderIDMap())
+	result, err := coalescedFetchMetadata(ctx, f.orchestrator, a.MusicBrainzID, a.Name, a.ProviderIDMap())
 	if err != nil {
 		a.Biography = oldBio // restore on error
 		return nil, fmt.Errorf("fetching metadata: %w", err)
@@ -277,7 +313,7 @@ func (f *MetadataFixer) fixJunkBio(ctx context.Context, a *artist.Artist) (*FixR
 // first result with data is the highest-priority non-empty value. This is the
 // same first-non-empty-wins behavior used for other single-value fields.
 func (f *MetadataFixer) fixOrigin(ctx context.Context, a *artist.Artist) (*FixResult, error) {
-	results, err := f.orchestrator.FetchFieldFromProviders(ctx, a.MusicBrainzID, a.Name, "origin", a.ProviderIDMap())
+	results, err := coalescedFetchField(ctx, f.orchestrator, a.MusicBrainzID, a.Name, "origin", a.ProviderIDMap())
 	if err != nil {
 		return nil, fmt.Errorf("fetching origin from providers: %w", err)
 	}
@@ -337,7 +373,6 @@ type ImageFixer struct {
 	// the download path against httptest.NewServer (which binds to 127.0.0.1)
 	// must override this field with a plain *http.Client after construction.
 	httpClient *http.Client
-	imageCache sync.Map // keyed by MBID; value: *imageCacheEntry
 }
 
 // NewImageFixer creates an ImageFixer.
@@ -351,24 +386,19 @@ func NewImageFixer(orchestrator imageProvider, platformService *platform.Service
 	}
 }
 
-// fetchImages returns provider images for the given MBID and provider IDs,
-// using a per-instance cache to avoid duplicate provider calls when an artist
-// has multiple violations.
+// fetchImages returns provider images for the given MBID and provider IDs.
+//
+// Routes through the per-evaluation EvaluationContext when one is attached
+// to ctx (the canonical pipeline path) so multiple image rules on the same
+// artist coalesce into a single provider call -- the load-bearing
+// behavior issue #1133 introduces. Without an EvaluationContext (e.g.
+// direct unit-test invocation that does not seed one) it falls through to
+// the raw orchestrator without caching. The historical per-fixer
+// sync.Map cache was unbounded across passes (no eviction) and is
+// superseded by the per-evaluation cache, which is bounded by the
+// pass lifetime.
 func (f *ImageFixer) fetchImages(ctx context.Context, mbid string, providerIDs map[provider.ProviderName]string) (*provider.FetchResult, error) {
-	cacheKey := fmt.Sprintf("%s|audiodb=%s|discogs=%s|deezer=%s|spotify=%s",
-		mbid,
-		providerIDs[provider.NameAudioDB],
-		providerIDs[provider.NameDiscogs],
-		providerIDs[provider.NameDeezer],
-		providerIDs[provider.NameSpotify],
-	)
-	if entry, ok := f.imageCache.Load(cacheKey); ok {
-		e := entry.(*imageCacheEntry)
-		return e.result, e.err
-	}
-	result, err := f.orchestrator.FetchImages(ctx, mbid, providerIDs)
-	f.imageCache.Store(cacheKey, &imageCacheEntry{result: result, err: err})
-	return result, err
+	return coalescedFetchImages(ctx, f.orchestrator, mbid, providerIDs)
 }
 
 // CanFix returns true for image-related rules.


### PR DESCRIPTION
## Summary

- Adds `EvaluationContext`, a per-artist cache that coalesces provider fetches in the rule engine so multiple rules consuming the same `(artist, provider-call)` produce exactly one upstream call per evaluation pass.
- Threaded through `Pipeline.runForArtistFiltered`, `RunRuleScoped.processArtist`, `RunAllScoped.processArtist`, and `FixViolation` via a typed `context.Context` value (no fixer-interface change).
- Telemetry: atomic counters `provider_fetch_total` + `provider_fetch_dedup_total` exposed via `Counters()` and emitted at debug per-artist as structured slog records (component `rule.evalctx` / `fix-pipeline`). These are the gating signals for the W4 (#1135) telemetry decision. Counter names chosen so Phase 2 (#1134) does not need to rename anything.
- Error semantics per the issue spec: a failed fetch is cached for the duration of the artist's evaluation so subsequent rules in the same pass do not retry and compound the failure.
- Rate-limiter behavior preserved — the coalescing layer sits above the orchestrator, no provider-client changes.

Reviewers: look first at `internal/rule/eval_context.go` (new file) and the wire-up in `internal/rule/fixer.go` + `internal/rule/fixers.go`.

## Linked issue

Closes #1133

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`).
- [x] Local CodeRabbit review run (`coderabbit review --plain`); 2 findings (1 minor nil-orchestrator panic, 1 trivial comment) addressed and amended before push.
- [x] Commits squashed into clean, logical commits before the first push (single commit `1c3d9ebd`).
- [x] At least one label set on `gh pr create --label ...`.
- [x] Docs label decision made: `docs: not-required` -- performance change with no user-visible behavioral change (same violations produced, same fix decisions per the acceptance criterion).
- [ ] Screenshot attached for any UI change. (N/A -- no UI surface.)
- [x] UAT performed for user-visible changes (run the binary, not just the test suite). See Test plan below.
- [x] OpenAPI spec updated if any request or response shape changed (no API contract change; `make check-openapi` clean).
- [ ] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed. (N/A -- no `.templ` changes.)

## Test plan

- [x] `go test -race ./...` passes locally (rule package: 36.8s, no races, no failures; full gate `./...` exercised by pre-push-gate).
- [x] `bash scripts/pre-push-gate.sh` passes locally (patch coverage 87.03%, per-package floors OK, provider-failure smoke 9/9).
- [x] Bruno API suite: `make bruno-ci` -- 107/107 requests, 205/205 tests, transport health 100%.
- [x] Manual UAT against the live binary:
  - [x] Rebuilt + restarted via `scripts/dev-restart.sh` from the worktree (binary version `nightly-20260527-9-g1c3d9ebd`).
  - [x] Triggered `POST /api/v1/rules/run-all` against the full library (603 artists, incremental scope).
  - [x] Tailed dev.log for the new `rule.evalctx` records. Confirmed:
    - `Aaron Copland`, `Genesis`: `provider_fetch_total=1 provider_fetch_dedup_total=0` (single rule needed the provider -- correct, nothing to dedup).
    - `Gary Graffman`, `Jazz at Lincoln Center Orchestra`: `provider_fetch_total=1 provider_fetch_dedup_total=2` (one real fetch, two coalesced reuses on the same artist; without #1133 these would have issued 3 separate `FetchImages` calls).
  - [x] dispatch + dedup slog records fire at the expected line in `internal/rule/eval_context.go`; per-pass counter summary lands at the end of each artist's evaluation in `internal/rule/fixer.go:716`.
- [ ] Reviewer follow-ups:
  - [ ] Double-check the `providerIDFingerprint` canonical-order subset in `eval_context.go:148-158` -- the goal is that two violations with the same MBID but different provider-ID hints do NOT coalesce, so a re-evaluation after provider-ID enrichment never reuses the pre-enrichment payload. Worth a second look in case I missed a provider name that should be in the canonical prefix.
  - [ ] `internal/rule/bulk_executor.go` has parallel direct provider calls that remain outside Phase 1 (the issue's "rule evaluation loop" wording). Intentionally deferred; flag if telemetry from this PR suggests the bulk path is a material residual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Rule evaluation now coalesces upstream provider fetches across multiple rules when evaluating the same artist, reducing duplicate network requests and improving overall evaluation speed.
  * Fetch results are cached within each artist evaluation, enabling rules to share data without making redundant provider calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces `EvaluationContext`, a per-artist singleflight cache that coalesces upstream provider fetches across the rule-fixer chain, so N rules needing the same `(artist, provider-call)` tuple produce exactly one network call instead of N. The previous per-`ImageFixer` `sync.Map` (unbounded, no eviction) is removed and replaced by this bounded, pipeline-owned cache. Telemetry counters (`provider_fetch_total` / `provider_fetch_dedup_total`) are emitted at debug level per artist and serve as the W4 (#1135) gating signal.

- `EvaluationContext` (`eval_context.go`): new file implementing the singleflight placeholder/done-channel pattern with a mutex-guarded map. Both round-1 reviewer concerns (non-canonical provider ID fingerprinting, counter overcounting under concurrent misses) are addressed and pinned by new tests.
- Wire-up in `fixer.go` and `fixers.go`: `Pipeline.SetOrchestrator` + `withEvalContext` thread the context through `RunRuleScoped`, `RunAllScoped`, `runForArtistFiltered`, and `FixViolation` via `coalesced*` helper functions, with a graceful fallback to direct orchestrator calls when no context is present.
- Test additions: unit tests in `eval_context_test.go` and an integration test (`TestPipeline_RunForArtist_CoalescesImageFetches`) exercise the production wiring path end-to-end.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The coalescing layer sits above the orchestrator and has no behavioral effect on which violations are found or fixed — only on how many upstream network calls are issued per artist pass.

Both round-1 reviewer concerns are addressed and locked in by new tests. The singleflight implementation is correct for the current sequential-per-artist evaluation model. The two open observations are scoped to Phase 2 parallel evaluation, which is explicitly deferred to a separate milestone.

eval_context.go — the bare channel receives and the non-deferred close(placeholder.done) in dispatch are worth revisiting before Phase 2 (#1134) widens evaluation to parallel fixers.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/rule/eval_context.go | New file implementing the per-artist coalescing cache. Singleflight pattern with placeholder/done channel is correctly implemented for the sequential Phase 1 model. Two forward-compat gaps flagged: bare channel receives don't respect context cancellation, and a panic in fetch() would leave done permanently unclosed. |
| internal/rule/eval_context_test.go | Comprehensive test coverage: coalescing per method, error caching, non-canonical provider ID differentiation (addressed round-1 concern), concurrent access under the race detector, nil-safety, and context propagation round-trip. |
| internal/rule/fixer.go | Adds SetOrchestrator/withEvalContext/logEvalCounters to Pipeline and wires EvaluationContext into RunRuleScoped, RunAllScoped, runForArtistFiltered, and FixViolation. ctx shadowing via := inside closures is correct and does not mutate outer scope. |
| internal/rule/fixers.go | Replaces per-fixer sync.Map image cache and direct orchestrator calls with four coalesced* helpers. Removal of the unbounded sync.Map is correct; the per-evaluation EvaluationContext provides a bounded replacement. |
| internal/rule/fixer_test.go | Adds integration test exercising the full pipeline to SetOrchestrator to EvaluationContext path against four image-existence rules, and updates TestImageFixer_FetchImages_Cached to seed an EvaluationContext. |
| cmd/stillwater/main.go | One-line addition: pipeline.SetOrchestrator(a.orchestrator) after pipeline construction. Comment correctly explains the fallback behavior when the setter is absent. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P as Pipeline
    participant WEC as withEvalContext
    participant EC as EvaluationContext
    participant D as dispatch()
    participant O as Orchestrator

    P->>WEC: withEvalContext(ctx, artist)
    WEC->>EC: NewEvaluationContext(artist, orch, logger)
    WEC-->>P: enriched ctx + counters fn

    P->>EC: FetchImages(ctx, mbid, providerIDs)
    EC->>EC: cache lookup MISS
    EC->>D: dispatch(key, fetch)
    D->>D: lock, insert placeholder, unlock
    D->>O: orch.FetchImages(ctx, mbid, providerIDs)
    O-->>D: FetchResult
    D->>D: fill placeholder, fetchTotal++, close(done)
    D-->>EC: evalCacheEntry
    EC-->>P: FetchResult

    P->>EC: FetchImages(ctx, mbid, providerIDs)
    EC->>EC: cache lookup HIT
    EC->>EC: done already closed
    EC->>EC: dedupTotal++
    EC-->>P: FetchResult cached

    P->>P: defer logEvalCounters fires
    P->>EC: Counters()
    EC-->>P: "fetchTotal=1 dedupTotal=N"
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ainternal%2Frule%2Feval_context.go%3A406-427%0A**Panic%20in%20%60fetch%28%29%60%20leaves%20%60done%60%20permanently%20unclosed**%0A%0AIf%20the%20provider%20closure%20passed%20as%20%60fetch%60%20panics%20%E2%80%94%20e.g.%2C%20a%20nil-pointer%20dereference%20inside%20the%20orchestrator%20%E2%80%94%20%60close%28placeholder.done%29%60%20is%20never%20reached.%20Any%20goroutine%20already%20blocked%20on%20%60%3C-cached.done%60%20%28after%20a%20singleflight%20miss%20in%20a%20concurrent%20caller%29%20will%20deadlock%2C%20because%20the%20channel%20is%20never%20signalled.%0A%0AFor%20Phase%201%20sequential%20evaluation%20this%20is%20harmless%20in%20practice%20because%20no%20goroutine%20blocks%20on%20%60done%60%20while%20another%20is%20fetching.%20However%2C%20the%20concurrent-access%20test%20already%20covers%20parallel%20callers%2C%20and%20the%20Phase%202%20widening%20explicitly%20relies%20on%20this%20singleflight%20contract.%20Deferring%20the%20close%20and%20capturing%20a%20sentinel%20error%20would%20harden%20the%20path%20before%20Phase%202%20widens%20usage.%0A%0A%23%23%23%20Issue%202%20of%202%0Ainternal%2Frule%2Feval_context.go%3A248-258%0A**Context%20cancellation%20ignored%20while%20waiting%20on%20%60%3C-cached.done%60**%0A%0AEvery%20location%20that%20waits%20on%20%60%3C-placeholder.done%60%20%28the%20fast-path%20hit%20in%20%60FetchImages%60%20%2F%20%60FetchMetadata%60%20%2F%20%60FetchFieldFromProviders%60%20%2F%20%60Search%60%2C%20and%20the%20singleflight%20re-check%20inside%20%60dispatch%60%29%20uses%20a%20bare%20channel%20receive.%20If%20%60ctx%60%20is%20cancelled%20or%20its%20deadline%20fires%20while%20another%20goroutine%20is%20executing%20the%20real%20fetch%2C%20the%20waiting%20caller%20is%20stuck%20until%20the%20fetch%20either%20completes%20or%20the%20process%20exits.%0A%0AIn%20Phase%201%20sequential%20execution%20the%20%60done%60%20channel%20is%20always%20already%20closed%20by%20the%20time%20a%20second%20call%20hits%20the%20cache%2C%20so%20the%20receive%20is%20never%20blocking.%20Once%20Phase%202%20%28%231134%29%20widens%20the%20evaluation%20to%20parallel%20fixers%2C%20this%20becomes%20a%20live%20hang%20under%20any%20context%20that%20can%20be%20cancelled.%20A%20%60select%20%7B%20case%20%3C-cached.done%3A%20...%3B%20case%20%3C-ctx.Done%28%29%3A%20...%20%7D%60%20in%20each%20wait%20site%20would%20respect%20the%20caller's%20deadline%20without%20breaking%20the%20dedup%20accounting.%0A%0A&repo=sydlexius%2Fstillwater&pr=1718&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(rule): address PR #1718 round 1 revi..."](https://github.com/sydlexius/stillwater/commit/e762ff3b0cd95c04d48944dc428d3f3082594a03) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34297846)</sub>

<!-- /greptile_comment -->