### PR TITLE
docs: fix Mermaid edge label, add mmdc pre-commit gate, document provider backoff

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,6 +12,7 @@
 #   6. govulncheck -- known vulnerabilities in dependencies
 #   7. hadolint -- Dockerfile best-practice linting
 #   8. markdownlint -- staged markdown files (mirrors CI Docs / Markdown Lint job)
+#   9. mermaid -- parse Mermaid diagrams in staged markdown (opt-in; needs mmdc)
 #
 # Skip with: git commit --no-verify (use sparingly)
 
@@ -280,6 +281,59 @@ if [ "${#STAGED_MD[@]}" -gt 0 ]; then
     fi
 else
     warn "markdownlint (no staged .md files)"
+fi
+
+# --------------------------------------------------------------------------
+# 9. mermaid -- parse Mermaid diagrams in staged markdown.
+# --------------------------------------------------------------------------
+# mkdocs renders Mermaid client-side (pymdownx.superfences custom_fence), so
+# `mkdocs build` never parses the diagram: a syntax error ships a broken page
+# that GitHub's stricter renderer rejects. mmdc parses every ```mermaid block
+# and exits non-zero on a parse error. It drives headless Chromium, so this is
+# an opt-in graceful skip. Install with:
+#   brew install mermaid-cli      (macOS / Linuxbrew)
+#   npm install -g @mermaid-js/mermaid-cli   (cross-platform alternative)
+# Only staged markdown that actually contains a ```mermaid fence is checked;
+# files without a diagram (and any unmodified file) are skipped. Detection and
+# validation both read the STAGED blob (`git show :path`) rather than the
+# working-tree file, so the gate validates exactly what is being committed: a
+# staged-but-unsaved fix is honored, and a working-tree fix that was not staged
+# cannot let a broken diagram slip through. This matters more here than for the
+# style linters above because this gate's whole job is to block broken diagrams.
+STAGED_MERMAID=()
+while IFS= read -r -d '' f; do
+    git show ":$f" 2>/dev/null | grep -q '```mermaid' && STAGED_MERMAID+=("$f")
+done < <(git diff --cached --name-only -z --diff-filter=ACMR -- '*.md')
+if [ "${#STAGED_MERMAID[@]}" -gt 0 ]; then
+    if command -v mmdc &>/dev/null; then
+        MERMAID_OUT_DIR=$(mktemp -d)
+        MERMAID_SRC_DIR=$(mktemp -d)
+        MERMAID_FAILED=0
+        for mdfile in "${STAGED_MERMAID[@]}"; do
+            # mmdc reads from a path, so materialize the staged blob to a temp
+            # file. Flatten the path into the filename to avoid basename
+            # collisions across directories while preserving the .md suffix.
+            staged_copy="$MERMAID_SRC_DIR/$(printf '%s' "$mdfile" | tr '/' '_')"
+            git show ":$mdfile" > "$staged_copy"
+            if ! MMDC_OUT=$(mmdc --input "$staged_copy" --output "$MERMAID_OUT_DIR/out.md" 2>&1); then
+                echo -e "${RED}${BOLD}FAIL${RESET} mermaid: $mdfile"
+                echo "$MMDC_OUT" | sed 's/^/  /'
+                MERMAID_FAILED=1
+            fi
+        done
+        rm -rf "$MERMAID_OUT_DIR" "$MERMAID_SRC_DIR"
+        if [ "$MERMAID_FAILED" -eq 1 ]; then
+            echo ""
+            echo "Fix the Mermaid syntax above. GitHub and the published docs site"
+            echo "reject it even though 'mkdocs build' renders client-side and does not."
+            exit 1
+        fi
+        pass "mermaid"
+    else
+        warn "mermaid (mmdc not installed -- brew install mermaid-cli)"
+    fi
+else
+    warn "mermaid (no staged .md with diagrams)"
 fi
 
 echo ""

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -14,6 +14,8 @@ All file writes (NFO, images) use a shared utility in `internal/filesystem/`: wr
 
 One per metadata provider, created at application startup, shared across all handlers and background jobs. MusicBrainz: 1 req/sec globally.
 
+The reactive complement to the limiter is a shared, context-aware retry helper (`DoWithRetry` in `internal/provider/retry.go`) that wraps each provider HTTP round-trip. It honors Retry-After (delta-seconds and HTTP-date) with a jittered, bounded exponential fallback, and applies distinct policies for 429 (more attempts) and 503 (fewer, for a possibly-unhealthy server).
+
 ## Adaptive batched transactions
 
 Small batches (< 100): single transaction. Medium (100-1000): transactions of 50. Large (1000+): transactions of 25 with short sleep. User actions get priority over background jobs.

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -7,7 +7,7 @@ Prerequisites and instructions for building Stillwater from source.
 | Tool | Version | Purpose | Install |
 |------|---------|---------|---------|
 | Go | 1.26.1+ | Compiler and runtime | https://go.dev/dl/ |
-| templ | latest | HTML template code generation | `go install github.com/a-h/templ/cmd/templ@latest` |
+| templ | pinned in `go.mod` (`tool` directive) | HTML template code generation | No separate install; run via `go tool templ generate` |
 | Tailwind CSS | see `ARG TAILWIND_VERSION` in [`build/docker/Dockerfile`](https://github.com/sydlexius/stillwater/blob/main/build/docker/Dockerfile) | CSS build (standalone CLI) | See below |
 | Git | any | Version control | https://git-scm.com/ |
 
@@ -19,6 +19,9 @@ Prerequisites and instructions for building Stillwater from source.
 | golangci-lint | Linting (`make lint`) | https://golangci-lint.run/welcome/install/ |
 | Bruno | API testing (collections in `api/bruno/`) | https://www.usebruno.com/ |
 | air | Hot reload during development (`make dev`) | `go install github.com/air-verse/air@latest` |
+| mermaid-cli (mmdc) | Validate Mermaid diagrams in docs (pre-commit mermaid check) | `brew install mermaid-cli` (or `npm install -g @mermaid-js/mermaid-cli`) |
+| hadolint | Lint Dockerfiles (`make hadolint`, pre-commit hadolint check) | `brew install hadolint` |
+| markdownlint-cli2 | Lint Markdown (pre-commit markdownlint check; CI Docs job) | `brew install markdownlint-cli2` (or `npx markdownlint-cli2`) |
 
 ## Installing Tailwind CSS Standalone CLI
 
@@ -62,7 +65,8 @@ cd stillwater
 go mod download
 
 # Generate templ code (converts .templ files to Go code)
-templ generate
+# templ is pinned via the go.mod tool directive; invoke it with `go tool`.
+go tool templ generate
 
 # Build Tailwind CSS
 tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minify
@@ -117,7 +121,7 @@ The Docker build handles templ generation implicitly (committed `_templ.go` file
 
 1. **Modify Go files** in `internal/` or `cmd/stillwater/`
 2. **Edit Templ templates** in `web/templates/` or `web/components/`
-   - Changes to `.templ` files require regeneration: `templ generate`
+   - Changes to `.templ` files require regeneration: `go tool templ generate`
    - Generated `_templ.go` files should be committed alongside source templates
 3. **Update CSS** in `web/static/css/input.css`
    - Rebuild: `tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minify`
@@ -152,7 +156,7 @@ Before committing or opening a PR:
 
 ```bash
 # Format code
-make fmt          # or: go fmt ./... && templ fmt web/
+make fmt          # or: go fmt ./... && go tool templ fmt web/
 
 # Run linter
 make lint         # or: golangci-lint run ./...

--- a/docs/site/src/contributing/architecture/index.md
+++ b/docs/site/src/contributing/architecture/index.md
@@ -26,7 +26,7 @@ flowchart TD
     API -->|NFO + image writes| FS
     API -->|metadata, image, and lock push| MediaServers
     API -->|folder-rename path push + write-back control| Lidarr
-    Lidarr -->|artist roster + events (webhooks)| API
+    Lidarr -->|"artist roster + events (webhooks)"| API
     API -->|fetch metadata + images| Providers
     FS -->|fsnotify events| API
 ```

--- a/docs/site/src/reference/providers.md
+++ b/docs/site/src/reference/providers.md
@@ -83,6 +83,12 @@ Each provider has its own rate limit. The capability matrix above lists them. St
 
 If you're driving heavy bulk evaluation, two knobs help: increase library scope to spread fetches over time, and stagger Fix-all runs rather than running multiple at once.
 
+The per-provider limit above is the proactive defense: it spaces requests so they stay under quota. Reactive backoff handles the case where a rate-limit response comes back anyway.
+
+On a 429 Too Many Requests, Stillwater honors the server's Retry-After hint. It parses both the seconds form and the HTTP-date form. When no hint is present, it falls back to a jittered exponential backoff. Retries are bounded to a few attempts, after which the call surfaces a transient error rather than blocking indefinitely.
+
+A 503 Service Unavailable is treated more conservatively, with a smaller bounded number of attempts and jittered backoff. This is how MusicBrainz usually signals throttling, typically with no Retry-After. The conservative retry lets a throttled call recover instead of being dropped, without hammering a server that may genuinely be unhealthy.
+
 ## What to configure where
 
 | You want to | Go to |


### PR DESCRIPTION
## Summary

- Fix a Mermaid parse error in the architecture system-topology diagram: the
  Lidarr->API edge label had unquoted parentheses, which Mermaid's pipe-label
  lexer reads as a node-shape token, so GitHub's renderer rejected the diagram.
  Quoting the label fixes it.
- Add a diff-scoped pre-commit gate (step 9) that runs `mmdc` on staged markdown
  containing a mermaid fence. It validates the staged blob (not the working
  tree), so the gate checks exactly what is being committed, and it gracefully
  skips when mmdc is absent. mkdocs renders Mermaid client-side, so
  `mkdocs build` never catches diagram syntax errors; mmdc reproduces GitHub's
  exact parse error.
- Refresh `docs/dev-setup.md`: add mermaid-cli, document the already-required
  hadolint and markdownlint-cli2, and correct the templ row to `go tool templ`
  (go.mod tool-directive pinning).
- Document the reactive rate-limit backoff (`DoWithRetry`) in the Providers
  reference and architecture-decisions: honors Retry-After (seconds and
  HTTP-date), jittered exponential fallback, and distinct 429/503 policies.

## Linked issue

Part of #1738 (the provider backoff docs are the companion to that feature).
The Mermaid edge-label fix and mmdc gate are not tied to an issue.

## Pre-flight checklist

- [x] Pre-push deterministic gate green (ran on push via the pre-push hook).
- [x] Local CodeRabbit review run; both findings (staged-content validation, prose readability) fixed before push.
- [x] Single clean squashed commit before first push.
- [x] Labels set (`documentation`, `chore`).
- [x] Docs label decision made (this PR is the docs change).
- N/A Screenshot (no UI change).
- N/A UAT / OpenAPI / templ (no binary, API, or templ changes).

## Test plan

- N/A `go test -race` (no Go code changed; the pre-push race suite ran green on push).
- mmdc pre-commit step validated: passes on the quoted edge label and reproduces
  the failure on the unquoted form; the new staged-content path was verified
  against the staged diagram blob.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced provider rate-limiting documentation with improved `429` and `503` error handling behavior.
  * Updated developer setup instructions for tooling configuration.

* **Chores**
  * Added Mermaid diagram validation to pre-commit hook for Markdown files.
  * Improved architecture decision and contributing documentation clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->