### PR TITLE
fix(worktree): guard remove-worktree against deleting the default branch (#1741)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,18 @@ worktree:
 ##   Example: make remove-worktree NAME=m49.5-merge-policy
 remove-worktree:
 	@test -n "$(NAME)" || (echo "error: NAME is required (e.g. make remove-worktree NAME=my-feature)"; exit 1)
+	@wt="../stillwater-$(NAME)"; \
+	if [ -d "$$wt" ]; then \
+		cur=$$(git -C "$$wt" symbolic-ref --quiet --short HEAD 2>/dev/null || true); \
+		def=$$(git -C "$$wt" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##'); \
+		if [ -n "$$cur" ] && [ -n "$$def" ] && [ "$$cur" = "$$def" ]; then \
+			echo "!!! WARNING: $$wt is on the default branch ('$$def')."; \
+			echo "!!! This is the 'gh pr merge --delete-branch' aftermath: gh checked out the default"; \
+			echo "!!! branch here before deleting the feature branch, so the feature branch is already"; \
+			echo "!!! gone. Branch deletion will be SKIPPED by cleanup-worktree.sh (issue #1741);"; \
+			echo "!!! continuing with worktree + tracker cleanup only."; \
+		fi; \
+	fi
 	@$(HOME)/.claude/scripts/cleanup-worktree.sh "$(NAME)" || \
 		echo "warning: cleanup-worktree.sh exited non-zero (worktree or branch may already be gone); continuing with tracker row removal"
 	@if [ -f "$(WORKTREES_MD)" ]; then \


### PR DESCRIPTION
## Summary

- Adds an independent, offline-only pre-check to the `remove-worktree` make target: if the target worktree is sitting on the repo default branch, it prints a prominent warning and continues with worktree + tracker cleanup only. This is the Stillwater-side **defense-in-depth** for issue #1741.
- Context: `gh pr merge --delete-branch` run from inside a worktree checks out the default branch there before deleting the feature branch, leaving the worktree on `main`. `cleanup-worktree.sh` then read the checked-out branch (`main`) and force-deleted it. The **primary fix** (a hard default-branch guard + gated `-D` fallback) landed in the shared, repo-agnostic `cleanup-worktree.sh` in the separate `claude-kit` gist repo, which does not use a PR workflow; this PR is the wrapper-side backstop in Stillwater.
- No user-visible application behavior changes; this is worktree tooling only. Reviewers should look at the new pre-check block in `Makefile` (`remove-worktree` target).

## Linked issue

Closes #1741

## Pre-flight checklist

- [x] Pre-push gate green locally (ran via `scripts/safe-push.sh`; all checks passed).
- [ ] Code review pass complete -- local CodeRabbit review intentionally waived for this tooling-only change (per maintainer instruction). Cloud CR will review on open.
- [x] Commits squashed into clean, logical commits before the first push (single commit).
- [x] At least one label set (`bug`, `docs: not-required`).
- [x] Docs label decision made: `docs: not-required` (tooling change, no user-visible behavioral change).
- [ ] Screenshot -- N/A (no UI change).
- [ ] UAT -- N/A for app behavior; the guard logic was validated directly (see Test plan).
- [ ] OpenAPI -- N/A (no request/response shape change).
- [ ] templ -- N/A (no `.templ` change).

## Test plan

- [x] `go test -race ./...` passes locally (run by the pre-push gate during push).
- [x] `bash scripts/pre-push-gate.sh` passes locally (run by the pre-push hook during push).
- [x] Validated the guard directly:
  - Hermetic test of the primary `cleanup-worktree.sh` guard (throwaway repo + bare origin + stubbed `gh`): Case A (worktree on default branch) keeps local `main` and warns; Case B (feature branch) deletes via the gated `-D` fallback; Case C (default branch unresolvable) refuses `-D` in safe mode. 6/6 checks passed, including the offline `symbolic-ref` path isolated with `gh` forced to fail.
  - Makefile target: `make -n remove-worktree` parses clean; detection logic confirmed to resolve `cur`/`def` correctly and not warn when off the default branch (no false positives).
- [ ] Reviewer follow-ups:
  - The primary fix lives in `claude-kit` (`cleanup-worktree.sh`), delivered outside this repo's PR flow -- flagging so reviewers know the wrapper change alone is not the whole fix.