### PR TITLE
feat(provider): respectful rate-limit backoff honoring Retry-After (#1738)

### DIFF
--- a/internal/provider/audiodb/audiodb.go
+++ b/internal/provider/audiodb/audiodb.go
@@ -3,6 +3,7 @@ package audiodb
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -79,13 +80,6 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 		return nil, err
 	}
 
-	if err := a.limiter.Wait(ctx, provider.NameAudioDB); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameAudioDB,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	reqURL := a.buildSearchURL(apiKey, name)
 	artists, err := a.fetchArtists(ctx, reqURL, apiKey)
 	if err != nil {
@@ -125,13 +119,6 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 		return nil, err
 	}
 
-	if err := a.limiter.Wait(ctx, provider.NameAudioDB); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameAudioDB,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	var reqURL string
 	if isNumericID(id) {
 		reqURL = a.buildDirectLookupURL(apiKey, id)
@@ -158,13 +145,6 @@ func (a *Adapter) GetImages(ctx context.Context, id string) ([]provider.ImageRes
 	apiKey, err := a.getAPIKey(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	if err := a.limiter.Wait(ctx, provider.NameAudioDB); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameAudioDB,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
 	}
 
 	var reqURL string
@@ -240,18 +220,34 @@ func (a *Adapter) buildLookupURL(apiKey, mbid string) string {
 // fetchArtists performs an HTTP GET and parses the artist list from the response.
 // Premium keys are sent in the X-API-KEY header (v2); the free key is embedded in the URL (v1).
 func (a *Adapter) fetchArtists(ctx context.Context, reqURL string, apiKey string) ([]AudioDBArtist, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	if isPremiumKey(apiKey) {
-		req.Header.Set("X-API-KEY", apiKey)
+	// do performs one HTTP attempt. The limiter wait lives inside it so each
+	// retry triggered by DoWithRetry still respects the per-provider budget.
+	do := func(ctx context.Context) (*http.Response, error) {
+		if err := a.limiter.Wait(ctx, provider.NameAudioDB); err != nil {
+			return nil, &provider.ErrProviderUnavailable{
+				Provider: provider.NameAudioDB,
+				Cause:    fmt.Errorf("rate limiter: %w", err),
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		if isPremiumKey(apiKey) {
+			req.Header.Set("X-API-KEY", apiKey)
+		}
+		a.logger.Debug("requesting", slog.String("url", reqURL))
+		return a.client.Do(req)
 	}
 
-	a.logger.Debug("requesting", slog.String("url", reqURL))
-
-	resp, err := a.client.Do(req)
+	// DoWithRetry consumes 429/503, so the status handling below only sees
+	// 200/other.
+	resp, err := provider.DoWithRetry(ctx, provider.SystemClock(), provider.NameAudioDB, provider.DefaultRetryPolicy(), do)
 	if err != nil {
+		var unavailable *provider.ErrProviderUnavailable
+		if errors.As(err, &unavailable) {
+			return nil, err
+		}
 		return nil, &provider.ErrProviderUnavailable{
 			Provider: provider.NameAudioDB,
 			Cause:    err,

--- a/internal/provider/audiodb/audiodb_test.go
+++ b/internal/provider/audiodb/audiodb_test.go
@@ -725,10 +725,11 @@ func TestFetchArtistsRetriesOn429(t *testing.T) {
 		t.Errorf("expected *provider.ErrProviderUnavailable, got %T: %v", err, err)
 	}
 
-	// MaxAttempts=3 means the server is hit exactly three times: the initial
-	// attempt plus two retries.
-	if got := hits.Load(); got != 3 {
-		t.Errorf("expected 3 requests (bounded retries), got %d", got)
+	// The adapter uses provider.DefaultRetryPolicy(), so the server is hit
+	// exactly MaxAttempts times: the initial attempt plus the bounded retries.
+	want := provider.DefaultRetryPolicy().MaxAttempts
+	if got := int(hits.Load()); got != want {
+		t.Errorf("expected %d requests (bounded retries), got %d", want, got)
 	}
 }
 

--- a/internal/provider/audiodb/audiodb_test.go
+++ b/internal/provider/audiodb/audiodb_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -686,6 +687,48 @@ func TestFreeKeyNumericIDRoutesToV1Direct(t *testing.T) {
 	}
 	if !strings.Contains(capturedPath, "/artist.php") {
 		t.Errorf("numeric ID with free key should route to /artist.php, got %q", capturedPath)
+	}
+}
+
+func TestFetchArtistsRetriesOn429(t *testing.T) {
+	limiter, settings := setupTest(t)
+
+	// Count every request the server receives so we can prove the retry
+	// loop is bounded by DefaultRetryPolicy.MaxAttempts (3).
+	var hits atomic.Int32
+
+	// Always reply 429 with "Retry-After: 0". The zero value makes
+	// provider.DoWithRetry compute a zero backoff, so the real clock never
+	// sleeps and the test runs instantly while still exercising the full
+	// retry-then-give-up path.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	useLoopbackTestClient(a)
+
+	// SearchArtist routes through fetchArtists, which wraps its HTTP call in
+	// provider.DoWithRetry (with limiter.Wait inside the retried closure).
+	_, err := a.SearchArtist(context.Background(), "radiohead")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+
+	var unavailable *provider.ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Errorf("expected *provider.ErrProviderUnavailable, got %T: %v", err, err)
+	}
+
+	// MaxAttempts=3 means the server is hit exactly three times: the initial
+	// attempt plus two retries.
+	if got := hits.Load(); got != 3 {
+		t.Errorf("expected 3 requests (bounded retries), got %d", got)
 	}
 }
 

--- a/internal/provider/deezer/deezer.go
+++ b/internal/provider/deezer/deezer.go
@@ -172,7 +172,7 @@ func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) 
 		}
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("creating request: %w", err)
 		}
 		req.Header.Set("Accept", "application/json")
 		return a.client.Do(req)

--- a/internal/provider/deezer/deezer.go
+++ b/internal/provider/deezer/deezer.go
@@ -3,6 +3,7 @@ package deezer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -60,13 +61,6 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 		return nil, nil
 	}
 
-	if err := a.limiter.Wait(ctx, provider.NameDeezer); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameDeezer,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	params := url.Values{
 		"q":     {name},
 		"limit": {"10"},
@@ -117,13 +111,6 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 		return nil, &provider.ErrNotFound{Provider: provider.NameDeezer, ID: id}
 	}
 
-	if err := a.limiter.Wait(ctx, provider.NameDeezer); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameDeezer,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	reqURL := fmt.Sprintf("%s/artist/%s", a.baseURL, url.PathEscape(id))
 	body, err := a.doRequest(ctx, reqURL)
 	if err != nil {
@@ -156,13 +143,6 @@ func (a *Adapter) GetImages(ctx context.Context, id string) ([]provider.ImageRes
 		return nil, &provider.ErrNotFound{Provider: provider.NameDeezer, ID: id}
 	}
 
-	if err := a.limiter.Wait(ctx, provider.NameDeezer); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameDeezer,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	reqURL := fmt.Sprintf("%s/artist/%s", a.baseURL, url.PathEscape(id))
 	body, err := a.doRequest(ctx, reqURL)
 	if err != nil {
@@ -177,16 +157,34 @@ func (a *Adapter) GetImages(ctx context.Context, id string) ([]provider.ImageRes
 	return imagesFromResult(&result), nil
 }
 
-// doRequest executes a GET request and returns the response body.
+// doRequest executes a GET request and returns the response body, backing off
+// and retrying on a rate-limited (429) or unavailable (503) response via
+// provider.DoWithRetry.
 func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-	if err != nil {
-		return nil, err
+	// do performs one HTTP attempt. The limiter wait lives inside it so each
+	// retry triggered by DoWithRetry still respects the per-provider budget.
+	do := func(ctx context.Context) (*http.Response, error) {
+		if err := a.limiter.Wait(ctx, provider.NameDeezer); err != nil {
+			return nil, &provider.ErrProviderUnavailable{
+				Provider: provider.NameDeezer,
+				Cause:    fmt.Errorf("rate limiter: %w", err),
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/json")
+		return a.client.Do(req)
 	}
-	req.Header.Set("Accept", "application/json")
 
-	resp, err := a.client.Do(req)
+	// DoWithRetry consumes 429/503, so the switch below only sees 200/404/other.
+	resp, err := provider.DoWithRetry(ctx, provider.SystemClock(), provider.NameDeezer, provider.DefaultRetryPolicy(), do)
 	if err != nil {
+		var unavailable *provider.ErrProviderUnavailable
+		if errors.As(err, &unavailable) {
+			return nil, err
+		}
 		return nil, &provider.ErrProviderUnavailable{
 			Provider: provider.NameDeezer,
 			Cause:    err,
@@ -200,12 +198,6 @@ func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) 
 	case http.StatusNotFound:
 		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil, &provider.ErrNotFound{Provider: provider.NameDeezer, ID: reqURL}
-	case http.StatusTooManyRequests:
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameDeezer,
-			Cause:    fmt.Errorf("rate limited by server"),
-		}
 	default:
 		_, _ = io.Copy(io.Discard, resp.Body)
 		return nil, &provider.ErrProviderUnavailable{

--- a/internal/provider/deezer/deezer_test.go
+++ b/internal/provider/deezer/deezer_test.go
@@ -288,10 +288,11 @@ func TestDoRequestRetriesOn429(t *testing.T) {
 		t.Errorf("expected *provider.ErrProviderUnavailable, got %T: %v", err, err)
 	}
 
-	// provider.DefaultRetryPolicy uses MaxAttempts=3, so the server must be hit
-	// exactly 3 times: one initial attempt plus two retries.
-	if got := hits.Load(); got != 3 {
-		t.Errorf("expected exactly 3 requests (MaxAttempts=3), got %d", got)
+	// The adapter uses provider.DefaultRetryPolicy(), so the server must be hit
+	// exactly MaxAttempts times: one initial attempt plus the bounded retries.
+	want := provider.DefaultRetryPolicy().MaxAttempts
+	if got := int(hits.Load()); got != want {
+		t.Errorf("expected exactly %d requests (MaxAttempts), got %d", want, got)
 	}
 }
 

--- a/internal/provider/deezer/deezer_test.go
+++ b/internal/provider/deezer/deezer_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -254,6 +255,116 @@ func TestGetImagesDefaultPhoto(t *testing.T) {
 	}
 	if len(images) != 0 {
 		t.Errorf("expected 0 images for artist with default placeholder, got %d", len(images))
+	}
+}
+
+func TestDoRequestRetriesOn429(t *testing.T) {
+	// The server always returns 429 with "Retry-After: 0". The zero-second
+	// Retry-After makes provider.DoWithRetry compute a zero wait between
+	// attempts, so the real clock never actually sleeps and the test runs
+	// instantly while still exercising the full retry path. Returning 429 on
+	// every request forces DoWithRetry to exhaust its budget, proving the
+	// retries are bounded (no retry storm) and surface as
+	// *provider.ErrProviderUnavailable.
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+
+	// "27" is a valid numeric Deezer ID, so the adapter performs the HTTP call
+	// instead of short-circuiting with ErrNotFound.
+	_, err := a.GetArtist(context.Background(), "27")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+
+	var unavailable *provider.ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Errorf("expected *provider.ErrProviderUnavailable, got %T: %v", err, err)
+	}
+
+	// provider.DefaultRetryPolicy uses MaxAttempts=3, so the server must be hit
+	// exactly 3 times: one initial attempt plus two retries.
+	if got := hits.Load(); got != 3 {
+		t.Errorf("expected exactly 3 requests (MaxAttempts=3), got %d", got)
+	}
+}
+
+func TestDoRequestRecoversAfter429(t *testing.T) {
+	// End-to-end recovery path: the first request is rate-limited (429 with a
+	// zero-second Retry-After so the test stays fast), and the retry succeeds
+	// with real artist JSON. This proves the adapter does not give up on a
+	// transient 429 -- it backs off and then returns the data.
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if hits.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(loadFixture(t, "artist_radiohead.json"))
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+
+	meta, err := a.GetArtist(context.Background(), "27")
+	if err != nil {
+		t.Fatalf("expected success after one retry, got error: %v", err)
+	}
+	if meta == nil || meta.Name == "" {
+		t.Fatalf("expected populated artist metadata, got %+v", meta)
+	}
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("expected 2 requests (one 429, one success), got %d", got)
+	}
+}
+
+func TestDoRequestWrapsTransportError(t *testing.T) {
+	// A connection-level failure (the server is already closed) is not a 429/503,
+	// so DoWithRetry returns it as a raw, untyped error. doRequest must wrap it in
+	// *provider.ErrProviderUnavailable so callers still see a transient failure.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	a := newTestAdapter(t, url)
+
+	_, err := a.GetArtist(context.Background(), "27")
+	var unavailable *provider.ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("expected *provider.ErrProviderUnavailable, got %T: %v", err, err)
+	}
+}
+
+func TestDoRequestHonorsCanceledContext(t *testing.T) {
+	// A canceled context makes the in-closure limiter wait fail before any HTTP
+	// call, surfacing as *provider.ErrProviderUnavailable from the rate-limiter
+	// branch. The server should therefore never be contacted.
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Write(loadFixture(t, "artist_radiohead.json"))
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := a.GetArtist(ctx, "27")
+	var unavailable *provider.ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("expected *provider.ErrProviderUnavailable, got %T: %v", err, err)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("expected 0 requests (limiter rejected before HTTP), got %d", got)
 	}
 }
 

--- a/internal/provider/discogs/discogs.go
+++ b/internal/provider/discogs/discogs.go
@@ -3,6 +3,7 @@ package discogs
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -59,13 +60,6 @@ func (a *Adapter) SearchArtist(ctx context.Context, name string) ([]provider.Art
 	token, err := a.getToken(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	if err := a.limiter.Wait(ctx, provider.NameDiscogs); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameDiscogs,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
 	}
 
 	params := url.Values{
@@ -139,13 +133,6 @@ func (a *Adapter) getArtistByID(ctx context.Context, id string) (*provider.Artis
 		return nil, err
 	}
 
-	if err := a.limiter.Wait(ctx, provider.NameDiscogs); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameDiscogs,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	reqURL := fmt.Sprintf("%s/artists/%s", a.baseURL, url.PathEscape(id))
 	body, err := a.doRequest(ctx, reqURL, token)
 	if err != nil {
@@ -205,13 +192,6 @@ func (a *Adapter) GetImages(ctx context.Context, id string) ([]provider.ImageRes
 		return nil, err
 	}
 
-	if err := a.limiter.Wait(ctx, provider.NameDiscogs); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameDiscogs,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	reqURL := fmt.Sprintf("%s/artists/%s", a.baseURL, url.PathEscape(id))
 	body, err := a.doRequest(ctx, reqURL, token)
 	if err != nil {
@@ -264,18 +244,34 @@ func (a *Adapter) getToken(ctx context.Context) (string, error) {
 }
 
 func (a *Adapter) doRequest(ctx context.Context, reqURL, token string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+	// do performs one HTTP attempt. The limiter wait lives inside it so each
+	// retry triggered by DoWithRetry still respects the per-provider budget.
+	do := func(ctx context.Context) (*http.Response, error) {
+		if err := a.limiter.Wait(ctx, provider.NameDiscogs); err != nil {
+			return nil, &provider.ErrProviderUnavailable{
+				Provider: provider.NameDiscogs,
+				Cause:    fmt.Errorf("rate limiter: %w", err),
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		req.Header.Set("Authorization", "Discogs token="+token)
+		req.Header.Set("User-Agent", version.UserAgent("Stillwater", ""))
+		req.Header.Set("Accept", "application/json")
+		a.logger.Debug("requesting", slog.String("url", reqURL))
+		return a.client.Do(req)
 	}
-	req.Header.Set("Authorization", "Discogs token="+token)
-	req.Header.Set("User-Agent", version.UserAgent("Stillwater", ""))
-	req.Header.Set("Accept", "application/json")
 
-	a.logger.Debug("requesting", slog.String("url", reqURL))
-
-	resp, err := a.client.Do(req)
+	// DoWithRetry consumes 429/503, so the status handling below only sees
+	// 200/404/401/403/other.
+	resp, err := provider.DoWithRetry(ctx, provider.SystemClock(), provider.NameDiscogs, provider.DefaultRetryPolicy(), do)
 	if err != nil {
+		var unavailable *provider.ErrProviderUnavailable
+		if errors.As(err, &unavailable) {
+			return nil, err
+		}
 		return nil, &provider.ErrProviderUnavailable{
 			Provider: provider.NameDiscogs,
 			Cause:    err,
@@ -304,12 +300,6 @@ func (a *Adapter) doRequest(ctx context.Context, reqURL, token string) ([]byte, 
 
 // getArtistReleases fetches a single page of releases for an artist from Discogs.
 func (a *Adapter) getArtistReleases(ctx context.Context, artistID, token string, page int) (*ArtistReleasesResponse, error) {
-	if err := a.limiter.Wait(ctx, provider.NameDiscogs); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameDiscogs,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
 	reqURL := fmt.Sprintf("%s/artists/%s/releases?sort=year&sort_order=desc&per_page=50&page=%d",
 		a.baseURL, url.PathEscape(artistID), page)
 	body, err := a.doRequest(ctx, reqURL, token)
@@ -325,12 +315,6 @@ func (a *Adapter) getArtistReleases(ctx context.Context, artistID, token string,
 
 // getMasterRelease fetches genre/style info from a master release.
 func (a *Adapter) getMasterRelease(ctx context.Context, masterID int, token string) (*MasterRelease, error) {
-	if err := a.limiter.Wait(ctx, provider.NameDiscogs); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameDiscogs,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
 	reqURL := fmt.Sprintf("%s/masters/%d", a.baseURL, masterID)
 	body, err := a.doRequest(ctx, reqURL, token)
 	if err != nil {

--- a/internal/provider/discogs/discogs_test.go
+++ b/internal/provider/discogs/discogs_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -350,6 +351,47 @@ func TestTopStylesEmpty(t *testing.T) {
 	got := topStyles(nil, 10)
 	if got != nil {
 		t.Errorf("expected nil for empty counts, got %v", got)
+	}
+}
+
+func TestDoRequestRetriesOn429(t *testing.T) {
+	limiter, settings := setupTest(t)
+
+	// Count every request the adapter makes. The handler always replies
+	// with 429 and "Retry-After: 0". The zero Retry-After makes
+	// provider.DoWithRetry's backoff wait evaluate to zero, so the real
+	// clock never sleeps and the test stays fast while still exercising
+	// the full retry loop inside doRequest.
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	useLoopbackTestClient(a)
+
+	// "1" is a valid numeric Discogs ID (isNumericID), so GetArtist routes
+	// through getArtistByID -> doRequest. The primary artist fetch returns
+	// 429 and errors out, so aggregateStyles never runs and only the
+	// primary doRequest path is exercised.
+	_, err := a.GetArtist(context.Background(), "1")
+	if err == nil {
+		t.Fatal("expected error from persistent 429, got nil")
+	}
+	var unavailable *provider.ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("expected ErrProviderUnavailable, got: %T: %v", err, err)
+	}
+
+	// provider.DefaultRetryPolicy uses MaxAttempts=3, so the single
+	// doRequest call hits the server exactly 3 times.
+	if got := hits.Load(); got != 3 {
+		t.Errorf("expected exactly 3 server hits (MaxAttempts=3), got %d", got)
 	}
 }
 

--- a/internal/provider/discogs/discogs_test.go
+++ b/internal/provider/discogs/discogs_test.go
@@ -388,10 +388,11 @@ func TestDoRequestRetriesOn429(t *testing.T) {
 		t.Fatalf("expected ErrProviderUnavailable, got: %T: %v", err, err)
 	}
 
-	// provider.DefaultRetryPolicy uses MaxAttempts=3, so the single
-	// doRequest call hits the server exactly 3 times.
-	if got := hits.Load(); got != 3 {
-		t.Errorf("expected exactly 3 server hits (MaxAttempts=3), got %d", got)
+	// The adapter uses provider.DefaultRetryPolicy(), so the single doRequest
+	// call hits the server exactly MaxAttempts times.
+	want := provider.DefaultRetryPolicy().MaxAttempts
+	if got := int(hits.Load()); got != want {
+		t.Errorf("expected exactly %d server hits (MaxAttempts), got %d", want, got)
 	}
 }
 

--- a/internal/provider/fanarttv/fanarttv.go
+++ b/internal/provider/fanarttv/fanarttv.go
@@ -78,23 +78,33 @@ func (a *Adapter) GetImages(ctx context.Context, mbid string) ([]provider.ImageR
 		return nil, &provider.ErrAuthRequired{Provider: provider.NameFanartTV}
 	}
 
-	if err := a.limiter.Wait(ctx, provider.NameFanartTV); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameFanartTV,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	reqURL := fmt.Sprintf("%s/%s?api_key=%s", a.baseURL, mbid, apiKey)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+
+	// do performs one HTTP attempt. The limiter wait lives inside it so each
+	// retry triggered by DoWithRetry still respects the per-provider budget.
+	do := func(ctx context.Context) (*http.Response, error) {
+		if err := a.limiter.Wait(ctx, provider.NameFanartTV); err != nil {
+			return nil, &provider.ErrProviderUnavailable{
+				Provider: provider.NameFanartTV,
+				Cause:    fmt.Errorf("rate limiter: %w", err),
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		a.logger.Debug("requesting images", slog.String("mbid", mbid))
+		return a.client.Do(req)
 	}
 
-	a.logger.Debug("requesting images", slog.String("mbid", mbid))
-
-	resp, err := a.client.Do(req)
+	// DoWithRetry consumes 429/503, so the status handling below only sees
+	// 200/404/other.
+	resp, err := provider.DoWithRetry(ctx, provider.SystemClock(), provider.NameFanartTV, provider.DefaultRetryPolicy(), do)
 	if err != nil {
+		var unavailable *provider.ErrProviderUnavailable
+		if errors.As(err, &unavailable) {
+			return nil, err
+		}
 		return nil, &provider.ErrProviderUnavailable{
 			Provider: provider.NameFanartTV,
 			Cause:    err,

--- a/internal/provider/fanarttv/fanarttv_test.go
+++ b/internal/provider/fanarttv/fanarttv_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -148,6 +149,47 @@ func TestGetImagesNoKey(t *testing.T) {
 	var authRequired *provider.ErrAuthRequired
 	if !errors.As(err, &authRequired) {
 		t.Errorf("expected ErrAuthRequired, got %T", err)
+	}
+}
+
+// TestGetImagesRetriesOn429 proves that GetImages routes through
+// provider.DoWithRetry and gives up after a bounded number of attempts when the
+// server keeps returning HTTP 429.
+//
+// The handler always answers "Retry-After: 0" alongside the 429 status. A
+// Retry-After of zero makes provider.DoWithRetry compute a zero backoff wait, so
+// the retries fire back-to-back against the real clock without any actual sleep.
+// That keeps the test fast and deterministic while still exercising the live
+// retry loop. provider.DefaultRetryPolicy uses MaxAttempts=3, so the server must
+// be hit exactly 3 times before the loop surfaces *ErrProviderUnavailable.
+func TestGetImagesRetriesOn429(t *testing.T) {
+	limiter, settings := setupTest(t)
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		// Retry-After: 0 -> zero backoff, so DoWithRetry does not sleep.
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	a := NewWithBaseURL(limiter, settings, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	a.client = &http.Client{Timeout: 10 * time.Second}
+
+	_, err := a.GetImages(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries on 429")
+	}
+	var unavailable *provider.ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Errorf("expected ErrProviderUnavailable, got %T: %v", err, err)
+	}
+
+	if got := hits.Load(); got != 3 {
+		t.Errorf("expected server to be hit 3 times (bounded retries), got %d", got)
 	}
 }
 

--- a/internal/provider/fanarttv/fanarttv_test.go
+++ b/internal/provider/fanarttv/fanarttv_test.go
@@ -188,8 +188,9 @@ func TestGetImagesRetriesOn429(t *testing.T) {
 		t.Errorf("expected ErrProviderUnavailable, got %T: %v", err, err)
 	}
 
-	if got := hits.Load(); got != 3 {
-		t.Errorf("expected server to be hit 3 times (bounded retries), got %d", got)
+	want := provider.DefaultRetryPolicy().MaxAttempts
+	if got := int(hits.Load()); got != want {
+		t.Errorf("expected server to be hit %d times (bounded retries), got %d", want, got)
 	}
 }
 

--- a/internal/provider/musicbrainz/musicbrainz.go
+++ b/internal/provider/musicbrainz/musicbrainz.go
@@ -3,6 +3,7 @@ package musicbrainz
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -665,26 +666,44 @@ func (a *Adapter) unmarshalWithFallback(ctx context.Context, base, pathAndQuery 
 	return nil
 }
 
-// doRequest executes an HTTP GET with rate limiting and standard headers.
+// doRequest executes an HTTP GET with rate limiting and standard headers,
+// backing off and retrying on a rate-limited (429) or unavailable (503)
+// response via provider.DoWithRetry.
 func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) {
-	if err := a.limiter.Wait(ctx, provider.NameMusicBrainz); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameMusicBrainz,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
+	// do performs one HTTP attempt. The limiter wait lives inside it so that
+	// every retry triggered by DoWithRetry still respects the per-provider
+	// request budget.
+	do := func(ctx context.Context) (*http.Response, error) {
+		if err := a.limiter.Wait(ctx, provider.NameMusicBrainz); err != nil {
+			return nil, &provider.ErrProviderUnavailable{
+				Provider: provider.NameMusicBrainz,
+				Cause:    fmt.Errorf("rate limiter: %w", err),
+			}
 		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		req.Header.Set("User-Agent", userAgent())
+		req.Header.Set("Accept", "application/json")
+
+		a.logger.Debug("requesting", slog.String("url", reqURL))
+		return a.client.Do(req)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+	// DoWithRetry honors a 429 Retry-After (and backs off conservatively on a
+	// 503) before giving up. It returns the first non-rate-limited response, so
+	// the status handling below only sees 200/404/other.
+	resp, err := provider.DoWithRetry(ctx, provider.SystemClock(), provider.NameMusicBrainz, provider.DefaultRetryPolicy(), do)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("User-Agent", userAgent())
-	req.Header.Set("Accept", "application/json")
-
-	a.logger.Debug("requesting", slog.String("url", reqURL))
-
-	resp, err := a.client.Do(req)
-	if err != nil {
+		// Either a transport error from client.Do or an exhausted-retry error
+		// (already an *ErrProviderUnavailable). Wrap the former so callers still
+		// see a provider-unavailable error.
+		var unavailable *provider.ErrProviderUnavailable
+		if errors.As(err, &unavailable) {
+			return nil, err
+		}
 		return nil, &provider.ErrProviderUnavailable{
 			Provider: provider.NameMusicBrainz,
 			Cause:    err,
@@ -697,15 +716,6 @@ func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) 
 		return nil, &provider.ErrNotFound{
 			Provider: provider.NameMusicBrainz,
 			ID:       reqURL,
-		}
-	}
-
-	if resp.StatusCode == http.StatusServiceUnavailable || resp.StatusCode == http.StatusTooManyRequests {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, &provider.ErrProviderUnavailable{
-			Provider:   provider.NameMusicBrainz,
-			Cause:      fmt.Errorf("HTTP %d", resp.StatusCode),
-			RetryAfter: 2 * time.Second,
 		}
 	}
 

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -519,7 +519,7 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 			} else {
 				o.logger.Debug("provider GetArtist failed",
 					slog.String("provider", string(name)),
-					slog.String("error", err.Error()),
+					slog.String("error", ScrubError(err)),
 					retryAfterAttr(err))
 				pr.err = err
 			}

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -332,7 +332,8 @@ func (o *Orchestrator) FetchImages(ctx context.Context, mbid string, providerIDs
 			}
 			o.logger.Warn("provider image fetch failed",
 				slog.String("provider", string(p.Name())),
-				slog.String("error", ScrubError(err)))
+				slog.String("error", ScrubError(err)),
+				retryAfterAttr(err))
 			result.Errors = append(result.Errors, fmt.Sprintf("%s: image fetch failed", p.Name()))
 			continue
 		}
@@ -356,13 +357,28 @@ func (o *Orchestrator) Search(ctx context.Context, name string) ([]ArtistSearchR
 		if err != nil {
 			o.logger.Warn("provider search failed",
 				slog.String("provider", string(p.Name())),
-				slog.String("error", ScrubError(err)))
+				slog.String("error", ScrubError(err)),
+				retryAfterAttr(err))
 			continue
 		}
 		allResults = append(allResults, results...)
 	}
 
 	return allResults, nil
+}
+
+// retryAfterAttr returns a slog attribute carrying the server-advised backoff
+// from an *ErrProviderUnavailable, or an empty (elided) attribute when the error
+// is not provider-unavailable or carried no Retry-After. This is the consumer of
+// the formerly-dead ErrProviderUnavailable.RetryAfter field: it surfaces the
+// backoff hint in logs today and gives a future adaptive rate limiter a signal
+// to hook. slog drops a zero Attr, so passing this unconditionally is safe.
+func retryAfterAttr(err error) slog.Attr {
+	var unavailable *ErrProviderUnavailable
+	if errors.As(err, &unavailable) && unavailable.RetryAfter > 0 {
+		return slog.Duration("retry_after", unavailable.RetryAfter)
+	}
+	return slog.Attr{}
 }
 
 // availableProviders returns only the registered providers whose API keys are
@@ -503,7 +519,8 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 			} else {
 				o.logger.Debug("provider GetArtist failed",
 					slog.String("provider", string(name)),
-					slog.String("error", err.Error()))
+					slog.String("error", err.Error()),
+					retryAfterAttr(err))
 				pr.err = err
 			}
 		} else {
@@ -535,7 +552,8 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 			} else {
 				o.logger.Warn("provider GetImages failed, preserving existing image data",
 					slog.String("provider", string(name)),
-					slog.String("error", ScrubError(err)))
+					slog.String("error", ScrubError(err)),
+					retryAfterAttr(err))
 				// Transient failure: store in imageErr so image fields are NOT
 				// marked as attempted. This prevents clearing existing image data
 				// when the provider was merely unreachable.

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -133,6 +133,14 @@ func DoWithRetry(
 			// closure). Not retryable here; hand it straight back.
 			return nil, err
 		}
+		if resp == nil {
+			// Defensive: a closure must not return (nil, nil). Treat it as a
+			// transient provider failure rather than panicking on resp.StatusCode.
+			return nil, &ErrProviderUnavailable{
+				Provider: name,
+				Cause:    fmt.Errorf("nil HTTP response from retry closure"),
+			}
+		}
 
 		status := resp.StatusCode
 		if status != http.StatusTooManyRequests && status != http.StatusServiceUnavailable {

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -1,0 +1,276 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Clock abstracts the two time operations DoWithRetry needs: reading "now"
+// (to turn an HTTP-date Retry-After into a duration) and sleeping in a way that
+// respects context cancellation. Production code uses the real clock; tests
+// inject a stub that records sleeps instead of actually waiting, which makes the
+// backoff schedule assertable without real delays.
+type Clock interface {
+	Now() time.Time
+	// Sleep blocks for d or until ctx is done, whichever comes first. It
+	// returns ctx.Err() if the context is canceled or its deadline is exceeded
+	// before d elapses, and nil otherwise.
+	Sleep(ctx context.Context, d time.Duration) error
+}
+
+// realClock is the production Clock backed by the standard library.
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+func (realClock) Sleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		// Nothing to wait for, but still honor an already-canceled context so
+		// callers see cancellation promptly rather than silently proceeding.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// SystemClock returns the production Clock. Provider adapters pass this to
+// DoWithRetry; tests pass a stub implementation instead.
+func SystemClock() Clock { return realClock{} }
+
+// RetryPolicy configures how DoWithRetry reacts to rate-limit (429) and
+// service-unavailable (503) responses. A single policy governs both, but 503 is
+// always handled conservatively (see DoWithRetry): an unhealthy server is
+// unlikely to recover within a short window and retrying it aggressively only
+// risks piling on.
+type RetryPolicy struct {
+	// MaxAttempts is the total number of HTTP attempts allowed for a 429
+	// response, including the first. Must be >= 1; a value of 1 disables
+	// retrying entirely.
+	MaxAttempts int
+	// MaxAttempts503 is the total number of attempts allowed for a 503 response,
+	// including the first. It is kept lower than MaxAttempts because a 503 may
+	// mean the server is genuinely unhealthy (not merely throttling), so we
+	// retry more cautiously. Must be >= 1. Some providers (notably MusicBrainz)
+	// signal rate limiting with a bare 503 and no Retry-After, so a bounded
+	// jittered retry here lets those calls recover rather than fail outright.
+	MaxAttempts503 int
+	// BaseDelay is the starting delay for the exponential-backoff fallback used
+	// when a 429 or 503 carries no Retry-After header.
+	BaseDelay time.Duration
+	// MaxDelay caps any single wait, whether it came from a Retry-After header
+	// or from the exponential fallback. It bounds how long one rate-limited
+	// call can stall.
+	MaxDelay time.Duration
+}
+
+// DefaultRetryPolicy is the standard policy applied by provider adapters:
+// up to three attempts for a 429 and two for a 503, starting at a 1-second
+// backoff and capped at 30 seconds per wait.
+func DefaultRetryPolicy() RetryPolicy {
+	return RetryPolicy{
+		MaxAttempts:    3,
+		MaxAttempts503: 2,
+		BaseDelay:      1 * time.Second,
+		MaxDelay:       30 * time.Second,
+	}
+}
+
+// DoWithRetry executes do, retrying on rate-limit (429) and, conservatively,
+// service-unavailable (503) responses according to policy. It returns the first
+// response whose status is neither 429 nor 503 (success or otherwise) for the
+// caller to handle with its own status switch; the caller owns closing that
+// response body. On a 429 it honors the server's Retry-After header (both the
+// delta-seconds and HTTP-date forms) and otherwise falls back to full-jitter
+// exponential backoff. All waits respect ctx cancellation via clk.Sleep.
+//
+// When retries are exhausted (or a 503 is not retried), it returns a typed
+// *ErrProviderUnavailable whose RetryAfter carries the last server-advised
+// backoff, so upstream logging and a future adaptive limiter can observe it.
+// Transport-level errors from do (e.g. an unreachable host) are returned as-is
+// and never retried: backoff is for rate limiting, not for connectivity faults.
+//
+// do must NOT close the response body; DoWithRetry drains and closes any
+// response it decides to discard before retrying.
+func DoWithRetry(
+	ctx context.Context,
+	clk Clock,
+	name ProviderName,
+	policy RetryPolicy,
+	do func(ctx context.Context) (*http.Response, error),
+) (*http.Response, error) {
+	if clk == nil {
+		clk = realClock{}
+	}
+	if policy.MaxAttempts < 1 {
+		policy.MaxAttempts = 1
+	}
+	if policy.MaxAttempts503 < 1 {
+		policy.MaxAttempts503 = 1
+	}
+
+	var lastRetryAfter time.Duration
+	for attempt := 0; ; attempt++ {
+		resp, err := do(ctx)
+		if err != nil {
+			// Transport/setup error (or a limiter error already wrapped by the
+			// closure). Not retryable here; hand it straight back.
+			return nil, err
+		}
+
+		status := resp.StatusCode
+		if status != http.StatusTooManyRequests && status != http.StatusServiceUnavailable {
+			// Success or a definitive non-retryable status: the caller's own
+			// switch handles it (and closes the body).
+			return resp, nil
+		}
+
+		retryAfter, hasHeader := parseRetryAfter(resp.Header.Get("Retry-After"), clk.Now())
+		lastRetryAfter = retryAfter
+		// We are discarding this response; drain a little and close so the
+		// connection can be reused.
+		drainAndClose(resp)
+
+		wait, retry := nextWait(policy, status, attempt, retryAfter, hasHeader)
+		if !retry {
+			return nil, &ErrProviderUnavailable{
+				Provider:   name,
+				Cause:      fmt.Errorf("HTTP %d (no retry remaining after %d attempt(s))", status, attempt+1),
+				RetryAfter: lastRetryAfter,
+			}
+		}
+
+		if err := clk.Sleep(ctx, wait); err != nil {
+			// Context canceled or deadline exceeded during the backoff wait.
+			return nil, &ErrProviderUnavailable{
+				Provider:   name,
+				Cause:      err,
+				RetryAfter: lastRetryAfter,
+			}
+		}
+	}
+}
+
+// nextWait decides whether DoWithRetry should retry after a rate-limit /
+// unavailable response, and if so how long to wait. attempt is zero-based (0 is
+// the first request just made).
+func nextWait(policy RetryPolicy, status, attempt int, retryAfter time.Duration, hasHeader bool) (time.Duration, bool) {
+	switch status {
+	case http.StatusServiceUnavailable:
+		// Conservative but not give-up: 503 gets fewer attempts than 429
+		// (MaxAttempts503) because the server may be genuinely unhealthy rather
+		// than merely throttling. We still back off and retry within that bound,
+		// honoring Retry-After when present and otherwise using a jittered
+		// exponential delay. The jitter is what keeps a fleet from re-firing in
+		// lockstep against a struggling host. This is the path MusicBrainz takes:
+		// it signals rate limiting with a bare 503 and no Retry-After, so the
+		// jittered fallback lets those calls recover instead of failing outright.
+		if attempt+1 >= policy.MaxAttempts503 {
+			return 0, false
+		}
+		if hasHeader {
+			return capDelay(retryAfter, policy.MaxDelay), true
+		}
+		return jitteredBackoff(policy.BaseDelay, policy.MaxDelay, attempt), true
+
+	case http.StatusTooManyRequests:
+		// attempt is zero-based, so attempt+1 is the number of requests made so
+		// far. Stop once that reaches MaxAttempts.
+		if attempt+1 >= policy.MaxAttempts {
+			return 0, false
+		}
+		if hasHeader {
+			return capDelay(retryAfter, policy.MaxDelay), true
+		}
+		return jitteredBackoff(policy.BaseDelay, policy.MaxDelay, attempt), true
+
+	default:
+		return 0, false
+	}
+}
+
+// capDelay clamps d to [0, maxDelay].
+func capDelay(d, maxDelay time.Duration) time.Duration {
+	if d < 0 {
+		return 0
+	}
+	if maxDelay > 0 && d > maxDelay {
+		return maxDelay
+	}
+	return d
+}
+
+// jitteredBackoff returns a full-jitter exponential backoff for the given
+// zero-based attempt: a uniformly random duration in [0, min(maxDelay,
+// base*2^attempt)]. Full jitter (random across the whole interval rather than a
+// fixed delay plus a small random nudge) spreads out clients that all hit a
+// rate limit at the same moment, which is what prevents a retry storm when many
+// workers back off together.
+func jitteredBackoff(base, maxDelay time.Duration, attempt int) time.Duration {
+	ceiling := base << attempt
+	// Guard against overflow: a large attempt count can shift ceiling past the
+	// int64 sign bit and flip it negative (two's complement wraparound), or it
+	// can simply exceed maxDelay. Either way, clamp to maxDelay.
+	if ceiling <= 0 || (maxDelay > 0 && ceiling > maxDelay) {
+		ceiling = maxDelay
+	}
+	if ceiling <= 0 {
+		return 0
+	}
+	// rand.Int64N panics on n <= 0; +1 makes the upper bound inclusive.
+	return time.Duration(rand.Int64N(int64(ceiling) + 1)) //nolint:gosec // jitter does not need a cryptographic RNG
+}
+
+// parseRetryAfter interprets an HTTP Retry-After header value. Per RFC 9110 it
+// may be either a number of seconds (delta-seconds, e.g. "120") or an HTTP-date
+// (e.g. "Wed, 21 Oct 2015 07:28:00 GMT"). now is supplied (rather than read from
+// the real clock) so the HTTP-date branch is deterministic under test. The
+// returned bool reports whether a usable value was parsed; a negative delta or a
+// date already in the past is floored to zero.
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(value); err == nil {
+		if secs < 0 {
+			secs = 0
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(value); err == nil {
+		d := t.Sub(now)
+		if d < 0 {
+			d = 0
+		}
+		return d, true
+	}
+	return 0, false
+}
+
+// drainAndClose discards a bounded amount of a discarded response body and
+// closes it, so the underlying connection can be returned to the pool. The cap
+// keeps a misbehaving server from making us read an unbounded error body.
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4*1024))
+	_ = resp.Body.Close()
+}

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -1,0 +1,595 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stubClock is a deterministic Clock for tests. It never actually sleeps;
+// instead it records the durations it was asked to wait so a test can assert
+// the exact backoff schedule. sleepHook, when set, lets a test simulate
+// context cancellation (or any other behavior) part-way through a wait.
+//
+// stubClock is used only from single-goroutine tests, so it needs no locking.
+type stubClock struct {
+	now       time.Time
+	sleeps    []time.Duration
+	sleepHook func(ctx context.Context, d time.Duration) error
+}
+
+func (c *stubClock) Now() time.Time { return c.now }
+
+func (c *stubClock) Sleep(ctx context.Context, d time.Duration) error {
+	c.sleeps = append(c.sleeps, d)
+	if c.sleepHook != nil {
+		return c.sleepHook(ctx, d)
+	}
+	return nil
+}
+
+// httpGet returns a do-closure suitable for DoWithRetry that issues a GET to
+// url. It deliberately does NOT close the response body: DoWithRetry owns the
+// lifetime of any response it decides to discard, and the caller closes the
+// final one.
+func httpGet(url string) func(context.Context) (*http.Response, error) {
+	return func(ctx context.Context) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+		if err != nil {
+			return nil, err
+		}
+		return http.DefaultClient.Do(req)
+	}
+}
+
+// doRetry runs DoWithRetry against a test server URL. It isolates the single
+// call that bodyclose cannot trace (the response originates inside the do-closure
+// and flows back through the DoWithRetry wrapper); callers receive a plain
+// response they close normally.
+func doRetry(ctx context.Context, clk Clock, policy RetryPolicy, url string) (*http.Response, error) {
+	return DoWithRetry(ctx, clk, NameMusicBrainz, policy, httpGet(url))
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	// A fixed "now" so HTTP-date math is deterministic.
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		header    string
+		wantDelay time.Duration
+		wantOK    bool
+	}{
+		{"empty", "", 0, false},
+		{"delta seconds", "120", 120 * time.Second, true},
+		{"zero seconds", "0", 0, true},
+		{"negative seconds floored", "-5", 0, true},
+		{"whitespace trimmed", "  30  ", 30 * time.Second, true},
+		{"http-date future", now.Add(45 * time.Second).UTC().Format(http.TimeFormat), 45 * time.Second, true},
+		{"http-date past floored", now.Add(-45 * time.Second).UTC().Format(http.TimeFormat), 0, true},
+		{"garbage", "soon", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDelay, gotOK := parseRetryAfter(tt.header, now)
+			if gotOK != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if gotDelay != tt.wantDelay {
+				t.Fatalf("delay = %v, want %v", gotDelay, tt.wantDelay)
+			}
+		})
+	}
+}
+
+func TestDoWithRetrySuccessPassthrough(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	clk := &stubClock{now: time.Now()}
+	policy := RetryPolicy{MaxAttempts: 3, BaseDelay: time.Second, MaxDelay: 30 * time.Second}
+
+	resp, err := doRetry(context.Background(), clk, policy, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("hits = %d, want 1", got)
+	}
+	if len(clk.sleeps) != 0 {
+		t.Fatalf("sleeps = %v, want none", clk.sleeps)
+	}
+}
+
+func TestDoWithRetry429HonorsRetryAfterDelta(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// First call is rate-limited with an explicit 2-second backoff,
+		// the second call succeeds.
+		if hits.Add(1) == 1 {
+			w.Header().Set("Retry-After", "2")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	clk := &stubClock{now: time.Now()}
+	policy := RetryPolicy{MaxAttempts: 3, BaseDelay: time.Second, MaxDelay: 30 * time.Second}
+
+	resp, err := doRetry(context.Background(), clk, policy, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("hits = %d, want 2", got)
+	}
+	if len(clk.sleeps) != 1 || clk.sleeps[0] != 2*time.Second {
+		t.Fatalf("sleeps = %v, want [2s]", clk.sleeps)
+	}
+}
+
+func TestDoWithRetry429HonorsRetryAfterHTTPDate(t *testing.T) {
+	// Fixed clock so the HTTP-date delta is exact.
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	retryAt := now.Add(7 * time.Second).UTC().Format(http.TimeFormat)
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hits.Add(1) == 1 {
+			w.Header().Set("Retry-After", retryAt)
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	clk := &stubClock{now: now}
+	policy := RetryPolicy{MaxAttempts: 3, BaseDelay: time.Second, MaxDelay: 30 * time.Second}
+
+	resp, err := doRetry(context.Background(), clk, policy, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if len(clk.sleeps) != 1 || clk.sleeps[0] != 7*time.Second {
+		t.Fatalf("sleeps = %v, want [7s]", clk.sleeps)
+	}
+}
+
+func TestDoWithRetry429JitterBounds(t *testing.T) {
+	// No Retry-After header: backoff falls back to full-jitter exponential.
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Rate-limit the first two calls, succeed on the third.
+		if hits.Add(1) <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	base := 100 * time.Millisecond
+	maxDelay := 10 * time.Second
+	clk := &stubClock{now: time.Now()}
+	policy := RetryPolicy{MaxAttempts: 3, BaseDelay: base, MaxDelay: maxDelay}
+
+	resp, err := doRetry(context.Background(), clk, policy, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if len(clk.sleeps) != 2 {
+		t.Fatalf("expected 2 sleeps, got %v", clk.sleeps)
+	}
+	// Full jitter: attempt n waits a random duration in [0, base*2^n], capped.
+	for n, got := range clk.sleeps {
+		ceiling := base << n // 100ms, then 200ms
+		if ceiling > maxDelay {
+			ceiling = maxDelay
+		}
+		if got < 0 || got > ceiling {
+			t.Fatalf("sleep[%d] = %v, want within [0, %v]", n, got, ceiling)
+		}
+	}
+}
+
+func TestDoWithRetry503RetriesConservatively(t *testing.T) {
+	// 503 without a Retry-After header (the MusicBrainz throttling case) still
+	// backs off and retries, but more cautiously than a 429: it is bounded by
+	// MaxAttempts503 and uses a jittered fallback delay. This proves the call
+	// recovers-or-fails within that smaller bound rather than giving up on the
+	// first 503.
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	clk := &stubClock{now: time.Now()}
+	policy := RetryPolicy{MaxAttempts: 3, MaxAttempts503: 2, BaseDelay: time.Second, MaxDelay: 30 * time.Second}
+
+	resp, err := doRetry(context.Background(), clk, policy, srv.URL)
+	if resp != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("expected nil response on failure")
+	}
+	var unavailable *ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("error = %v, want *ErrProviderUnavailable", err)
+	}
+	// MaxAttempts503 = 2: the server is hit twice (one initial, one retry), and
+	// that is strictly fewer than the 429 budget (3).
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("hits = %d, want 2 (MaxAttempts503)", got)
+	}
+	// One jittered backoff between the two attempts, bounded by MaxDelay.
+	if len(clk.sleeps) != 1 {
+		t.Fatalf("sleeps = %v, want exactly 1", clk.sleeps)
+	}
+	if clk.sleeps[0] < 0 || clk.sleeps[0] > policy.MaxDelay {
+		t.Fatalf("sleep = %v, want within [0, %v]", clk.sleeps[0], policy.MaxDelay)
+	}
+}
+
+func TestDoWithRetry503FailsFastWhenMaxAttempts503IsOne(t *testing.T) {
+	// With MaxAttempts503 = 1, a 503 is not retried at all: the strictly
+	// conservative "treat the server as down" stance remains available.
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	clk := &stubClock{now: time.Now()}
+	policy := RetryPolicy{MaxAttempts: 3, MaxAttempts503: 1, BaseDelay: time.Second, MaxDelay: 30 * time.Second}
+
+	resp, err := doRetry(context.Background(), clk, policy, srv.URL)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	var unavailable *ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("error = %v, want *ErrProviderUnavailable", err)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("hits = %d, want 1 (no retry)", got)
+	}
+	if len(clk.sleeps) != 0 {
+		t.Fatalf("sleeps = %v, want none", clk.sleeps)
+	}
+}
+
+func TestDoWithRetry503SingleRetryWithRetryAfter(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Retry-After", "3")
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	clk := &stubClock{now: time.Now()}
+	policy := RetryPolicy{MaxAttempts: 3, MaxAttempts503: 2, BaseDelay: time.Second, MaxDelay: 30 * time.Second}
+
+	resp, err := doRetry(context.Background(), clk, policy, srv.URL)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	var unavailable *ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("error = %v, want *ErrProviderUnavailable", err)
+	}
+	// 503 WITH a Retry-After header honors it for exactly one retry (the 503
+	// budget is 2 attempts), so the header wait is used rather than jitter.
+	if got := hits.Load(); got != 2 {
+		t.Fatalf("hits = %d, want 2", got)
+	}
+	if len(clk.sleeps) != 1 || clk.sleeps[0] != 3*time.Second {
+		t.Fatalf("sleeps = %v, want [3s]", clk.sleeps)
+	}
+	if unavailable.RetryAfter != 3*time.Second {
+		t.Fatalf("RetryAfter = %v, want 3s", unavailable.RetryAfter)
+	}
+}
+
+func TestDoWithRetryNoRetryStorm(t *testing.T) {
+	// A server that always rate-limits must be hit exactly MaxAttempts times,
+	// never more: bounded attempts prevent a retry storm.
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Retry-After", "0") // avoid any real delay even on a real clock
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	clk := &stubClock{now: time.Now()}
+	const maxAttempts = 3
+	policy := RetryPolicy{MaxAttempts: maxAttempts, BaseDelay: time.Second, MaxDelay: 30 * time.Second}
+
+	resp, err := doRetry(context.Background(), clk, policy, srv.URL)
+	if resp != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("expected nil response on exhaustion")
+	}
+	var unavailable *ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("error = %v, want *ErrProviderUnavailable", err)
+	}
+	if got := hits.Load(); got != maxAttempts {
+		t.Fatalf("hits = %d, want %d", got, maxAttempts)
+	}
+	// One sleep between each of the (maxAttempts) requests except the last.
+	if len(clk.sleeps) != maxAttempts-1 {
+		t.Fatalf("sleeps = %v, want %d", clk.sleeps, maxAttempts-1)
+	}
+}
+
+func TestDoWithRetryExhaustionPopulatesRetryAfter(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Retry-After", "9")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	clk := &stubClock{now: time.Now()}
+	policy := RetryPolicy{MaxAttempts: 2, BaseDelay: time.Second, MaxDelay: 30 * time.Second}
+
+	resp, err := doRetry(context.Background(), clk, policy, srv.URL)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	var unavailable *ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("error = %v, want *ErrProviderUnavailable", err)
+	}
+	// The previously-dead RetryAfter field is now populated from the last header.
+	if unavailable.RetryAfter != 9*time.Second {
+		t.Fatalf("RetryAfter = %v, want 9s", unavailable.RetryAfter)
+	}
+	if unavailable.Provider != NameMusicBrainz {
+		t.Fatalf("Provider = %v, want %v", unavailable.Provider, NameMusicBrainz)
+	}
+}
+
+func TestDoWithRetryRespectsContextCancellation(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Simulate the context being canceled while we are waiting to retry.
+	clk := &stubClock{
+		now: time.Now(),
+		sleepHook: func(ctx context.Context, d time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+	}
+	policy := RetryPolicy{MaxAttempts: 3, BaseDelay: time.Second, MaxDelay: 30 * time.Second}
+
+	resp, err := doRetry(ctx, clk, policy, srv.URL)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want wrapped context.Canceled", err)
+	}
+	var unavailable *ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("error = %v, want *ErrProviderUnavailable", err)
+	}
+	// Cancellation during the wait means the second request never fires.
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("hits = %d, want 1", got)
+	}
+}
+
+func TestDoWithRetryTransportErrorNotRetried(t *testing.T) {
+	// A connection-level failure (server already closed) is returned as-is and
+	// is not retried: backoff is for rate limiting, not for unreachable hosts.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	clk := &stubClock{now: time.Now()}
+	policy := RetryPolicy{MaxAttempts: 3, BaseDelay: time.Second, MaxDelay: 30 * time.Second}
+
+	resp, err := doRetry(context.Background(), clk, policy, url)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("expected a transport error")
+	}
+	if len(clk.sleeps) != 0 {
+		t.Fatalf("sleeps = %v, want none (transport errors are not retried)", clk.sleeps)
+	}
+}
+
+func TestSystemClockSleepRespectsContext(t *testing.T) {
+	clk := SystemClock()
+
+	// A zero/negative duration returns immediately with no error.
+	if err := clk.Sleep(context.Background(), 0); err != nil {
+		t.Fatalf("Sleep(0) = %v, want nil", err)
+	}
+
+	// An already-canceled context returns its error rather than waiting.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := clk.Sleep(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Sleep with canceled ctx = %v, want context.Canceled", err)
+	}
+}
+
+func TestSystemClockNowAndSleepCompletes(t *testing.T) {
+	clk := SystemClock()
+
+	// Now returns a sane, non-zero time.
+	if clk.Now().IsZero() {
+		t.Fatal("Now() returned the zero time")
+	}
+
+	// A short sleep that is not interrupted returns nil (covers the timer path).
+	if err := clk.Sleep(context.Background(), time.Millisecond); err != nil {
+		t.Fatalf("Sleep(1ms) = %v, want nil", err)
+	}
+}
+
+func TestDoWithRetryCapsRetryAfterAtMaxDelay(t *testing.T) {
+	// A Retry-After far larger than MaxDelay must be clamped to MaxDelay so a
+	// hostile or misconfigured server cannot stall a call indefinitely.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "3600") // 1 hour
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	clk := &stubClock{now: time.Now()}
+	policy := RetryPolicy{MaxAttempts: 2, BaseDelay: time.Second, MaxDelay: 5 * time.Second}
+
+	resp, err := doRetry(context.Background(), clk, policy, srv.URL)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	var unavailable *ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("error = %v, want *ErrProviderUnavailable", err)
+	}
+	if len(clk.sleeps) != 1 || clk.sleeps[0] != 5*time.Second {
+		t.Fatalf("sleeps = %v, want [5s] (capped at MaxDelay)", clk.sleeps)
+	}
+	// The surfaced RetryAfter reflects the raw header, not the capped wait.
+	if unavailable.RetryAfter != 3600*time.Second {
+		t.Fatalf("RetryAfter = %v, want 3600s", unavailable.RetryAfter)
+	}
+}
+
+func TestDoWithRetryNoHeaderBackoffCappedAtMaxDelay(t *testing.T) {
+	// With no Retry-After header and a MaxDelay below the exponential ceiling,
+	// the jittered backoff is bounded by MaxDelay.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	clk := &stubClock{now: time.Now()}
+	// BaseDelay (1s) already exceeds MaxDelay (10ms), forcing the cap branch.
+	policy := RetryPolicy{MaxAttempts: 2, BaseDelay: time.Second, MaxDelay: 10 * time.Millisecond}
+
+	resp, err := doRetry(context.Background(), clk, policy, srv.URL)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("expected an error after exhausting retries")
+	}
+	if len(clk.sleeps) != 1 {
+		t.Fatalf("expected 1 sleep, got %v", clk.sleeps)
+	}
+	if clk.sleeps[0] < 0 || clk.sleeps[0] > 10*time.Millisecond {
+		t.Fatalf("sleep = %v, want within [0, 10ms]", clk.sleeps[0])
+	}
+}
+
+func TestDoWithRetryPassesThroughNon200(t *testing.T) {
+	// A non-retryable error status (e.g. 500) is handed back to the caller
+	// untouched for its own handling, not retried.
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	clk := &stubClock{now: time.Now()}
+	policy := RetryPolicy{MaxAttempts: 3, BaseDelay: time.Second, MaxDelay: 30 * time.Second}
+
+	resp, err := doRetry(context.Background(), clk, policy, srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", resp.StatusCode)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("hits = %d, want 1 (500 is not retried)", got)
+	}
+}
+
+func TestRetryAfterAttr(t *testing.T) {
+	// A provider-unavailable error carrying a Retry-After yields a duration attr.
+	attr := retryAfterAttr(&ErrProviderUnavailable{Provider: NameMusicBrainz, RetryAfter: 5 * time.Second})
+	if attr.Key != "retry_after" {
+		t.Fatalf("key = %q, want retry_after", attr.Key)
+	}
+	if attr.Value.Duration() != 5*time.Second {
+		t.Fatalf("value = %v, want 5s", attr.Value.Duration())
+	}
+
+	// A wrapped provider-unavailable error is still detected through the chain.
+	wrapped := fmt.Errorf("context: %w", &ErrProviderUnavailable{RetryAfter: 2 * time.Second})
+	if got := retryAfterAttr(wrapped); got.Value.Duration() != 2*time.Second {
+		t.Fatalf("wrapped value = %v, want 2s", got.Value.Duration())
+	}
+
+	// No Retry-After, and a non-provider error, both yield an elided (empty) attr.
+	if got := retryAfterAttr(&ErrProviderUnavailable{Provider: NameMusicBrainz}); !got.Equal(slog.Attr{}) {
+		t.Fatalf("expected empty attr for zero RetryAfter, got %+v", got)
+	}
+	if got := retryAfterAttr(errors.New("boom")); !got.Equal(slog.Attr{}) {
+		t.Fatalf("expected empty attr for non-provider error, got %+v", got)
+	}
+}
+
+func TestDefaultRetryPolicy(t *testing.T) {
+	p := DefaultRetryPolicy()
+	if p.MaxAttempts < 2 {
+		t.Fatalf("MaxAttempts = %d, want >= 2 so 429s are actually retried", p.MaxAttempts)
+	}
+	if p.BaseDelay <= 0 || p.MaxDelay <= 0 {
+		t.Fatalf("delays must be positive: %+v", p)
+	}
+	if p.MaxDelay < p.BaseDelay {
+		t.Fatalf("MaxDelay (%v) must be >= BaseDelay (%v)", p.MaxDelay, p.BaseDelay)
+	}
+}

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -459,6 +459,28 @@ func TestSystemClockSleepRespectsContext(t *testing.T) {
 	}
 }
 
+func TestDoWithRetryNilResponseIsAnError(t *testing.T) {
+	// A misbehaving closure that returns (nil, nil) must not panic; DoWithRetry
+	// turns it into a typed transient error.
+	clk := &stubClock{now: time.Now()}
+	policy := RetryPolicy{MaxAttempts: 3, MaxAttempts503: 2, BaseDelay: time.Second, MaxDelay: 30 * time.Second}
+
+	do := func(context.Context) (*http.Response, error) { return nil, nil }
+
+	resp, err := DoWithRetry(context.Background(), clk, NameMusicBrainz, policy, do)
+	if resp != nil {
+		_ = resp.Body.Close()
+		t.Fatalf("expected nil response")
+	}
+	var unavailable *ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("error = %v, want *ErrProviderUnavailable", err)
+	}
+	if len(clk.sleeps) != 0 {
+		t.Fatalf("sleeps = %v, want none (nil response is not retried)", clk.sleeps)
+	}
+}
+
 func TestSystemClockNowAndSleepCompletes(t *testing.T) {
 	clk := SystemClock()
 

--- a/internal/provider/spotify/spotify.go
+++ b/internal/provider/spotify/spotify.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -293,28 +294,26 @@ func (a *Adapter) refreshToken(ctx context.Context, creds *spotifyCredentials) (
 	return tokenResp.AccessToken, expiry, nil
 }
 
-// doRequest executes an authenticated GET request with rate limiting.
-// On 401, invalidates the cached token and retries once.
+// doRequest executes an authenticated GET request with rate limiting and
+// rate-limit backoff. On 401, it invalidates the cached token and retries once
+// with a fresh token; 429/503 backoff is handled separately by DoWithRetry.
 func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) {
-	if err := a.limiter.Wait(ctx, provider.NameSpotify); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameSpotify,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	token, err := a.getToken(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	body, statusCode, err := a.executeRequest(ctx, reqURL, token)
+	resp, err := a.doWithToken(ctx, reqURL, token)
 	if err != nil {
 		return nil, err
 	}
 
-	// On 401, invalidate token and retry once
-	if statusCode == http.StatusUnauthorized {
+	// On 401, invalidate the cached token and retry once with a fresh one. The
+	// stale response must be drained and closed before issuing the retry.
+	if resp.StatusCode == http.StatusUnauthorized {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4*1024))
+		_ = resp.Body.Close()
+
 		a.mu.Lock()
 		a.cachedToken = ""
 		a.tokenExpiry = time.Time{}
@@ -325,68 +324,64 @@ func (a *Adapter) doRequest(ctx context.Context, reqURL string) ([]byte, error) 
 			return nil, err
 		}
 
+		resp, err = a.doWithToken(ctx, reqURL, token)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024))
+	case http.StatusUnauthorized, http.StatusForbidden:
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, &provider.ErrAuthRequired{Provider: provider.NameSpotify}
+	case http.StatusNotFound:
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, &provider.ErrNotFound{Provider: provider.NameSpotify, ID: reqURL}
+	default:
+		// 429/503 are consumed by DoWithRetry (it returns an error on
+		// exhaustion), so anything reaching here is an unexpected status.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, &provider.ErrProviderUnavailable{
+			Provider: provider.NameSpotify,
+			Cause:    fmt.Errorf("unexpected status %d", resp.StatusCode),
+		}
+	}
+}
+
+// doWithToken performs a single rate-limited GET with the given bearer token,
+// retrying on a 429/503 via DoWithRetry, and returns the first non-rate-limited
+// response. The caller owns closing the returned body.
+func (a *Adapter) doWithToken(ctx context.Context, reqURL, token string) (*http.Response, error) {
+	// do performs one HTTP attempt. The limiter wait lives inside it so each
+	// retry still respects the per-provider request budget.
+	do := func(ctx context.Context) (*http.Response, error) {
 		if err := a.limiter.Wait(ctx, provider.NameSpotify); err != nil {
 			return nil, &provider.ErrProviderUnavailable{
 				Provider: provider.NameSpotify,
 				Cause:    fmt.Errorf("rate limiter: %w", err),
 			}
 		}
-
-		body, statusCode, err = a.executeRequest(ctx, reqURL, token)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 		if err != nil {
 			return nil, err
 		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Accept", "application/json")
+		return a.client.Do(req)
 	}
 
-	switch statusCode {
-	case http.StatusOK:
-		return body, nil
-	case http.StatusUnauthorized, http.StatusForbidden:
-		return nil, &provider.ErrAuthRequired{Provider: provider.NameSpotify}
-	case http.StatusNotFound:
-		return nil, &provider.ErrNotFound{Provider: provider.NameSpotify, ID: reqURL}
-	case http.StatusTooManyRequests:
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameSpotify,
-			Cause:    fmt.Errorf("rate limited by server"),
-		}
-	default:
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameSpotify,
-			Cause:    fmt.Errorf("unexpected status %d", statusCode),
-		}
-	}
-}
-
-// executeRequest performs a single HTTP GET with the given bearer token.
-func (a *Adapter) executeRequest(ctx context.Context, reqURL, token string) ([]byte, int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+	resp, err := provider.DoWithRetry(ctx, provider.SystemClock(), provider.NameSpotify, provider.DefaultRetryPolicy(), do)
 	if err != nil {
-		return nil, 0, err
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := a.client.Do(req)
-	if err != nil {
-		return nil, 0, &provider.ErrProviderUnavailable{
-			Provider: provider.NameSpotify,
-			Cause:    err,
+		var unavailable *provider.ErrProviderUnavailable
+		if errors.As(err, &unavailable) {
+			return nil, err
 		}
+		return nil, &provider.ErrProviderUnavailable{Provider: provider.NameSpotify, Cause: err}
 	}
-	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
-
-	// For non-200 responses, drain body
-	if resp.StatusCode != http.StatusOK {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		return nil, resp.StatusCode, nil
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024))
-	if err != nil {
-		return nil, resp.StatusCode, fmt.Errorf("reading response body: %w", err)
-	}
-	return body, resp.StatusCode, nil
+	return resp, nil
 }
 
 // IsSpotifyID reports whether id is a valid Spotify artist ID.

--- a/internal/provider/spotify/spotify.go
+++ b/internal/provider/spotify/spotify.go
@@ -366,7 +366,7 @@ func (a *Adapter) doWithToken(ctx context.Context, reqURL, token string) (*http.
 		}
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("creating request: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("Accept", "application/json")

--- a/internal/provider/spotify/spotify_test.go
+++ b/internal/provider/spotify/spotify_test.go
@@ -559,8 +559,9 @@ func TestDoRequestRetriesOn429(t *testing.T) {
 	if !errors.As(err, &unavailable) {
 		t.Errorf("expected *provider.ErrProviderUnavailable, got %T: %v", err, err)
 	}
-	if got := dataHits.Load(); got != 3 {
-		t.Errorf("expected data endpoint hit 3 times (MaxAttempts=3), got %d", got)
+	want := provider.DefaultRetryPolicy().MaxAttempts
+	if got := int(dataHits.Load()); got != want {
+		t.Errorf("expected data endpoint hit %d times (MaxAttempts), got %d", want, got)
 	}
 }
 

--- a/internal/provider/spotify/spotify_test.go
+++ b/internal/provider/spotify/spotify_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -516,6 +517,50 @@ func TestDoRequestRetryOn401(t *testing.T) {
 	}
 	if apiCalls != 2 {
 		t.Errorf("expected 2 API calls (initial + retry), got %d", apiCalls)
+	}
+}
+
+func TestDoRequestRetriesOn429(t *testing.T) {
+	// Spotify routes the data round-trip through provider.DoWithRetry, which
+	// retries 429 responses up to DefaultRetryPolicy().MaxAttempts (3) times.
+	//
+	// The token request happens BEFORE the data request, so the token endpoint
+	// must return a valid 200 + token JSON or the test fails before it ever
+	// reaches the 429 path. Only the data endpoint returns 429.
+	//
+	// The "Retry-After: 0" header makes DoWithRetry's computed wait zero, so the
+	// real clock never sleeps and the test runs without artificial delay while
+	// still exercising the full retry loop.
+	var dataHits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/token" {
+			// Token request must succeed first.
+			w.Write(loadFixture(t, "token_response.json"))
+			return
+		}
+		// All other (data) paths: count the hit and force a 429 with a
+		// zero-second Retry-After so the backoff wait is instant.
+		dataHits.Add(1)
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL, srv.URL+"/token", map[provider.ProviderName]string{
+		provider.NameSpotify: validCredentialsJSON(),
+	})
+
+	_, err := a.GetArtist(context.Background(), "4Z8W4fKeB5YxbusRsdQVPb")
+	if err == nil {
+		t.Fatal("expected error after exhausting 429 retries")
+	}
+	var unavailable *provider.ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Errorf("expected *provider.ErrProviderUnavailable, got %T: %v", err, err)
+	}
+	if got := dataHits.Load(); got != 3 {
+		t.Errorf("expected data endpoint hit 3 times (MaxAttempts=3), got %d", got)
 	}
 }
 

--- a/internal/provider/wikidata/wikidata.go
+++ b/internal/provider/wikidata/wikidata.go
@@ -3,6 +3,7 @@ package wikidata
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -104,13 +105,6 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 		return nil, &provider.ErrNotFound{Provider: provider.NameWikidata, ID: id}
 	}
 
-	if err := a.limiter.Wait(ctx, provider.NameWikidata); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikidata,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	langPrefs := provider.MetadataLanguages(ctx)
 	query := buildArtistQuery(id, langPrefs)
 	bindings, err := a.executeSPARQL(ctx, query)
@@ -141,13 +135,6 @@ func (a *Adapter) GetImages(ctx context.Context, mbid string) ([]provider.ImageR
 	// Validate MBID format before interpolating into SPARQL query to prevent injection.
 	if !provider.IsUUID(mbid) {
 		return nil, &provider.ErrNotFound{Provider: provider.NameWikidata, ID: mbid}
-	}
-
-	if err := a.limiter.Wait(ctx, provider.NameWikidata); err != nil {
-		return nil, &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikidata,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
 	}
 
 	query := buildImageQuery(mbid)
@@ -201,13 +188,6 @@ func (a *Adapter) GetImages(ctx context.Context, mbid string) ([]provider.ImageR
 	var results []provider.ImageResult
 	var hadResolveErrors bool
 	for _, e := range entries {
-		if err := a.limiter.Wait(ctx, provider.NameWikidata); err != nil {
-			return nil, &provider.ErrProviderUnavailable{
-				Provider: provider.NameWikidata,
-				Cause:    fmt.Errorf("rate limiter: %w", err),
-			}
-		}
-
 		info, err := a.resolveCommonsURL(ctx, e.filename)
 		if err != nil {
 			hadResolveErrors = true
@@ -258,17 +238,33 @@ func (a *Adapter) executeSPARQL(ctx context.Context, query string) ([]SPARQLBind
 	}
 	reqURL := a.endpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+	// do performs one HTTP attempt. The limiter wait lives inside it so each
+	// retry triggered by DoWithRetry still respects the per-provider budget.
+	do := func(ctx context.Context) (*http.Response, error) {
+		if err := a.limiter.Wait(ctx, provider.NameWikidata); err != nil {
+			return nil, &provider.ErrProviderUnavailable{
+				Provider: provider.NameWikidata,
+				Cause:    fmt.Errorf("rate limiter: %w", err),
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+		if err != nil {
+			return nil, fmt.Errorf("creating request: %w", err)
+		}
+		req.Header.Set("User-Agent", version.UserAgent("Stillwater", "https://github.com/sydlexius/stillwater"))
+		req.Header.Set("Accept", "application/sparql-results+json")
+		a.logger.Debug("executing SPARQL query")
+		return a.client.Do(req)
 	}
-	req.Header.Set("User-Agent", version.UserAgent("Stillwater", "https://github.com/sydlexius/stillwater"))
-	req.Header.Set("Accept", "application/sparql-results+json")
 
-	a.logger.Debug("executing SPARQL query")
-
-	resp, err := a.client.Do(req)
+	// DoWithRetry consumes 429/503, so the status handling below only sees
+	// 200/other.
+	resp, err := provider.DoWithRetry(ctx, provider.SystemClock(), provider.NameWikidata, provider.DefaultRetryPolicy(), do)
 	if err != nil {
+		var unavailable *provider.ErrProviderUnavailable
+		if errors.As(err, &unavailable) {
+			return nil, err
+		}
 		return nil, &provider.ErrProviderUnavailable{
 			Provider: provider.NameWikidata,
 			Cause:    err,
@@ -482,15 +478,27 @@ func (a *Adapter) resolveCommonsURL(ctx context.Context, filename string) (*Comm
 	}
 	reqURL := a.commonsEndpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-	if err != nil {
-		return nil, fmt.Errorf("creating commons request: %w", err)
+	// do performs one HTTP attempt. The limiter wait lives inside it so each
+	// retry triggered by DoWithRetry still respects the per-provider budget.
+	do := func(ctx context.Context) (*http.Response, error) {
+		if err := a.limiter.Wait(ctx, provider.NameWikidata); err != nil {
+			return nil, &provider.ErrProviderUnavailable{
+				Provider: provider.NameWikidata,
+				Cause:    fmt.Errorf("rate limiter: %w", err),
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+		if err != nil {
+			return nil, fmt.Errorf("creating commons request: %w", err)
+		}
+		req.Header.Set("User-Agent", version.UserAgent("Stillwater", "https://github.com/sydlexius/stillwater"))
+		a.logger.Debug("resolving commons image", slog.String("filename", filename))
+		return a.client.Do(req)
 	}
-	req.Header.Set("User-Agent", version.UserAgent("Stillwater", "https://github.com/sydlexius/stillwater"))
 
-	a.logger.Debug("resolving commons image", slog.String("filename", filename))
-
-	resp, err := a.client.Do(req)
+	// DoWithRetry consumes 429/503; the prefix is preserved so callers still
+	// recognize commons-resolution failures (which are logged, not fatal).
+	resp, err := provider.DoWithRetry(ctx, provider.SystemClock(), provider.NameWikidata, provider.DefaultRetryPolicy(), do)
 	if err != nil {
 		return nil, fmt.Errorf("commons request: %w", err)
 	}

--- a/internal/provider/wikidata/wikidata.go
+++ b/internal/provider/wikidata/wikidata.go
@@ -125,6 +125,79 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 	return mapArtist(mbidForMap, bindings), nil
 }
 
+// commonsImageEntry pairs a Commons filename with the image type it was found
+// under (P18 thumb vs P154 logo) while resolving SPARQL bindings to URLs.
+type commonsImageEntry struct {
+	filename string
+	imgType  provider.ImageType
+}
+
+// dedupeImageEntries collects unique Commons filenames from the P18 (image) and
+// P154 (logo) bindings. The SPARQL response may repeat rows when both properties
+// exist, so entries are deduped by (imageType, filename) -- the same file can
+// still appear as both a thumb and a logo.
+func dedupeImageEntries(bindings []SPARQLBinding) []commonsImageEntry {
+	seen := make(map[string]bool)
+	var entries []commonsImageEntry
+	add := func(value string, imgType provider.ImageType) {
+		if value == "" {
+			return
+		}
+		fn := extractCommonsFilename(value)
+		if fn == "" {
+			return
+		}
+		key := string(imgType) + ":" + fn
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		entries = append(entries, commonsImageEntry{filename: fn, imgType: imgType})
+	}
+	for i := range bindings {
+		b := &bindings[i]
+		add(b.Image.Value, provider.ImageThumb)
+		add(b.Logo.Value, provider.ImageLogo)
+	}
+	return entries
+}
+
+// resolveImageEntries resolves each Commons filename to a direct URL. It returns
+// the resolved images, the last transient (rate-limited) failure seen (so its
+// RetryAfter hint can be propagated when every candidate fails), and whether any
+// resolution errored at all (to distinguish "no images" from "all failed").
+func (a *Adapter) resolveImageEntries(ctx context.Context, entries []commonsImageEntry) ([]provider.ImageResult, *provider.ErrProviderUnavailable, bool) {
+	var results []provider.ImageResult
+	var lastUnavailable *provider.ErrProviderUnavailable
+	var hadResolveErrors bool
+	for _, e := range entries {
+		info, err := a.resolveCommonsURL(ctx, e.filename)
+		if err != nil {
+			hadResolveErrors = true
+			var unavailable *provider.ErrProviderUnavailable
+			if errors.As(err, &unavailable) {
+				lastUnavailable = unavailable
+			}
+			a.logger.Warn("failed to resolve commons image",
+				slog.String("filename", e.filename),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		if info == nil {
+			continue
+		}
+		results = append(results, provider.ImageResult{
+			URL:    info.URL,
+			Type:   e.imgType,
+			Width:  info.Width,
+			Height: info.Height,
+			Source: string(provider.NameWikidata),
+		})
+	}
+	return results, lastUnavailable, hadResolveErrors
+}
+
 // GetImages fetches artist images from Wikimedia Commons via Wikidata properties
 // P18 (image/photo) and P154 (logo). The SPARQL query returns Commons filenames
 // which are then resolved to direct URLs via the Wikimedia Commons API.
@@ -147,72 +220,23 @@ func (a *Adapter) GetImages(ctx context.Context, mbid string) ([]provider.ImageR
 		return nil, &provider.ErrNotFound{Provider: provider.NameWikidata, ID: mbid}
 	}
 
-	// Collect unique filenames from P18 (image) and P154 (logo) properties.
-	// The SPARQL response may contain multiple rows if both properties exist.
-	// Dedupe by (imageType, filename) so the same Commons file can appear as
-	// both a thumb (P18) and a logo (P154) without the second being dropped.
-	type imageEntry struct {
-		filename string
-		imgType  provider.ImageType
-	}
-	seen := make(map[string]bool)
-	var entries []imageEntry
-
-	for i := range bindings {
-		b := &bindings[i]
-		if b.Image.Value != "" {
-			fn := extractCommonsFilename(b.Image.Value)
-			key := string(provider.ImageThumb) + ":" + fn
-			if fn != "" && !seen[key] {
-				seen[key] = true
-				entries = append(entries, imageEntry{filename: fn, imgType: provider.ImageThumb})
-			}
-		}
-		if b.Logo.Value != "" {
-			fn := extractCommonsFilename(b.Logo.Value)
-			key := string(provider.ImageLogo) + ":" + fn
-			if fn != "" && !seen[key] {
-				seen[key] = true
-				entries = append(entries, imageEntry{filename: fn, imgType: provider.ImageLogo})
-			}
-		}
-	}
-
+	entries := dedupeImageEntries(bindings)
 	if len(entries) == 0 {
 		return nil, &provider.ErrNotFound{Provider: provider.NameWikidata, ID: mbid}
 	}
 
 	// Resolve each filename to a direct URL via the Commons API.
-	// Track whether any resolution attempt returned an error so we can
-	// distinguish "no images found" from "all resolutions failed."
-	var results []provider.ImageResult
-	var hadResolveErrors bool
-	for _, e := range entries {
-		info, err := a.resolveCommonsURL(ctx, e.filename)
-		if err != nil {
-			hadResolveErrors = true
-			a.logger.Warn("failed to resolve commons image",
-				slog.String("filename", e.filename),
-				slog.String("error", err.Error()),
-			)
-			continue
-		}
-		if info == nil {
-			continue
-		}
-
-		results = append(results, provider.ImageResult{
-			URL:    info.URL,
-			Type:   e.imgType,
-			Width:  info.Width,
-			Height: info.Height,
-			Source: string(provider.NameWikidata),
-		})
-	}
+	results, lastUnavailable, hadResolveErrors := a.resolveImageEntries(ctx, entries)
 
 	if len(results) == 0 {
 		// If resolution errors occurred, the failure is transient, not "not found."
 		if hadResolveErrors {
+			// Propagate the typed unavailable error (with its RetryAfter) when we
+			// captured one, so upstream logging and a future adaptive limiter keep
+			// the Commons backoff signal.
+			if lastUnavailable != nil {
+				return nil, lastUnavailable
+			}
 			return nil, &provider.ErrProviderUnavailable{
 				Provider: provider.NameWikidata,
 				Cause:    fmt.Errorf("commons image resolution failed for all candidates"),
@@ -500,6 +524,13 @@ func (a *Adapter) resolveCommonsURL(ctx context.Context, filename string) (*Comm
 	// recognize commons-resolution failures (which are logged, not fatal).
 	resp, err := provider.DoWithRetry(ctx, provider.SystemClock(), provider.NameWikidata, provider.DefaultRetryPolicy(), do)
 	if err != nil {
+		// Preserve a typed *ErrProviderUnavailable unchanged so its RetryAfter
+		// hint survives for the GetImages aggregation below; wrap only other
+		// errors with call-site context.
+		var unavailable *provider.ErrProviderUnavailable
+		if errors.As(err, &unavailable) {
+			return nil, unavailable
+		}
 		return nil, fmt.Errorf("commons request: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup

--- a/internal/provider/wikidata/wikidata_test.go
+++ b/internal/provider/wikidata/wikidata_test.go
@@ -657,10 +657,11 @@ func TestExecuteSPARQLRetriesOn429(t *testing.T) {
 		t.Errorf("expected ErrProviderUnavailable, got %T: %v", err, err)
 	}
 
-	// DefaultRetryPolicy uses MaxAttempts=3, so the server must be hit exactly
-	// three times: retries are bounded, not unbounded.
-	if got := hits.Load(); got != 3 {
-		t.Errorf("expected exactly 3 requests (bounded retries), got %d", got)
+	// The adapter uses provider.DefaultRetryPolicy(), so the server must be hit
+	// exactly MaxAttempts times: retries are bounded, not unbounded.
+	want := provider.DefaultRetryPolicy().MaxAttempts
+	if got := int(hits.Load()); got != want {
+		t.Errorf("expected exactly %d requests (bounded retries), got %d", want, got)
 	}
 }
 
@@ -747,5 +748,43 @@ func TestGetImagesCommonsResolutionFailure(t *testing.T) {
 	var unavail *provider.ErrProviderUnavailable
 	if !errors.As(err, &unavail) {
 		t.Errorf("expected ErrProviderUnavailable, got %T: %v", err, err)
+	}
+}
+
+func TestGetImagesCommonsRateLimitedPreservesRetryAfter(t *testing.T) {
+	// SPARQL returns valid image filenames but the Commons endpoint always
+	// rate-limits with a Retry-After. GetImages must surface a typed
+	// ErrProviderUnavailable whose RetryAfter is preserved from the Commons
+	// 429, rather than collapsing to a generic error.
+	sparqlData := loadFixture(t, "images_p18_only.json")
+
+	commonsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer commonsSrv.Close()
+
+	sparqlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/sparql-results+json")
+		if r.URL.Query().Get("query") == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, _ = w.Write(sparqlData)
+	}))
+	defer sparqlSrv.Close()
+
+	limiter := provider.NewRateLimiterMap()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	a := NewWithEndpoints(limiter, logger, sparqlSrv.URL, commonsSrv.URL)
+	useLoopbackTestClient(a)
+
+	_, err := a.GetImages(context.Background(), "11111111-1111-1111-1111-111111111111")
+	var unavail *provider.ErrProviderUnavailable
+	if !errors.As(err, &unavail) {
+		t.Fatalf("expected ErrProviderUnavailable, got %T: %v", err, err)
+	}
+	if unavail.RetryAfter != time.Second {
+		t.Fatalf("RetryAfter = %v, want 1s (preserved from the Commons 429)", unavail.RetryAfter)
 	}
 }

--- a/internal/provider/wikidata/wikidata_test.go
+++ b/internal/provider/wikidata/wikidata_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -618,6 +619,97 @@ func TestGetArtist_LangPrefPassedToSPARQL(t *testing.T) {
 	}
 	if !strings.Contains(capturedQuery, "fr") {
 		t.Errorf("SPARQL query does not include 'fr' lang preference; query: %s", capturedQuery)
+	}
+}
+
+// TestExecuteSPARQLRetriesOn429 verifies that executeSPARQL routes through
+// provider.DoWithRetry so that HTTP 429 responses trigger bounded retries.
+//
+// The server always replies with "Retry-After: 0" alongside status 429. The
+// zero-second Retry-After makes DoWithRetry's backoff wait elapse immediately,
+// so the real clock never actually sleeps and the test stays fast. Because the
+// server never recovers, DoWithRetry exhausts its budget and the call surfaces
+// *provider.ErrProviderUnavailable. The hit counter proves the retry loop is
+// bounded at DefaultRetryPolicy's MaxAttempts (3), not infinite.
+func TestExecuteSPARQLRetriesOn429(t *testing.T) {
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		// Retry-After: 0 means DoWithRetry waits zero time between attempts.
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	limiter := provider.NewRateLimiterMap()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	a := NewWithEndpoint(limiter, logger, srv.URL)
+	// Override the SafeClient-backed default (which rejects httptest's loopback) with a plain client.
+	useLoopbackTestClient(a)
+
+	// GetArtist routes through executeSPARQL for the retry-wired request path.
+	_, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
+	if err == nil {
+		t.Fatal("expected error when server always returns 429")
+	}
+	var unavailable *provider.ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Errorf("expected ErrProviderUnavailable, got %T: %v", err, err)
+	}
+
+	// DefaultRetryPolicy uses MaxAttempts=3, so the server must be hit exactly
+	// three times: retries are bounded, not unbounded.
+	if got := hits.Load(); got != 3 {
+		t.Errorf("expected exactly 3 requests (bounded retries), got %d", got)
+	}
+}
+
+func TestExecuteSPARQLWrapsTransportError(t *testing.T) {
+	// A connection-level failure (the endpoint is already closed) is not a
+	// 429/503, so DoWithRetry returns the raw transport error. executeSPARQL must
+	// wrap it in *provider.ErrProviderUnavailable for callers.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+
+	limiter := provider.NewRateLimiterMap()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	a := NewWithEndpoint(limiter, logger, url)
+	useLoopbackTestClient(a)
+
+	_, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
+	var unavailable *provider.ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("expected *provider.ErrProviderUnavailable, got %T: %v", err, err)
+	}
+}
+
+func TestExecuteSPARQLHonorsCanceledContext(t *testing.T) {
+	// A canceled context makes the in-closure limiter wait fail before any HTTP
+	// call, surfacing as *provider.ErrProviderUnavailable from the rate-limiter
+	// branch. The endpoint should never be contacted.
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	limiter := provider.NewRateLimiterMap()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	a := NewWithEndpoint(limiter, logger, srv.URL)
+	useLoopbackTestClient(a)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := a.GetArtist(ctx, "a74b1b7f-71a5-4011-9441-d0b5e4122711")
+	var unavailable *provider.ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("expected *provider.ErrProviderUnavailable, got %T: %v", err, err)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Fatalf("expected 0 requests (limiter rejected before HTTP), got %d", got)
 	}
 }
 

--- a/internal/provider/wikipedia/wikipedia.go
+++ b/internal/provider/wikipedia/wikipedia.go
@@ -151,12 +151,6 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 			candidateTitle = enTitle
 		case qid != "":
 			// Look up the localized sitelink via Wikidata.
-			if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
-				return nil, &provider.ErrProviderUnavailable{
-					Provider: provider.NameWikipedia,
-					Cause:    fmt.Errorf("rate limiter: %w", err),
-				}
-			}
 			localized, err := a.resolveToLocalizedTitle(ctx, qid, lang)
 			if err != nil {
 				var notFound *provider.ErrNotFound
@@ -186,12 +180,6 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 		}
 
 		// Fetch the article intro extract for biography text.
-		if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
-			return nil, &provider.ErrProviderUnavailable{
-				Provider: provider.NameWikipedia,
-				Cause:    fmt.Errorf("rate limiter: %w", err),
-			}
-		}
 		actionEP := a.actionEndpointForLang(lang)
 		gotName, gotExtract, err := a.fetchExtractFrom(ctx, actionEP, candidateTitle)
 		if err != nil {
@@ -250,15 +238,8 @@ func (a *Adapter) GetArtist(ctx context.Context, id string) (*provider.ArtistMet
 	// so we always use the English endpoint even when the biography came from a
 	// localized wiki. This is best-effort: if it fails, we still return the
 	// biography. Context cancellation is propagated because it signals the
-	// caller wants to stop entirely.
-	if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-		a.logger.Warn("rate limiter wait failed for wikitext fetch",
-			slog.String("title", title), slog.Any("error", err))
-		return meta, nil
-	}
+	// caller wants to stop entirely (handled by the fetchWikitext error check
+	// below, which now owns the limiter wait via DoWithRetry).
 	wikitext, err := a.fetchWikitext(ctx, title)
 	if err != nil {
 		if ctx.Err() != nil {
@@ -342,36 +323,59 @@ func (a *Adapter) GetImages(_ context.Context, _ string) ([]provider.ImageResult
 	return nil, nil
 }
 
+// doGet issues a single GET to reqURL, retrying on a rate-limited (429) or
+// unavailable (503) response via provider.DoWithRetry. The limiter wait lives
+// inside each attempt so retries still respect the per-provider budget. accept,
+// when non-empty, sets the Accept header (the User-Agent is always set). The
+// caller owns closing the returned body and handling every non-rate-limited
+// status (200/404/other); DoWithRetry consumes 429/503.
+func (a *Adapter) doGet(ctx context.Context, reqURL, accept string) (*http.Response, error) {
+	do := func(ctx context.Context) (*http.Response, error) {
+		if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
+			return nil, &provider.ErrProviderUnavailable{
+				Provider: provider.NameWikipedia,
+				Cause:    fmt.Errorf("rate limiter: %w", err),
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
+		if err != nil {
+			return nil, &provider.ErrProviderUnavailable{
+				Provider: provider.NameWikipedia,
+				Cause:    fmt.Errorf("creating request: %w", err),
+			}
+		}
+		req.Header.Set("User-Agent", userAgent)
+		if accept != "" {
+			req.Header.Set("Accept", accept)
+		}
+		return a.client.Do(req)
+	}
+
+	resp, err := provider.DoWithRetry(ctx, provider.SystemClock(), provider.NameWikipedia, provider.DefaultRetryPolicy(), do)
+	if err != nil {
+		var unavailable *provider.ErrProviderUnavailable
+		if errors.As(err, &unavailable) {
+			return nil, err
+		}
+		return nil, &provider.ErrProviderUnavailable{Provider: provider.NameWikipedia, Cause: err}
+	}
+	return resp, nil
+}
+
 // TestConnection verifies connectivity to the Wikipedia Action API, the
 // Wikidata SPARQL endpoint, and the Wikidata entity API, since GetArtist
 // depends on all three services for MBID, Q-ID, and article title lookups.
 func (a *Adapter) TestConnection(ctx context.Context) error {
 	// Probe 1: Wikipedia Action API
-	if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
-		return &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	params := url.Values{
 		"action": {"query"},
 		"meta":   {"siteinfo"},
 		"siprop": {"general"},
 		"format": {"json"},
 	}
-	wikiReq, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		a.actionEndpoint+"?"+params.Encode(), http.NoBody)
+	wikiResp, err := a.doGet(ctx, a.actionEndpoint+"?"+params.Encode(), "")
 	if err != nil {
 		return err
-	}
-	wikiReq.Header.Set("User-Agent", userAgent)
-	wikiResp, err := a.client.Do(wikiReq)
-	if err != nil {
-		return &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("wikipedia Action API: %w", err),
-		}
 	}
 	defer wikiResp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 	_, _ = io.Copy(io.Discard, wikiResp.Body)
@@ -383,30 +387,13 @@ func (a *Adapter) TestConnection(ctx context.Context) error {
 	}
 
 	// Probe 2: Wikidata SPARQL endpoint
-	if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
-		return &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	sparqlQuery := url.Values{
 		"query":  {`ASK { wd:Q5 wdt:P31 wd:Q16521 }`},
 		"format": {"json"},
 	}
-	sparqlReq, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		a.wikidataEndpoint+"?"+sparqlQuery.Encode(), http.NoBody)
+	sparqlResp, err := a.doGet(ctx, a.wikidataEndpoint+"?"+sparqlQuery.Encode(), "application/sparql-results+json")
 	if err != nil {
 		return err
-	}
-	sparqlReq.Header.Set("User-Agent", userAgent)
-	sparqlReq.Header.Set("Accept", "application/sparql-results+json")
-	sparqlResp, err := a.client.Do(sparqlReq)
-	if err != nil {
-		return &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("wikidata SPARQL: %w", err),
-		}
 	}
 	defer sparqlResp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 	_, _ = io.Copy(io.Discard, sparqlResp.Body)
@@ -418,31 +405,15 @@ func (a *Adapter) TestConnection(ctx context.Context) error {
 	}
 
 	// Probe 3: Wikidata entity API (used for Q-ID sitelink resolution)
-	if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
-		return &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("rate limiter: %w", err),
-		}
-	}
-
 	entityParams := url.Values{
 		"action": {"wbgetentities"},
 		"ids":    {"Q5"},
 		"props":  {"sitelinks"},
 		"format": {"json"},
 	}
-	entityReq, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		a.wikidataAPIEndpoint+"?"+entityParams.Encode(), http.NoBody)
+	entityResp, err := a.doGet(ctx, a.wikidataAPIEndpoint+"?"+entityParams.Encode(), "")
 	if err != nil {
 		return err
-	}
-	entityReq.Header.Set("User-Agent", userAgent)
-	entityResp, err := a.client.Do(entityReq)
-	if err != nil {
-		return &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("wikidata entity API: %w", err),
-		}
 	}
 	defer entityResp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 	_, _ = io.Copy(io.Discard, entityResp.Body)
@@ -462,21 +433,9 @@ func (a *Adapter) TestConnection(ctx context.Context) error {
 func (a *Adapter) resolveToTitleAndQID(ctx context.Context, id string) (string, string, error) {
 	switch {
 	case provider.IsUUID(id):
-		if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
-			return "", "", &provider.ErrProviderUnavailable{
-				Provider: provider.NameWikipedia,
-				Cause:    fmt.Errorf("rate limiter: %w", err),
-			}
-		}
 		return a.resolveFromMBID(ctx, id)
 
 	case isQID(id):
-		if err := a.limiter.Wait(ctx, provider.NameWikipedia); err != nil {
-			return "", "", &provider.ErrProviderUnavailable{
-				Provider: provider.NameWikipedia,
-				Cause:    fmt.Errorf("rate limiter: %w", err),
-			}
-		}
 		title, err := a.resolveFromQID(ctx, id)
 		if err != nil {
 			return "", "", err
@@ -547,24 +506,11 @@ func (a *Adapter) resolveFromMBID(ctx context.Context, mbid string) (string, str
 	}
 	reqURL := a.wikidataEndpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-	if err != nil {
-		return "", "", &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("creating SPARQL request: %w", err),
-		}
-	}
-	req.Header.Set("User-Agent", userAgent)
-	req.Header.Set("Accept", "application/sparql-results+json")
-
 	a.logger.Debug("resolving MBID to Wikipedia title via Wikidata", slog.String("mbid", mbid))
 
-	resp, err := a.client.Do(req)
+	resp, err := a.doGet(ctx, reqURL, "application/sparql-results+json")
 	if err != nil {
-		return "", "", &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    err,
-		}
+		return "", "", err
 	}
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
@@ -638,24 +584,12 @@ func (a *Adapter) resolveToLocalizedTitle(ctx context.Context, qid, lang string)
 	}
 	reqURL := a.wikidataAPIEndpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-	if err != nil {
-		return "", &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("creating Wikidata API request: %w", err),
-		}
-	}
-	req.Header.Set("User-Agent", userAgent)
-
 	a.logger.Debug("resolving localized Wikipedia title via Wikidata sitelinks",
 		slog.String("qid", qid), slog.String("lang", lang))
 
-	resp, err := a.client.Do(req)
+	resp, err := a.doGet(ctx, reqURL, "")
 	if err != nil {
-		return "", &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    err,
-		}
+		return "", err
 	}
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
@@ -708,23 +642,11 @@ func (a *Adapter) resolveFromQID(ctx context.Context, qid string) (string, error
 	}
 	reqURL := a.wikidataAPIEndpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-	if err != nil {
-		return "", &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("creating Wikidata API request: %w", err),
-		}
-	}
-	req.Header.Set("User-Agent", userAgent)
-
 	a.logger.Debug("resolving Q-ID to Wikipedia title via Wikidata sitelinks", slog.String("qid", qid))
 
-	resp, err := a.client.Do(req)
+	resp, err := a.doGet(ctx, reqURL, "")
 	if err != nil {
-		return "", &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    err,
-		}
+		return "", err
 	}
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
@@ -808,23 +730,11 @@ func (a *Adapter) fetchExtractFrom(ctx context.Context, endpoint, title string) 
 	}
 	reqURL := endpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-	if err != nil {
-		return "", "", &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("creating extract request: %w", err),
-		}
-	}
-	req.Header.Set("User-Agent", userAgent)
-
 	a.logger.Debug("fetching Wikipedia extract", slog.String("title", title))
 
-	resp, err := a.client.Do(req)
+	resp, err := a.doGet(ctx, reqURL, "")
 	if err != nil {
-		return "", "", &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    err,
-		}
+		return "", "", err
 	}
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 
@@ -881,23 +791,11 @@ func (a *Adapter) fetchWikitext(ctx context.Context, title string) (string, erro
 	}
 	reqURL := a.actionEndpoint + "?" + params.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, http.NoBody)
-	if err != nil {
-		return "", &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    fmt.Errorf("creating wikitext request: %w", err),
-		}
-	}
-	req.Header.Set("User-Agent", userAgent)
-
 	a.logger.Debug("fetching Wikipedia wikitext", slog.String("title", title))
 
-	resp, err := a.client.Do(req)
+	resp, err := a.doGet(ctx, reqURL, "")
 	if err != nil {
-		return "", &provider.ErrProviderUnavailable{
-			Provider: provider.NameWikipedia,
-			Cause:    err,
-		}
+		return "", err
 	}
 	defer resp.Body.Close() //nolint:errcheck // Close error not actionable on HTTP response cleanup
 

--- a/internal/provider/wikipedia/wikipedia_test.go
+++ b/internal/provider/wikipedia/wikipedia_test.go
@@ -577,10 +577,11 @@ func TestDoGetRetriesOn429(t *testing.T) {
 	if !errors.As(err, &unavailable) {
 		t.Fatalf("expected *provider.ErrProviderUnavailable, got %T: %v", err, err)
 	}
-	// DefaultRetryPolicy uses MaxAttempts=3 for 429, so the endpoint is hit
-	// exactly three times: bounded retries, no storm.
-	if got := hits.Load(); got != 3 {
-		t.Fatalf("expected exactly 3 requests (MaxAttempts=3), got %d", got)
+	// The adapter uses provider.DefaultRetryPolicy(), so the endpoint is hit
+	// exactly MaxAttempts times for a 429: bounded retries, no storm.
+	want := provider.DefaultRetryPolicy().MaxAttempts
+	if got := int(hits.Load()); got != want {
+		t.Fatalf("expected exactly %d requests (MaxAttempts), got %d", want, got)
 	}
 }
 

--- a/internal/provider/wikipedia/wikipedia_test.go
+++ b/internal/provider/wikipedia/wikipedia_test.go
@@ -553,6 +553,37 @@ func okServer(t *testing.T) *httptest.Server {
 	}))
 }
 
+func TestDoGetRetriesOn429(t *testing.T) {
+	// The shared doGet helper routes every Wikipedia/Wikidata round-trip through
+	// provider.DoWithRetry. A UUID lookup resolves via the SPARQL endpoint
+	// (resolveFromMBID -> doGet), so pointing that endpoint at an always-429
+	// server exercises the retry path. "Retry-After: 0" keeps the wait at zero
+	// so the real clock never sleeps while the full bounded retry loop still
+	// runs.
+	var hits atomic.Int64
+	sparqlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer sparqlSrv.Close()
+
+	// Only the SPARQL endpoint is reached; resolveFromMBID fails before any
+	// action/entity call, so those URLs are placeholders.
+	a := newTestAdapter(t, "http://localhost", sparqlSrv.URL, "http://localhost")
+
+	_, err := a.GetArtist(context.Background(), "a74b1b7f-71a5-4011-9441-d0b5e4122711")
+	var unavailable *provider.ErrProviderUnavailable
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("expected *provider.ErrProviderUnavailable, got %T: %v", err, err)
+	}
+	// DefaultRetryPolicy uses MaxAttempts=3 for 429, so the endpoint is hit
+	// exactly three times: bounded retries, no storm.
+	if got := hits.Load(); got != 3 {
+		t.Fatalf("expected exactly 3 requests (MaxAttempts=3), got %d", got)
+	}
+}
+
 func TestTestConnection(t *testing.T) {
 	actionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{"query": map[string]any{"general": map[string]any{}}})

--- a/scripts/patch-coverage.sh
+++ b/scripts/patch-coverage.sh
@@ -43,7 +43,8 @@
 # Inputs (all via environment; all optional):
 #   COVER_OUT                  path to coverage profile (default: coverage.out)
 #   BASE                       diff base (default: git merge-base main HEAD)
-#   PATCH_COVERAGE_THRESHOLD   required percent (default: 70)
+#   PATCH_COVERAGE_THRESHOLD   required percent (default: 75, matching
+#                              codecov.yml and the pre-push gate)
 #   PATCH_COVERAGE_EXCLUDE     extra pathspec excludes, space-separated
 #                              (default: empty; *_test.go is always added)
 #
@@ -54,7 +55,7 @@
 set -euo pipefail
 
 COVER_OUT="${COVER_OUT:-coverage.out}"
-THRESHOLD="${PATCH_COVERAGE_THRESHOLD:-70}"
+THRESHOLD="${PATCH_COVERAGE_THRESHOLD:-75}"
 EXTRA_EXCLUDES="${PATCH_COVERAGE_EXCLUDE:-}"
 
 # Validate the threshold up front. awk's numeric coercion quietly maps a


### PR DESCRIPTION
## Summary

- Providers previously gave up on the first `429`/`503`, returning a transient error with no retry and a dead `RetryAfter` field. This adds a shared, context-aware retry helper (`internal/provider/retry.go`) and routes every rule-pipeline provider through it so a rate-limited call backs off and recovers.
- **User-visible behavior change:** on a `429`, Stillwater now honors the server's `Retry-After` (delta-seconds and HTTP-date) with a full-jitter exponential fallback and bounded attempts; on a `503` (how MusicBrainz signals throttling, usually with no `Retry-After`) it retries more conservatively (fewer, jittered, bounded) rather than dropping the fetch. The previously-dead `ErrProviderUnavailable.RetryAfter` is now populated and logged.
- Reviewers: start at `retry.go` (`DoWithRetry`/`nextWait` policy), then the mechanical per-adapter wiring. Note `limiter.Wait` moved *inside* each retried closure so retries still respect the per-provider budget (the precondition for #1730's worker pool not retry-storming).

## Linked issue

Closes #1738

## Pre-flight checklist

- [x] Pre-push gate green locally (ran automatically by the pre-push hook on push).
- [x] Code review pass complete (`coderabbit review --plain` run locally twice; both findings fixed before push).
- [x] Commits squashed into one clean commit before the first push.
- [x] At least one label set (`enhancement`, `performance`, `needs-docs-review`).
- [x] Docs label decision made: `needs-docs-review` (user-visible behavior change; the providers.md "Rate-limit awareness" note is being handled in a separate docs PR, coordinated to avoid colliding with the active docs work).
- [ ] Screenshot attached for any UI change. (N/A: no UI change.)
- [ ] UAT performed for user-visible changes (run the binary). (Not feasible: real providers will not emit a 429 on demand. Substituted by integration tests that exercise the full adapter stacks against httptest servers simulating 429/503 + Retry-After; see Test plan.)
- [x] OpenAPI spec updated if any request or response shape changed. (N/A: no API shape change; `make check-openapi` is part of the green gate.)
- [x] `templ generate` re-run if any `.templ` changed. (N/A: no `.templ` changes.)

## Test plan

- [x] `go test -race ./...` passes locally (full suite run by the pre-push gate; targeted `./internal/provider/...` race run also captured clean).
- [x] `bash scripts/pre-push-gate.sh` passes locally (via the pre-push hook; provider-failure smoke harness 9/9).
- [x] Integration flows exercised (substitute for binary UAT, through the real adapter stacks):
  - [x] Deezer recovers and returns artist data after a `429` (retry succeeds).
  - [x] Each adapter (deezer, wikidata, fanart.tv, audiodb, discogs, spotify, wikipedia) surfaces a bounded `ErrProviderUnavailable` after persistent `429` (exactly MaxAttempts hits, no storm).
  - [x] Canceled context fails at the in-closure limiter before any HTTP call; transport errors are wrapped.
  - [x] Helper suite: `Retry-After` delta + HTTP-date, jitter bounds, `503` conservative-retry vs fail-fast, ctx-cancel mid-wait, MaxDelay capping.
- [ ] Reviewer follow-ups:
  - [ ] 503 policy: this gives `503`-without-`Retry-After` a bounded jittered retry (2 attempts) specifically so MusicBrainz throttling recovers; confirm that is the desired trade-off vs strict fail-fast.
  - [ ] Docs: a "Rate-limit awareness" note (providers.md) + an ADR line are being authored in a separate docs PR; the rule-engine mermaid is intentionally unchanged (this feature is below that layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when external services are rate-limited or temporarily unavailable—requests now retry with bounded backoff and propagate clearer "provider unavailable" hints.

* **Refactor**
  * Centralized retry and per-attempt rate-limiting across provider integrations for consistent request behavior and error mapping.

* **Tests**
  * Added adapter-level and retry/backoff unit tests validating retry bounds, Retry-After handling, cancellation, and error propagation.

* **Chores**
  * Raised default patch-coverage threshold from 70 to 75.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->