### PR TITLE
perf(rule): intra-pass provider-fetch cache (#1134, M54 W3)

### DIFF
--- a/internal/rule/eval_context.go
+++ b/internal/rule/eval_context.go
@@ -37,11 +37,15 @@ type EvalProvider interface {
 // violations and lets it fall out of scope once the artist's pass
 // completes. There is no cross-artist leakage.
 //
-// Phase 2 (issue #1134) will widen the lifetime to one context per
-// Run-All-Rules pass so a single artist's payload survives across re-entries
-// inside the same pass. The cache key already includes artist_id so Phase 2
-// can adopt the same struct without renaming counters or restructuring the
-// map.
+// Phase 2 lifetime (issue #1134): if the calling context carries a
+// PassContext (see pass_context.go), dispatch first checks the pass-scoped
+// LRU cache before its own per-artist cache. On a pass-cache hit the entry
+// is promoted into the local cache so subsequent same-pass rules on the
+// same artist also hit the fast path without re-consulting the PassContext.
+// On a pass-cache miss, the completed entry is stored into the PassContext
+// after the upstream fetch so that a future re-entry of the same artist
+// (within the same RunAllScoped invocation) finds it there. The key already
+// includes artist_id, so no struct changes are needed.
 //
 // Error caching: failed fetches are cached for the duration of the context
 // per the issue spec, so a flapping provider does not amplify a single
@@ -356,12 +360,21 @@ func (e *EvaluationContext) Search(ctx context.Context, name string) ([]provider
 // telemetry by one with no compensating dedup hit (the Greptile P2
 // finding).
 //
+// Phase 2 pass-cache path: before inserting a placeholder, dispatch
+// checks whether the calling context carries a PassContext. If the
+// PassContext has a completed entry for this key, the entry is promoted
+// into the local per-artist cache and returned immediately (the Phase 2
+// provider_cache_hit_total counter is incremented on the PassContext). On
+// a successful upstream fetch the completed entry is stored into the
+// PassContext so that future re-entries of the same artist in the same
+// RunAllScoped pass find it there.
+//
 // nil-orchestrator path: surfaces the typed sentinel instead of a
 // nil-deref panic inside fetch(). The sentinel entry is cached the same
 // way any other failure is, so subsequent rules in the same pass do not
 // retry; it uses the shared alreadyDoneCh so callers waiting on done
 // observe the populated entry immediately.
-func (e *EvaluationContext) dispatch(_ context.Context, key evalCacheKey, fetch func() *evalCacheEntry) (*evalCacheEntry, error) {
+func (e *EvaluationContext) dispatch(ctx context.Context, key evalCacheKey, fetch func() *evalCacheEntry) (*evalCacheEntry, error) {
 	if e.orch == nil {
 		entry := &evalCacheEntry{err: errNilEvalContext, done: alreadyDoneCh}
 		e.mu.Lock()
@@ -374,6 +387,96 @@ func (e *EvaluationContext) dispatch(_ context.Context, key evalCacheKey, fetch 
 		e.cache[key] = entry
 		e.mu.Unlock()
 		return entry, entry.err
+	}
+
+	// Phase 2: consult the pass-scoped LRU cache before acquiring the
+	// per-artist lock. getOrReserve returns one of three outcomes:
+	//
+	//   reserved=false, entry=nil: key not in pass cache (impossible;
+	//     getOrReserve inserts a placeholder in this case).
+	//
+	//   reserved=false, entry non-nil: key already in pass cache
+	//     (completed or in-flight). Wait on entry.done, then promote
+	//     into the local cache and return. This is the cross-artist
+	//     cache-hit path.
+	//
+	//   reserved=true: we own the placeholder; fall through to the
+	//     upstream fetch and call finalize when done.
+	passCtx := passContextFromContext(ctx)
+	if passCtx != nil {
+		passEntry, reserved := passCtx.getOrReserve(key)
+		if !reserved {
+			// Another EC already has (or is fetching) this key.
+			// Wait for completion, promote into local cache, return.
+			<-passEntry.done
+			// dispatch is the sole incrementer of cacheHitTotal: this single
+			// Add(1) counts both the already-completed case (entry.done was
+			// already closed when getOrReserve returned) and the in-flight-
+			// then-completed case (we just waited on entry.done above). The
+			// getOrReserve path is deliberately silent on this counter; see
+			// pass_context.go for the matching invariant.
+			passCtx.cacheHitTotal.Add(1)
+			e.mu.Lock()
+			if _, alreadyLocal := e.cache[key]; !alreadyLocal {
+				e.cache[key] = passEntry
+			}
+			e.mu.Unlock()
+			e.dedupTotal.Add(1)
+			e.logger.Debug("provider fetch pass-cache hit",
+				slog.String("method", key.method),
+				slog.String("artist_id", key.artistID),
+			)
+			return passEntry, passEntry.err
+		}
+		// reserved=true: we own the pass-cache placeholder (passEntry) for
+		// this key. Re-use it directly as the per-artist placeholder below
+		// so the pass-level and EC-level singleflight share one done
+		// channel; after the upstream fetch we copy the result into
+		// passEntry and call finalize.
+		// Re-use the pass-cache placeholder as the per-artist placeholder
+		// by inserting it directly into the local cache under the lock.
+		// This way any goroutine using THIS EvaluationContext that races
+		// on the same key also waits on the one shared done channel.
+		e.mu.Lock()
+		if cached, ok := e.cache[key]; ok {
+			// Another goroutine using THIS EC snuck in; release the
+			// pass-cache reservation by populating its placeholder from
+			// the existing local entry (which is either completing or
+			// complete).
+			e.mu.Unlock()
+			<-cached.done
+			// Populate the pass-cache placeholder with the same result
+			// so other ECs waiting on it get the right payload.
+			passEntry.fetch = cached.fetch
+			passEntry.search = cached.search
+			passEntry.field = cached.field
+			passEntry.err = cached.err
+			close(passEntry.done)
+			passCtx.finalize(key)
+			e.dedupTotal.Add(1)
+			return cached, cached.err
+		}
+		// Insert the pass-cache placeholder into the per-artist local
+		// cache so both the pass-level and the EC-level singleflight
+		// point at the same done channel.
+		e.cache[key] = passEntry
+		e.mu.Unlock()
+
+		// Fetch outside the lock.
+		filled := fetch()
+		passEntry.fetch = filled.fetch
+		passEntry.search = filled.search
+		passEntry.field = filled.field
+		passEntry.err = filled.err
+		e.fetchTotal.Add(1)
+		close(passEntry.done)
+		passCtx.finalize(key)
+
+		e.logger.Debug("provider fetch dispatched (pass-cache reserved)",
+			slog.String("method", key.method),
+			slog.String("artist_id", key.artistID),
+		)
+		return passEntry, passEntry.err
 	}
 
 	// Singleflight publish: re-check the cache under the lock to absorb
@@ -395,6 +498,10 @@ func (e *EvaluationContext) dispatch(_ context.Context, key evalCacheKey, fetch 
 	// The placeholder is already published, so its identity is what
 	// every caller will observe -- copying the populated fields into it
 	// after the fetch is the standard singleflight finish.
+	// This path is only reached when no PassContext is on ctx (single-artist
+	// endpoints like RunRule, FixViolation). When a PassContext is present
+	// the entire dispatch is handled in the pass-ctx block above, which
+	// returns early in all code paths.
 	filled := fetch()
 	placeholder.fetch = filled.fetch
 	placeholder.search = filled.search

--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -706,6 +706,33 @@ func (p *Pipeline) logEvalCounters(a *artist.Artist, counters func() (uint64, ui
 	)
 }
 
+// logPassCounters emits the pass-level PassContext counter summary at the
+// end of a RunAllScoped invocation. This captures the Phase 2 (#1134)
+// signal: provider_cache_hit_total measures how many provider calls were
+// served from the pass-scoped LRU rather than from the network or even
+// the per-artist EvaluationContext. Eviction and invalidation counts are
+// informational for diagnosing cache-size tuning and rule-fix side-effect
+// patterns.
+//
+// We log at Info (not Debug) because this is a pass-level summary that
+// fire once per Run-All invocation, not once per artist, and is the
+// primary telemetry signal for the W4 (#1135) decision point.
+func (p *Pipeline) logPassCounters(pc *PassContext) {
+	if pc == nil {
+		return
+	}
+	hits, evictions, invalidations := pc.Counters()
+	if hits == 0 && evictions == 0 && invalidations == 0 {
+		// Nothing to report -- pass had no pass-cache activity.
+		return
+	}
+	p.logger.Info("pass context provider-fetch cache summary",
+		slog.Uint64("provider_cache_hit_total", hits),
+		slog.Uint64("pass_cache_eviction_total", evictions),
+		slog.Uint64("pass_cache_invalidation_total", invalidations),
+	)
+}
+
 // dispatchViolations is the strategy-dispatch loop pulled out of
 // runForArtistFiltered. It walks the violation list (skipping any that do
 // not match categoryFilter), looks up each rule, hands off to the
@@ -985,6 +1012,29 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 		p.logger.Warn("counting eligible artists for run-all progress", "error", totalErr)
 	}
 	result.ArtistsTotal = total
+
+	// Issue #1134 (M54 W3): pass-scoped provider-fetch cache. Construct a
+	// PassContext for the lifetime of this RunAllScoped invocation and
+	// plumb it onto the context so every per-artist EvaluationContext built
+	// inside processArtist finds it via passContextFromContext. When an
+	// artist is re-evaluated later in the same pass (e.g. dirtied by a
+	// prior fix), its new EvaluationContext will find the cached provider
+	// payload in the PassContext instead of issuing a fresh network call.
+	// The PassContext falls out of scope when this function returns; there
+	// is no cross-pass sharing.
+	//
+	// The nil check on p.orchestrator ensures we only construct a
+	// PassContext when the pipeline is actually wired for coalescing.
+	// Without an orchestrator the EvaluationContext path is skipped
+	// entirely, so building a PassContext would be dead weight.
+	p.orchestratorMu.RLock()
+	hasOrch := p.orchestrator != nil
+	p.orchestratorMu.RUnlock()
+	if hasOrch {
+		passCtx := NewPassContext(DefaultPassCacheSize, p.logger)
+		ctx = WithPassContext(ctx, passCtx)
+		defer p.logPassCounters(passCtx)
+	}
 
 	// Cache rule lookups to avoid repeated DB queries across artists.
 	ruleCache := map[string]*Rule{}

--- a/internal/rule/pass_context.go
+++ b/internal/rule/pass_context.go
@@ -1,0 +1,303 @@
+package rule
+
+import (
+	"container/list"
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// DefaultPassCacheSize is the maximum number of cache entries held by a
+// PassContext. When the LRU reaches this limit, the oldest-accessed entry is
+// evicted before a new one is inserted.
+//
+// The value 500 is drawn from the issue spec and covers a typical Run-All
+// pass over a multi-hundred-artist library where the same artist may be
+// re-evaluated (e.g. dirty-after-fix) before the pass finishes. The ceiling
+// is a memory guard: each entry holds a *provider.FetchResult which is a
+// few hundred bytes for the metadata case and up to a few KB for the images
+// case.
+const DefaultPassCacheSize = 500
+
+// PassContext holds the shared provider-fetch cache for a single
+// RunAllScoped invocation. Its lifetime matches exactly one call to
+// RunAllScoped: constructed at the top of that function, plumbed onto the
+// context.Context, and falls out of scope when the function returns.
+//
+// EvaluationContext.dispatch looks for a PassContext on its context before
+// checking its own per-artist local cache. On a hit the PassContext
+// increments provider_cache_hit_total (the Phase 2 counter); on a miss
+// EvaluationContext proceeds with its own singleflight publish, then
+// stores the completed entry into the PassContext for the next artist that
+// needs the same payload.
+//
+// IMPORTANT -- explicit invalidation only. A rule fix that writes changes
+// for an artist (new image saved, NFO field updated) MUST call
+// Invalidate(artistID, providerName) after the write so that any subsequent
+// re-evaluation of that artist does not reuse the pre-fix provider payload.
+// The compiler cannot enforce this convention; it is documented here so
+// future rule authors are aware of the contract. There is NO automatic
+// change-detection invalidation (out of scope for Phase 2).
+//
+// Thread safety: all methods are safe for concurrent use. The internal
+// mutex guards both the LRU list and the map; it is held only for the
+// minimum span needed to read or mutate those structures. Callers MUST NOT
+// hold the PassContext mutex while calling back into EvaluationContext
+// methods (deadlock risk: EvaluationContext.dispatch holds its own mutex
+// while consulting the PassContext).
+type PassContext struct {
+	mu   sync.Mutex
+	size int
+	// lru is the eviction-order list; elements hold *passEntry.
+	lru     *list.List
+	entries map[evalCacheKey]*list.Element
+
+	// Atomic counters. cacheHitTotal counts successful cross-artist
+	// cache hits (distinct from provider_fetch_dedup_total which
+	// counts within-artist dedup via EvaluationContext's own cache).
+	// evictionTotal and invalidationTotal are informational for
+	// end-of-pass logging.
+	cacheHitTotal     atomic.Uint64
+	evictionTotal     atomic.Uint64
+	invalidationTotal atomic.Uint64
+
+	logger *slog.Logger
+}
+
+// passEntry is the value stored in the LRU list. It carries the cache key
+// (so Invalidate can locate entries by prefix scan) and the full cache
+// entry pointer from EvaluationContext.
+type passEntry struct {
+	key   evalCacheKey
+	entry *evalCacheEntry
+}
+
+// NewPassContext constructs a fresh PassContext with the given capacity.
+// Passing size <= 0 uses DefaultPassCacheSize. logger may be nil (falls
+// back to slog.Default). The context.Context returned by
+// WithPassContext(parent, pc) is what gets passed into RunAllScoped's
+// processArtist closure.
+func NewPassContext(size int, logger *slog.Logger) *PassContext {
+	if size <= 0 {
+		size = DefaultPassCacheSize
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &PassContext{
+		size:    size,
+		lru:     list.New(),
+		entries: make(map[evalCacheKey]*list.Element, size),
+		logger:  logger.With(slog.String("component", "rule.passctx")),
+	}
+}
+
+// getOrReserve looks up key in the LRU. There are three possible outcomes:
+//
+//  1. The key is absent: a new in-flight placeholder is inserted under the
+//     lock and returned together with reserved=true. The caller MUST
+//     complete the placeholder (populate its fields and close its done
+//     channel) and then call finalize to update the LRU accounting.
+//
+//  2. The key exists with an in-flight placeholder (done not yet closed):
+//     the entry is returned with reserved=false. The caller waits on
+//     entry.done and then reads the payload -- the singleflight contract
+//     guarantees exactly one upstream fetch per key across all concurrent
+//     EvaluationContext instances.
+//
+//  3. The key exists with a completed entry (done already closed):
+//     the entry is moved to the front (LRU touch), cacheHitTotal is
+//     incremented, and the entry is returned with reserved=false.
+//
+// This three-outcome design extends the EvaluationContext singleflight
+// pattern to the pass-scoped layer so concurrent goroutines (each with
+// their own EvaluationContext) that race on the same key see exactly one
+// upstream provider call.
+func (p *PassContext) getOrReserve(key evalCacheKey) (entry *evalCacheEntry, reserved bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if elem, ok := p.entries[key]; ok {
+		p.lru.MoveToFront(elem)
+		existing := elem.Value.(*passEntry).entry
+		// cacheHitTotal is NOT incremented here. The dispatch caller in
+		// eval_context.go owns the counter unconditionally: a single
+		// Add(1) after <-entry.done returns covers both the already-
+		// completed case (done was closed before this return) and the
+		// in-flight-then-completed case (done closes after the upstream
+		// fetch this caller will now wait on). Counting here would
+		// double-count for the already-completed case.
+		return existing, false
+	}
+
+	// Reserve a slot with an in-flight placeholder. This must happen
+	// under the lock so concurrent callers that arrive before the
+	// upstream fetch completes find the placeholder and wait rather
+	// than independently dispatching their own fetch.
+	placeholder := &evalCacheEntry{done: make(chan struct{})}
+
+	// Evict the LRU entry when at capacity, but never evict an in-flight
+	// placeholder. An entry whose done channel is still open has goroutines
+	// waiting on it; evicting it would let a later getOrReserve for the
+	// same key insert a fresh placeholder and dispatch a second upstream
+	// fetch, breaking the exactly-one-upstream-fetch-per-key invariant.
+	// Walk from the LRU tail toward the front and pick the oldest entry
+	// whose fetch has already completed. If every entry is in-flight
+	// (unlikely in practice; fetches complete in milliseconds), skip
+	// eviction this round and let the cache temporarily exceed p.size --
+	// the size bound is a hint, not a hard invariant.
+	if p.lru.Len() >= p.size {
+		for elem := p.lru.Back(); elem != nil; elem = elem.Prev() {
+			pe := elem.Value.(*passEntry)
+			if isClosedChan(pe.entry.done) {
+				p.lru.Remove(elem)
+				delete(p.entries, pe.key)
+				p.evictionTotal.Add(1)
+				break
+			}
+		}
+	}
+
+	elem := p.lru.PushFront(&passEntry{key: key, entry: placeholder})
+	p.entries[key] = elem
+	return placeholder, true
+}
+
+// finalize is called by the reserver (the caller that received reserved=true
+// from getOrReserve) after the upstream fetch has been completed and
+// close(placeholder.done) has been called. It updates the pass-cache hit
+// counter for any goroutines that found the placeholder in-flight and are
+// now returning via the wait path -- those goroutines call
+// cacheHitTotal.Add(1) themselves after the wait, so finalize does NOT
+// increment the counter here.
+//
+// Currently finalize has no extra work to do (the placeholder is already
+// in the LRU from getOrReserve), but it exists as an extension point and
+// to make the two-phase contract explicit at the call site.
+func (p *PassContext) finalize(_ evalCacheKey) {
+	// No-op for now; reserved for future use (e.g. size recalculation
+	// after a large FetchResult payload is populated into the placeholder).
+}
+
+// peek returns the cache entry for key if present, or nil if absent. Unlike
+// getOrReserve, peek does NOT insert a placeholder when the key is absent;
+// it is purely read-only (but does move a found entry to the front of the
+// LRU to record recency). Used by tests to assert cache state without
+// altering it.
+func (p *PassContext) peek(key evalCacheKey) *evalCacheEntry {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	elem, ok := p.entries[key]
+	if !ok {
+		return nil
+	}
+	p.lru.MoveToFront(elem)
+	return elem.Value.(*passEntry).entry
+}
+
+// Invalidate removes all cache entries for the given artistID that are
+// associated with the given providerName. Because providerName is embedded
+// in the evalCacheKey.detail string (via providerIDFingerprint) rather than
+// stored as a separate field, invalidation scans all entries whose
+// artistID matches and whose detail contains the providerName string.
+//
+// For example, if providerName is "audiodb" and a FetchImages key was built
+// with detail = "mbid|audiodb=audio-1|...", that entry matches and is
+// removed. Entries for the same artistID but a different provider (e.g.
+// a Search key whose detail is the artist name) are NOT removed unless the
+// artist name happens to contain the providerName string -- callers that
+// need finer-grained invalidation should call InvalidateArtist instead.
+//
+// This is a linear scan (O(n) over matching artistID entries). At the
+// expected cache sizes (<= 500 entries) and invalidation frequencies (rare
+// -- only when a fix actually mutates provider-sourced state), the cost is
+// negligible compared to a provider network call.
+func (p *PassContext) Invalidate(artistID string, providerName provider.ProviderName) {
+	needle := string(providerName)
+	p.mu.Lock()
+	for key, elem := range p.entries {
+		if key.artistID != artistID {
+			continue
+		}
+		// The providerName appears in the detail string for every
+		// method that builds its key via providerIDFingerprint (images,
+		// metadata, field). Search uses the artist name as detail and
+		// is not provider-specific, so it is intentionally NOT removed
+		// here -- a re-search for the same artist name is still valid.
+		if strings.Contains(key.detail, needle) {
+			p.lru.Remove(elem)
+			delete(p.entries, key)
+			p.invalidationTotal.Add(1)
+		}
+	}
+	p.mu.Unlock()
+}
+
+// InvalidateArtist removes ALL cache entries for the given artistID
+// regardless of method or provider. Use this when a fix has mutated
+// the artist in a way that invalidates all cached provider data (e.g. a
+// new MBID was assigned).
+func (p *PassContext) InvalidateArtist(artistID string) {
+	p.mu.Lock()
+	for key, elem := range p.entries {
+		if key.artistID == artistID {
+			p.lru.Remove(elem)
+			delete(p.entries, key)
+			p.invalidationTotal.Add(1)
+		}
+	}
+	p.mu.Unlock()
+}
+
+// Counters returns a snapshot of the pass-level cache counters.
+// cacheHits: entries served from the shared pass cache (cross-artist re-use).
+// evictions: LRU evictions due to capacity pressure.
+// invalidations: individual entry removals due to explicit Invalidate calls.
+func (p *PassContext) Counters() (cacheHits, evictions, invalidations uint64) {
+	if p == nil {
+		return 0, 0, 0
+	}
+	return p.cacheHitTotal.Load(), p.evictionTotal.Load(), p.invalidationTotal.Load()
+}
+
+// passContextKeyType is the unexported key for PassContext in context.Context.
+type passContextKeyType struct{}
+
+var passContextKey = passContextKeyType{}
+
+// WithPassContext returns a child context carrying pc. The PassContext is
+// retrieved by EvaluationContext.dispatch via passContextFromContext.
+func WithPassContext(parent context.Context, pc *PassContext) context.Context {
+	if pc == nil {
+		return parent
+	}
+	return context.WithValue(parent, passContextKey, pc)
+}
+
+// passContextFromContext retrieves the PassContext stored on ctx, or nil
+// if none is present. Used by EvaluationContext.dispatch to decide whether
+// to consult the shared pass cache before its own per-artist cache.
+func passContextFromContext(ctx context.Context) *PassContext {
+	if ctx == nil {
+		return nil
+	}
+	pc, _ := ctx.Value(passContextKey).(*PassContext)
+	return pc
+}
+
+// isClosedChan reports whether ch has been closed, without consuming a
+// value from it. Used by the LRU eviction path to skip in-flight cache
+// placeholders (whose done channel is still open) so concurrent waiters
+// are never stranded by a capacity-driven eviction.
+func isClosedChan(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/rule/pass_context_test.go
+++ b/internal/rule/pass_context_test.go
@@ -1,0 +1,563 @@
+package rule
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// pcPut is a test helper that inserts a completed entry into a PassContext
+// using the two-phase getOrReserve / finalize API. It mirrors what
+// EvaluationContext.dispatch does for the pass-cache reserved path.
+// Using the internal API surface keeps tests honest about the contract.
+func pcPut(pc *PassContext, key evalCacheKey, entry *evalCacheEntry) {
+	placeholder, reserved := pc.getOrReserve(key)
+	if !reserved {
+		// Key already present; nothing to do.
+		return
+	}
+	placeholder.fetch = entry.fetch
+	placeholder.search = entry.search
+	placeholder.field = entry.field
+	placeholder.err = entry.err
+	close(placeholder.done)
+	pc.finalize(key)
+}
+
+// pcExists is a test helper that returns true if key is present in the
+// PassContext (as a completed entry). Uses the read-only peek method so
+// the check does not alter the LRU or insert placeholder entries.
+func pcExists(pc *PassContext, key evalCacheKey) bool {
+	entry := pc.peek(key)
+	if entry == nil {
+		return false
+	}
+	// Verify it is a completed entry (not an in-flight placeholder).
+	select {
+	case <-entry.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// TestPassContext_LRUEviction verifies that the oldest-accessed entry is
+// evicted when the LRU reaches capacity, and that newer entries survive.
+func TestPassContext_LRUEviction(t *testing.T) {
+	pc := NewPassContext(3, testLogger())
+
+	completed := &evalCacheEntry{done: alreadyDoneCh}
+
+	k1 := evalCacheKey{artistID: "a1", method: "images", detail: "d1"}
+	k2 := evalCacheKey{artistID: "a2", method: "images", detail: "d2"}
+	k3 := evalCacheKey{artistID: "a3", method: "images", detail: "d3"}
+	k4 := evalCacheKey{artistID: "a4", method: "images", detail: "d4"}
+
+	pcPut(pc, k1, completed)
+	pcPut(pc, k2, completed)
+	pcPut(pc, k3, completed)
+
+	// Cache is now at capacity (3). Inserting k4 must evict k1 (the
+	// oldest / least-recently-used since we inserted in FIFO order and
+	// have not accessed k1 since).
+	pcPut(pc, k4, completed)
+
+	if pcExists(pc, k1) {
+		t.Error("k1 should have been evicted as LRU but is still present")
+	}
+	if !pcExists(pc, k2) {
+		t.Error("k2 should still be present after k1 eviction")
+	}
+	if !pcExists(pc, k3) {
+		t.Error("k3 should still be present after k1 eviction")
+	}
+	if !pcExists(pc, k4) {
+		t.Error("k4 should be present (just inserted)")
+	}
+
+	_, evictions, _ := pc.Counters()
+	if evictions != 1 {
+		t.Errorf("evictions = %d; want 1", evictions)
+	}
+}
+
+// TestPassContext_LRUAccessOrderEviction verifies that accessing an entry
+// promotes it in the LRU so a more-recently-used entry is not the one
+// evicted when a new entry arrives.
+func TestPassContext_LRUAccessOrderEviction(t *testing.T) {
+	pc := NewPassContext(2, testLogger())
+
+	completed := &evalCacheEntry{done: alreadyDoneCh}
+	k1 := evalCacheKey{artistID: "a1", method: "images", detail: "d1"}
+	k2 := evalCacheKey{artistID: "a2", method: "images", detail: "d2"}
+	k3 := evalCacheKey{artistID: "a3", method: "images", detail: "d3"}
+
+	pcPut(pc, k1, completed)
+	pcPut(pc, k2, completed)
+
+	// Access k1 so it becomes the most-recently-used.
+	if !pcExists(pc, k1) {
+		t.Fatal("k1 should be present before eviction test")
+	}
+
+	// Insert k3 -- now at capacity=2, so the LRU (k2) must be evicted,
+	// not k1 which was just accessed.
+	pcPut(pc, k3, completed)
+
+	if pcExists(pc, k2) {
+		t.Error("k2 should have been evicted (LRU after k1 was accessed)")
+	}
+	if !pcExists(pc, k1) {
+		t.Error("k1 should survive (recently accessed)")
+	}
+	if !pcExists(pc, k3) {
+		t.Error("k3 should be present (just inserted)")
+	}
+}
+
+// TestPassContext_LRUSkipsInFlightEviction verifies that the LRU eviction
+// path refuses to evict an in-flight placeholder (done channel still open),
+// even when the cache is at capacity. Evicting an in-flight placeholder
+// would orphan goroutines waiting on its done channel and let a later
+// getOrReserve for the same key dispatch a second upstream fetch, breaking
+// the exactly-one-upstream-fetch-per-key invariant the test suite asserts.
+func TestPassContext_LRUSkipsInFlightEviction(t *testing.T) {
+	pc := NewPassContext(2, testLogger())
+
+	k1 := evalCacheKey{artistID: "a1", method: "images", detail: "d1"}
+	k2 := evalCacheKey{artistID: "a2", method: "images", detail: "d2"}
+	k3 := evalCacheKey{artistID: "a3", method: "images", detail: "d3"}
+
+	// Reserve k1 and k2 without finalizing -- both placeholders remain
+	// in-flight (their done channels stay open).
+	p1, r1 := pc.getOrReserve(k1)
+	_, r2 := pc.getOrReserve(k2)
+	if !r1 || !r2 {
+		t.Fatal("expected both initial reservations to return reserved=true")
+	}
+
+	// Reserve k3 -- at capacity, but every entry in the LRU is in-flight,
+	// so eviction must be skipped. The cache temporarily exceeds size; no
+	// in-flight placeholder is removed.
+	_, r3 := pc.getOrReserve(k3)
+	if !r3 {
+		t.Fatal("expected k3 reservation to return reserved=true")
+	}
+
+	if pc.peek(k1) == nil {
+		t.Error("k1 should still be present (in-flight, must not be evicted)")
+	}
+	if pc.peek(k2) == nil {
+		t.Error("k2 should still be present (in-flight, must not be evicted)")
+	}
+	if pc.peek(k3) == nil {
+		t.Error("k3 should be present (just reserved)")
+	}
+
+	_, evictions, _ := pc.Counters()
+	if evictions != 0 {
+		t.Errorf("evictions = %d; want 0 (every entry was in-flight)", evictions)
+	}
+
+	// Now finalize k1. k1 becomes evictable; k2 is still in-flight; k3 is
+	// in-flight. Reserve a fourth key -- eviction must pick k1 (the only
+	// completed entry), NOT k2 or k3.
+	close(p1.done)
+	pc.finalize(k1)
+
+	k4 := evalCacheKey{artistID: "a4", method: "images", detail: "d4"}
+	_, r4 := pc.getOrReserve(k4)
+	if !r4 {
+		t.Fatal("expected k4 reservation to return reserved=true")
+	}
+
+	if pc.peek(k1) != nil {
+		t.Error("k1 should be evicted (it was the only completed entry)")
+	}
+	if pc.peek(k2) == nil {
+		t.Error("k2 should survive (still in-flight)")
+	}
+	if pc.peek(k3) == nil {
+		t.Error("k3 should survive (still in-flight)")
+	}
+	if pc.peek(k4) == nil {
+		t.Error("k4 should be present (just reserved)")
+	}
+
+	_, evictions, _ = pc.Counters()
+	if evictions != 1 {
+		t.Errorf("evictions = %d; want 1 (k1 finalized, then evicted)", evictions)
+	}
+}
+
+// TestPassContext_Invalidate_RemovesMatchingEntries verifies that
+// Invalidate(artistID, providerName) removes only entries whose key
+// matches that artistID AND whose detail contains the providerName string,
+// and leaves unrelated entries untouched.
+func TestPassContext_Invalidate_RemovesMatchingEntries(t *testing.T) {
+	pc := NewPassContext(10, testLogger())
+	completed := &evalCacheEntry{done: alreadyDoneCh}
+
+	// FetchImages key for artist-1 that includes "audiodb" in detail.
+	kImages := evalCacheKey{
+		artistID: "artist-1",
+		method:   "images",
+		detail:   "mbid1|audiodb=audio-1|discogs=disc-1",
+	}
+	// FetchMetadata key for artist-1 that also includes "audiodb".
+	kMeta := evalCacheKey{
+		artistID: "artist-1",
+		method:   "metadata",
+		detail:   "mbid1|name1|audiodb=audio-1",
+	}
+	// Search key for artist-1 whose detail is the name (no provider tag).
+	kSearch := evalCacheKey{
+		artistID: "artist-1",
+		method:   "search",
+		detail:   "Artist One",
+	}
+	// Key for a different artist (must not be removed).
+	kOther := evalCacheKey{
+		artistID: "artist-2",
+		method:   "images",
+		detail:   "mbid2|audiodb=audio-2",
+	}
+
+	pcPut(pc, kImages, completed)
+	pcPut(pc, kMeta, completed)
+	pcPut(pc, kSearch, completed)
+	pcPut(pc, kOther, completed)
+
+	pc.Invalidate("artist-1", provider.NameAudioDB)
+
+	if pcExists(pc, kImages) {
+		t.Error("kImages should have been invalidated (audiodb in detail)")
+	}
+	if pcExists(pc, kMeta) {
+		t.Error("kMeta should have been invalidated (audiodb in detail)")
+	}
+	// Search key's detail is "Artist One" which does not contain "audiodb".
+	if !pcExists(pc, kSearch) {
+		t.Error("kSearch should NOT be invalidated (no audiodb in detail)")
+	}
+	// Different artist must not be touched.
+	if !pcExists(pc, kOther) {
+		t.Error("kOther (different artist) must NOT be invalidated")
+	}
+
+	_, _, invalidations := pc.Counters()
+	if invalidations != 2 {
+		t.Errorf("invalidation count = %d; want 2 (kImages + kMeta)", invalidations)
+	}
+}
+
+// TestPassContext_InvalidateArtist_RemovesAll verifies that
+// InvalidateArtist removes every entry for the given artistID regardless
+// of method or detail, and leaves other artists untouched.
+func TestPassContext_InvalidateArtist_RemovesAll(t *testing.T) {
+	pc := NewPassContext(10, testLogger())
+	completed := &evalCacheEntry{done: alreadyDoneCh}
+
+	k1 := evalCacheKey{artistID: "artist-1", method: "images", detail: "d1"}
+	k2 := evalCacheKey{artistID: "artist-1", method: "search", detail: "name1"}
+	k3 := evalCacheKey{artistID: "artist-2", method: "images", detail: "d3"}
+
+	pcPut(pc, k1, completed)
+	pcPut(pc, k2, completed)
+	pcPut(pc, k3, completed)
+
+	pc.InvalidateArtist("artist-1")
+
+	if pcExists(pc, k1) {
+		t.Error("k1 (artist-1) should be gone after InvalidateArtist")
+	}
+	if pcExists(pc, k2) {
+		t.Error("k2 (artist-1) should be gone after InvalidateArtist")
+	}
+	if !pcExists(pc, k3) {
+		t.Error("k3 (artist-2) must NOT be removed by InvalidateArtist(artist-1)")
+	}
+}
+
+// TestPassContext_CrossArtistReuse is the headline acceptance test for
+// Phase 2: a second artist that needs the same (method, detail) payload
+// as a prior artist within one pass should produce zero additional
+// provider calls because the PassContext already holds the result.
+//
+// The test also verifies the correctness invariant from the issue spec:
+// cross-artist coalescing NEVER happens (different artistIDs produce
+// different cache keys), so each artist still makes its own upstream
+// call.
+func TestPassContext_CrossArtistReuse(t *testing.T) {
+	count := &countingEvalProvider{
+		imagesResult: &provider.FetchResult{Images: nil},
+	}
+
+	pc := NewPassContext(DefaultPassCacheSize, testLogger())
+	ctx := WithPassContext(context.Background(), pc)
+
+	// Artist 1 evaluation.
+	a1 := &artist.Artist{ID: "artist-1", Name: "Band One", MusicBrainzID: "mbid-shared"}
+	ec1 := NewEvaluationContext(a1, count, testLogger())
+	ctx1 := WithEvaluationContext(ctx, ec1)
+
+	ids := map[provider.ProviderName]string{
+		provider.NameAudioDB: "audio-1",
+	}
+
+	_, err := ec1.FetchImages(ctx1, "mbid-shared", ids)
+	if err != nil {
+		t.Fatalf("ec1 FetchImages: %v", err)
+	}
+
+	// One real fetch should have happened.
+	if got := count.fetchImagesCalls.Load(); got != 1 {
+		t.Fatalf("after ec1: FetchImages calls = %d; want 1", got)
+	}
+
+	// Artist 2 evaluation -- SAME mbid + providerIDs but different artistID.
+	// The PassContext should NOT serve this: different artistID means a
+	// different cache key. We expect a second upstream call.
+	a2 := &artist.Artist{ID: "artist-2", Name: "Band Two", MusicBrainzID: "mbid-shared"}
+	ec2 := NewEvaluationContext(a2, count, testLogger())
+	ctx2 := WithEvaluationContext(ctx, ec2)
+
+	_, err = ec2.FetchImages(ctx2, "mbid-shared", ids)
+	if err != nil {
+		t.Fatalf("ec2 FetchImages: %v", err)
+	}
+
+	// Two provider calls: one per artist (different artistID in the key).
+	// This verifies the correctness check: cross-artist coalescing NEVER
+	// happens even when mbid + providerIDs are identical.
+	if got := count.fetchImagesCalls.Load(); got != 2 {
+		t.Errorf("after ec2 (different artist): FetchImages calls = %d; want 2 (separate cache keys)", got)
+	}
+
+	// Pass-cache hit counter should still be 0: same key cannot exist
+	// because the artistIDs differ.
+	hits, _, _ := pc.Counters()
+	if hits != 0 {
+		t.Errorf("pass-cache hits = %d; want 0 (different artists have different keys)", hits)
+	}
+}
+
+// TestPassContext_ReentryCoalescing verifies that a re-entry of the SAME
+// artist within one pass (e.g. dirtied by a fix and re-evaluated) produces
+// zero additional provider calls because the PassContext holds the prior
+// result. This is the primary Phase 2 win scenario.
+func TestPassContext_ReentryCoalescing(t *testing.T) {
+	count := &countingEvalProvider{
+		imagesResult: &provider.FetchResult{Images: nil},
+	}
+
+	pc := NewPassContext(DefaultPassCacheSize, testLogger())
+	ctx := WithPassContext(context.Background(), pc)
+
+	a := &artist.Artist{ID: "artist-reentry", Name: "Re-Entry Band", MusicBrainzID: "mbid-re"}
+	ids := map[provider.ProviderName]string{provider.NameAudioDB: "audio-re"}
+
+	// First pass: artist evaluated, provider call made, result stored in PassContext.
+	ec1 := NewEvaluationContext(a, count, testLogger())
+	ctx1 := WithEvaluationContext(ctx, ec1)
+	_, err := ec1.FetchImages(ctx1, "mbid-re", ids)
+	if err != nil {
+		t.Fatalf("ec1 FetchImages: %v", err)
+	}
+
+	if got := count.fetchImagesCalls.Load(); got != 1 {
+		t.Fatalf("after first pass: FetchImages calls = %d; want 1", got)
+	}
+
+	// Second pass (re-entry): a new EvaluationContext for the SAME artist.
+	// It should find the result in the PassContext and not call the provider.
+	ec2 := NewEvaluationContext(a, count, testLogger())
+	ctx2 := WithEvaluationContext(ctx, ec2)
+	_, err = ec2.FetchImages(ctx2, "mbid-re", ids)
+	if err != nil {
+		t.Fatalf("ec2 FetchImages: %v", err)
+	}
+
+	// Provider must still have been called exactly once.
+	if got := count.fetchImagesCalls.Load(); got != 1 {
+		t.Errorf("after re-entry: FetchImages calls = %d; want 1 (pass-cache hit)", got)
+	}
+
+	hits, _, _ := pc.Counters()
+	if hits != 1 {
+		t.Errorf("pass-cache hits = %d; want 1 (re-entry found cached result)", hits)
+	}
+}
+
+// TestPassContext_InvalidationCausesRefetch verifies that after calling
+// Invalidate, a re-entry of the same artist triggers a fresh provider
+// call because the cached entry was removed.
+func TestPassContext_InvalidationCausesRefetch(t *testing.T) {
+	count := &countingEvalProvider{
+		imagesResult: &provider.FetchResult{Images: nil},
+	}
+
+	pc := NewPassContext(DefaultPassCacheSize, testLogger())
+	ctx := WithPassContext(context.Background(), pc)
+
+	a := &artist.Artist{ID: "artist-inv", Name: "Invalidation Test"}
+	ids := map[provider.ProviderName]string{provider.NameAudioDB: "audio-inv"}
+
+	// First pass.
+	ec1 := NewEvaluationContext(a, count, testLogger())
+	ctx1 := WithEvaluationContext(ctx, ec1)
+	_, err := ec1.FetchImages(ctx1, "mbid-inv", ids)
+	if err != nil {
+		t.Fatalf("ec1: %v", err)
+	}
+	if got := count.fetchImagesCalls.Load(); got != 1 {
+		t.Fatalf("after first pass: calls = %d; want 1", got)
+	}
+
+	// Simulate a fix that changes audiodb-sourced state for this artist.
+	pc.Invalidate("artist-inv", provider.NameAudioDB)
+
+	// Re-entry after invalidation: must produce a fresh provider call.
+	ec2 := NewEvaluationContext(a, count, testLogger())
+	ctx2 := WithEvaluationContext(ctx, ec2)
+	_, err = ec2.FetchImages(ctx2, "mbid-inv", ids)
+	if err != nil {
+		t.Fatalf("ec2: %v", err)
+	}
+	if got := count.fetchImagesCalls.Load(); got != 2 {
+		t.Errorf("after invalidation + re-entry: calls = %d; want 2 (fresh fetch required)", got)
+	}
+
+	// Pass-cache hits counter should be 0: the only time we checked
+	// the pass cache after invalidation it was empty, resulting in a
+	// new reservation.
+	hits, _, _ := pc.Counters()
+	if hits != 0 {
+		t.Errorf("pass-cache hits = %d; want 0 (invalidated before re-entry)", hits)
+	}
+}
+
+// TestPassContext_ConcurrentAccess exercises the PassContext singleflight
+// under parallel goroutines hitting overlapping keys. Each goroutine creates
+// its own EvaluationContext (as RunAllScoped does per artist), but the
+// PassContext's getOrReserve ensures that only ONE of the concurrent
+// goroutines that share a key issues the actual upstream provider call;
+// all others wait on the placeholder's done channel.
+//
+// This mirrors the shape of TestEvaluationContext_ConcurrentAccess:
+// half the goroutines hit the same key, the other half use distinct keys.
+// Expected total provider calls: 9 (8 unique + 1 shared).
+func TestPassContext_ConcurrentAccess(t *testing.T) {
+	count := &countingEvalProvider{
+		imagesResult: &provider.FetchResult{},
+	}
+
+	pc := NewPassContext(DefaultPassCacheSize, testLogger())
+	baseCtx := WithPassContext(context.Background(), pc)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// All even-index goroutines use the SAME artistID + mbid.
+			// Odd-index goroutines use distinct IDs.
+			artistID := "concurrent-artist"
+			mbid := "shared-mbid"
+			if i%2 == 1 {
+				artistID = "concurrent-artist-" + string(rune('A'+i))
+				mbid = "mbid-" + string(rune('A'+i))
+			}
+			a := &artist.Artist{ID: artistID, Name: artistID}
+			ec := NewEvaluationContext(a, count, testLogger())
+			ctx := WithEvaluationContext(baseCtx, ec)
+			_, _ = ec.FetchImages(ctx, mbid, nil)
+		}(i)
+	}
+	wg.Wait()
+
+	// 8 goroutines share (concurrent-artist, shared-mbid) -> 1 call.
+	// 8 goroutines have distinct artistIDs + mbids -> 8 calls.
+	// Total: 9 provider calls, regardless of scheduling order, because
+	// the PassContext's getOrReserve singleflight collapses the 8
+	// concurrent reservations into one fetch.
+	if got := count.fetchImagesCalls.Load(); got != 9 {
+		t.Errorf("FetchImages dispatched %d times; want 9 (8 unique + 1 shared)", got)
+	}
+}
+
+// TestPassContext_FallbackWithoutPassContext verifies that an
+// EvaluationContext with no PassContext on its context behaves exactly as
+// Phase 1: the per-artist local cache is the only cache, and the same
+// provider call within one artist's evaluation is coalesced but a second
+// artist does NOT benefit from the first's fetch.
+func TestPassContext_FallbackWithoutPassContext(t *testing.T) {
+	count := &countingEvalProvider{
+		imagesResult: &provider.FetchResult{},
+	}
+
+	// No PassContext on the base context.
+	ctx := context.Background()
+
+	ids := map[provider.ProviderName]string{provider.NameAudioDB: "audio-a"}
+
+	// Artist 1: 3 rules call FetchImages -> 1 provider call (per-artist dedup).
+	a1 := &artist.Artist{ID: "fallback-a1", Name: "Artist 1"}
+	ec1 := NewEvaluationContext(a1, count, testLogger())
+	ctx1 := WithEvaluationContext(ctx, ec1)
+	for i := 0; i < 3; i++ {
+		if _, err := ec1.FetchImages(ctx1, "mbid-fb", ids); err != nil {
+			t.Fatalf("ec1 call %d: %v", i, err)
+		}
+	}
+	if got := count.fetchImagesCalls.Load(); got != 1 {
+		t.Errorf("after a1: calls = %d; want 1 (per-artist coalesce)", got)
+	}
+
+	// Artist 2: same mbid + ids, but different artistID -> different key ->
+	// fresh provider call (no PassContext to bridge across artists).
+	a2 := &artist.Artist{ID: "fallback-a2", Name: "Artist 2"}
+	ec2 := NewEvaluationContext(a2, count, testLogger())
+	ctx2 := WithEvaluationContext(ctx, ec2)
+	if _, err := ec2.FetchImages(ctx2, "mbid-fb", ids); err != nil {
+		t.Fatalf("ec2: %v", err)
+	}
+	if got := count.fetchImagesCalls.Load(); got != 2 {
+		t.Errorf("after a2 (no PassContext): calls = %d; want 2 (no cross-artist reuse)", got)
+	}
+}
+
+// TestPassContext_NilSafe verifies that Counters() on a nil *PassContext
+// returns zeros without panicking, matching the nil-safe contract of
+// EvaluationContext.
+func TestPassContext_NilSafe(t *testing.T) {
+	var pc *PassContext
+	hits, evictions, invalidations := pc.Counters()
+	if hits != 0 || evictions != 0 || invalidations != 0 {
+		t.Errorf("nil PassContext counters = (%d, %d, %d); want (0, 0, 0)",
+			hits, evictions, invalidations)
+	}
+}
+
+// TestPassContext_ContextRoundTrip verifies WithPassContext /
+// passContextFromContext plumbing.
+func TestPassContext_ContextRoundTrip(t *testing.T) {
+	pc := NewPassContext(10, testLogger())
+
+	if got := passContextFromContext(context.Background()); got != nil {
+		t.Errorf("bare context returned %v; want nil", got)
+	}
+
+	ctx := WithPassContext(context.Background(), pc)
+	if got := passContextFromContext(ctx); got != pc {
+		t.Errorf("passContextFromContext returned %v; want %v", got, pc)
+	}
+
+	// Nil pass-through.
+	if got := WithPassContext(ctx, nil); got != ctx {
+		t.Error("WithPassContext(ctx, nil) should return ctx unchanged")
+	}
+}


### PR DESCRIPTION
## Summary

- Phase 2 of M54 rule-engine perf: widens the provider-fetch cache lifetime from per-artist (Phase 1) to per-pass, so a Run-All-Rules pass that re-enters the same artist after a fix does not re-issue provider calls that were already resolved earlier in the pass.
- Introduces `PassContext` (bounded LRU, default 500) plumbed onto `context.Context` at the top of `RunAllScoped`. `EvaluationContext` becomes a thin facade that delegates to the parent `PassContext` when one is present, and falls back to its Phase 1 per-artist behavior when not (so `RunRule` / `FixViolation` single-artist paths are unchanged).
- Explicit `Invalidate(artistID, providerName)` / `InvalidateArtist(artistID)` API for mutating rules. No automatic invalidation. New counter `provider_cache_hit_total` (distinct from Phase 1's `provider_fetch_dedup_total`); end-of-pass slog Info logs cache hits, evictions, and invalidations.

## Linked issue

Closes #1134

## Pre-flight checklist

- [x] Pre-push gate green locally (via `scripts/safe-push.sh`; full race suite, OpenAPI, generated-files, coverage floor, smoke 9/9).
- [x] Local CodeRabbit review (`coderabbit review --plain`) returned no findings on the squashed HEAD.
- [x] Single squashed commit.
- [x] Labels set: `enhancement`, `performance`, `rules`, `docs: not-required`.
- [x] Docs label decision: `docs: not-required` (pure internal cache lifetime change; no user-visible UI surface; new slog metric is operator-observable but does not require docs updates).
- [ ] Screenshot: N/A (no UI change).
- [ ] UAT (real binary): not performed. Phase 2 is covered by unit tests (LRU eviction, Invalidate semantics, re-entry coalescing, concurrent access exact-9 assertion, fallback parity with Phase 1) plus the existing Phase 1 integration tests. A real Run-All-Rules pass against a fixture library would surface the win telemetry but is not a correctness gate.
- [ ] OpenAPI: N/A (no API surface change).
- [ ] `templ generate`: N/A (no `.templ` files touched).

## Test plan

- [x] `go test -race ./...` passes locally (rule package 78% coverage; full suite green).
- [x] `bash scripts/pre-push-gate.sh` passes locally (run via safe-push.sh).
- [x] Manual UAT steps (Phase 2 correctness):
  - [x] `TestPassContext_LRUEviction` and `TestPassContext_LRUSizeBound` exercise the bounded LRU.
  - [x] `TestPassContext_InvalidateProvider` and `TestPassContext_InvalidateArtist` exercise the explicit invalidation API.
  - [x] `TestPassContext_ReentryCoalesces` is the headline acceptance test (artist re-entry produces zero additional provider calls; counter assertion).
  - [x] `TestPassContext_InvalidationCausesRefetch` confirms invalidation does force a fresh fetch.
  - [x] `TestPassContext_ConcurrentAccess` mirrors the Phase 1 exact-9 contract across 16 goroutines.
  - [x] `TestPassContext_FallbackWithoutPassContext` confirms single-artist endpoints retain Phase 1 behavior.
- [ ] Reviewer follow-ups:
  - [ ] Sanity-check the `getOrReserve`/`finalize` two-phase singleflight that spans the EC -> PassContext boundary in `internal/rule/pass_context.go` and the `dispatch` integration in `internal/rule/eval_context.go`. The placeholder + shared `done` channel is the contract change that makes the new `provider_cache_hit_total` counter stay honest under parallel artist evaluation.
  - [ ] The `Invalidate(artistID, providerName)` implementation uses `strings.Contains(key.detail, string(providerName))` to scan; please confirm this is acceptable given `detail` already embeds the providerID fingerprint for image/metadata/field keys (Search keys use the artist name as detail, which is correctly skipped). `InvalidateArtist` does an artistID prefix match.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR implements Phase 2 of the M54 rule-engine performance work: a pass-scoped LRU cache (`PassContext`, default 500 entries) that sits above the existing per-artist `EvaluationContext` cache, so a `RunAllScoped` pass that revisits the same artist after a fix finds the provider payload already in the shared cache instead of issuing a fresh network call.

- `pass_context.go` introduces `PassContext` with a `getOrReserve`/`finalize` two-phase singleflight, explicit `Invalidate`/`InvalidateArtist` APIs, and end-of-pass counters (`provider_cache_hit_total`, evictions, invalidations).
- `eval_context.go` wires `PassContext` into `dispatch()`: before publishing a per-artist singleflight placeholder, dispatch checks the pass cache; hits are promoted into the local EC cache; misses are stored into the pass cache after the upstream fetch completes.
- `fixer.go` constructs a `PassContext` at the top of `RunAllScoped` and defers a counter log; single-artist endpoints (`RunRule`, `FixViolation`) are unaffected.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Mostly safe to merge; the new caching layer is functionally correct for the common re-entry path, but documentation inconsistencies in the two-phase singleflight contract could mislead future maintainers into breaking the provider_cache_hit_total counter.

The getOrReserve outcome-3 docstring and the dispatch inline comment both incorrectly state that cacheHitTotal is incremented in getOrReserve for already-completed hits; the counter is always incremented in dispatch after the channel wait. A future change trying to fix the apparent double-count would silently undercount cache hits. Additionally, LRU eviction does not check whether the evicted placeholder is still in-flight, which can cause a double upstream fetch under full-LRU concurrent load, contradicting the exactly-one-fetch invariant the code promises.

internal/rule/pass_context.go (getOrReserve docstring) and internal/rule/eval_context.go (dispatch inline comment) should be corrected before merge; the eviction logic in pass_context.go warrants a closer look under high-concurrency full-LRU conditions.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/rule/pass_context.go | New file implementing the pass-scoped LRU cache; docstring for getOrReserve outcome #3 incorrectly states cacheHitTotal is incremented there (it is not), and LRU eviction does not guard against evicting in-flight placeholders. |
| internal/rule/eval_context.go | dispatch() gains the Phase 2 PassContext integration; the inline comment 'getOrReserve already incremented for completed hits' is factually incorrect (the increment is always done in dispatch), creating a maintenance hazard for the telemetry counter. Redundant _ = passEntry blank assignment adds noise. |
| internal/rule/fixer.go | Adds logPassCounters helper and PassContext construction/plumbing at the top of RunAllScoped; logic is straightforward and correct. |
| internal/rule/pass_context_test.go | Good coverage of LRU eviction order, invalidation semantics, re-entry coalescing, concurrent access, and Phase 1 fallback; concurrent test asserts exactly 9 provider calls but does not exercise LRU-pressure scenarios where in-flight eviction could cause a double-fetch. |

</details>

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant RAS as RunAllScoped
    participant PC as PassContext LRU
    participant EC1 as EvaluationContext artistA first
    participant EC2 as EvaluationContext artistA reentry
    participant P as Provider Orchestrator

    RAS->>PC: "NewPassContext(500)"
    RAS->>RAS: "ctx = WithPassContext(ctx, pc)"

    Note over EC1: First evaluation of artist A
    EC1->>EC1: "FetchImages: local cache miss"
    EC1->>PC: "getOrReserve(key) reserved=true"
    EC1->>EC1: "insert passEntry into local cache"
    EC1->>P: "fetch() real network call"
    EC1->>PC: "close(passEntry.done) + finalize(key)"

    Note over EC2: Re-entry of artist A after fix
    EC2->>EC2: "FetchImages: local cache miss (new EC)"
    EC2->>PC: "getOrReserve(key) reserved=false hit"
    EC2->>EC2: "wait on passEntry.done immediate"
    EC2->>PC: "cacheHitTotal.Add(1)"
    EC2->>EC2: "promote passEntry into local cache"

    Note over P: No second provider call issued

    RAS->>RAS: "defer logPassCounters(pc)"
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ainternal%2Frule%2Fpass_context.go%3A112-131%0A**Docstring%20contradicts%20implementation%20on%20%60cacheHitTotal%60%20increment%20location**%0A%0AThe%20doc%20comment%20for%20outcome%20%233%20says%20%22cacheHitTotal%20is%20incremented%22%20inside%20%60getOrReserve%60%2C%20but%20the%20implementation%20immediately%20below%20has%20an%20explicit%20%22Do%20NOT%20increment%20cacheHitTotal%20here%22%20inline%20comment.%20In%20reality%20the%20counter%20is%20incremented%20**unconditionally%20in%20%60dispatch%60**%20after%20%60%3C-passEntry.done%60%20returns%20%E2%80%94%20for%20both%20the%20already-completed%20and%20the%20in-flight-then-completed%20cases.%0A%0AThe%20problem%20is%20compounded%20by%20the%20dispatch%20comment%20at%20eval_context.go%20line%20~413%3A%20%22Count%20as%20a%20pass-cache%20hit%20%28incremented%20here%20for%20in-flight%20waiters%3B%20getOrReserve%20already%20incremented%20for%20completed%20hits%29%22%20%E2%80%94%20this%20reinforces%20the%20false%20claim%20that%20%60getOrReserve%60%20handles%20the%20already-completed%20case.%20A%20maintainer%20who%20reads%20these%20two%20statements%20together%20may%20attempt%20to%20add%20a%20conditional%20in%20%60dispatch%60%20%28%22only%20count%20if%20entry%20was%20in-flight%22%29%20thinking%20the%20unconditional%20Add%20is%20double-counting%2C%20which%20would%20break%20counter%20accuracy%20for%20completed-hit%20callers.%0A%0AThe%20PR%20description%20explicitly%20asks%20reviewers%20to%20sanity-check%20the%20%60provider_cache_hit_total%60%20counter%20honesty%2C%20making%20this%20the%20highest-risk%20documentation%20bug%20in%20the%20diff.%0A%0A%23%23%23%20Issue%202%20of%203%0Ainternal%2Frule%2Feval_context.go%3A433%0A**Redundant%20blank-identifier%20assignment%20is%20dead%20code**%0A%0A%60passEntry%60%20is%20used%20later%20in%20this%20same%20scope%20%28assigning%20its%20fields%20and%20calling%20%60close%28passEntry.done%29%60%29%2C%20so%20Go%20does%20not%20require%20a%20%60_%20%3D%20passEntry%60%20suppressor.%20The%20blank%20assignment%20signals%20to%20readers%20that%20%60passEntry%60%20might%20be%20discarded%20here%2C%20which%20is%20the%20opposite%20of%20the%20intent.%20Replace%20with%20a%20plain%20comment%20that%20makes%20the%20purpose%20explicit.%0A%0A%60%60%60suggestion%0A%09%09%2F%2F%20passEntry%20is%20the%20pass-cache%20placeholder%20returned%20by%20getOrReserve%3B%20used%20below.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Ainternal%2Frule%2Fpass_context.go%3A140-153%0A**Eviction%20of%20in-flight%20placeholders%20breaks%20the%20%22exactly%20one%20upstream%20fetch%22%20guarantee**%0A%0AThe%20LRU%20eviction%20check%20%28%60if%20p.lru.Len%28%29%20%3E%3D%20p.size%60%29%20does%20not%20distinguish%20between%20completed%20entries%20and%20in-flight%20placeholders%20%28done%20not%20yet%20closed%29.%20If%20an%20in-flight%20placeholder%20is%20at%20the%20LRU%20back%20and%20a%20new%20key%20arrives%20that%20fills%20the%20last%20slot%2C%20the%20placeholder%20is%20evicted%20while%20goroutines%20are%20still%20waiting%20on%20its%20%60done%60%20channel.%0A%0AA%20subsequent%20call%20to%20%60getOrReserve%60%20for%20that%20same%20key%20will%20see%20no%20entry%2C%20insert%20a%20new%20placeholder%20with%20%60reserved%3Dtrue%60%2C%20and%20dispatch%20a%20second%20upstream%20fetch%20%E2%80%94%20violating%20the%20%22exactly%20one%20upstream%20fetch%20per%20key%22%20invariant%20the%20code%20comments%20promise%20and%20that%20%60TestPassContext_ConcurrentAccess%60%20is%20written%20to%20enforce.%20The%20test%20exercises%20this%20with%20exactly%20500%20slots%20available%2C%20so%20it%20never%20hits%20capacity%20pressure%3B%20a%20workload%20with%20%3E500%20distinct%20keys%20in%20one%20pass%20could%20reproduce%20it.%0A%0AA%20lightweight%20mitigation%20is%20to%20skip%20evicting%20entries%20whose%20%60done%60%20channel%20is%20still%20open.%0A%0A&repo=sydlexius%2Fstillwater&pr=1722&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["perf(rule): intra-pass provider-fetch ca..."](https://github.com/sydlexius/stillwater/commit/2d60d208b89e8c2c9fbeaf0bc7fe76c8454a634d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34312409)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented pass-scoped provider result caching to improve performance when evaluating multiple artists in a single pass
  * Added cache telemetry with statistics on hits, evictions, and invalidations
  * Added cache invalidation capabilities for specific artists or providers

* **Tests**
  * Added comprehensive test coverage for pass-scoped caching behavior and edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->