### PR TITLE
chore(release): drop redundant '## Stillwater {tag}' header from release body (#1732)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -153,8 +153,6 @@ release:
   # Footer below appends Docker pull + full-changelog link regardless,
   # so even a minimal tag annotation produces a useful release page.
   header: |
-    ## Stillwater {{ .Tag }}
-
     {{ if .Prerelease }}> This is a pre-release version. Use the `beta` Docker tag to try it out.{{ end }}
 
     {{ .TagBody }}


### PR DESCRIPTION
## Summary

- Remove the `## Stillwater {{ .Tag }}` H2 from the goreleaser `release.header` template. The GitHub Release page already shows the project name and tag in its header card, so the H2 was redundant and pushed the release-notes intro below the visible area (had to be re-uploaded post-publish on v1.5.0).
- Keep the prerelease-notice conditional and the `{{ .TagBody }}` injection.
- No binary or test impact; this is a release-time template only.

## Linked issue

Closes #1732

## Pre-flight checklist

- [x] Pre-push gate green locally (ran automatically by the pre-push hook).
- [x] Code review pass complete (local CodeRabbit: no findings).
- [x] Commits squashed into one clean commit before the first push.
- [x] At least one label set (`chore`, `docs: not-required`).
- [x] Docs label decision made: `docs: not-required` (release-time template, no user-visible app or docs behavior change).
- [ ] Screenshot attached for any UI change. (N/A.)
- [ ] OpenAPI spec updated. (N/A -- no API change.)
- [ ] `templ generate` re-run. (N/A -- no `.templ` change.)

## Test plan

- [x] `goreleaser check` passes (config still validates after the edit).
- [x] `bash scripts/pre-push-gate.sh` passes locally (ran on push).
- [ ] Full verification is the next nightly publish: the Release body should render with the prerelease notice + tag body but no redundant H2 header. (Cannot be exercised locally without cutting a tag.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined release notes header formatting by removing redundant version information, allowing prerelease status and tag content to display more directly in release announcements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1734?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->