### PR TITLE
fix(docs): render API reference with Scalar and align docs site to M55 palette

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,11 +60,13 @@ jobs:
       - name: Lint OpenAPI spec
         run: npx --yes "@redocly/cli@${REDOCLY_CLI_VERSION}" lint internal/api/openapi.yaml
 
-      - name: Build API reference
-        run: |
-          mkdir -p docs/site/site/api
-          npx --yes "@redocly/cli@${REDOCLY_CLI_VERSION}" build-docs internal/api/openapi.yaml \
-            --output docs/site/site/api/index.html
+      - name: Build API reference (Scalar)
+        # Render the API reference with Scalar, reusing the exact vendored
+        # bundle + theme the app serves (internal/api/handlers_docs.go) so the
+        # published reference matches the in-app one: M55 palette, native
+        # light/dark toggle. The redocly lint step above still validates the
+        # spec; we no longer use redocly to render.
+        run: docs/site/build-api-reference.sh docs/site/site
 
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,12 +6,22 @@ on:
     paths:
       - 'docs/site/**'
       - 'internal/api/openapi.yaml'
+      # Vendored Scalar assets the API reference is built from
+      # (build-api-reference.sh copies these); rebuild when the app theme
+      # or bundle changes so the published reference stays in lockstep.
+      - 'web/static/js/scalar-api-reference.min.js'
+      - 'web/static/css/scalar-theme.css'
       - '.github/workflows/pages.yml'
   pull_request:
     branches: [main]
     paths:
       - 'docs/site/**'
       - 'internal/api/openapi.yaml'
+      # Vendored Scalar assets the API reference is built from
+      # (build-api-reference.sh copies these); rebuild when the app theme
+      # or bundle changes so the published reference stays in lockstep.
+      - 'web/static/js/scalar-api-reference.min.js'
+      - 'web/static/css/scalar-theme.css'
       - '.github/workflows/pages.yml'
   workflow_dispatch:
 

--- a/docs/site/build-api-reference.sh
+++ b/docs/site/build-api-reference.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Build the standalone Scalar API reference into the MkDocs site output.
+#
+# Mirrors the in-app reference served by internal/api/handlers_docs.go: it
+# reuses the exact vendored Scalar bundle and theme stylesheet the app ships,
+# so the published docs reference and the in-app reference stay in lockstep
+# (same renderer, same M55 palette, same native light/dark toggle).
+#
+# Run this AFTER `mkdocs build`, which produces the site output dir. The Pages
+# CI workflow calls it; it is also runnable locally to get a full API page that
+# `mkdocs build` alone does not produce.
+#
+# Usage: docs/site/build-api-reference.sh [SITE_DIR]
+#   SITE_DIR defaults to docs/site/site (MkDocs' default output dir).
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/../.." && pwd)
+site_dir=${1:-"${script_dir}/site"}
+
+scalar_js="${repo_root}/web/static/js/scalar-api-reference.min.js"
+scalar_css="${repo_root}/web/static/css/scalar-theme.css"
+openapi_spec="${repo_root}/internal/api/openapi.yaml"
+
+# Fail loudly if any input is missing rather than emitting a half-built page.
+for f in "${scalar_js}" "${scalar_css}" "${openapi_spec}"; do
+  if [[ ! -f "${f}" ]]; then
+    echo "build-api-reference: required input not found: ${f}" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -d "${site_dir}" ]]; then
+  echo "build-api-reference: site dir not found: ${site_dir} (run 'mkdocs build' first)" >&2
+  exit 1
+fi
+
+api_dir="${site_dir}/api"
+mkdir -p "${api_dir}"
+
+cp "${scalar_js}" "${api_dir}/scalar-api-reference.min.js"
+cp "${scalar_css}" "${api_dir}/scalar-theme.css"
+cp "${openapi_spec}" "${api_dir}/openapi.yaml"
+
+# Mirror internal/api/handlers_docs.go: Scalar bundle + Stillwater theme. Asset
+# paths are relative so the page works under the GitHub Pages project subpath.
+cat > "${api_dir}/index.html" <<'HTML'
+<!doctype html>
+<html lang="en">
+<head>
+  <title>API Reference - Stillwater</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="scalar-theme.css" />
+</head>
+<body>
+  <script
+    id="api-reference"
+    data-url="openapi.yaml"
+    data-configuration='{"theme":"none","darkMode":true}'
+  ></script>
+  <script src="scalar-api-reference.min.js"></script>
+</body>
+</html>
+HTML
+
+echo "build-api-reference: wrote ${api_dir}/index.html"

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -23,17 +23,19 @@ theme:
   name: material
   custom_dir: overrides
   palette:
+    # primary/accent: custom -> colors defined in stylesheets/extra.css to
+    # match the M55 blue palette (blue-600 / blue-500).
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-sunny
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: indigo
-      accent: indigo
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-night
         name: Switch to dark mode
@@ -153,4 +155,8 @@ nav:
       - PR workflow: contributing/pr-workflow.md
       - Worktrees: contributing/worktrees.md
       - Milestone protocol: contributing/milestone-protocol.md
+  # /api/ is overwritten at deploy time with the standalone Scalar reference
+  # (see docs/site/build-api-reference.sh). A relative link is correct: clicking
+  # it does a normal full-page load to that document. navigation.instant falls
+  # back to a real navigation for non-Material pages, so it does not break.
   - API Reference: api/index.md

--- a/docs/site/src/api/index.md
+++ b/docs/site/src/api/index.md
@@ -7,13 +7,15 @@ hide:
 
 # API Reference
 
-The API reference is published as a standalone Redoc page. It covers every
-endpoint Stillwater exposes under `/api/v1/`, including request bodies,
-response shapes, and authentication requirements.
+The API reference is published as a standalone Scalar page, the same renderer
+and theme the app serves in-product. It covers every endpoint Stillwater
+exposes under `/api/v1/`, including request bodies, response shapes, and
+authentication requirements, with a built-in light/dark toggle.
 
-[Open the API reference on GitHub Pages](https://sydlexius.github.io/stillwater/api/index.html){ .md-button .md-button--primary }
+[Open the API reference on GitHub Pages](https://sydlexius.github.io/stillwater/api/){ .md-button .md-button--primary }
 
-> **Note for local builds:** The Redoc page (`api/index.html`) is generated
-> by the CI pipeline after the MkDocs build step. It is not present in local
-> `mkdocs build` output. See `.github/workflows/pages.yml` for the generation
-> step.
+> **Note for local builds:** The Scalar page at `api/` overwrites this stub in
+> the deployed build, so what you see here renders only in local
+> `mkdocs build` output. To produce the full reference locally, run
+> `docs/site/build-api-reference.sh docs/site/site` after `mkdocs build`. See
+> `.github/workflows/pages.yml` for the CI generation step.

--- a/docs/site/src/stylesheets/extra.css
+++ b/docs/site/src/stylesheets/extra.css
@@ -1,3 +1,46 @@
+/* --- M55 palette ---------------------------------------------------------
+   mkdocs.yml sets primary/accent to "custom" so the brand color is defined
+   here rather than via a Material built-in. These match the app's M55 blue:
+   blue-600 (#2563eb, the site theme_color / Scalar button hover) for primary
+   and blue-500 (#3b82f6, the app's --scalar-color-accent) for accent. Applies
+   to both the slate (dark) and default (light) schemes. */
+/* The "custom" palette keyword only sets the base --md-*-fg-color; Material
+   does NOT regenerate the --light / --dark / --transparent companion shades,
+   so they keep the default indigo. We must set them explicitly. The
+   --transparent accent (10% alpha, "1a") drives every highlight background:
+   hover/active nav + TOC items, search-term highlights, and Mermaid fills. */
+[data-md-color-primary="custom"] {
+  --md-primary-fg-color: #2563eb;
+  --md-primary-fg-color--light: #3b82f6;
+  --md-primary-fg-color--dark: #1d4ed8;
+  --md-primary-fg-color--transparent: #2563eb1a;
+}
+
+[data-md-color-accent="custom"] {
+  --md-accent-fg-color: #3b82f6;
+  --md-accent-fg-color--transparent: #3b82f61a;
+}
+
+/* Code syntax tokens. Material's defaults lean purple/magenta/pink for the
+   keyword/function/constant/special tokens. Retarget them to a cool
+   blue-family set that matches M55. Done per scheme because a token color must
+   contrast against both the dark slate and the light code background, and a
+   single value cannot do both. Strings (green), numbers (coral), and the
+   neutral slate tokens are already on-palette, so they are left untouched. */
+[data-md-color-scheme="slate"] {
+  --md-code-hl-keyword-color: #60a5fa;   /* blue-400  */
+  --md-code-hl-function-color: #22d3ee;  /* cyan-400  */
+  --md-code-hl-constant-color: #7dd3fc;  /* sky-300   */
+  --md-code-hl-special-color: #2dd4bf;   /* teal-400  */
+}
+
+[data-md-color-scheme="default"] {
+  --md-code-hl-keyword-color: #1d4ed8;   /* blue-700  */
+  --md-code-hl-function-color: #0e7490;  /* cyan-700  */
+  --md-code-hl-constant-color: #0369a1;  /* sky-700   */
+  --md-code-hl-special-color: #0f766e;   /* teal-700  */
+}
+
 /* Bottom-align the trailing link in grid cards so calls-to-action sit on a
    common baseline regardless of description length. */
 .md-typeset .grid.cards > ul > li {


### PR DESCRIPTION
## Summary

- Replace the docs-site API reference renderer (`redocly build-docs`) with Scalar, reusing the exact vendored bundle and theme the app already serves (`internal/api/handlers_docs.go`) via the new `docs/site/build-api-reference.sh`. The old Redoc page used Redoc's default theme (no M55 palette, no light/dark toggle) and `navigation.instant` could not reliably render it, so the "API Reference" links appeared broken. `redocly lint` is kept for spec validation.
- Switch the docs site palette from indigo to the M55 blue (primary `#2563eb`, accent `#3b82f6`). The Material `custom` palette keyword only sets the base color, so the transparent companion shades (which drive hover/active/search highlight backgrounds) and the code-syntax tokens are overridden too.
- User-visible: the published API reference now matches M55 and has a working light/dark toggle; docs-site highlights are blue instead of indigo. All API-reference links open in the same tab (the nav entry cannot get `target="_blank"` without JS, which the project forbids, so they are kept consistent).

## Linked issue

Closes #1760

## Pre-flight checklist

- [x] Pre-push gate green locally (ran via the pre-push hook on push).
- [ ] Code review pass: deferred to cloud CodeRabbit on PR open (local CR is reserved for when the online quota is exhausted; budget showed 5/5 free).
- [x] Commits squashed into a single clean commit before the first push.
- [x] At least one label set on `gh pr create --label ...`.
- [x] Docs label decision made: `docs: not-required` (this PR is itself the docs-site change; no separate docs surface needs updating).
- [ ] Screenshot: not attached (no image host); verification was done in-browser locally, described below.
- [x] UAT performed (built and served the site, verified in a real browser; see Test plan).
- [x] OpenAPI spec: no request/response shape changed (N/A).
- [x] `templ generate`: no `.templ` files changed (N/A).

## Test plan

- [x] `go test -race ./...` / `scripts/pre-push-gate.sh` pass locally (run by the pre-push hook; push succeeded).
- [x] Manual UAT (mkdocs-material 9.7.6, the pinned version; built with `build-api-reference.sh`, served, driven via browser):
  - [x] `/api/` renders the Scalar reference with the M55 slate/blue theme; the native light/dark toggle flips (`#0f172a` <-> `#f8f9fa`).
  - [x] Docs-site hover/active/search highlight accents are blue (`#3b82f61a`), not indigo; header/buttons/links are M55 blue.
  - [x] Code-block syntax tokens render in a blue/cyan/green family (no purple/magenta/pink) and stay readable in both schemes.
  - [x] Clicking the nav "API Reference" (relative, same-origin like production) does a clean full-page load into Scalar; no broken/blank page. "Browse the API" and the reference button also load same-tab.
- [ ] Reviewer follow-ups:
  - [ ] Note: `m55-1341-sse-catalog` also edits `docs/site/mkdocs.yml`, but in a disjoint region (architecture nav entry vs. this PR's palette block + API Reference nav entry), so the two merge cleanly; whichever lands second just rebases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the in-site API viewer with a standalone, vendored API reference and updated docs to describe local/CI generation and deployment behavior
  * Applied a custom color palette and refined theme variants for light/dark modes across the site

* **Chores**
  * Updated the Pages build workflow and added a dedicated script to generate and copy the standalone API reference during site builds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->