### PR TITLE
fix(lock): break silent re-lock loop in scanner/fixer/handler (#1726, v1.5.0 bump)

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -157,6 +157,7 @@ type Application struct {
 	webhookDispatcher   *webhook.Dispatcher
 	backupService       *backup.Service
 	maintenanceService  *maintenance.Service
+	lockSyncService     *connection.LockSync
 	settingsIOService   *settingsio.Service
 	updaterService      *updater.Service
 	probeCache          *watcher.ProbeCache
@@ -727,6 +728,11 @@ func (a *Application) wireRuleEngine(ctx context.Context, logger *slog.Logger) e
 		// the event bus so the SSE hub can surface them as toasts.
 		Notifier: publish.NewBusNotifier(a.eventBus),
 	})
+	// LockSync pulls platform-side <lockdata> changes back into Stillwater
+	// (issue #1726 Part C). Wired here because all three dependencies
+	// (DB, connection service, artist service) are now ready.
+	a.lockSyncService = connection.NewLockSync(db, a.connectionService, a.artistService, publish.LockSyncClientFactory(), logger)
+
 	// Wire the rename-time platform syncer so Service.RenameDirectory
 	// re-issues the artist path on Emby/Jellyfin/Lidarr after a successful
 	// directory rename (#1222, #1231). The publisher already owns
@@ -746,7 +752,7 @@ func (a *Application) wireRuleEngine(ctx context.Context, logger *slog.Logger) e
 	a.ruleEngine.SetReleaseGroupFetcher(releaseGroupFetcher)
 
 	fixers := []rule.Fixer{
-		rule.NewNFOFixer(a.nfoSnapshotService, a.nfoSettingsService, a.fsCheck, a.expectedWrites),
+		rule.NewNFOFixer(a.nfoSnapshotService, a.nfoSettingsService, a.fsCheck, a.expectedWrites, a.publisher),
 		rule.NewMetadataFixer(a.orchestrator, logger),
 		rule.NewNameLanguageFixer(a.orchestrator, logger),
 		rule.NewImageFixer(a.orchestrator, a.platformService, a.fsCheck, logger),
@@ -799,6 +805,28 @@ func resolveReleaseGroupFetcher(registry *provider.Registry) provider.ReleaseGro
 //
 // logManager.Close, eventBus.Stop, and db.Close are deferred in run() so
 // they fire even if this phase returns early.
+// startLockSyncScheduler launches the LockSync platform-pull scheduler if
+// lockSyncService is wired and lock_sync.interval_minutes is not 0
+// (explicit disable). Negative values fall back to the 30-minute default,
+// which matches the cadence at which most Stillwater users notice and react
+// to platform-side changes without hammering Emby/Jellyfin for libraries
+// with thousands of artists. Extracted from startListeners to keep that
+// method's cognitive complexity under the lint cap.
+func (a *Application) startLockSyncScheduler(ctx context.Context, db *sql.DB, logger *slog.Logger) {
+	if a.lockSyncService == nil {
+		return
+	}
+	lockSyncMinutes := getDBIntSetting(ctx, db, "lock_sync.interval_minutes", 30)
+	if lockSyncMinutes < 0 {
+		lockSyncMinutes = 30
+	}
+	if lockSyncMinutes == 0 {
+		logger.Info("lock-sync scheduler disabled", slog.String("setting", "lock_sync.interval_minutes"))
+		return
+	}
+	go a.lockSyncService.StartScheduler(ctx, time.Duration(lockSyncMinutes)*time.Minute, 60*time.Second)
+}
+
 func (a *Application) startListeners() error {
 	if a.router == nil {
 		return errors.New("startListeners: buildServices must run first")
@@ -854,6 +882,9 @@ func (a *Application) startListeners() error {
 		}
 		go a.maintenanceService.StartExistsFlagScanner(ctx, time.Duration(existsFlagHours)*time.Hour, 10*time.Second)
 	}
+
+	// LockSync platform-pull scheduler (issue #1726 Part C).
+	a.startLockSyncScheduler(ctx, db, logger)
 
 	// Foreign-file scanner.
 	{

--- a/docs/site/src/getting-started/connect-emby.md
+++ b/docs/site/src/getting-started/connect-emby.md
@@ -54,6 +54,7 @@ Each connection has a set of feature toggles that control how Stillwater interac
 - **Image write.** Stillwater pushes artwork (primary, backdrop, banner, logo) to Emby via its API.
 - **Trigger refresh.** After pushing edits, Stillwater asks Emby to refresh the affected items so the new metadata appears in Emby's UI without waiting for Emby's own scan schedule.
 - **Read MusicBrainz IDs.** Stillwater reads the `ProviderIds` field on Emby's artist records and uses those IDs as starting points for its own provider lookups. Saves a round trip and avoids re-identifying artists Emby already resolved.
+- **Lock-state sync from Emby.** A scheduled background job (default cadence: every 30 minutes) walks every artist Stillwater has linked to this Emby connection, reads the platform's `LockData` flag, and updates Stillwater's per-artist lock state to match. Lets you toggle a lock in either Emby's UI or Stillwater's UI and have both views agree on the next sync. Stillwater records `lock_source=platform` on locks pulled this way so the origin is visible in the artist's lock history. Locks toggled in Stillwater within the last 5 minutes are protected from being overwritten by a stale platform snapshot. Configure the cadence via the `lock_sync.interval_minutes` setting (set to 0 to disable).
 
 ## Let Stillwater manage server files
 

--- a/docs/site/src/getting-started/connect-jellyfin.md
+++ b/docs/site/src/getting-started/connect-jellyfin.md
@@ -57,6 +57,7 @@ Each connection has a set of feature toggles that control how Stillwater interac
 - **Image write.** Stillwater pushes artwork (primary, backdrop, banner, logo) to Jellyfin via its API.
 - **Trigger refresh.** After pushing edits, Stillwater asks Jellyfin to refresh the affected items so the new metadata appears in Jellyfin's UI without waiting for Jellyfin's own scan schedule.
 - **Read MusicBrainz IDs.** Stillwater reads the `ProviderIds` field on Jellyfin's artist records and uses those IDs as starting points for its own provider lookups. Saves a round trip and avoids re-identifying artists Jellyfin already resolved.
+- **Lock-state sync from Jellyfin.** A scheduled background job (default cadence: every 30 minutes) walks every artist Stillwater has linked to this Jellyfin connection, reads the platform's `LockData` flag, and updates Stillwater's per-artist lock state to match. Lets you toggle a lock in either Jellyfin's UI or Stillwater's UI and have both views agree on the next sync. Stillwater records `lock_source=platform` on locks pulled this way so the origin is visible in the artist's lock history. Locks toggled in Stillwater within the last 5 minutes are protected from being overwritten by a stale platform snapshot. Configure the cadence via the `lock_sync.interval_minutes` setting (set to 0 to disable).
 
 ## Let Stillwater manage server files
 

--- a/internal/api/handlers_artist_lock.go
+++ b/internal/api/handlers_artist_lock.go
@@ -39,6 +39,10 @@ func (r *Router) handleLockArtist(w http.ResponseWriter, req *http.Request) {
 	// Propagate the new lock state to every connected platform immediately
 	// so Emby/Jellyfin show the pin without requiring a manual push.
 	r.publisher.PushLocks(req.Context(), updated)
+	// Rewrite the on-disk NFO so its <lockdata> matches the new DB state
+	// (issue #1726). Without this, the next scan would re-import the stale
+	// lockdata from the NFO and undo the user's toggle.
+	r.publisher.WriteBackNFO(req.Context(), updated)
 
 	writeJSON(w, http.StatusOK, updated)
 }
@@ -73,6 +77,10 @@ func (r *Router) handleUnlockArtist(w http.ResponseWriter, req *http.Request) {
 	}
 
 	r.publisher.PushLocks(req.Context(), updated)
+	// Rewrite the on-disk NFO so its <lockdata> matches the new DB state
+	// (issue #1726). Without this, the next scan would re-import the stale
+	// lockdata from the NFO and undo the user's unlock.
+	r.publisher.WriteBackNFO(req.Context(), updated)
 
 	writeJSON(w, http.StatusOK, updated)
 }

--- a/internal/api/handlers_artist_lock_test.go
+++ b/internal/api/handlers_artist_lock_test.go
@@ -1,13 +1,18 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/nfo"
 )
 
 // TestHandleLockArtistField exercises the POST and DELETE field-lock
@@ -252,6 +257,81 @@ func TestHandleUnlockArtist_NotFound(t *testing.T) {
 	r.handleUnlockArtist(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+// TestHandleLockArtist_RewritesNFO is the regression fixture for issue #1726.
+// Locking an artist via the API must rewrite the on-disk NFO so its
+// <lockdata> matches the new DB state; otherwise the next scan would
+// re-import the stale value and undo the toggle.
+func TestHandleLockArtist_RewritesNFO(t *testing.T) {
+	t.Parallel()
+	r, svc := testRouter(t)
+	ctx := context.Background()
+
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Lock NFO Rewrite", Path: dir}
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Seed an NFO with lockdata=false so the lock path has something to
+	// overwrite. The handler's WriteBackNFO is a no-op when no NFO is
+	// present on disk (that is by design: creating new NFOs is the rule
+	// engine's job, not the lock handler's).
+	nfoPath := filepath.Join(dir, "artist.nfo")
+	seed := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<artist>
+  <name>Lock NFO Rewrite</name>
+  <lockdata>false</lockdata>
+</artist>`)
+	if err := os.WriteFile(nfoPath, seed, 0o644); err != nil {
+		t.Fatalf("seed NFO: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/lock", nil)
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+	r.handleLockArtist(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("lock status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	data, err := os.ReadFile(nfoPath)
+	if err != nil {
+		t.Fatalf("read NFO: %v", err)
+	}
+	parsed, err := nfo.Parse(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("parse NFO: %v", err)
+	}
+	if !parsed.LockData {
+		t.Error("NFO LockData = false after lock; expected true (#1726)")
+	}
+
+	// Unlock and verify the NFO flips back.
+	req = httptest.NewRequest(http.MethodDelete, "/api/v1/artists/"+a.ID+"/lock", nil)
+	req.SetPathValue("id", a.ID)
+	w = httptest.NewRecorder()
+	r.handleUnlockArtist(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("unlock status = %d, body = %s", w.Code, w.Body.String())
+	}
+	data, err = os.ReadFile(nfoPath)
+	if err != nil {
+		t.Fatalf("read NFO after unlock: %v", err)
+	}
+	parsed, err = nfo.Parse(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("parse NFO after unlock: %v", err)
+	}
+	if parsed.LockData {
+		t.Error("NFO LockData = true after unlock; expected false (#1726)")
+	}
+	// Belt-and-braces: also assert the literal element disappeared from
+	// the serialized form, so a future parser change cannot mask a
+	// regression by always returning false for the LockData field.
+	if strings.Contains(string(data), "<lockdata>true</lockdata>") {
+		t.Errorf("NFO still contains <lockdata>true</lockdata> after unlock:\n%s", data)
 	}
 }
 

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -1316,17 +1316,37 @@ func (s *Service) Search(ctx context.Context, query string) ([]Artist, error) {
 }
 
 // validLockSources enumerates the allowed values for lock_source.
+//
+// "user"           -- explicit toggle in the Stillwater UI / API.
+// "initial_import" -- first-time discovery of an artist whose NFO already
+//
+//	carries <lockdata>true</lockdata>; written by the
+//	scanner only on the new-artist path, never on re-scan
+//	(issue #1726).
+//
+// "platform"       -- platform-side lock pulled from Emby/Jellyfin
+//
+//	IsLocked by the scheduled LockSync pull.
+//
+// "imported"       -- legacy value, no longer written. Pre-#1726 the scanner
+//
+//	stamped this on every re-scan, driving the silent
+//	re-lock loop. Migration 014 clears existing rows;
+//	accepted here so a downgrade does not break Lock().
 var validLockSources = map[string]bool{
-	"user":     true,
-	"imported": true,
+	"user":           true,
+	"initial_import": true,
+	"platform":       true,
+	"imported":       true,
 }
 
-// Lock sets the metadata lock on an artist with the given source ("user" or "imported").
+// Lock sets the metadata lock on an artist with the given source.
+// Allowed values: "user", "initial_import", "platform", "imported".
 // When locked, automated operations (rule fixers, metadata fetchers, image operations)
 // skip the artist. Manual edits remain allowed.
 func (s *Service) Lock(ctx context.Context, id, source string) error {
 	if !validLockSources[source] {
-		return fmt.Errorf("invalid lock source %q: must be \"user\" or \"imported\"", source)
+		return fmt.Errorf("invalid lock source %q: must be one of \"user\", \"initial_import\", \"platform\", \"imported\"", source)
 	}
 	return s.artists.SetLock(ctx, id, true, source)
 }

--- a/internal/connection/locksync.go
+++ b/internal/connection/locksync.go
@@ -1,0 +1,256 @@
+// Package connection provides the LockSync service in this file. LockSync
+// pulls per-artist <lockdata> state from Emby/Jellyfin back into the
+// Stillwater database so a user toggling the pin in the platform UI is
+// reflected in artists.locked on the next scheduled sweep (issue #1726
+// Part C).
+//
+// The Emby/Jellyfin clients already expose ArtistPlatformState.IsLocked --
+// nothing else in the codebase reads it, so the wire-up here is the only
+// consumer.
+package connection
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// LockSyncLockSourcePlatform is the lock_source attribution written when
+// LockSync flips artists.locked based on a platform pull. Defined as a
+// constant so the value is grep-able and the tests assert against the
+// same string.
+const LockSyncLockSourcePlatform = "platform"
+
+// lockSyncRecentPushWindow is the grace period during which a recent
+// Stillwater-initiated lock change (artists.locked_at within the window)
+// suppresses platform-overrides-DB updates. Without it, a user toggle
+// in the Stillwater UI could race against a scheduled pull: the pull's
+// snapshot was taken before PushLocks reached the platform, so it would
+// see the pre-toggle value and immediately undo the user's change. Five
+// minutes is well above any realistic platform push round-trip.
+const lockSyncRecentPushWindow = 5 * time.Minute
+
+// LockSyncArtistLocker is the slice of artist.Service LockSync needs to
+// mutate the lock state. Declared as an interface so the connection
+// package does not import internal/artist (which would create a cycle:
+// artist already imports connection in some test paths).
+type LockSyncArtistLocker interface {
+	Lock(ctx context.Context, id, source string) error
+	Unlock(ctx context.Context, id string) error
+}
+
+// LockSyncConnectionLister is the slice of connection.Service LockSync
+// needs. Real callers pass *Service directly; the interface keeps the
+// scheduler testable with a stub.
+type LockSyncConnectionLister interface {
+	GetByID(ctx context.Context, id string) (*Connection, error)
+}
+
+// LockSyncClientFactory builds an ArtistStateGetter for the given
+// connection. Injected (never optional) so the connection package does
+// not need to import the emby/jellyfin sub-packages -- that would form
+// an import cycle since both clients import connection for shared
+// types. The production factory lives in cmd/stillwater/main.go where
+// the sub-packages can be referenced freely.
+type LockSyncClientFactory func(conn *Connection, logger *slog.Logger) ArtistStateGetter
+
+// LockSync is the pull-side counterpart to publish.Publisher.PushLocks:
+// it walks every artist_platform_ids row, asks the owning platform for
+// its current IsLocked value, and updates artists.locked when the
+// platform value differs from the DB.
+type LockSync struct {
+	db      *sql.DB
+	conns   LockSyncConnectionLister
+	artists LockSyncArtistLocker
+	factory LockSyncClientFactory
+	logger  *slog.Logger
+	syncWin time.Duration
+}
+
+// NewLockSync constructs a LockSync. factory must be non-nil; the
+// production wiring in cmd/stillwater/main.go passes a closure that
+// branches on conn.Type to emby/jellyfin clients.
+func NewLockSync(db *sql.DB, conns LockSyncConnectionLister, artists LockSyncArtistLocker, factory LockSyncClientFactory, logger *slog.Logger) *LockSync {
+	return &LockSync{
+		db:      db,
+		conns:   conns,
+		artists: artists,
+		factory: factory,
+		logger:  logger.With(slog.String("component", "lock-sync")),
+		syncWin: lockSyncRecentPushWindow,
+	}
+}
+
+// SetRecentPushWindow overrides the grace period; intended for tests
+// that need to drive the sync with sub-second windows.
+func (s *LockSync) SetRecentPushWindow(d time.Duration) { s.syncWin = d }
+
+// pullRow is one (artist, platform-mapping) tuple drained from the
+// LockSync sweep query before any platform-side calls run.
+type pullRow struct {
+	artistID         string
+	connectionID     string
+	platformArtistID string
+	dbLocked         bool
+	lockedAt         sql.NullString
+}
+
+// Run performs one full LockSync sweep and returns the number of
+// artists whose lock state was changed. Errors on individual rows are
+// logged and skipped; the sweep continues so a single broken platform
+// connection does not block sync for everyone else.
+func (s *LockSync) Run(ctx context.Context) (int, error) {
+	// Stream the (artist_id, connection_id, platform_artist_id,
+	// locked, locked_at) tuples in one pass; LockSync ignores rows
+	// where the connection is disabled (resolved later) and rows
+	// whose locked_at falls inside the recent-push window.
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT api.artist_id, api.connection_id, api.platform_artist_id,
+		       a.locked, a.locked_at
+		FROM artist_platform_ids api
+		JOIN artists a ON a.id = api.artist_id`)
+	if err != nil {
+		return 0, fmt.Errorf("query lock-sync rows: %w", err)
+	}
+	defer rows.Close() //nolint:errcheck // read-only cursor
+
+	var queue []pullRow
+	for rows.Next() {
+		var r pullRow
+		var lockedInt int
+		if err := rows.Scan(&r.artistID, &r.connectionID, &r.platformArtistID, &lockedInt, &r.lockedAt); err != nil {
+			return 0, fmt.Errorf("scan lock-sync row: %w", err)
+		}
+		r.dbLocked = lockedInt != 0
+		queue = append(queue, r)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate lock-sync rows: %w", err)
+	}
+
+	// Drain the cursor before issuing any writes -- modernc.org/sqlite
+	// is single-writer and holding the SELECT cursor open during the
+	// follow-up Lock/Unlock would serialize badly.
+	changed := 0
+	for _, r := range queue {
+		if ctx.Err() != nil {
+			return changed, ctx.Err()
+		}
+		if s.applyRow(ctx, r) {
+			changed++
+		}
+	}
+	return changed, nil
+}
+
+// applyRow handles one (artist, platform-mapping) tuple: skip-or-pull the
+// platform state, decide whether the DB needs to flip, and apply the
+// change. Returns true iff a real mutation landed. Pulled out of Run so
+// the cognitive complexity stays under the lint threshold; the per-row
+// logic is otherwise pure conditionals.
+func (s *LockSync) applyRow(ctx context.Context, r pullRow) bool {
+	if s.skipRecentPush(r.lockedAt) {
+		return false
+	}
+	conn, err := s.conns.GetByID(ctx, r.connectionID)
+	if err != nil {
+		s.logger.Warn("lock-sync: connection lookup failed",
+			slog.String("artist_id", r.artistID),
+			slog.String("connection_id", r.connectionID),
+			slog.String("error", err.Error()))
+		return false
+	}
+	if conn == nil || !conn.Enabled {
+		return false
+	}
+	client := s.factory(conn, s.logger)
+	if client == nil {
+		return false
+	}
+	state, err := client.GetArtistDetail(ctx, r.platformArtistID)
+	if err != nil {
+		s.logger.Warn("lock-sync: platform detail fetch failed",
+			slog.String("artist_id", r.artistID),
+			slog.String("connection", conn.Name),
+			slog.String("error", err.Error()))
+		return false
+	}
+	if state == nil || state.IsLocked == r.dbLocked {
+		return false
+	}
+	if !s.mutateLock(ctx, r.artistID, state.IsLocked) {
+		return false
+	}
+	s.logger.Info("lock-sync: applied platform lock change",
+		slog.String("artist_id", r.artistID),
+		slog.String("connection", conn.Name),
+		slog.Bool("locked", state.IsLocked))
+	return true
+}
+
+// mutateLock dispatches Lock or Unlock based on the desired final state,
+// logging and swallowing any error. Returns true iff the mutation
+// succeeded.
+func (s *LockSync) mutateLock(ctx context.Context, artistID string, lock bool) bool {
+	if lock {
+		if err := s.artists.Lock(ctx, artistID, LockSyncLockSourcePlatform); err != nil {
+			s.logger.Warn("lock-sync: Lock failed",
+				slog.String("artist_id", artistID),
+				slog.String("error", err.Error()))
+			return false
+		}
+		return true
+	}
+	if err := s.artists.Unlock(ctx, artistID); err != nil {
+		s.logger.Warn("lock-sync: Unlock failed",
+			slog.String("artist_id", artistID),
+			slog.String("error", err.Error()))
+		return false
+	}
+	return true
+}
+
+// skipRecentPush reports whether the artist's locked_at falls within
+// the recent-push grace window. A NULL locked_at (unlocked artist that
+// has never been locked) cannot be a recent push, so it does not skip.
+func (s *LockSync) skipRecentPush(lockedAt sql.NullString) bool {
+	if !lockedAt.Valid || lockedAt.String == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, lockedAt.String)
+	if err != nil {
+		return false
+	}
+	return time.Since(t) < s.syncWin
+}
+
+// StartScheduler runs Run on a fixed interval until ctx is canceled.
+// Mirrors the cadence-only loops used elsewhere in the codebase.
+func (s *LockSync) StartScheduler(ctx context.Context, interval, startupDelay time.Duration) {
+	s.logger.Info("lock-sync scheduler started",
+		slog.String("interval", interval.String()),
+		slog.String("startup_delay", startupDelay.String()))
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(startupDelay):
+	}
+	if _, err := s.Run(ctx); err != nil {
+		s.logger.Error("initial lock-sync failed", slog.String("error", err.Error()))
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("lock-sync scheduler stopped")
+			return
+		case <-ticker.C:
+			if _, err := s.Run(ctx); err != nil {
+				s.logger.Error("lock-sync failed", slog.String("error", err.Error()))
+			}
+		}
+	}
+}

--- a/internal/connection/locksync_test.go
+++ b/internal/connection/locksync_test.go
@@ -1,0 +1,371 @@
+package connection
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sydlexius/stillwater/internal/database"
+	"github.com/sydlexius/stillwater/internal/encryption"
+)
+
+// stubLocker records Lock/Unlock calls for assertion.
+type stubLocker struct {
+	mu        sync.Mutex
+	locks     []string
+	unlocks   []string
+	sources   []string
+	lockErr   error
+	unlockErr error
+}
+
+func (s *stubLocker) Lock(_ context.Context, id, source string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.locks = append(s.locks, id)
+	s.sources = append(s.sources, source)
+	return s.lockErr
+}
+
+func (s *stubLocker) Unlock(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unlocks = append(s.unlocks, id)
+	return s.unlockErr
+}
+
+// stubStateGetter returns a fixed ArtistPlatformState per platform ID.
+// errs lets a test route an error to a specific platform-id while letting
+// other ids succeed -- needed to prove the sweep continues past an
+// individual failure rather than aborting at the first error.
+type stubStateGetter struct {
+	states map[string]*ArtistPlatformState
+	errs   map[string]error
+	err    error
+}
+
+func (s *stubStateGetter) GetArtistDetail(_ context.Context, platformArtistID string) (*ArtistPlatformState, error) {
+	if e, ok := s.errs[platformArtistID]; ok {
+		return nil, e
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.states[platformArtistID], nil
+}
+
+// setupLockSyncDB returns a fresh in-memory DB with migrations applied,
+// the connection service for inserting test connection rows, and a
+// helper to insert an artist + platform mapping ready for LockSync to
+// consume.
+func setupLockSyncDB(t *testing.T) (*LockSync, *Service, *stubLocker, *stubStateGetter, func(artistID, name string, locked bool, platformConnID, platformArtistID string)) {
+	t.Helper()
+	db, err := database.Open(":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	enc, _, err := encryption.NewEncryptor("")
+	if err != nil {
+		t.Fatalf("encryptor: %v", err)
+	}
+	connSvc := NewService(db, enc)
+	locker := &stubLocker{}
+	getter := &stubStateGetter{states: make(map[string]*ArtistPlatformState)}
+
+	factory := func(_ *Connection, _ *slog.Logger) ArtistStateGetter { return getter }
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	lockSync := NewLockSync(db, connSvc, locker, factory, logger)
+
+	insert := func(artistID, name string, locked bool, connID, platformArtistID string) {
+		t.Helper()
+		lockedInt := 0
+		var lockedAt any
+		if locked {
+			lockedInt = 1
+			lockedAt = "2020-01-01T00:00:00Z"
+		}
+		// path NOT NULL: supply a placeholder that is unique per artist.
+		if _, err := db.Exec(`INSERT INTO artists (id, name, path, locked, locked_at) VALUES (?, ?, ?, ?, ?)`,
+			artistID, name, "/music/"+artistID, lockedInt, lockedAt); err != nil {
+			t.Fatalf("insert artist: %v", err)
+		}
+		if _, err := db.Exec(`INSERT INTO artist_platform_ids (artist_id, connection_id, platform_artist_id) VALUES (?, ?, ?)`,
+			artistID, connID, platformArtistID); err != nil {
+			t.Fatalf("insert platform id: %v", err)
+		}
+	}
+	return lockSync, connSvc, locker, getter, insert
+}
+
+// newEnabledEmby creates and persists an enabled emby connection,
+// returning its id.
+func newEnabledEmby(t *testing.T, svc *Service) string {
+	t.Helper()
+	c := &Connection{Name: "Emby", Type: TypeEmby, URL: "http://emby", APIKey: "k", Enabled: true}
+	if err := svc.Create(context.Background(), c); err != nil {
+		t.Fatalf("Create connection: %v", err)
+	}
+	return c.ID
+}
+
+// TestLockSync_PullsLockFromPlatform asserts the canonical case: the
+// platform reports IsLocked=true, the DB has locked=0, LockSync flips
+// it on with lock_source="platform".
+func TestLockSync_PullsLockFromPlatform(t *testing.T) {
+	t.Parallel()
+	lockSync, connSvc, locker, getter, insert := setupLockSyncDB(t)
+	lockSync.SetRecentPushWindow(time.Nanosecond) // disable the grace gate
+
+	connID := newEnabledEmby(t, connSvc)
+	insert("a1", "Aretha", false, connID, "emby-a1")
+	getter.states["emby-a1"] = &ArtistPlatformState{IsLocked: true}
+
+	changed, err := lockSync.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if changed != 1 {
+		t.Errorf("changed = %d, want 1", changed)
+	}
+	if len(locker.locks) != 1 || locker.locks[0] != "a1" {
+		t.Errorf("locks = %v, want [a1]", locker.locks)
+	}
+	if len(locker.sources) != 1 || locker.sources[0] != LockSyncLockSourcePlatform {
+		t.Errorf("sources = %v, want [%q]", locker.sources, LockSyncLockSourcePlatform)
+	}
+}
+
+// TestLockSync_PullsUnlockFromPlatform mirrors the previous test in the
+// reverse direction: DB locked=1, platform IsLocked=false.
+func TestLockSync_PullsUnlockFromPlatform(t *testing.T) {
+	t.Parallel()
+	lockSync, connSvc, locker, getter, insert := setupLockSyncDB(t)
+	lockSync.SetRecentPushWindow(time.Nanosecond)
+
+	connID := newEnabledEmby(t, connSvc)
+	insert("a2", "Beyonce", true, connID, "emby-a2")
+	getter.states["emby-a2"] = &ArtistPlatformState{IsLocked: false}
+
+	changed, err := lockSync.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if changed != 1 {
+		t.Errorf("changed = %d, want 1", changed)
+	}
+	if len(locker.unlocks) != 1 || locker.unlocks[0] != "a2" {
+		t.Errorf("unlocks = %v, want [a2]", locker.unlocks)
+	}
+}
+
+// TestLockSync_NoOpWhenInSync verifies the sweep skips rows whose
+// platform state already matches the DB. Most rows on most sweeps
+// hit this branch in production.
+func TestLockSync_NoOpWhenInSync(t *testing.T) {
+	t.Parallel()
+	lockSync, connSvc, locker, getter, insert := setupLockSyncDB(t)
+	lockSync.SetRecentPushWindow(time.Nanosecond)
+
+	connID := newEnabledEmby(t, connSvc)
+	insert("a3", "Carole", false, connID, "emby-a3")
+	getter.states["emby-a3"] = &ArtistPlatformState{IsLocked: false}
+
+	changed, err := lockSync.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if changed != 0 {
+		t.Errorf("changed = %d, want 0", changed)
+	}
+	if len(locker.locks)+len(locker.unlocks) != 0 {
+		t.Errorf("expected no mutations, got locks=%v unlocks=%v", locker.locks, locker.unlocks)
+	}
+}
+
+// TestLockSync_SkipsRecentPush is the conflict-policy fixture: when a
+// user just toggled the lock via the Stillwater UI, the artist's
+// locked_at is recent and LockSync must NOT overwrite it from the
+// platform's still-stale snapshot. Without this gate, the next sweep
+// would silently undo every user toggle in the same way the original
+// re-lock loop did.
+func TestLockSync_SkipsRecentPush(t *testing.T) {
+	t.Parallel()
+	lockSync, connSvc, locker, getter, insert := setupLockSyncDB(t)
+	// Leave the default 5-minute window in place. The seeded locked_at
+	// is now-ish (insert uses 2020 but we override below).
+
+	connID := newEnabledEmby(t, connSvc)
+	insert("a4", "Dolly", true, connID, "emby-a4")
+	// Recent-unlock companion: a4b is unlocked but locked_at is fresh
+	// (e.g. user just toggled OFF in the UI). Platform still reports
+	// IsLocked=true (stale snapshot). Without the gate the sweep would
+	// re-lock the artist and silently undo the user's unlock -- exactly
+	// the loop this PR is fixing, but via the LockSync surface.
+	insert("a4b", "Emmylou", false, connID, "emby-a4b")
+	// Bump locked_at into the window so the gate triggers on both rows.
+	if _, err := lockSync.db.Exec(`UPDATE artists SET locked_at = ? WHERE id IN ('a4', 'a4b')`,
+		time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("update locked_at: %v", err)
+	}
+	// Platform says unlocked for a4 (would call Unlock without the gate)
+	// and locked for a4b (would call Lock without the gate).
+	getter.states["emby-a4"] = &ArtistPlatformState{IsLocked: false}
+	getter.states["emby-a4b"] = &ArtistPlatformState{IsLocked: true}
+
+	changed, err := lockSync.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if changed != 0 {
+		t.Errorf("changed = %d, want 0 (recent push must suppress both directions)", changed)
+	}
+	if len(locker.unlocks) != 0 {
+		t.Errorf("unlocks = %v, want empty (recent push gate must block re-unlock from stale platform)", locker.unlocks)
+	}
+	if len(locker.locks) != 0 {
+		t.Errorf("locks = %v, want empty (recent push gate must block re-lock from stale platform)", locker.locks)
+	}
+}
+
+// TestLockSync_SkipsDisabledConnection guards against a disabled
+// Emby/Jellyfin entry triggering platform requests during a sweep.
+func TestLockSync_SkipsDisabledConnection(t *testing.T) {
+	t.Parallel()
+	lockSync, connSvc, locker, getter, insert := setupLockSyncDB(t)
+	lockSync.SetRecentPushWindow(time.Nanosecond)
+
+	// Create disabled connection.
+	c := &Connection{Name: "EmbyOff", Type: TypeEmby, URL: "http://emby", APIKey: "k", Enabled: false}
+	if err := connSvc.Create(context.Background(), c); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	insert("a5", "Etta", false, c.ID, "emby-a5")
+	getter.states["emby-a5"] = &ArtistPlatformState{IsLocked: true}
+
+	changed, err := lockSync.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if changed != 0 || len(locker.locks) != 0 {
+		t.Errorf("expected no work for disabled connection; changed=%d locks=%v", changed, locker.locks)
+	}
+}
+
+// TestLockSync_SurvivesPlatformError checks that a single failing
+// GetArtistDetail does not abort the sweep for the rest of the queue:
+// the failing row is skipped, a healthy row in the same sweep is still
+// mutated. Routes the error per platform-id so only the failing row
+// returns an error and we can assert the healthy row was processed.
+func TestLockSync_SurvivesPlatformError(t *testing.T) {
+	t.Parallel()
+	lockSync, connSvc, locker, getter, insert := setupLockSyncDB(t)
+	lockSync.SetRecentPushWindow(time.Nanosecond)
+	getter.errs = map[string]error{"emby-a6": errors.New("HTTP 500")}
+
+	connID := newEnabledEmby(t, connSvc)
+	insert("a6", "Florence", false, connID, "emby-a6")
+	getter.states["emby-a6"] = &ArtistPlatformState{IsLocked: true}
+	// Healthy second row: must still mutate after the first row errors.
+	insert("a6b", "Gladys", false, connID, "emby-a6b")
+	getter.states["emby-a6b"] = &ArtistPlatformState{IsLocked: true}
+
+	changed, err := lockSync.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if changed != 1 {
+		t.Errorf("changed = %d, want 1 (healthy row must process despite failing row)", changed)
+	}
+	if len(locker.locks) != 1 || locker.locks[0] != "a6b" {
+		t.Errorf("locks = %v, want [a6b] (healthy row only; failing row skipped)", locker.locks)
+	}
+}
+
+// TestLockSync_LockErrorIsLoggedAndSkipped exercises the mutateLock
+// error path: the underlying Lock call fails, the row is skipped, and
+// the sweep continues. Pairs with the Lock-success path covered above
+// so both branches of mutateLock are exercised.
+func TestLockSync_LockErrorIsLoggedAndSkipped(t *testing.T) {
+	t.Parallel()
+	lockSync, connSvc, locker, getter, insert := setupLockSyncDB(t)
+	lockSync.SetRecentPushWindow(time.Nanosecond)
+	locker.lockErr = errors.New("DB locked")
+
+	connID := newEnabledEmby(t, connSvc)
+	insert("a7", "Grace", false, connID, "emby-a7")
+	getter.states["emby-a7"] = &ArtistPlatformState{IsLocked: true}
+
+	changed, err := lockSync.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if changed != 0 {
+		t.Errorf("changed = %d, want 0 (Lock failed)", changed)
+	}
+}
+
+// TestLockSync_UnlockErrorIsLoggedAndSkipped mirrors the Lock-error
+// test for the Unlock branch of mutateLock: when the underlying Unlock
+// fails, the row is skipped, the sweep continues, and the changed
+// counter does not advance.
+func TestLockSync_UnlockErrorIsLoggedAndSkipped(t *testing.T) {
+	t.Parallel()
+	lockSync, connSvc, locker, getter, insert := setupLockSyncDB(t)
+	lockSync.SetRecentPushWindow(time.Nanosecond)
+	locker.unlockErr = errors.New("DB locked")
+
+	connID := newEnabledEmby(t, connSvc)
+	insert("a8", "Helena", true, connID, "emby-a8")
+	getter.states["emby-a8"] = &ArtistPlatformState{IsLocked: false}
+
+	changed, err := lockSync.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if changed != 0 {
+		t.Errorf("changed = %d, want 0 (Unlock failed)", changed)
+	}
+}
+
+// TestLockSync_StartSchedulerStopsOnCancel verifies the scheduler
+// loop exits cleanly when the context is canceled, including a
+// canceled initial-delay path.
+func TestLockSync_StartSchedulerStopsOnCancel(t *testing.T) {
+	t.Parallel()
+	lockSync, _, _, _, _ := setupLockSyncDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		// Long enough that the test cancel beats the first tick.
+		lockSync.StartScheduler(ctx, time.Hour, time.Millisecond)
+		close(done)
+	}()
+	// Give the scheduler a moment to enter its loop, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler did not exit within 2s of cancel")
+	}
+}
+
+// TestLockSync_LockSourcePlatformConstant is a tiny invariance test:
+// the lock_source string is part of the user-facing contract (the UI
+// displays it) and the artist service's validation accepts it. Pin
+// the constant so a typo in either side is caught.
+func TestLockSync_LockSourcePlatformConstant(t *testing.T) {
+	t.Parallel()
+	if LockSyncLockSourcePlatform != "platform" {
+		t.Errorf("LockSyncLockSourcePlatform = %q, want %q", LockSyncLockSourcePlatform, "platform")
+	}
+}

--- a/internal/database/migrations/014_clear_imported_locks.sql
+++ b/internal/database/migrations/014_clear_imported_locks.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+-- Issue #1726: clear locks parasitically applied by the pre-fix scanner
+-- re-import loop.
+--
+-- Before #1726 the scanner stamped lock_source='imported', locked=1 on every
+-- re-scan whenever the on-disk NFO carried <lockdata>true</lockdata>, and the
+-- NFOExistsFixer hardcoded <lockdata>true</lockdata> on every NFO it wrote.
+-- The combination silently re-locked most artists in users' libraries and
+-- undid any unlock via the UI.
+--
+-- After the fix:
+--  - The scanner re-scan path never writes artists.locked.
+--  - The new-artist discovery path uses lock_source='initial_import'.
+--  - The platform-pull path uses lock_source='platform'.
+--  - User UI toggles continue to use lock_source='user'.
+--
+-- That leaves any row with lock_source='imported' as a legacy artifact of
+-- the loop. The safe-by-construction recovery is to clear them in one shot;
+-- users who intentionally want those rows locked can re-lock from the UI
+-- (which then carries the correct 'user' provenance).
+UPDATE artists
+SET locked = 0,
+    locked_at = NULL,
+    lock_source = ''
+WHERE lock_source = 'imported';
+
+-- +goose Down
+-- One-way migration. The legacy 'imported' provenance is meaningless after
+-- the loop is gone and there is no information in the DB to reconstruct
+-- which rows were originally written by the scanner loop versus which were
+-- legitimately locked. Down is therefore a no-op rather than an attempt at
+-- a fake restoration.
+SELECT 1;

--- a/internal/database/migrations/015_lock_source_values.sql
+++ b/internal/database/migrations/015_lock_source_values.sql
@@ -1,0 +1,144 @@
+-- +goose Up
+-- Issue #1726: extend artists.lock_source CHECK constraint to allow the
+-- new attribution values introduced by the lock-loop fix:
+--   * 'initial_import' -- replaces the scanner re-import 'imported' on the
+--                         new-artist code path; never written on re-scan.
+--   * 'platform'       -- written by connection.LockSync when a platform-side
+--                         <lockdata> change is pulled into Stillwater.
+--
+-- SQLite cannot ALTER a CHECK constraint in place: the canonical pattern is
+-- create-new-table + INSERT SELECT + drop-old + rename. The rebuild reflects
+-- the post-004 schema (no library_id column) and re-creates every index that
+-- was attached to the old table (idx_artists_name, _path, _locked,
+-- _dirty_eval from 001; _name_lower from 004; _name_id from 011).
+
+-- +goose StatementBegin
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE artists_new (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    sort_name TEXT,
+    type TEXT NOT NULL DEFAULT '',
+    gender TEXT NOT NULL DEFAULT '',
+    origin TEXT NOT NULL DEFAULT '',
+    disambiguation TEXT NOT NULL DEFAULT '',
+    genres TEXT NOT NULL DEFAULT '[]',
+    styles TEXT NOT NULL DEFAULT '[]',
+    moods TEXT NOT NULL DEFAULT '[]',
+    years_active TEXT NOT NULL DEFAULT '',
+    born TEXT NOT NULL DEFAULT '',
+    formed TEXT NOT NULL DEFAULT '',
+    died TEXT NOT NULL DEFAULT '',
+    disbanded TEXT NOT NULL DEFAULT '',
+    biography TEXT NOT NULL DEFAULT '',
+    path TEXT NOT NULL,
+    nfo_exists INTEGER NOT NULL DEFAULT 0,
+    health_score REAL NOT NULL DEFAULT 0.0,
+    health_evaluated_at TEXT DEFAULT NULL,
+    dirty_since TEXT DEFAULT NULL,
+    rules_evaluated_at TEXT DEFAULT NULL,
+    is_excluded INTEGER NOT NULL DEFAULT 0,
+    exclusion_reason TEXT NOT NULL DEFAULT '',
+    is_classical INTEGER NOT NULL DEFAULT 0,
+    locked INTEGER NOT NULL DEFAULT 0,
+    lock_source TEXT NOT NULL DEFAULT '' CHECK (lock_source IN ('', 'user', 'imported', 'initial_import', 'platform')),
+    locked_at TEXT CHECK (locked = 0 OR (locked = 1 AND locked_at IS NOT NULL)),
+    locked_fields TEXT NOT NULL DEFAULT '[]',
+    metadata_sources TEXT NOT NULL DEFAULT '{}',
+    last_scanned_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO artists_new SELECT
+    id, name, sort_name, type, gender, origin, disambiguation,
+    genres, styles, moods, years_active, born, formed, died, disbanded,
+    biography, path, nfo_exists, health_score, health_evaluated_at,
+    dirty_since, rules_evaluated_at, is_excluded, exclusion_reason,
+    is_classical, locked, lock_source, locked_at, locked_fields,
+    metadata_sources, last_scanned_at, created_at, updated_at
+FROM artists;
+
+DROP TABLE artists;
+ALTER TABLE artists_new RENAME TO artists;
+
+CREATE INDEX idx_artists_name ON artists(name);
+CREATE INDEX idx_artists_path ON artists(path);
+CREATE INDEX idx_artists_locked ON artists(locked);
+CREATE INDEX idx_artists_dirty_eval ON artists(dirty_since, rules_evaluated_at);
+CREATE INDEX idx_artists_name_lower ON artists(LOWER(name));
+CREATE INDEX idx_artists_name_id ON artists(name, id);
+
+PRAGMA foreign_keys = ON;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+PRAGMA foreign_keys = OFF;
+
+-- Coerce rows written with the new values back into the legacy
+-- vocabulary so the old CHECK constraint accepts them. Silently
+-- relabeling as 'user' would misattribute the lock, so the safer
+-- choice is to clear those rows (mirrors migration 014's intent).
+UPDATE artists
+SET locked = 0, locked_at = NULL, lock_source = ''
+WHERE lock_source IN ('platform', 'initial_import');
+
+CREATE TABLE artists_old (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    sort_name TEXT,
+    type TEXT NOT NULL DEFAULT '',
+    gender TEXT NOT NULL DEFAULT '',
+    origin TEXT NOT NULL DEFAULT '',
+    disambiguation TEXT NOT NULL DEFAULT '',
+    genres TEXT NOT NULL DEFAULT '[]',
+    styles TEXT NOT NULL DEFAULT '[]',
+    moods TEXT NOT NULL DEFAULT '[]',
+    years_active TEXT NOT NULL DEFAULT '',
+    born TEXT NOT NULL DEFAULT '',
+    formed TEXT NOT NULL DEFAULT '',
+    died TEXT NOT NULL DEFAULT '',
+    disbanded TEXT NOT NULL DEFAULT '',
+    biography TEXT NOT NULL DEFAULT '',
+    path TEXT NOT NULL,
+    nfo_exists INTEGER NOT NULL DEFAULT 0,
+    health_score REAL NOT NULL DEFAULT 0.0,
+    health_evaluated_at TEXT DEFAULT NULL,
+    dirty_since TEXT DEFAULT NULL,
+    rules_evaluated_at TEXT DEFAULT NULL,
+    is_excluded INTEGER NOT NULL DEFAULT 0,
+    exclusion_reason TEXT NOT NULL DEFAULT '',
+    is_classical INTEGER NOT NULL DEFAULT 0,
+    locked INTEGER NOT NULL DEFAULT 0,
+    lock_source TEXT NOT NULL DEFAULT '' CHECK (lock_source IN ('', 'user', 'imported')),
+    locked_at TEXT CHECK (locked = 0 OR (locked = 1 AND locked_at IS NOT NULL)),
+    locked_fields TEXT NOT NULL DEFAULT '[]',
+    metadata_sources TEXT NOT NULL DEFAULT '{}',
+    last_scanned_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO artists_old SELECT
+    id, name, sort_name, type, gender, origin, disambiguation,
+    genres, styles, moods, years_active, born, formed, died, disbanded,
+    biography, path, nfo_exists, health_score, health_evaluated_at,
+    dirty_since, rules_evaluated_at, is_excluded, exclusion_reason,
+    is_classical, locked, lock_source, locked_at, locked_fields,
+    metadata_sources, last_scanned_at, created_at, updated_at
+FROM artists;
+
+DROP TABLE artists;
+ALTER TABLE artists_old RENAME TO artists;
+
+CREATE INDEX idx_artists_name ON artists(name);
+CREATE INDEX idx_artists_path ON artists(path);
+CREATE INDEX idx_artists_locked ON artists(locked);
+CREATE INDEX idx_artists_dirty_eval ON artists(dirty_since, rules_evaluated_at);
+CREATE INDEX idx_artists_name_lower ON artists(LOWER(name));
+CREATE INDEX idx_artists_name_id ON artists(name, id);
+
+PRAGMA foreign_keys = ON;
+-- +goose StatementEnd

--- a/internal/publish/publisher.go
+++ b/internal/publish/publisher.go
@@ -146,12 +146,23 @@ func (p *Publisher) notifyPushFailure(connectionName, errorClass, artistID, arti
 	p.notifier.NotifyConnectionPushFailed(connectionName, errorClass, artistID, artistName, operation, err)
 }
 
-// resolveLockNFO returns the per-library NFOLockData setting for the artist's
-// owning library, or false when no library claims the path. The lookup is
-// best-effort: any error or unset library defaults to false (the safe,
-// pre-#1264 default of "do not stamp lockdata").
-func (p *Publisher) resolveLockNFO(ctx context.Context, a *artist.Artist) bool {
-	if p.libraryService == nil || a == nil || a.Path == "" {
+// ResolveLockNFO returns the effective <lockdata> value for the artist: the
+// OR of the per-artist lock flag and the per-library NFOLockData setting
+// (issue #1726). Either knob being on stamps lockdata=true; both off leaves
+// it absent. The library lookup is best-effort and defaults to false on
+// error so a transient DB hiccup never silently flips the lock bit on.
+//
+// Exported so the rule package (NFOExistsFixer) can call into the same
+// resolver the publisher uses; keeping the logic in one place is the entire
+// point of the refactor.
+func (p *Publisher) ResolveLockNFO(ctx context.Context, a *artist.Artist) bool {
+	if a == nil {
+		return false
+	}
+	if a.Locked {
+		return true
+	}
+	if p == nil || p.libraryService == nil || a.Path == "" {
 		return false
 	}
 	lib, err := p.libraryService.FindForArtistPath(ctx, a.Path)
@@ -225,7 +236,7 @@ func (p *Publisher) WriteBackNFO(ctx context.Context, a *artist.Artist) {
 		}
 	}
 
-	lockNFO := p.resolveLockNFO(ctx, a)
+	lockNFO := p.ResolveLockNFO(ctx, a)
 	if err := nfo.WriteBackArtistNFOWithFieldMap(ctx, a, p.nfoSnapshotService, p.logger, fm, lockNFO); err != nil {
 		p.logger.Error("NFO write-back failed",
 			slog.String("artist_id", a.ID),
@@ -445,6 +456,27 @@ func newLockSyncer(conn *connection.Connection, logger *slog.Logger) connection.
 		return jellyfin.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger)
 	default:
 		return nil
+	}
+}
+
+// LockSyncClientFactory returns the production factory used by the
+// connection.LockSync platform-pull scheduler (issue #1726 Part C). Lives
+// here so cmd/stillwater/main.go does not need to import the emby /
+// jellyfin sub-packages directly, and the connection package does not
+// need to import them (which would form an import cycle).
+func LockSyncClientFactory() connection.LockSyncClientFactory {
+	return func(conn *connection.Connection, logger *slog.Logger) connection.ArtistStateGetter {
+		if conn == nil {
+			return nil
+		}
+		switch conn.Type {
+		case connection.TypeEmby:
+			return emby.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger)
+		case connection.TypeJellyfin:
+			return jellyfin.New(conn.URL, conn.APIKey, conn.PlatformUserID, logger)
+		default:
+			return nil
+		}
 	}
 }
 

--- a/internal/publish/publisher_test.go
+++ b/internal/publish/publisher_test.go
@@ -247,10 +247,34 @@ func (errorResolver) FindForArtistPath(_ context.Context, _ string) (*library.Li
 	return nil, fmt.Errorf("resolver boom")
 }
 
-// TestResolveLockNFO covers every branch of Publisher.resolveLockNFO:
+// TestLockSyncClientFactory verifies the factory wired into
+// cmd/stillwater/main.go: Emby -> emby client, Jellyfin -> jellyfin
+// client, anything else (including nil) -> nil. The branches matter
+// because LockSync uses the nil return as the "this connection has no
+// lock concept" signal.
+func TestLockSyncClientFactory(t *testing.T) {
+	logger := silentLogger()
+	factory := LockSyncClientFactory()
+
+	if got := factory(nil, logger); got != nil {
+		t.Errorf("nil connection -> %T, want nil", got)
+	}
+	if got := factory(&connection.Connection{Type: connection.TypeEmby, URL: "http://e", PlatformUserID: "u"}, logger); got == nil {
+		t.Error("TypeEmby -> nil; want non-nil emby client")
+	}
+	if got := factory(&connection.Connection{Type: connection.TypeJellyfin, URL: "http://j", PlatformUserID: "u"}, logger); got == nil {
+		t.Error("TypeJellyfin -> nil; want non-nil jellyfin client")
+	}
+	if got := factory(&connection.Connection{Type: connection.TypeLidarr}, logger); got != nil {
+		t.Errorf("TypeLidarr -> %T, want nil (no lock concept)", got)
+	}
+}
+
+// TestResolveLockNFO covers every branch of Publisher.ResolveLockNFO:
 // nil libraryService, nil artist, empty path, lookup error, no match, and
-// matched library with NFOLockData on or off. The default in every
-// non-true case must be false (issue #1264 safe default).
+// matched library with NFOLockData on or off. Issue #1264 set the safe
+// default to false; issue #1726 OR-ed in artist.Locked, which is covered
+// by a separate test below.
 func TestResolveLockNFO(t *testing.T) {
 	logger := silentLogger()
 
@@ -258,50 +282,61 @@ func TestResolveLockNFO(t *testing.T) {
 
 	t.Run("nil libraryService -> false", func(t *testing.T) {
 		p := New(Deps{Logger: logger})
-		if got := p.resolveLockNFO(context.Background(), a); got {
+		if got := p.ResolveLockNFO(context.Background(), a); got {
 			t.Error("nil libraryService must default to false")
 		}
 	})
 
 	t.Run("nil artist -> false", func(t *testing.T) {
 		p := New(Deps{Logger: logger, LibraryService: &alwaysOnResolver{}})
-		if got := p.resolveLockNFO(context.Background(), nil); got {
+		if got := p.ResolveLockNFO(context.Background(), nil); got {
 			t.Error("nil artist must default to false")
 		}
 	})
 
 	t.Run("empty artist path -> false", func(t *testing.T) {
 		p := New(Deps{Logger: logger, LibraryService: &alwaysOnResolver{}})
-		if got := p.resolveLockNFO(context.Background(), &artist.Artist{ID: "x"}); got {
+		if got := p.ResolveLockNFO(context.Background(), &artist.Artist{ID: "x"}); got {
 			t.Error("empty artist path must default to false")
 		}
 	})
 
 	t.Run("resolver error -> false (best-effort)", func(t *testing.T) {
 		p := New(Deps{Logger: logger, LibraryService: &errorResolver{}})
-		if got := p.resolveLockNFO(context.Background(), a); got {
+		if got := p.ResolveLockNFO(context.Background(), a); got {
 			t.Error("resolver error must default to false (best-effort)")
 		}
 	})
 
 	t.Run("no matching library -> false", func(t *testing.T) {
 		p := New(Deps{Logger: logger, LibraryService: &nilResolver{}})
-		if got := p.resolveLockNFO(context.Background(), a); got {
+		if got := p.ResolveLockNFO(context.Background(), a); got {
 			t.Error("no matching library must default to false")
 		}
 	})
 
 	t.Run("library with NFOLockData=true -> true", func(t *testing.T) {
 		p := New(Deps{Logger: logger, LibraryService: &alwaysOnResolver{}})
-		if got := p.resolveLockNFO(context.Background(), a); !got {
+		if got := p.ResolveLockNFO(context.Background(), a); !got {
 			t.Error("matched library with NFOLockData=true must return true")
 		}
 	})
 
 	t.Run("library with NFOLockData=false -> false", func(t *testing.T) {
 		p := New(Deps{Logger: logger, LibraryService: &alwaysOffResolver{}})
-		if got := p.resolveLockNFO(context.Background(), a); got {
+		if got := p.ResolveLockNFO(context.Background(), a); got {
 			t.Error("matched library with NFOLockData=false must return false")
+		}
+	})
+
+	// Issue #1726 OR-of-knobs: per-artist Locked alone is sufficient to
+	// flip the resolver true, regardless of the library setting (and
+	// without even consulting the library lookup).
+	t.Run("artist.Locked=true with NFOLockData=false -> true (#1726)", func(t *testing.T) {
+		p := New(Deps{Logger: logger, LibraryService: &alwaysOffResolver{}})
+		locked := &artist.Artist{ID: "a1", Path: "/music/jazz/Coltrane", Locked: true}
+		if got := p.ResolveLockNFO(context.Background(), locked); !got {
+			t.Error("artist.Locked=true must return true even when library NFOLockData=false")
 		}
 	})
 }

--- a/internal/rule/fixers.go
+++ b/internal/rule/fixers.go
@@ -87,23 +87,36 @@ func coalescedFetchImages(ctx context.Context, orch imageProvider, mbid string, 
 	return orch.FetchImages(ctx, mbid, providerIDs)
 }
 
+// LockNFOResolver returns whether the artist's NFO should carry
+// <lockdata>true</lockdata>. The canonical implementation lives in
+// publish.Publisher.ResolveLockNFO and returns
+// artist.Locked || library.NFOLockData (issue #1726). Injected as a narrow
+// interface so the rule package does not depend on the publish package.
+type LockNFOResolver interface {
+	ResolveLockNFO(ctx context.Context, a *artist.Artist) bool
+}
+
 // NFOFixer creates missing artist.nfo files from the artist's current metadata.
 type NFOFixer struct {
 	SnapshotService    *nfo.SnapshotService
 	nfoSettingsService *nfo.NFOSettingsService
 	fsCheck            *SharedFSCheck
 	expectedWrites     *watcher.ExpectedWrites
+	lockResolver       LockNFOResolver
 }
 
 // NewNFOFixer creates an NFOFixer with an optional shared-filesystem guard.
 // The nfoSettings parameter is used to read the current field map for
 // platform-specific NFO element mapping; if nil, the default mapping is used.
-func NewNFOFixer(snapshotService *nfo.SnapshotService, nfoSettings *nfo.NFOSettingsService, fsCheck *SharedFSCheck, expectedWrites *watcher.ExpectedWrites) *NFOFixer {
+// lockResolver supplies the OR-of-knobs (artist.Locked || library.NFOLockData)
+// per issue #1726; when nil the fixer falls back to artist.Locked only.
+func NewNFOFixer(snapshotService *nfo.SnapshotService, nfoSettings *nfo.NFOSettingsService, fsCheck *SharedFSCheck, expectedWrites *watcher.ExpectedWrites, lockResolver LockNFOResolver) *NFOFixer {
 	return &NFOFixer{
 		SnapshotService:    snapshotService,
 		nfoSettingsService: nfoSettings,
 		fsCheck:            fsCheck,
 		expectedWrites:     expectedWrites,
+		lockResolver:       lockResolver,
 	}
 }
 
@@ -147,7 +160,16 @@ func (f *NFOFixer) Fix(ctx context.Context, a *artist.Artist, _ *Violation) (*Fi
 		}
 	}
 	nfoData := nfo.FromArtistWithFieldMap(a, fm)
-	nfoData.LockData = true
+	// Stamp lockdata only when either the per-artist lock or the per-library
+	// NFOLockData setting is on (issue #1726). Without this OR, the fixer
+	// unconditionally stamped lockdata=true, which the scanner then
+	// re-imported as artists.locked=true on every rescan, silently undoing
+	// any user unlock.
+	if f.lockResolver != nil {
+		nfoData.LockData = f.lockResolver.ResolveLockNFO(ctx, a)
+	} else {
+		nfoData.LockData = a.Locked
+	}
 	var buf bytes.Buffer
 	if err := nfo.Write(&buf, nfoData); err != nil {
 		return nil, fmt.Errorf("generating nfo: %w", err)

--- a/internal/rule/fixers_nfo_lockdata_test.go
+++ b/internal/rule/fixers_nfo_lockdata_test.go
@@ -1,0 +1,127 @@
+package rule
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/nfo"
+)
+
+// stubLockResolver lets the truth-table tests inject the four
+// (artist.Locked x library.NFOLockData) cells without standing up the
+// publisher's library lookup machinery.
+type stubLockResolver struct{ value bool }
+
+func (s stubLockResolver) ResolveLockNFO(_ context.Context, _ *artist.Artist) bool {
+	return s.value
+}
+
+// TestNFOFixer_LockDataTruthTable enumerates the four cells of the
+// (artist.Locked, library.NFOLockData) truth table the issue #1726 fix
+// must honor. The resolver returns the OR of the two knobs in
+// production; here we drive it directly with the precomputed OR so the
+// test pins the fixer contract independently of the resolver's
+// internals.
+func TestNFOFixer_LockDataTruthTable(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		artistLocked bool
+		libraryLock  bool
+		want         bool
+	}{
+		{"both off", false, false, false},
+		{"artist on, library off", true, false, true},
+		{"artist off, library on", false, true, true},
+		{"both on", true, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			a := &artist.Artist{
+				Name:          "Truth Table",
+				SortName:      "Truth Table",
+				Path:          dir,
+				LibraryID:     "lib-test",
+				MusicBrainzID: "mbid-truth",
+				Locked:        tc.artistLocked,
+			}
+			// Resolver returns the OR; the fixer must stamp the OR.
+			f := &NFOFixer{
+				fsCheck:      nonSharedFSCheck(),
+				lockResolver: stubLockResolver{value: tc.artistLocked || tc.libraryLock},
+			}
+			res, err := f.Fix(context.Background(), a, &Violation{RuleID: RuleNFOExists})
+			if err != nil {
+				t.Fatalf("Fix: %v", err)
+			}
+			if !res.Fixed {
+				t.Fatalf("Fixed=false, message=%q", res.Message)
+			}
+			data, err := os.ReadFile(filepath.Join(dir, "artist.nfo"))
+			if err != nil {
+				t.Fatalf("read NFO: %v", err)
+			}
+			parsed, err := nfo.Parse(bytes.NewReader(data))
+			if err != nil {
+				t.Fatalf("parse NFO: %v", err)
+			}
+			if parsed.LockData != tc.want {
+				t.Errorf("LockData = %v, want %v (artist=%v library=%v)", parsed.LockData, tc.want, tc.artistLocked, tc.libraryLock)
+			}
+		})
+	}
+}
+
+// TestNFOFixer_NoResolverFallsBackToArtistLocked guards the
+// constructor's nil-resolver fallback. With no resolver, the fixer must
+// stamp lockdata from artist.Locked alone -- never the old hardcoded
+// true.
+func TestNFOFixer_NoResolverFallsBackToArtistLocked(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		locked bool
+	}{
+		{"unlocked", false},
+		{"locked", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			a := &artist.Artist{
+				Name:          "Fallback",
+				SortName:      "Fallback",
+				Path:          dir,
+				LibraryID:     "lib-test",
+				MusicBrainzID: "mbid-fb",
+				Locked:        tc.locked,
+			}
+			f := NewNFOFixer(nil, nil, nonSharedFSCheck(), nil, nil)
+			res, err := f.Fix(context.Background(), a, &Violation{RuleID: RuleNFOExists})
+			if err != nil {
+				t.Fatalf("Fix: %v", err)
+			}
+			if !res.Fixed {
+				t.Fatalf("Fixed=false, message=%q", res.Message)
+			}
+			data, err := os.ReadFile(filepath.Join(dir, "artist.nfo"))
+			if err != nil {
+				t.Fatalf("read NFO: %v", err)
+			}
+			parsed, err := nfo.Parse(bytes.NewReader(data))
+			if err != nil {
+				t.Fatalf("parse NFO: %v", err)
+			}
+			if parsed.LockData != tc.locked {
+				t.Errorf("LockData = %v, want %v", parsed.LockData, tc.locked)
+			}
+		})
+	}
+}

--- a/internal/rule/shared_fs_test.go
+++ b/internal/rule/shared_fs_test.go
@@ -98,7 +98,7 @@ func TestNFOFixer_SharedFS_Skips(t *testing.T) {
 	check := NewSharedFSCheck(&stubLibQuerier{
 		lib: &library.Library{SharedFSStatus: library.SharedFSSuspected},
 	}, logger)
-	fixer := NewNFOFixer(nil, nil, check, nil)
+	fixer := NewNFOFixer(nil, nil, check, nil, nil)
 	a := &artist.Artist{Name: "Test", Path: t.TempDir(), LibraryID: "lib-1"}
 	v := &Violation{RuleID: RuleNFOExists}
 	result, err := fixer.Fix(context.Background(), a, v)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -430,9 +430,14 @@ func (s *Service) processNewArtist(ctx context.Context, dirPath, name, libraryID
 	// Parse NFO if it exists for metadata
 	if detected.NFOExists {
 		if s.populateFromNFO(dirPath, a) {
-			// Import lockdata from NFO only for newly discovered artists.
+			// Import lockdata from NFO only on the new-artist path: this is
+			// the first time Stillwater sees the artist, so the NFO's
+			// <lockdata>true</lockdata> is the only available signal. Tagged
+			// with the dedicated "initial_import" lock_source so the user can
+			// distinguish first-discovery imports from explicit user locks or
+			// platform-pulled locks (issue #1726).
 			a.Locked = true
-			a.LockSource = "imported"
+			a.LockSource = "initial_import"
 			now := time.Now().UTC()
 			a.LockedAt = &now
 		}
@@ -582,17 +587,16 @@ func (s *Service) processExistingArtist(ctx context.Context, dirPath string, exi
 
 	// Re-parse NFO for updated metadata. Skip for locked artists
 	// to avoid overwriting user-curated metadata.
+	//
+	// IMPORTANT (issue #1726): the re-scan path must NEVER write
+	// artists.locked. Before the fix, populateFromNFO returning true (the
+	// NFO carries <lockdata>true</lockdata>) re-locked the artist on every
+	// rescan, silently undoing user unlocks. The canonical lock signal is
+	// (per-artist UI toggle) || (per-library NFOLockData setting) ||
+	// (scheduled platform pull). The NFO file is downstream of those, not
+	// upstream, so the scanner ignores its lockdata bit on re-scan.
 	if detected.NFOExists && !existing.Locked {
-		if s.populateFromNFO(dirPath, existing) {
-			// Mirror the new-artist path: an NFO carrying
-			// <lockdata>true</lockdata> (set by Stillwater or another
-			// tool) surfaces as an artist-level lock so the UI reflects
-			// that the metadata is locked. One-way (NFO -> artist).
-			existing.Locked = true
-			existing.LockSource = "imported"
-			lockedAt := time.Now().UTC()
-			existing.LockedAt = &lockedAt
-		}
+		s.populateFromNFO(dirPath, existing)
 	}
 
 	now := time.Now().UTC()

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1241,13 +1241,13 @@ func TestArtistService_ReconcileImages_IdempotentConvergence(t *testing.T) {
 	}
 }
 
-// TestScan_LockDataImportedOnRescan verifies that <lockdata>true</lockdata>
-// added to an existing artist's NFO (e.g. by another tool, or a later
-// Stillwater write under a per-library NFOLockData=true setting) is mirrored
-// to the artist-level Locked flag on the next scan, so the artist UI reflects
-// that the metadata is locked. Regression coverage for the rescan path that
-// previously discarded populateFromNFO's lockdata return value.
-func TestScan_LockDataImportedOnRescan(t *testing.T) {
+// TestScan_LockDataNotReimportedOnRescan is the regression fixture for
+// issue #1726. Before the fix, an NFO carrying <lockdata>true</lockdata> on
+// the rescan path silently re-locked the artist on every scan, undoing any
+// user unlock. The canonical lock signals are now: user UI toggle,
+// per-library NFOLockData setting, and scheduled platform pull -- the
+// scanner's re-scan path no longer touches artists.locked.
+func TestScan_LockDataNotReimportedOnRescan(t *testing.T) {
 	t.Parallel()
 	libDir := t.TempDir()
 	createArtistDir(t, libDir, "Portishead")
@@ -1268,8 +1268,8 @@ func TestScan_LockDataImportedOnRescan(t *testing.T) {
 		t.Fatal("artist should start unlocked when no NFO exists")
 	}
 
-	// Drop in an NFO with lockdata=true (simulating an external tool, or a
-	// downstream Stillwater write under NFOLockData=true).
+	// Drop in an NFO with lockdata=true (e.g. a stale on-disk lockdata bit
+	// from a pre-fix Stillwater write). The re-scan must NOT re-lock.
 	nfoContent := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <artist>
   <name>Portishead</name>
@@ -1289,14 +1289,55 @@ func TestScan_LockDataImportedOnRescan(t *testing.T) {
 	if a == nil {
 		t.Fatal("artist not found after second scan")
 	}
-	if !a.Locked {
-		t.Error("Locked should be true after rescan picked up <lockdata>true</lockdata>")
+	if a.Locked {
+		t.Error("Locked must remain false after rescan; NFO lockdata is not a re-scan signal (#1726)")
 	}
-	if a.LockSource != "imported" {
-		t.Errorf("LockSource = %q, want \"imported\"", a.LockSource)
+	if a.LockSource != "" {
+		t.Errorf("LockSource = %q, want empty (no lock applied)", a.LockSource)
+	}
+	if a.LockedAt != nil {
+		t.Errorf("LockedAt = %v, want nil (no lock applied -- partial lock-state writes would surface here)", a.LockedAt)
+	}
+}
+
+// TestScan_LockDataImportedOnInitialDiscovery verifies the new-artist code
+// path still imports <lockdata>true</lockdata>: that is the only place the
+// scanner gets to seed artists.locked, tagged with "initial_import" so the
+// user can distinguish it from a user-toggle or platform-pulled lock
+// (#1726).
+func TestScan_LockDataImportedOnInitialDiscovery(t *testing.T) {
+	t.Parallel()
+	libDir := t.TempDir()
+	createArtistDir(t, libDir, "Massive Attack")
+	nfoContent := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<artist>
+  <name>Massive Attack</name>
+  <lockdata>true</lockdata>
+</artist>`
+	nfoPath := filepath.Join(libDir, "Massive Attack", "artist.nfo")
+	if err := os.WriteFile(nfoPath, []byte(nfoContent), 0o644); err != nil {
+		t.Fatalf("writing nfo: %v", err)
+	}
+
+	svc, artistSvc := setupScanner(t, libDir)
+	ctx := context.Background()
+	if _, err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	waitForScan(t, svc, 5*time.Second)
+
+	a, _ := artistSvc.GetByPath(ctx, filepath.Join(libDir, "Massive Attack"))
+	if a == nil {
+		t.Fatal("artist not found")
+	}
+	if !a.Locked {
+		t.Error("initial discovery with lockdata=true should set Locked")
+	}
+	if a.LockSource != "initial_import" {
+		t.Errorf("LockSource = %q, want \"initial_import\"", a.LockSource)
 	}
 	if a.LockedAt == nil {
-		t.Error("LockedAt should be set after lockdata import")
+		t.Error("LockedAt should be set on initial-import lock")
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,7 +8,7 @@ package version
 // real release artifact from a developer's `make build` output (both get
 // non-"unknown" values via the Makefile's git/date probes).
 var (
-	Version   = "1.4.0"
+	Version   = "1.5.0"
 	Commit    = "unknown"
 	Date      = "unknown"
 	BuildType = ""

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1100,6 +1100,54 @@ if [[ "$FULL" -eq 1 ]]; then
     -X POST "$SW_BASE/api/v1/settings/backup") || backup_code="000"
   assert_status "POST /api/v1/settings/backup (--full)" "200" "$backup_code"
 
+  # Lock-loop regression (#1726). Catches the silent re-lock bug where the
+  # NFOExistsFixer hardcoded <lockdata>true</lockdata> and the scanner
+  # re-imported it on every scan, undoing user unlocks. Sequence: lock via
+  # API (handler must rewrite NFO with lockdata=true), unlock via API
+  # (handler must rewrite NFO with lockdata removed), then run scanner.
+  # If fix A (handler-side NFO rewrite) or B (fixer OR-of-knobs) regresses,
+  # the post-scan locked state will be 1 instead of 0.
+  if [[ -n "$ARTIST_ID" && "$ARTIST_ID" != "unknown" ]]; then
+    lock_code=$(curl -s -o /dev/null -w "%{http_code}" "${AUTH[@]}" \
+      -X POST "$SW_BASE/api/v1/artists/$ARTIST_ID/lock") || lock_code="000"
+    assert_status_in "POST /api/v1/artists/$ARTIST_ID/lock (#1726 setup)" "$lock_code" 200 409
+    unlock_code=$(curl -s -o /dev/null -w "%{http_code}" "${AUTH[@]}" \
+      -X DELETE "$SW_BASE/api/v1/artists/$ARTIST_ID/lock") || unlock_code="000"
+    assert_status_in "DELETE /api/v1/artists/$ARTIST_ID/lock (#1726 setup)" "$unlock_code" 200 409
+    scan_resp=$(curl -s -w "\n%{http_code}" "${AUTH[@]}" -X POST "$SW_BASE/api/v1/scanner/run") || scan_resp=$'\n000'
+    scan_body=$(echo "$scan_resp" | sed '$d')
+    scan_code=$(echo "$scan_resp" | tail -n 1)
+    assert_status_in "POST /api/v1/scanner/run (#1726 setup)" "$scan_code" 200 202
+    scan_id=""
+    if [[ "$scan_code" == "200" || "$scan_code" == "202" ]]; then
+      scan_id=$(echo "$scan_body" | jq -r '.id // empty' 2>/dev/null || true)
+    fi
+    if [[ -n "$scan_id" ]]; then
+      scan_status=""
+      for _ in 1 2 3 4 5 6 7 8 9 10; do
+        sleep 2
+        scan_status=$(curl -s "${AUTH[@]}" "$SW_BASE/api/v1/scanner/status" | jq -r '.status // empty' 2>/dev/null || true)
+        if [[ "$scan_status" == "completed" || "$scan_status" == "failed" ]]; then
+          break
+        fi
+      done
+      if [[ "$scan_status" != "completed" ]]; then
+        echo "[FAIL] #1726 regression -- scanner did not reach completed state (status=$scan_status)"
+        FAIL=$((FAIL + 1))
+        FAILURES+=("#1726 regression -- scanner did not reach completed state (status=$scan_status)")
+      else
+        post_locked=$(curl -s "${AUTH[@]}" "$SW_BASE/api/v1/artists/$ARTIST_ID" | jq -r '.artist.locked' 2>/dev/null || echo "PARSE_ERROR")
+        assert_json_value "GET /api/v1/artists/$ARTIST_ID locked after unlock+scan (#1726)" "false" "$post_locked"
+      fi
+    else
+      echo "[FAIL] #1726 regression -- scanner/run did not return an id"
+      FAIL=$((FAIL + 1))
+      FAILURES+=("#1726 regression -- scanner/run did not return an id")
+    fi
+  else
+    echo "[SKIP] #1726 lock-loop regression -- no ARTIST_ID discovered"
+  fi
+
   echo ""
 fi
 


### PR DESCRIPTION
## Summary

- **Breaks the silent re-lock loop on user libraries (#1726)** -- three independent code paths conspired to silently re-lock artists after the user unlocked them in the Stillwater UI. NFOExistsFixer hardcoded `<lockdata>true</lockdata>` on every NFO; the lock/unlock handler updated the DB and pushed to Emby/Jellyfin but never rewrote the on-disk NFO; the scanner re-imported the stale NFO lockdata on every existing-artist re-scan. Result: real-user libraries saw 588 of 614 artists silently locked. This PR fixes all three plus adds the missing Emby/Jellyfin platform-pull path that was half-finished in main.
- **User-visible**: a one-time SQL migration (014) clears the loop's fingerprint (`lock_source='imported'` rows) on first startup so already-silently-locked libraries recover without manual intervention. A new `lock_sync.interval_minutes` setting (default 30) controls how often Stillwater pulls platform-side lock toggles back from Emby/Jellyfin.
- **Bumps `internal/version` to `1.5.0`** so a single PR closes the M54 milestone work and unlocks the v1.5.0 tag.
- **Reviewer focus**: `internal/rule/fixers.go:150` (OR-of-knobs replaces hardcoded `true`), `internal/api/handlers_artist_lock.go:42-83` (handler now calls `WriteBackNFO` after `PushLocks`), `internal/scanner/scanner.go:585-595` (re-scan no longer writes `artists.locked`), `internal/connection/locksync.go` (new platform-pull service), and the two new migrations.

### Reviewer note (preempting a likely CR misread)

A local CodeRabbit run flagged the docs phrase "within the last 5 minutes" as inconsistent with `60*time.Second` in `cmd/stillwater/main.go:873`, suggesting the docs should say "60 seconds". **The local CR is mistaken.** That `60*time.Second` is the third arg to `StartScheduler` -- the `startupDelay` (how long to wait before the first sweep on process start). The actual recent-push grace window is `lockSyncRecentPushWindow = 5 * time.Minute` at `internal/connection/locksync.go:32`. The docs are correct; the function signature is `StartScheduler(ctx, interval, startupDelay)`, not `(ctx, interval, graceWindow)`. Cloud CR is likely to repeat this finding -- please disregard.

## Linked issue

Closes #1726

## Pre-flight checklist

- [x] Pre-push gate green locally.
- [x] Code review pass complete (`coderabbit review --plain` on `c869bfd4` -- 2 trivial findings addressed (sync-name shadow + exact-equality assertion), 2 "major" findings on docs intentionally not actioned per Reviewer note above).
- [x] Commits squashed into clean, logical commits before the first push (single commit).
- [x] At least one label set on `gh pr create --label ...`.
- [x] Docs label decision made: user-visible behavior change -- adds `needs-docs-review` AND ships the docs in the same PR.
- [ ] Screenshot attached for any UI change. N/A (no UI change; behavior is a fix to the lock/unlock toggle that already exists).
- [x] UAT performed for user-visible changes. Synthetic UAT via curl against a running dev instance with 614 artists:
  - Migration 014: 588 silent locks (`lock_source='imported'`) cleared on startup -> 0 remain.
  - Lock via API -> NFO on disk now carries `<lockdata>true</lockdata>`.
  - Unlock via API -> NFO `<lockdata>` removed.
  - Inject stale `<lockdata>true</lockdata>` into NFO + full library scan -> artist stays `locked=0` (the critical regression check).
  - `scripts/smoke.sh --full` now includes a permanent regression check for this loop in Tier 4.
- [x] OpenAPI spec updated if any request or response shape changed. N/A (no API shape changes).
- [x] `templ generate` re-run and `*_templ.go` committed. N/A (no `.templ` changes).

## Test plan

- [x] `go test -race ./...` passes locally (via pre-push gate).
- [x] `bash scripts/pre-push-gate.sh` passes locally.
- [x] Manual UAT steps performed:
  - [x] Lock/unlock round-trip rewrites NFO `<lockdata>` correctly.
  - [x] Full scanner run with stale `<lockdata>true</lockdata>` injected does NOT re-lock.
  - [x] `scripts/smoke.sh --full` -- new #1726 Tier 4 check passes.
  - [ ] Manual cross-platform UAT (Emby/Jellyfin lock toggle round-trips into Stillwater via LockSync platform pull) -- deferred to post-merge real-environment verification; locksync_test.go covers the unit-level contracts (10+ tests including conflict policy, disabled connections, platform errors, recent-push grace window).
- [ ] Reviewer follow-ups: see Reviewer note above re: the 5-minute grace window. Otherwise none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform lock synchronization: scheduled background job to sync artist lock state from Emby/Jellyfin (configurable cadence, default 30 min)
  * Artist lock operations now update on-disk NFOs so file metadata matches database
  * New initial-import behavior: NFO lockdata on first discovery sets artist as locked

* **Bug Fixes**
  * Protects recent local lock changes from being overwritten by platform snapshots
  * Prevents NFO lockdata from re-locking existing artists on rescan

* **Documentation**
  * Added Emby/Jellyfin docs describing lock-state sync and config toggle

* **Chores**
  * Version bumped to 1.5.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->