### PR TITLE
feat(sse): formalise event catalog + Last-Event-ID replay buffer

### DIFF
--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -152,6 +152,7 @@ nav:
           - Providers and coalesce: contributing/architecture/providers-and-coalesce.md
           - Settings import/export: contributing/architecture/settings-import-export.md
           - Event bus and workers: contributing/architecture/event-bus-and-workers.md
+          - SSE event catalog: contributing/architecture/sse-events.md
       - PR workflow: contributing/pr-workflow.md
       - Worktrees: contributing/worktrees.md
       - Milestone protocol: contributing/milestone-protocol.md

--- a/docs/site/src/contributing/architecture/event-bus-and-workers.md
+++ b/docs/site/src/contributing/architecture/event-bus-and-workers.md
@@ -89,6 +89,10 @@ early-exit error path.
 | Filesystem watcher (`fsnotify` + poll fallback) | `internal/watcher/watcher.go` |
 | Scanner background goroutine and `Shutdown` | `internal/scanner/scanner.go` |
 
+The browser-facing contract for the SSE stream -- the endpoint, frame format,
+the full event catalog, and `Last-Event-ID` reconnect/replay semantics -- is
+documented in [SSE event catalog](sse-events.md).
+
 The scanner's own walk and the events it emits are detailed in
 [Scanner pipeline](scanner-pipeline.md).
 

--- a/docs/site/src/contributing/architecture/sse-events.md
+++ b/docs/site/src/contributing/architecture/sse-events.md
@@ -74,12 +74,13 @@ notification on their own.
 own response: the resolving tab updates via HTMX, and the SSE event drives the
 same refresh in other open tabs.
 
-### Logs events (dedicated stream)
+### Logs events (planned dedicated stream)
 
-`logs.line` and `logs.throttled` are part of this catalog but are **not**
+`logs.line` and `logs.throttled` are reserved in this catalog but are **not**
 broadcast over `/api/v1/events/stream` -- a raw log firehose must not fan out to
-every connected tab. They are emitted on the dedicated logs stream
-(`GET /api/v1/logs/stream`). Their envelopes:
+every connected tab. They are **not emitted yet**: a dedicated logs stream
+(`GET /api/v1/logs/stream`) is planned in #1338 and will produce them. The event
+names and envelopes are documented here so #1338 can rely on a frozen contract:
 
 | Event | `data` payload |
 |---|---|

--- a/docs/site/src/contributing/architecture/sse-events.md
+++ b/docs/site/src/contributing/architecture/sse-events.md
@@ -1,0 +1,120 @@
+---
+description: The Stillwater server-sent events (SSE) catalog, frame format, and Last-Event-ID reconnect/replay semantics.
+---
+
+# SSE event catalog
+
+Stillwater pushes live updates to the browser over a single server-sent events
+(SSE) stream. This page is the contract for that stream: the one endpoint, the
+frame format, every event a client can subscribe to, and how reconnect replays
+missed events. For how events flow internally from producers to the SSE hub, see
+[Event bus and workers](event-bus-and-workers.md).
+
+## Endpoint
+
+```
+GET /api/v1/events/stream
+```
+
+One long-lived connection per browser tab, `Content-Type: text/event-stream`.
+The handler clears the write deadline so the stream stays open, sends an initial
+`connected` frame, and then forwards events as they are broadcast, with a
+`: heartbeat` comment every 30 seconds to keep intermediaries from closing an
+idle connection.
+
+## Frame format
+
+Every event is written as:
+
+```
+id: <monotonic id>
+event: <type>
+data: <json>
+
+```
+
+The JSON `data` is the full event envelope:
+
+| Field | Meaning |
+|---|---|
+| `id` | Monotonic per-process event id. Mirrors the SSE `id:` line; the browser echoes it back as `Last-Event-ID` on reconnect. Absent on transport-only frames (`connected`). |
+| `type` | The event name (same as the `event:` line). |
+| `title` | Short human-readable summary, used as a plain-toast fallback. |
+| `message` | Full notification body text. |
+| `timestamp` | When the event occurred (RFC 3339). |
+| `data` | Optional per-event structured payload (see the catalog below). |
+
+The `id:` line is emitted only when the event carries an id, so the `connected`
+handshake never advances the client's `Last-Event-ID`.
+
+## Catalog
+
+These are the events broadcast to browser clients over the stream above. Their
+consumers read the structured `data`; events flagged "toast" also surface a
+notification on their own.
+
+| Event | Surface | `data` payload |
+|---|---|---|
+| `connected` | Transport handshake; carries `{replayed, bufferLoss}` (see below). | `{replayed, bufferLoss}` |
+| `scan.completed` | toast | scan summary fields |
+| `bulk.completed` | toast | `{type, status}` |
+| `artist.new` | toast | artist fields |
+| `artist.updated` | toast | artist fields |
+| `metadata.fixed` | toast | `{message}` |
+| `rule.violation` | toast | `{message}` |
+| `conflict.changed` | conflict banner refetch | `{banner_state}` |
+| `operation.progress` | ProgressPill | `{op_id, label, processed, total, status, cancel_url?}` |
+| `connection.push_failed` | error toast | `{connection, error_class, artist_name?}` |
+| `activity.recent` | next dashboard activity rail | `{ts, kind, text, artistId?}` |
+| `settings.changed` | cross-tab settings refetch/toast | `{sectionId, updatedBy, ts}` |
+| `dashboard.action-resolved` | cross-tab action-queue + badge refresh | none (signal only) |
+
+`dashboard.action-resolved` is the cross-tab counterpart of the
+`dashboard:action-resolved` HTMX trigger that a resolving handler sets on its
+own response: the resolving tab updates via HTMX, and the SSE event drives the
+same refresh in other open tabs.
+
+### Logs events (dedicated stream)
+
+`logs.line` and `logs.throttled` are part of this catalog but are **not**
+broadcast over `/api/v1/events/stream` -- a raw log firehose must not fan out to
+every connected tab. They are emitted on the dedicated logs stream
+(`GET /api/v1/logs/stream`). Their envelopes:
+
+| Event | `data` payload |
+|---|---|
+| `logs.line` | a structured log record |
+| `logs.throttled` | `{dropped, window}` when the server-side rate limit sheds lines |
+
+## Reconnect and replay
+
+The browser `EventSource` reconnects automatically on a dropped connection,
+resending the last `id:` it saw as the `Last-Event-ID` request header. The hub
+retains recent events in a bounded in-memory ring buffer -- **1,000 events or 5
+minutes, whichever limit is reached first** -- and on reconnect replays the
+events the client missed (those with an id greater than `Last-Event-ID`) before
+resuming live delivery.
+
+The `connected` frame reports the outcome in its `data`:
+
+| Field | Meaning |
+|---|---|
+| `replayed` | Number of buffered events replayed for this reconnect. |
+| `bufferLoss` | `true` when the requested `Last-Event-ID` is no longer recoverable from the buffer (evicted, never issued, or unparsable). |
+
+When `bufferLoss` is `true` the client cannot trust replay to bridge the gap and
+should refetch derived state instead. This happens when the client was offline
+longer than the buffer window, or after a server restart resets the id counter.
+
+Because event ids are monotonic, the client tracks a high-water mark and toasts
+each event at most once: replayed frames at or below the mark are suppressed,
+while events genuinely missed while offline (ids above the mark) still toast.
+
+## Where to look
+
+| Topic | File |
+|---|---|
+| SSE hub, `Broadcast`, replay ring buffer, `Replay`, `SubscribeToEventBus` | `internal/api/handlers_sse.go` |
+| Stream handler, `Last-Event-ID` replay, heartbeat | `internal/api/handlers_sse.go` (`handleSSEStream`) |
+| Event type constants and bus `Publish`/`Subscribe` | `internal/event/bus.go` |
+| Browser client, reconnect backoff, toast dedupe, CustomEvent dispatch | `web/static/js/sse.js` |

--- a/docs/site/src/reference/_doc-anchors.txt
+++ b/docs/site/src/reference/_doc-anchors.txt
@@ -42,6 +42,13 @@ contributing/architecture/settings-import-export#settings-importexport
 contributing/architecture/settings-import-export#transactional-per-section-apply
 contributing/architecture/settings-import-export#user-remap-role-coercion-and-oobe-restore
 contributing/architecture/settings-import-export#where-to-look
+contributing/architecture/sse-events#catalog
+contributing/architecture/sse-events#endpoint
+contributing/architecture/sse-events#frame-format
+contributing/architecture/sse-events#logs-events-dedicated-stream
+contributing/architecture/sse-events#reconnect-and-replay
+contributing/architecture/sse-events#sse-event-catalog
+contributing/architecture/sse-events#where-to-look
 core-concepts/artists-and-libraries#artist-directories
 core-concepts/artists-and-libraries#artists
 core-concepts/artists-and-libraries#artists-and-libraries

--- a/docs/site/src/reference/_doc-anchors.txt
+++ b/docs/site/src/reference/_doc-anchors.txt
@@ -45,7 +45,7 @@ contributing/architecture/settings-import-export#where-to-look
 contributing/architecture/sse-events#catalog
 contributing/architecture/sse-events#endpoint
 contributing/architecture/sse-events#frame-format
-contributing/architecture/sse-events#logs-events-dedicated-stream
+contributing/architecture/sse-events#logs-events-planned-dedicated-stream
 contributing/architecture/sse-events#reconnect-and-replay
 contributing/architecture/sse-events#sse-event-catalog
 contributing/architecture/sse-events#where-to-look

--- a/internal/api/handlers_fix.go
+++ b/internal/api/handlers_fix.go
@@ -122,6 +122,7 @@ func (r *Router) handleFixViolation(w http.ResponseWriter, req *http.Request) {
 			} else {
 				// No undo toast -- trigger queue refresh immediately.
 				w.Header().Set("HX-Trigger", "dashboard:action-resolved")
+				r.emitActionResolved()
 				w.WriteHeader(http.StatusOK)
 			}
 		} else {
@@ -309,6 +310,7 @@ func (r *Router) handleUndoFix(w http.ResponseWriter, req *http.Request) {
 	if isHTMXRequest(req) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("HX-Trigger", "dashboard:action-resolved")
+		r.emitActionResolved()
 		w.WriteHeader(http.StatusOK)
 		// Empty response removes the toast element via outerHTML swap.
 		return

--- a/internal/api/handlers_notifications.go
+++ b/internal/api/handlers_notifications.go
@@ -171,6 +171,7 @@ func (r *Router) handleDismissViolation(w http.ResponseWriter, req *http.Request
 	// Return empty HTML for HTMX hx-swap="outerHTML" to remove the row.
 	// Trigger dashboard counter refresh when called from the dashboard.
 	w.Header().Set("HX-Trigger", "dashboard:action-resolved")
+	r.emitActionResolved()
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 }
@@ -215,6 +216,7 @@ func (r *Router) handleBulkDismissViolations(w http.ResponseWriter, req *http.Re
 	r.InvalidateHealthCache()
 
 	w.Header().Set("HX-Trigger", "dashboard:action-resolved")
+	r.emitActionResolved()
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintf(w, "%d", n) //nolint:errcheck // Best-effort write to HTTP response; client disconnect mid-write is not actionable

--- a/internal/api/handlers_notifications_test.go
+++ b/internal/api/handlers_notifications_test.go
@@ -3,14 +3,51 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/event"
 	"github.com/sydlexius/stillwater/internal/rule"
 )
+
+// TestDismissViolation_EmitsDashboardActionResolved verifies dismissing a
+// violation both preserves the same-tab HX-Trigger header AND re-emits
+// dashboard.action-resolved on the SSE bus so the action-queue badge updates
+// in other open tabs.
+func TestDismissViolation_EmitsDashboardActionResolved(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	bus := event.NewBus(logger, 16)
+	r.eventBus = bus
+	got := make(chan event.Event, 1)
+	bus.Subscribe(event.DashboardActionResolved, func(e event.Event) { got <- e })
+	go bus.Start()
+	defer bus.Stop()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/notifications/v1/dismiss", nil)
+	req.SetPathValue("id", "v1")
+	w := httptest.NewRecorder()
+	r.handleDismissViolation(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("dismiss expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if trig := w.Header().Get("HX-Trigger"); trig != "dashboard:action-resolved" {
+		t.Errorf("HX-Trigger = %q, want dashboard:action-resolved (same-tab preserved)", trig)
+	}
+	select {
+	case <-got:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dashboard.action-resolved not published on dismiss")
+	}
+}
 
 func seedNotificationViolations(t *testing.T, svc *rule.Service) {
 	t.Helper()

--- a/internal/api/handlers_preferences.go
+++ b/internal/api/handlers_preferences.go
@@ -805,11 +805,14 @@ func (r *Router) handlePatchPreferences(w http.ResponseWriter, req *http.Request
 		// emitted when a write actually landed (an empty PATCH is a no-op).
 		// The hub is in-process, so delivery is effectively immediate.
 		if r.eventBus != nil {
+			// settings.changed is broadcast to every connected client, so the
+			// payload must not carry the actor's user id (that would leak who
+			// changed a per-user preference to all other users). A bare
+			// section + timestamp is enough for other tabs to refetch.
 			r.eventBus.Publish(event.Event{
 				Type: event.SettingsChanged,
 				Data: map[string]any{
 					"sectionId": "preferences",
-					"updatedBy": userID,
 					"ts":        time.Now().UTC().Format(time.RFC3339),
 				},
 			})

--- a/internal/api/handlers_preferences.go
+++ b/internal/api/handlers_preferences.go
@@ -8,8 +8,10 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/api/middleware"
+	"github.com/sydlexius/stillwater/internal/event"
 	"github.com/sydlexius/stillwater/internal/langpref"
 	"github.com/sydlexius/stillwater/internal/provider"
 	"github.com/sydlexius/stillwater/internal/provider/tagdict"
@@ -797,6 +799,20 @@ func (r *Router) handlePatchPreferences(w http.ResponseWriter, req *http.Request
 			r.logger.Error("commit preferences patch", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 			return
+		}
+
+		// Announce the change so other open tabs can refetch or toast. Only
+		// emitted when a write actually landed (an empty PATCH is a no-op).
+		// The hub is in-process, so delivery is effectively immediate.
+		if r.eventBus != nil {
+			r.eventBus.Publish(event.Event{
+				Type: event.SettingsChanged,
+				Data: map[string]any{
+					"sectionId": "preferences",
+					"updatedBy": userID,
+					"ts":        time.Now().UTC().Format(time.RFC3339),
+				},
+			})
 		}
 	}
 

--- a/internal/api/handlers_preferences_test.go
+++ b/internal/api/handlers_preferences_test.go
@@ -211,12 +211,14 @@ func TestPatchPreferences_PublishesSettingsChanged(t *testing.T) {
 	}
 	select {
 	case e := <-got:
-		if e.Data["updatedBy"] != userID {
-			t.Errorf("updatedBy = %v, want %v", e.Data["updatedBy"], userID)
-		}
 		sectionID, ok := e.Data["sectionId"].(string)
-		if !ok || sectionID == "" {
-			t.Errorf("expected non-empty string sectionId in settings.changed data, got %v (type %T)", e.Data["sectionId"], e.Data["sectionId"])
+		if !ok || sectionID != "preferences" {
+			t.Errorf("sectionId = %v (type %T), want %q", e.Data["sectionId"], e.Data["sectionId"], "preferences")
+		}
+		// settings.changed is broadcast to every client, so it must not leak
+		// the actor's user id to other users.
+		if _, leaked := e.Data["updatedBy"]; leaked {
+			t.Errorf("settings.changed must not carry updatedBy (cross-user broadcast leak), got %v", e.Data["updatedBy"])
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("settings.changed not published after a successful PATCH")

--- a/internal/api/handlers_preferences_test.go
+++ b/internal/api/handlers_preferences_test.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/event"
 	"github.com/sydlexius/stillwater/internal/provider"
 )
 
@@ -174,6 +178,59 @@ func TestValidateScalarPref(t *testing.T) {
 				t.Errorf("validateScalarPref(%q,%q) = (%q,%v), want (%q,%v)", tt.key, tt.val, got, ok, tt.want, tt.wantOK)
 			}
 		})
+	}
+}
+
+// TestPatchPreferences_PublishesSettingsChanged verifies a successful merge
+// publishes a settings.changed event (so other open tabs can refetch/toast),
+// carrying the user that made the change, and that a rejected PATCH publishes
+// nothing.
+func TestPatchPreferences_PublishesSettingsChanged(t *testing.T) {
+	t.Parallel()
+	r, _, userID := testRouterWithAuth(t)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	bus := event.NewBus(logger, 16)
+	r.eventBus = bus
+
+	got := make(chan event.Event, 1)
+	bus.Subscribe(event.SettingsChanged, func(e event.Event) { got <- e })
+	go bus.Start()
+	defer bus.Stop()
+
+	patch := func(body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPatch, "/api/v1/preferences", strings.NewReader(body))
+		req = withUserCtx(req, userID)
+		w := httptest.NewRecorder()
+		r.handlePatchPreferences(w, req)
+		return w
+	}
+
+	if w := patch(`{"theme":"dark"}`); w.Code != http.StatusOK {
+		t.Fatalf("PATCH expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	select {
+	case e := <-got:
+		if e.Data["updatedBy"] != userID {
+			t.Errorf("updatedBy = %v, want %v", e.Data["updatedBy"], userID)
+		}
+		sectionID, ok := e.Data["sectionId"].(string)
+		if !ok || sectionID == "" {
+			t.Errorf("expected non-empty string sectionId in settings.changed data, got %v (type %T)", e.Data["sectionId"], e.Data["sectionId"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("settings.changed not published after a successful PATCH")
+	}
+
+	// A rejected PATCH (unknown key) must not publish settings.changed.
+	if w := patch(`{"totally_unknown_key":"x"}`); w.Code != http.StatusBadRequest {
+		t.Fatalf("unknown-key PATCH expected 400, got %d", w.Code)
+	}
+	select {
+	case e := <-got:
+		t.Errorf("unexpected settings.changed published after a rejected PATCH: %+v", e.Data)
+	case <-time.After(200 * time.Millisecond):
+		// expected: nothing published
 	}
 }
 

--- a/internal/api/handlers_rule.go
+++ b/internal/api/handlers_rule.go
@@ -547,6 +547,7 @@ func (r *Router) handleRunArtistRules(w http.ResponseWriter, req *http.Request) 
 	// refreshed list inline instead of having to navigate away. Pages that
 	// do not listen for it are unaffected.
 	w.Header().Set("HX-Trigger", "dashboard:action-resolved, artist:show-violations-tab")
+	r.emitActionResolved()
 
 	// Dashboard URL pre-filtered to this artist, kept in the JSON response
 	// below for non-HTMX clients. The HTMX fragment omits the link because

--- a/internal/api/handlers_sse.go
+++ b/internal/api/handlers_sse.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -12,8 +13,22 @@ import (
 	"github.com/sydlexius/stillwater/internal/event"
 )
 
+// Replay buffer defaults: the hub retains recent broadcasts so a client that
+// reconnects with a Last-Event-ID header can be caught up without losing
+// events. Bounded by whichever limit is hit first (count or age).
+const (
+	defaultSSEBufferMaxEvents = 1000
+	defaultSSEBufferTTL       = 5 * time.Minute
+)
+
 // SSEEvent is a single server-sent event payload delivered to browser clients.
 type SSEEvent struct {
+	// ID is the monotonic event id assigned by the hub on broadcast. It is
+	// emitted as the SSE `id:` field so the browser EventSource echoes it back
+	// as the Last-Event-ID header on reconnect, driving replay. Empty for
+	// transport-only frames (the initial "connected" event) that must not
+	// advance the client's last-seen id.
+	ID string `json:"id,omitempty"`
 	// Type is the SSE event name (e.g. "scan.completed", "rule.violation").
 	Type string `json:"type"`
 	// Title is a short human-readable summary for toast/notification display.
@@ -32,12 +47,32 @@ type SSEClient struct {
 	userID string
 }
 
+// bufferedSSEEvent is one entry in the hub's replay ring buffer: the broadcast
+// event plus the id and wall-clock time used for replay and TTL eviction.
+type bufferedSSEEvent struct {
+	id  uint64
+	at  time.Time
+	evt SSEEvent
+}
+
 // SSEHub manages connected SSE clients and fans out events from the event bus.
 // It is safe for concurrent access from multiple goroutines.
 type SSEHub struct {
 	mu      sync.RWMutex
 	clients map[*SSEClient]struct{}
 	logger  *slog.Logger
+
+	// nextID is the monotonic counter stamped onto each broadcast event.
+	nextID uint64
+	// buffer is the replay ring. Entries from head to the end are "live"
+	// (within the count + TTL bounds); entries before head are dead and
+	// reclaimed on the next compaction.
+	buffer []bufferedSSEEvent
+	head   int
+	// bufMax / bufTTL bound the live window; now is injectable for tests.
+	bufMax int
+	bufTTL time.Duration
+	now    func() time.Time
 }
 
 // NewSSEHub creates a new SSE hub.
@@ -45,6 +80,9 @@ func NewSSEHub(logger *slog.Logger) *SSEHub {
 	return &SSEHub{
 		clients: make(map[*SSEClient]struct{}),
 		logger:  logger,
+		bufMax:  defaultSSEBufferMaxEvents,
+		bufTTL:  defaultSSEBufferTTL,
+		now:     func() time.Time { return time.Now().UTC() },
 	}
 }
 
@@ -72,11 +110,18 @@ func (h *SSEHub) Unregister(c *SSEClient) {
 	h.logger.Debug("sse client disconnected", "user_id", c.userID, "clients", h.ClientCount())
 }
 
-// Broadcast sends an event to all connected clients. If a client's buffer is
-// full the event is dropped for that client (non-blocking).
+// Broadcast assigns the event a monotonic id, records it in the replay buffer,
+// and fans it out to all connected clients. If a client's buffer is full the
+// event is dropped for that client (non-blocking) -- but it stays in the replay
+// buffer, so a client that reconnects can still recover it via Last-Event-ID.
 func (h *SSEHub) Broadcast(evt SSEEvent) {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.nextID++
+	evt.ID = strconv.FormatUint(h.nextID, 10)
+	h.recordEvent(evt, h.nextID, h.now())
+
 	for c := range h.clients {
 		select {
 		case c.ch <- evt:
@@ -85,6 +130,74 @@ func (h *SSEHub) Broadcast(evt SSEEvent) {
 				"user_id", c.userID, "type", evt.Type)
 		}
 	}
+}
+
+// recordEvent appends e to the replay buffer and evicts entries older than
+// bufTTL or beyond bufMax. head marks the oldest live entry; the backing slice
+// is only physically compacted once the dead prefix grows to dominate it, which
+// keeps Broadcast amortized O(1) rather than reallocating on every event.
+// Callers must hold h.mu.
+func (h *SSEHub) recordEvent(e SSEEvent, id uint64, at time.Time) {
+	h.buffer = append(h.buffer, bufferedSSEEvent{id: id, at: at, evt: e})
+
+	// TTL eviction: advance past entries older than the retention window.
+	for h.head < len(h.buffer) && at.Sub(h.buffer[h.head].at) > h.bufTTL {
+		h.head++
+	}
+	// Count eviction: keep at most bufMax live entries.
+	if live := len(h.buffer) - h.head; live > h.bufMax {
+		h.head += live - h.bufMax
+	}
+	// Compact when the dead prefix is at least as large as the live tail,
+	// bounding the backing array to roughly 2*bufMax and letting the GC
+	// reclaim evicted events.
+	if h.head > 0 && h.head >= len(h.buffer)-h.head {
+		h.buffer = append([]bufferedSSEEvent(nil), h.buffer[h.head:]...)
+		h.head = 0
+	}
+}
+
+// Replay returns the buffered events a reconnecting client missed, given the
+// Last-Event-ID it last saw. boundary is the highest id the hub has assigned so
+// far; the caller uses it to suppress duplicate live delivery of events that
+// replay already covered. complete is false when the requested id is no longer
+// recoverable from the buffer (evicted, never issued, or unparsable) -- the
+// client should then refetch derived state instead of trusting replay.
+func (h *SSEHub) Replay(lastEventID string) (events []SSEEvent, boundary uint64, complete bool) {
+	id, err := strconv.ParseUint(lastEventID, 10, 64)
+	if err != nil {
+		return nil, 0, false
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	boundary = h.nextID
+	live := h.buffer[h.head:]
+	if len(live) == 0 {
+		// Nothing buffered: the client is current only if it already saw the
+		// latest id we assigned.
+		return nil, boundary, id == h.nextID
+	}
+
+	oldest := live[0].id
+	newest := live[len(live)-1].id
+	switch {
+	case id > newest:
+		// Client claims an id we never issued (server restart / counter
+		// reset): treat as loss.
+		return nil, boundary, false
+	case id+1 < oldest:
+		// The event after the client's last-seen id was evicted: gap.
+		return nil, boundary, false
+	}
+
+	for i := range live {
+		if live[i].id > id {
+			events = append(events, live[i].evt)
+		}
+	}
+	return events, boundary, true
 }
 
 // ClientCount returns the number of connected SSE clients.
@@ -216,6 +329,13 @@ func buildConnectionPushFailedMsg(data map[string]any) string {
 	return base
 }
 
+// buildActivityRecentMsg surfaces the human-readable text of a recent-activity
+// item for the next dashboard's live rail. The rail consumes the structured
+// Data directly; this message is the plain-toast fallback.
+func buildActivityRecentMsg(data map[string]any) string {
+	return strVal(data, "text")
+}
+
 // SubscribeToEventBus registers event bus handlers that convert internal events
 // into SSE events and broadcast them to all connected clients.
 //
@@ -241,6 +361,13 @@ func (h *SSEHub) SubscribeToEventBus(bus *event.Bus) {
 		// error_class + artist_name fields; the raw transport error is
 		// deliberately NOT in Data. See internal/publish/notifier.go.
 		{event.ConnectionPushFailed, "Platform push failed", buildConnectionPushFailedMsg},
+		// M55 next-channel events. These are low-volume cross-tab / dashboard
+		// signals; their consumers read the structured Data, so the Title is
+		// only a plain-toast fallback. logs.line / logs.throttled are NOT here
+		// (emitted on the dedicated logs stream in #1338).
+		{event.ActivityRecent, "Recent activity", buildActivityRecentMsg},
+		{event.SettingsChanged, "Settings changed", nil},
+		{event.DashboardActionResolved, "Action resolved", nil},
 	}
 
 	for _, m := range mappings {
@@ -262,6 +389,18 @@ func (h *SSEHub) SubscribeToEventBus(bus *event.Bus) {
 			})
 		})
 	}
+}
+
+// emitActionResolved re-emits the dashboard action-resolved signal on the SSE
+// bus so the action-queue badge updates across all open tabs. The originating
+// handler still sets the "dashboard:action-resolved" HX-Trigger header for the
+// same-tab HTMX update; this is the cross-tab counterpart. Safe to call with a
+// nil bus (no-op).
+func (r *Router) emitActionResolved() {
+	if r.eventBus == nil {
+		return
+	}
+	r.eventBus.Publish(event.Event{Type: event.DashboardActionResolved})
 }
 
 // handleSSEStream serves the SSE endpoint. It keeps the connection open,
@@ -302,20 +441,47 @@ func (r *Router) handleSSEStream(w http.ResponseWriter, req *http.Request) {
 		r.logger.Error("failed to clear write deadline for SSE stream", "err", err)
 	}
 
-	// Register this client with the hub.
+	// Register this client with the hub. Register BEFORE computing replay so
+	// that any event broadcast during replay still lands on the live channel
+	// (no gap); the replay boundary then suppresses the duplicate.
 	client := r.sseHub.Register(userID)
 
 	// Ensure we unregister on disconnect.
 	defer r.sseHub.Unregister(client)
 
-	// Send initial connection confirmation.
+	// Replay any events missed since the client's last-seen id. The browser
+	// EventSource sends Last-Event-ID automatically on reconnect; a query
+	// param fallback keeps the endpoint testable and usable by non-browser
+	// clients. boundary dedupes the live channel below; bufferLoss tells the
+	// client replay could not bridge the gap so it should refetch state.
+	var replay []SSEEvent
+	var boundary uint64
+	bufferLoss := false
+	if lastEventID := lastEventIDFromRequest(req); lastEventID != "" {
+		var complete bool
+		replay, boundary, complete = r.sseHub.Replay(lastEventID)
+		bufferLoss = !complete
+	}
+
+	// Send initial connection confirmation. The connected frame carries no
+	// `id:` (empty SSEEvent.ID) so it never advances the client's last-seen id.
 	if err := writeSSEEvent(w, "connected", SSEEvent{
 		Type:      "connected",
 		Title:     "Connected",
 		Message:   "SSE stream established",
 		Timestamp: time.Now().UTC(),
+		Data: map[string]any{
+			"replayed":   len(replay),
+			"bufferLoss": bufferLoss,
+		},
 	}, r.logger); err != nil {
 		return
+	}
+	// Replay missed events; each retains its original id and type.
+	for _, evt := range replay {
+		if err := writeSSEEvent(w, evt.Type, evt, r.logger); err != nil {
+			return
+		}
 	}
 	flusher.Flush()
 
@@ -332,6 +498,14 @@ func (r *Router) handleSSEStream(w http.ResponseWriter, req *http.Request) {
 			if !ok {
 				// Channel closed (hub shut down).
 				return
+			}
+			// Skip events already delivered via replay (id <= boundary). This
+			// dedupes the window between Register and Replay, where an event
+			// can land on both the live channel and the replay set.
+			if boundary > 0 && evt.ID != "" {
+				if eid, err := strconv.ParseUint(evt.ID, 10, 64); err == nil && eid <= boundary {
+					continue
+				}
 			}
 			if err := writeSSEEvent(w, evt.Type, evt, r.logger); err != nil {
 				// Write failed -- client likely disconnected.
@@ -358,7 +532,14 @@ func writeSSEEvent(w http.ResponseWriter, eventType string, evt SSEEvent, logger
 		logger.Warn("sse event marshal failed", "type", eventType, "error", err)
 		return err
 	}
-	// SSE format: "event: <type>\ndata: <json>\n\n"
+	// SSE format: "id: <id>\nevent: <type>\ndata: <json>\n\n". The id line is
+	// emitted only when the event carries one, so transport-only frames (the
+	// connected handshake) do not advance the browser's Last-Event-ID.
+	if evt.ID != "" {
+		if _, err := w.Write([]byte("id: " + evt.ID + "\n")); err != nil {
+			return err
+		}
+	}
 	if _, err := w.Write([]byte("event: " + eventType + "\n")); err != nil {
 		return err
 	}
@@ -372,6 +553,16 @@ func writeSSEEvent(w http.ResponseWriter, eventType string, evt SSEEvent, logger
 		return err
 	}
 	return nil
+}
+
+// lastEventIDFromRequest returns the client's last-seen SSE event id. Browsers
+// send it via the Last-Event-ID header on automatic reconnect; the
+// last_event_id query param is a fallback for non-browser clients and tests.
+func lastEventIDFromRequest(req *http.Request) string {
+	if id := req.Header.Get("Last-Event-ID"); id != "" {
+		return id
+	}
+	return req.URL.Query().Get("last_event_id")
 }
 
 // userIDFromRequest extracts the user ID from the request context.

--- a/internal/api/handlers_sse.go
+++ b/internal/api/handlers_sse.go
@@ -173,10 +173,18 @@ func (h *SSEHub) Replay(lastEventID string) (events []SSEEvent, boundary uint64,
 	defer h.mu.RUnlock()
 
 	boundary = h.nextID
-	live := h.buffer[h.head:]
+	// Apply the TTL cutoff at read time as well: head only advances on
+	// broadcast (recordEvent), so during an idle period a reconnect could
+	// otherwise be handed events older than the retention window.
+	start := h.head
+	now := h.now()
+	for start < len(h.buffer) && now.Sub(h.buffer[start].at) > h.bufTTL {
+		start++
+	}
+	live := h.buffer[start:]
 	if len(live) == 0 {
-		// Nothing buffered: the client is current only if it already saw the
-		// latest id we assigned.
+		// Nothing live: the client is current only if it already saw the
+		// latest id we assigned (anything older fell outside the window).
 		return nil, boundary, id == h.nextID
 	}
 

--- a/internal/api/handlers_sse_test.go
+++ b/internal/api/handlers_sse_test.go
@@ -226,6 +226,39 @@ func TestSSEHub_ReplayDetectsBufferLoss(t *testing.T) {
 	}
 }
 
+// TestSSEHub_ReplayEnforcesTTLAtReadTime verifies replay honors the retention
+// window even when no new broadcast has arrived to trigger eviction: head only
+// advances in recordEvent, so during an idle period Replay must apply the TTL
+// cutoff itself rather than hand back stale events.
+func TestSSEHub_ReplayEnforcesTTLAtReadTime(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	cur := base
+	hub := NewSSEHub(slog.Default())
+	hub.now = func() time.Time { return cur }
+	hub.bufTTL = 5 * time.Minute
+
+	for i := 0; i < 3; i++ {
+		hub.Broadcast(SSEEvent{Type: "x"})
+	}
+
+	// Advance past the TTL with no new broadcasts (idle period) so eviction
+	// never ran in recordEvent.
+	cur = base.Add(6 * time.Minute)
+
+	// A client reconnecting with an old id: every buffered event now falls
+	// outside the window, so replay must report buffer loss (refetch), not
+	// hand back stale events.
+	if _, _, complete := hub.Replay("1"); complete {
+		t.Error("expected buffer loss when all buffered events aged out of the TTL window")
+	}
+	// A client already at the newest id is still current: no replay, complete.
+	events, _, complete := hub.Replay("3")
+	if !complete || len(events) != 0 {
+		t.Errorf("current client: complete=%v events=%d, want true/0", complete, len(events))
+	}
+}
+
 // TestSSEHub_ReplayRejectsUnparsableID treats a malformed Last-Event-ID as
 // buffer loss rather than guessing, so a corrupt header forces a clean refetch.
 func TestSSEHub_ReplayRejectsUnparsableID(t *testing.T) {

--- a/internal/api/handlers_sse_test.go
+++ b/internal/api/handlers_sse_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -147,6 +148,241 @@ func TestSSEHub_SubscribeToEventBus(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("did not receive event within timeout")
 	}
+}
+
+// TestSSEHub_BroadcastAssignsMonotonicIDs verifies every broadcast event is
+// stamped with a distinct, increasing decimal id. The id is what the browser
+// EventSource echoes back as the Last-Event-ID header on reconnect, so it must
+// be present and strictly increasing for replay to work.
+func TestSSEHub_BroadcastAssignsMonotonicIDs(t *testing.T) {
+	t.Parallel()
+	hub := NewSSEHub(slog.Default())
+	c := hub.Register("u1")
+	defer hub.Unregister(c)
+
+	hub.Broadcast(SSEEvent{Type: "test"})
+	hub.Broadcast(SSEEvent{Type: "test"})
+
+	first := <-c.ch
+	second := <-c.ch
+
+	if first.ID != "1" {
+		t.Errorf("first event ID = %q, want %q", first.ID, "1")
+	}
+	if second.ID != "2" {
+		t.Errorf("second event ID = %q, want %q", second.ID, "2")
+	}
+}
+
+// TestSSEHub_ReplayReturnsEventsAfterLastID verifies a client that reconnects
+// with a Last-Event-ID inside the buffer window is handed exactly the events it
+// missed, in order, plus the boundary id used to dedupe live delivery.
+func TestSSEHub_ReplayReturnsEventsAfterLastID(t *testing.T) {
+	t.Parallel()
+	hub := NewSSEHub(slog.Default())
+	for i := 0; i < 5; i++ {
+		hub.Broadcast(SSEEvent{Type: "test"})
+	}
+
+	events, boundary, complete := hub.Replay("2")
+	if !complete {
+		t.Fatal("expected complete replay, got buffer loss")
+	}
+	if boundary != 5 {
+		t.Errorf("boundary = %d, want 5", boundary)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 replayed events (ids 3,4,5), got %d", len(events))
+	}
+	if events[0].ID != "3" || events[2].ID != "5" {
+		t.Errorf("replayed ids = %q..%q, want 3..5", events[0].ID, events[2].ID)
+	}
+}
+
+// TestSSEHub_ReplayDetectsBufferLoss verifies that a Last-Event-ID older than
+// the retained window reports buffer loss (so the client refetches derived
+// state), while a client already at the newest id replays nothing and is
+// considered current.
+func TestSSEHub_ReplayDetectsBufferLoss(t *testing.T) {
+	t.Parallel()
+	hub := NewSSEHub(slog.Default())
+	hub.bufMax = 3 // force eviction of the oldest events
+	for i := 0; i < 10; i++ {
+		hub.Broadcast(SSEEvent{Type: "test"})
+	}
+
+	// Client last saw id 2, but only ids 8,9,10 remain buffered -> gap.
+	if _, _, complete := hub.Replay("2"); complete {
+		t.Error("expected buffer loss for evicted id, got complete replay")
+	}
+
+	// A client already at the newest id is current: complete, no events.
+	events, _, complete := hub.Replay("10")
+	if !complete {
+		t.Error("expected complete replay for a current client")
+	}
+	if len(events) != 0 {
+		t.Errorf("expected no replay for a current client, got %d", len(events))
+	}
+}
+
+// TestSSEHub_ReplayRejectsUnparsableID treats a malformed Last-Event-ID as
+// buffer loss rather than guessing, so a corrupt header forces a clean refetch.
+func TestSSEHub_ReplayRejectsUnparsableID(t *testing.T) {
+	t.Parallel()
+	hub := NewSSEHub(slog.Default())
+	hub.Broadcast(SSEEvent{Type: "test"})
+	if _, _, complete := hub.Replay("not-a-number"); complete {
+		t.Error("expected buffer loss for an unparsable Last-Event-ID")
+	}
+}
+
+// TestHandleSSEStream_ReplaysFromLastEventID verifies the stream handler reads
+// the Last-Event-ID request header and replays the buffered events the client
+// missed, each carrying its `id:` frame.
+func TestHandleSSEStream_ReplaysFromLastEventID(t *testing.T) {
+	t.Parallel()
+	logger := slog.Default()
+	hub := NewSSEHub(logger)
+	r := &Router{sseHub: hub, logger: logger}
+
+	// Buffer three events before any client connects.
+	for i := 0; i < 3; i++ {
+		hub.Broadcast(SSEEvent{Type: "scan.completed", Message: "done"})
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := middleware.WithTestUserID(req.Context(), "test-user")
+		r.handleSSEStream(w, req.WithContext(ctx))
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpReq.Header.Set("Last-Event-ID", "1") // client last saw event 1
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	var got []string
+	sawID2, sawID3 := false, false
+	for scanner.Scan() {
+		line := scanner.Text()
+		got = append(got, line)
+		if line == "id: 2" {
+			sawID2 = true
+		}
+		if line == "id: 3" {
+			sawID3 = true
+		}
+		if sawID2 && sawID3 {
+			break
+		}
+	}
+	if !sawID2 || !sawID3 {
+		t.Errorf("expected replay of ids 2 and 3, got frames:\n%s", strings.Join(got, "\n"))
+	}
+}
+
+// TestSSEHub_BroadcastsNextChannelEvents verifies the new next-channel event
+// types defined for M55 are mapped through SubscribeToEventBus and reach
+// connected clients with their structured Data preserved. These are the
+// cross-tab / dashboard events that flow through the main events stream;
+// logs.line / logs.throttled are deliberately NOT mapped here because they are
+// emitted on the dedicated logs stream (#1338).
+func TestSSEHub_BroadcastsNextChannelEvents(t *testing.T) {
+	t.Parallel()
+	logger := slog.Default()
+	hub := NewSSEHub(logger)
+	bus := event.NewBus(logger, 64)
+	hub.SubscribeToEventBus(bus)
+
+	c := hub.Register("u1")
+	defer hub.Unregister(c)
+
+	go bus.Start()
+	defer bus.Stop()
+
+	cases := []struct {
+		typ  event.Type
+		data map[string]any
+	}{
+		{event.SettingsChanged, map[string]any{"sectionId": "preferences", "updatedBy": "u1"}},
+		{event.DashboardActionResolved, map[string]any{}},
+		{event.ActivityRecent, map[string]any{"kind": "scan", "text": "Scan finished"}},
+	}
+	for _, tc := range cases {
+		bus.Publish(event.Event{Type: tc.typ, Data: tc.data})
+	}
+
+	got := map[string]bool{}
+	for range cases {
+		select {
+		case e := <-c.ch:
+			got[e.Type] = true
+		case <-time.After(2 * time.Second):
+			t.Fatal("did not receive all next-channel events within timeout")
+		}
+	}
+	for _, tc := range cases {
+		if !got[string(tc.typ)] {
+			t.Errorf("missing broadcast for event type %q", tc.typ)
+		}
+	}
+}
+
+// TestSSEHub_ConcurrentBroadcastReplay hammers Broadcast (write lock + buffer
+// mutation), Replay (read lock + buffer read), and client churn concurrently so
+// the race detector can catch any unsynchronized access to the replay buffer.
+func TestSSEHub_ConcurrentBroadcastReplay(t *testing.T) {
+	t.Parallel()
+	hub := NewSSEHub(slog.Default())
+	hub.bufMax = 50 // small window so eviction/compaction runs under contention
+
+	reader := hub.Register("reader")
+	// Drain the reader so Broadcast never blocks on a full client buffer; the
+	// range ends when Unregister closes reader.ch after the workload.
+	drained := make(chan struct{})
+	go func() {
+		defer close(drained)
+		for range reader.ch {
+		}
+	}()
+
+	const iters = 2000
+	var wg sync.WaitGroup
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				hub.Broadcast(SSEEvent{Type: "x"})
+			}
+		}()
+	}
+	for w := 0; w < 4; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				hub.Replay("10")
+				_ = hub.ClientCount()
+			}
+		}()
+	}
+	wg.Wait()
+
+	hub.Unregister(reader)
+	<-drained
 }
 
 func TestHandleSSEStream(t *testing.T) {

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -12350,7 +12350,10 @@ paths:
         connected browser clients. Events include scan completions, rule
         violations, bulk operation results, artist updates, and the
         next-channel events settings.changed, dashboard.action-resolved, and
-        activity.recent.
+        activity.recent. Log events (`logs.line`, `logs.throttled`) are
+        deliberately NOT delivered on this stream -- they are reserved for a
+        dedicated logs stream so a high-volume log feed never fans out to every
+        connected tab.
 
         Each event carries a monotonic `id:` frame. The browser EventSource
         echoes the last id back as the `Last-Event-ID` header on reconnect; the

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -12348,15 +12348,27 @@ paths:
       description: |
         Server-Sent Events endpoint that streams real-time system events to
         connected browser clients. Events include scan completions, rule
-        violations, bulk operation results, and artist updates.
+        violations, bulk operation results, artist updates, and the
+        next-channel events settings.changed, dashboard.action-resolved, and
+        activity.recent.
 
-        The connection sends a heartbeat comment every 30 seconds to keep
-        the connection alive. Clients should auto-reconnect on disconnect.
+        Each event carries a monotonic `id:` frame. The browser EventSource
+        echoes the last id back as the `Last-Event-ID` header on reconnect; the
+        server then replays the events the client missed from a bounded ring
+        buffer (1000 events / 5 minutes, whichever is hit first). The initial
+        `connected` frame carries `data.replayed` (count replayed) and
+        `data.bufferLoss` (true when the gap could not be bridged, in which case
+        the client should refetch derived state). A heartbeat comment is sent
+        every 30 seconds to keep the connection alive.
+
+        See the SSE event catalog (Contributing > Architecture > SSE event
+        catalog) for the full event list, frame format, and reconnect semantics.
 
         Event format follows the SSE specification with named events:
         ```
+        id: 42
         event: scan.completed
-        data: {"type":"scan.completed","title":"Scan completed","message":"Library scan finished","timestamp":"...","data":{}}
+        data: {"id":"42","type":"scan.completed","title":"Scan completed","message":"Library scan finished","timestamp":"...","data":{}}
         ```
       operationId: getEventStream
       tags:

--- a/internal/api/testdata/openapi-coverage-baseline.json
+++ b/internal/api/testdata/openapi-coverage-baseline.json
@@ -15,7 +15,6 @@
   "deleteProviderKey",
   "deleteProviderMirror",
   "deleteWebhook",
-  "dismissViolation",
   "exportComplianceReport",
   "getAPIDocs",
   "getArtist",

--- a/internal/api/testdata/openapi-coverage.json
+++ b/internal/api/testdata/openapi-coverage.json
@@ -375,7 +375,7 @@
     "method": "POST",
     "path": "/notifications/{id}/dismiss",
     "handler": "handleDismissViolation",
-    "covered": false
+    "covered": true
   },
   {
     "operationId": "downloadBackup",

--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -46,6 +46,29 @@ const (
 	// caller, so there is no other way for the operator to learn that the
 	// platform write failed.
 	ConnectionPushFailed Type = "connection.push_failed"
+
+	// --- M55 next-channel events (catalog defined by #1341) ---
+
+	// ActivityRecent carries a single recent-activity item for the next
+	// dashboard's live activity rail. Data: {ts, kind, text, artistId?}.
+	// Emission is wired by the dashboard work (#1334); the type and SSE
+	// mapping live here so that issue does not have to touch the catalog.
+	ActivityRecent Type = "activity.recent"
+	// SettingsChanged fires after a successful preferences/settings write so
+	// other open tabs can refetch or toast. Data: {sectionId, updatedBy, ts}.
+	SettingsChanged Type = "settings.changed"
+	// DashboardActionResolved mirrors the existing "dashboard:action-resolved"
+	// HTMX trigger onto the SSE bus so the action-queue badge updates across
+	// tabs, not just in the tab that resolved the action.
+	DashboardActionResolved Type = "dashboard.action-resolved"
+	// LogsLine and LogsThrottled are emitted by the dedicated logs stream
+	// (#1338 GET /api/v1/logs/stream), NOT broadcast through the main events
+	// hub (a raw log firehose must not fan out to every connected client).
+	// The types are cataloged here so #1338 can rely on the envelope shapes:
+	// LogsLine Data carries a structured log record; LogsThrottled Data
+	// carries {dropped, window} when the server-side rate limit sheds lines.
+	LogsLine      Type = "logs.line"
+	LogsThrottled Type = "logs.throttled"
 )
 
 // Event represents something that happened in the system.

--- a/web/components/_doc-anchors.txt
+++ b/web/components/_doc-anchors.txt
@@ -42,6 +42,13 @@ contributing/architecture/settings-import-export#settings-importexport
 contributing/architecture/settings-import-export#transactional-per-section-apply
 contributing/architecture/settings-import-export#user-remap-role-coercion-and-oobe-restore
 contributing/architecture/settings-import-export#where-to-look
+contributing/architecture/sse-events#catalog
+contributing/architecture/sse-events#endpoint
+contributing/architecture/sse-events#frame-format
+contributing/architecture/sse-events#logs-events-dedicated-stream
+contributing/architecture/sse-events#reconnect-and-replay
+contributing/architecture/sse-events#sse-event-catalog
+contributing/architecture/sse-events#where-to-look
 core-concepts/artists-and-libraries#artist-directories
 core-concepts/artists-and-libraries#artists
 core-concepts/artists-and-libraries#artists-and-libraries

--- a/web/components/_doc-anchors.txt
+++ b/web/components/_doc-anchors.txt
@@ -45,7 +45,7 @@ contributing/architecture/settings-import-export#where-to-look
 contributing/architecture/sse-events#catalog
 contributing/architecture/sse-events#endpoint
 contributing/architecture/sse-events#frame-format
-contributing/architecture/sse-events#logs-events-dedicated-stream
+contributing/architecture/sse-events#logs-events-planned-dedicated-stream
 contributing/architecture/sse-events#reconnect-and-replay
 contributing/architecture/sse-events#sse-event-catalog
 contributing/architecture/sse-events#where-to-look

--- a/web/static/js/sse.js
+++ b/web/static/js/sse.js
@@ -27,7 +27,7 @@
   // which we already toasted; event ids are monotonic, so we only toast an
   // id greater than this mark. Events missed while offline still carry ids
   // above the mark, so their toasts fire exactly once.
-  var maxSeenId = 0;
+  var maxSeenId = -1;
 
   // wasDisconnected gates the reconnect-rehydrate path so the initial
   // page-load `connected` event does NOT fire status fetches (the page
@@ -137,8 +137,13 @@
   // reports whether the frame is a replay duplicate (id at or below the mark).
   // Frames without a numeric id (the connected handshake) never dedupe.
   function noteSeenID(evt) {
-    var evtId = evt && evt.lastEventId ? parseInt(evt.lastEventId, 10) : 0;
-    if (!evtId || isNaN(evtId)) {
+    // Distinguish "no id" (empty Last-Event-ID, e.g. the connected handshake)
+    // from a valid id of 0: the replay contract only requires a monotonic
+    // decimal id, so 0 must advance the mark rather than fold into the no-id
+    // path. maxSeenId starts at -1 so a first id of 0 is not its own duplicate.
+    var rawId = evt && typeof evt.lastEventId === "string" ? evt.lastEventId : "";
+    var evtId = rawId === "" ? NaN : parseInt(rawId, 10);
+    if (isNaN(evtId)) {
       return false;
     }
     if (evtId <= maxSeenId) {
@@ -205,8 +210,10 @@
     }
 
     // Keep the toast high-water mark in step with the shared id sequence so a
-    // later toast event is not mistaken for a replay duplicate.
-    noteSeenID(evt);
+    // later toast event is not mistaken for a replay duplicate. Capture the
+    // flag: connection.push_failed renders a user-visible toast below and must
+    // not re-toast replayed frames on reconnect.
+    var isReplayDuplicate = noteSeenID(evt);
 
     // dashboard.action-resolved is the cross-tab counterpart of the
     // "dashboard:action-resolved" HTMX trigger the resolving tab sets on its
@@ -224,7 +231,7 @@
     // write actually failed. The connection name + error class come from
     // the publish.busNotifier event data; an optional artist context lets
     // the message disambiguate when N platforms failed for the same item.
-    if (eventType === "connection.push_failed" && typeof window.showToast === "function") {
+    if (eventType === "connection.push_failed" && !isReplayDuplicate && typeof window.showToast === "function") {
       var conn = (data && data.connection) || "";
       var errClass = (data && data.error_class) || "push failed";
       var artist = (data && data.artist_name) || "";

--- a/web/static/js/sse.js
+++ b/web/static/js/sse.js
@@ -22,6 +22,13 @@
   var maxRetryDelay = 30000; // cap at 30 seconds
   var retryTimer = null;
 
+  // maxSeenId is the highest SSE event id we have already surfaced. On
+  // reconnect the server replays buffered events (Last-Event-ID), some of
+  // which we already toasted; event ids are monotonic, so we only toast an
+  // id greater than this mark. Events missed while offline still carry ids
+  // above the mark, so their toasts fire exactly once.
+  var maxSeenId = 0;
+
   // wasDisconnected gates the reconnect-rehydrate path so the initial
   // page-load `connected` event does NOT fire status fetches (the page
   // already rendered with the latest in-flight state from server-side
@@ -49,7 +56,17 @@
   // name has no addEventListener registration, so each new server-side
   // event type must appear here or its sse:<name> CustomEvent never
   // fires.
-  var structuredEvents = ["operation.progress", "connection.push_failed"];
+  var structuredEvents = [
+    "operation.progress",
+    "connection.push_failed",
+    // M55 next-channel events. Cross-tab / dashboard signals that render via
+    // their own consumers (no generic toast). Each must be listed here or
+    // EventSource silently drops the frame and its sse:<name> CustomEvent
+    // never fires.
+    "settings.changed",
+    "activity.recent",
+    "dashboard.action-resolved"
+  ];
 
   function connect() {
     if (source) {
@@ -116,6 +133,21 @@
     };
   }
 
+  // noteSeenID advances the toast high-water mark from an SSE frame's id and
+  // reports whether the frame is a replay duplicate (id at or below the mark).
+  // Frames without a numeric id (the connected handshake) never dedupe.
+  function noteSeenID(evt) {
+    var evtId = evt && evt.lastEventId ? parseInt(evt.lastEventId, 10) : 0;
+    if (!evtId || isNaN(evtId)) {
+      return false;
+    }
+    if (evtId <= maxSeenId) {
+      return true;
+    }
+    maxSeenId = evtId;
+    return false;
+  }
+
   function handleEvent(eventType, evt) {
     var data;
     try {
@@ -124,16 +156,24 @@
       return;
     }
 
+    // Suppress toasts for events already surfaced before a reconnect: replayed
+    // frames carry ids at or below the high-water mark. We still advance the
+    // mark and refresh derived UI below so missed-while-offline events (ids
+    // above the mark) toast exactly once.
+    var isReplayDuplicate = noteSeenID(evt);
+
     // Show toast notification.
     var toastType = toastEvents[eventType];
     var message = data.message || data.title || "Event received";
 
-    if (toastType === "success" && typeof window.showSuccessToast === "function") {
-      window.showSuccessToast(message);
-    } else if (toastType === "warning" && typeof window.showWarningToast === "function") {
-      window.showWarningToast(message);
-    } else if (typeof window.showToast === "function") {
-      window.showToast(message);
+    if (!isReplayDuplicate) {
+      if (toastType === "success" && typeof window.showSuccessToast === "function") {
+        window.showSuccessToast(message);
+      } else if (toastType === "warning" && typeof window.showWarningToast === "function") {
+        window.showWarningToast(message);
+      } else if (typeof window.showToast === "function") {
+        window.showToast(message);
+      }
     }
 
     // Refresh the notification badge count. The badge is loaded via HTMX
@@ -162,6 +202,20 @@
       data = JSON.parse(evt.data);
     } catch (e) {
       return;
+    }
+
+    // Keep the toast high-water mark in step with the shared id sequence so a
+    // later toast event is not mistaken for a replay duplicate.
+    noteSeenID(evt);
+
+    // dashboard.action-resolved is the cross-tab counterpart of the
+    // "dashboard:action-resolved" HTMX trigger the resolving tab sets on its
+    // response. Re-dispatch that same body event here so the action-queue and
+    // notification badge refresh in other open tabs via the existing HTMX
+    // wiring (which listens for "dashboard:action-resolved from:body").
+    if (eventType === "dashboard.action-resolved") {
+      document.body.dispatchEvent(new CustomEvent("dashboard:action-resolved", {bubbles: true}));
+      refreshNotificationBadge();
     }
 
     // connection.push_failed is the user-visible surface from #1088; the


### PR DESCRIPTION
## Summary

- W1 SSE foundation for the M55 `next` channel: formalises the existing `GET /api/v1/events/stream` channel into a documented catalog and adds reconnect durability.
- **Reliability (the why):** the hub was fire-and-forget, so a dropped connection silently lost events. Every broadcast now carries a monotonic `id:` frame and is retained in a bounded replay ring buffer (1000 events / 5 min, whichever first); a client that reconnects with `Last-Event-ID` is replayed the events it missed. On buffer loss the `connected` handshake reports `bufferLoss` so the client refetches derived state. The browser dedupes replayed toasts via a monotonic high-water mark.
- **New next-channel events:** `settings.changed` (fired on a successful `PATCH /api/v1/preferences`) and `dashboard.action-resolved` (re-emitted on the bus from every existing `dashboard:action-resolved` HX-Trigger site, for cross-tab badge updates; same-tab HTMX trigger preserved). `activity.recent` and `logs.line`/`logs.throttled` are cataloged (type + mapping) but their **producers are intentionally deferred** to the issues that build the producing endpoints (#1334 dashboard, #1338 logs) — there is no code to emit them yet.
- Reviewers: start at `internal/api/handlers_sse.go` (`Broadcast` ring buffer + `Replay`) and `handleSSEStream` (Last-Event-ID handling + dedupe boundary).

## Linked issue

Closes #1341

## Pre-flight checklist

- [x] Pre-push gate green (ran automatically via the pre-push hook on push; full `./...` race suite + lint + coverage passed).
- [ ] `/prep-pr` / `pr-review-toolkit` not run. A local `coderabbit review --plain` pass was run and its 2 findings addressed (test type-assertion hardening; OpenAPI `events/stream` description refreshed for the new id/replay behavior). Cloud CR will review on this PR.
- [x] Squashed into one clean commit before first push.
- [x] Labels set (`enhancement`, `api`, `scope: medium`).
- [x] Docs label decision: docs are included in this PR (new "SSE event catalog" page), so neither `docs: not-required` nor `needs-docs-review` applies.
- [x] No UI change (backend SSE + ES5 client JS); no screenshot needed.
- [x] UAT performed against the running binary (see Test plan).
- [x] OpenAPI updated: `events/stream` description refreshed to document id frames + Last-Event-ID replay + the `connected` `{replayed, bufferLoss}` fields; `make check-openapi` passes. (No structured per-event schema added — this endpoint models its response as `type: string`, like all SSE events; the full catalog lives in the new docs page.)
- [x] No `.templ` files changed; nothing to regenerate.

## Test plan

- [x] `go test -race ./...` passes (run by the pre-push gate; all packages `ok`). Targeted concurrency test `TestSSEHub_ConcurrentBroadcastReplay` hammers Broadcast/Replay/client-churn under `-race`.
- [x] `bash scripts/pre-push-gate.sh` passes (run by the pre-push hook; push succeeded).
- [x] Manual UAT against the dev binary (`SW_UX` build on :1973, Bearer auth):
  - [x] `connected` frame carries `{bufferLoss:false, replayed:0}` and no `id:` line.
  - [x] `PATCH /api/v1/preferences {"theme":"dark"}` -> reconnect with `last_event_id=0` replays `id: 1` / `event: settings.changed` with `{sectionId, updatedBy, ts}`; `connected` reports `replayed:1`.
  - [x] Dismiss a violation -> reconnect replays `event: dashboard.action-resolved`.
- [ ] Reviewer follow-ups:
  - [ ] Scope grew beyond the issue's `scope: small` to the full acceptance list (per owner decision) — hence `scope: medium`.
  - [ ] Confirm the OpenAPI choice (prose description vs structured per-event schema) is acceptable for SSE.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SSE replayable stream with bounded buffer (1,000 events / 5 min) and initial "connected" frame.
  * Client-side replay deduplication and cross-tab broadcast for settings changes and dashboard actions.

* **Documentation**
  * Added comprehensive SSE event catalog, endpoint/frame format, reconnect/replay semantics, and examples.
  * Updated API docs to reflect SSE replay behavior.

* **Bug Fixes**
  * Ensure action-resolved events emit on dismiss/run flows and preference updates.

* **Tests**
  * Added SSE replay/concurrency and event publication tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->