### PR TITLE
chore(ci): dedup git hooks and CI, fix docs API reference nav

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -111,9 +111,6 @@ if [ -n "$STAGED_TEMPL" ]; then
     # Always use the version pinned in go.mod via the tool directive.
     TEMPL_CMD="go tool templ"
 
-    # Save current state of generated files, regenerate, compare
-    TEMPL_GEN_FILES=$(git diff --cached --name-only -- '*_templ.go' || true)
-
     if ! $TEMPL_CMD generate 2>/tmp/pre-commit-templ.log; then
         echo -e "${RED}${BOLD}FAIL${RESET} templ generate:"
         cat /tmp/pre-commit-templ.log | head -20
@@ -195,27 +192,47 @@ else
 fi
 
 # --------------------------------------------------------------------------
-# 5. golangci-lint -- full linter suite (matches CI exactly)
+# 5. golangci-lint -- lint the packages touched by staged .go files
 # --------------------------------------------------------------------------
-if [ -n "$STAGED_GO_ANY" ]; then
+# Scoped to the packages of staged .go files rather than the whole module.
+# pre-commit runs on every commit, and a full `golangci-lint run ./...` adds
+# ~30s cold to each one. The pre-push gate (diff-only + gocognit measurement
+# re-pass) and CI's lint job (full ./...) both lint comprehensively, so the
+# per-commit pass only needs fast feedback on what is being committed.
+# Package directories (not bare file paths) are passed so the typechecker can
+# resolve cross-file symbols defined in sibling files of the same package;
+# feeding bare *.go paths breaks typecheck and silently drops findings (#1650).
+if [ -n "$STAGED_GO" ]; then
     if ! command -v golangci-lint &>/dev/null; then
         warn "golangci-lint (not installed, skipping)"
     else
-        if ! LINT_OUTPUT=$(golangci-lint run ./... 2>&1); then
+        STAGED_GO_PKGS=$(printf '%s\n' "$STAGED_GO" \
+            | xargs -n1 dirname \
+            | sort -u \
+            | sed 's|^|./|; s|$|/...|')
+        # shellcheck disable=SC2086  # newline-split into package args is intentional
+        if ! LINT_OUTPUT=$(golangci-lint run $STAGED_GO_PKGS 2>&1); then
             echo -e "${RED}${BOLD}FAIL${RESET} golangci-lint:"
             echo "$LINT_OUTPUT"
             exit 1
         fi
-        pass "golangci-lint"
+        pass "golangci-lint (staged packages)"
     fi
 else
-    warn "golangci-lint (no staged .go / go.mod / go.sum files)"
+    warn "golangci-lint (no staged .go files)"
 fi
 
 # --------------------------------------------------------------------------
-# 6. govulncheck -- check for known vulnerabilities in dependencies
+# 6. govulncheck -- scan dependencies only when go.mod / go.sum changed
 # --------------------------------------------------------------------------
-if [ -n "$STAGED_GO_ANY" ]; then
+# govulncheck scans the whole module against a network-fetched vuln DB, which
+# is too slow to run on every code commit. Its result can only change when the
+# dependency set changes, so gate it on staged go.mod / go.sum. CI's
+# security.yml runs govulncheck unconditionally against the live DB as the
+# authoritative backstop, and the pre-push gate deliberately skips it (see
+# reference_govulncheck_local_vs_ci), so nothing is lost by scoping here.
+STAGED_GO_MOD=$(git diff --cached --name-only --diff-filter=ACM -- 'go.mod' 'go.sum' || true)
+if [ -n "$STAGED_GO_MOD" ]; then
     if ! command -v govulncheck &>/dev/null; then
         warn "govulncheck (not installed, skipping)"
     else
@@ -227,7 +244,7 @@ if [ -n "$STAGED_GO_ANY" ]; then
         pass "govulncheck"
     fi
 else
-    warn "govulncheck (no staged .go / go.mod / go.sum files)"
+    warn "govulncheck (no staged go.mod / go.sum changes)"
 fi
 
 # --------------------------------------------------------------------------

--- a/.github/actions/setup-tailwind/action.yml
+++ b/.github/actions/setup-tailwind/action.yml
@@ -1,0 +1,25 @@
+# Composite action: install the pinned standalone Tailwind CSS binary.
+#
+# Single source of truth for the linux-x64 (glibc) Tailwind binary used by CI
+# jobs (gate.yml, bruno-ci.yml). To bump Tailwind, update TAILWIND_VERSION and
+# recompute TAILWIND_SHA256 from the release page here -- all CI callers pick
+# it up automatically.
+#
+# NOT shared with build/docker/Dockerfile: the image uses the -musl variant,
+# which is a different binary with a different checksum. Keep the Dockerfile's
+# pin in sync manually when bumping this one.
+name: Setup Tailwind CSS
+description: Install the pinned standalone Tailwind CSS v4 linux-x64 binary.
+runs:
+  using: composite
+  steps:
+    - name: Install Tailwind CSS
+      shell: bash
+      env:
+        TAILWIND_VERSION: v4.2.0
+        TAILWIND_SHA256: 8f65e2d21c675f1e8d265219979d17d10634c1f553a2f583265b7edb28726432
+      run: |
+        curl -fsSLO --retry 3 --retry-delay 2 --retry-all-errors "https://github.com/tailwindlabs/tailwindcss/releases/download/${TAILWIND_VERSION}/tailwindcss-linux-x64"
+        echo "${TAILWIND_SHA256}  tailwindcss-linux-x64" | sha256sum -c -
+        chmod +x tailwindcss-linux-x64
+        sudo mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss

--- a/.github/workflows/bruno-ci.yml
+++ b/.github/workflows/bruno-ci.yml
@@ -75,28 +75,14 @@ jobs:
         if: steps.filter.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         run: go tool templ generate
 
-      - name: Install Tailwind CSS standalone binary
+      # Install Tailwind via the shared composite action (single source of
+      # truth for the linux-x64 binary version + SHA). The project's input.css
+      # uses v4 syntax (@import "tailwindcss"), so the standalone binary that
+      # bundles tailwindcss is required rather than an npm install. See
+      # .github/actions/setup-tailwind for the version/SHA and the note on why
+      # this differs from the Dockerfile's musl binary.
+      - uses: ./.github/actions/setup-tailwind
         if: steps.filter.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
-        # The project's input.css uses v4 syntax (@import "tailwindcss") which
-        # postcss-import cannot resolve from a globally npm-installed package
-        # because module resolution starts at the input.css directory. The
-        # canonical install (per build/docker/Dockerfile) is the standalone
-        # binary from GitHub Releases, which bundles tailwindcss internally
-        # and skips module resolution entirely.
-        #
-        # NOTE: GitHub ubuntu-latest is glibc-based, so we use the plain
-        # tailwindcss-linux-x64 (NOT the -musl variant the Dockerfile uses).
-        # Different binary, different checksum -- keep TAILWIND_VERSION and
-        # the matching arch's SHA256 in sync with build/docker/Dockerfile
-        # whenever bumping the version.
-        env:
-          TAILWIND_VERSION: v4.2.0
-          TAILWIND_SHA256: 8f65e2d21c675f1e8d265219979d17d10634c1f553a2f583265b7edb28726432
-        run: |
-          curl -fsSLO "https://github.com/tailwindlabs/tailwindcss/releases/download/${TAILWIND_VERSION}/tailwindcss-linux-x64"
-          echo "${TAILWIND_SHA256}  tailwindcss-linux-x64" | sha256sum -c -
-          chmod +x tailwindcss-linux-x64
-          sudo mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss
 
       - name: Build Tailwind CSS
         if: steps.filter.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -3,6 +3,13 @@ name: Docs Drift
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    # The job's internal dorny/paths-filter also reads `docs/**`, but that is
+    # deliberately NOT in this trigger: the advisory ("code changed without
+    # docs") is only meaningful when a code path is present in the PR. The
+    # pull_request paths filter and the internal filter both evaluate the full
+    # PR diff (head vs base), so a docs-only follow-up push still re-triggers
+    # and clears the advisory as long as the PR still touches one of these
+    # code paths -- which is the only case the advisory applies to.
     paths:
       - 'internal/provider/**'
       - 'internal/connection/**'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,9 @@ on:
       - '**/*.md'
       - '.github/ISSUE_TEMPLATE/**'
       - '.markdownlint-cli2.yaml'
+      # Spell-check config consumed by the crate-ci/typos step: a rule change
+      # here alters lint outcomes on unchanged markdown, so it must re-trigger.
+      - '.typos.toml'
       - '.github/workflows/docs.yml'
   pull_request:
     paths:
@@ -15,6 +18,9 @@ on:
       - '**/*.md'
       - '.github/ISSUE_TEMPLATE/**'
       - '.markdownlint-cli2.yaml'
+      # Spell-check config consumed by the crate-ci/typos step: a rule change
+      # here alters lint outcomes on unchanged markdown, so it must re-trigger.
+      - '.typos.toml'
       - '.github/workflows/docs.yml'
 
 concurrency:

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -14,6 +14,10 @@
 #      compares against the local floor file.
 #   3. Fuzz matrix drift: verifies fuzz.yml matrix matches live Fuzz* funcs.
 #      fuzz.yml runs the drift check only on a weekly schedule, not on PRs.
+#   4. Provider failure smoke: asserts every covered handler surface reports
+#      provider failures explicitly instead of returning empty data.
+#   5. Tool version drift: asserts the lint/spell tool versions pinned in the
+#      bash hook, the pre-commit config, and the CI workflows all agree.
 #
 # Trigger design:
 #   Runs unconditionally on every push to main and every PR targeting main
@@ -72,19 +76,9 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      # Install Tailwind CSS standalone binary.
-      # Version and SHA must match build/docker/Dockerfile and bruno-ci.yml.
-      # To update: bump TAILWIND_VERSION, recompute SHA256 from the release page,
-      # and update all three locations together.
-      - name: Install Tailwind CSS
-        env:
-          TAILWIND_VERSION: v4.2.0
-          TAILWIND_SHA256: 8f65e2d21c675f1e8d265219979d17d10634c1f553a2f583265b7edb28726432
-        run: |
-          curl -fsSLO "https://github.com/tailwindlabs/tailwindcss/releases/download/${TAILWIND_VERSION}/tailwindcss-linux-x64"
-          echo "${TAILWIND_SHA256}  tailwindcss-linux-x64" | sha256sum -c -
-          chmod +x tailwindcss-linux-x64
-          sudo mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss
+      # Install Tailwind CSS via the shared composite action (single source of
+      # truth for version + SHA; see .github/actions/setup-tailwind).
+      - uses: ./.github/actions/setup-tailwind
 
       - name: Regenerate templ
         run: go tool templ generate
@@ -271,16 +265,8 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Install Tailwind CSS
+      - uses: ./.github/actions/setup-tailwind
         if: steps.filter.outputs.relevant == 'true'
-        env:
-          TAILWIND_VERSION: v4.2.0
-          TAILWIND_SHA256: 8f65e2d21c675f1e8d265219979d17d10634c1f553a2f583265b7edb28726432
-        run: |
-          curl -fsSLO "https://github.com/tailwindlabs/tailwindcss/releases/download/${TAILWIND_VERSION}/tailwindcss-linux-x64"
-          echo "${TAILWIND_SHA256}  tailwindcss-linux-x64" | sha256sum -c -
-          chmod +x tailwindcss-linux-x64
-          sudo mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss
 
       - name: Run provider failure smoke test
         if: steps.filter.outputs.relevant == 'true'
@@ -289,3 +275,24 @@ jobs:
       - name: Skip (no relevant changes)
         if: steps.filter.outputs.relevant != 'true'
         run: echo "No Go source or smoke script changes; provider failure smoke skipped."
+
+  # ---------------------------------------------------------------------------
+  # Tool version drift
+  #
+  # Replicates the '=== Tool version drift ===' step in
+  # scripts/pre-push-gate.sh.  Asserts the lint/spell tool versions pinned
+  # independently in .githooks/pre-commit, .pre-commit-config.yaml, ci.yml,
+  # and docs.yml all agree.  A grep-only check, so no Go toolchain is needed;
+  # always runs and always emits a terminal status.
+  # ---------------------------------------------------------------------------
+  tool-versions:
+    name: Tool Version Drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Check tool version alignment
+        run: bash scripts/check-tool-versions.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,10 @@
 # pre-commit framework (https://pre-commit.com). The canonical hook
 # wired via `core.hooksPath = .githooks` is `.githooks/pre-commit`,
 # which mirrors these checks in plain bash and is what CI expects.
-# Tool version pins below should stay in sync with the canonical hook
-# (notably: markdownlint-cli2 v0.22.1, golangci-lint v2.12.2, typos v1.44.0).
+# Tool version pins below should stay in sync with the canonical hook and CI
+# (notably: markdownlint-cli2 v0.22.1, golangci-lint v2.12.2, typos v1.46.2).
+# scripts/check-tool-versions.sh asserts these agree across all entrypoints
+# and runs in the pre-push gate, so a drift here fails before push.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -23,7 +25,8 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.44.0
+    # Keep in sync with .github/workflows/docs.yml (crate-ci/typos SHA pin).
+    rev: v1.46.2
     hooks:
       - id: typos
 

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -12,7 +12,10 @@ WORKDIR /src
 # Compute fresh hashes via:
 #   curl -fsSLO https://github.com/tailwindlabs/tailwindcss/releases/download/<vX>/tailwindcss-linux-{x64,arm64}-musl
 #   shasum -a 256 tailwindcss-linux-*-musl
-# Keep .github/workflows/bruno-ci.yml in sync with TAILWIND_VERSION + TAILWIND_SHA256_X64.
+# This Dockerfile pins the musl binaries (x64 + arm64). The CI workflows pin the
+# glibc linux-x64 binary in .github/actions/setup-tailwind, which owns
+# TAILWIND_VERSION + its x64 SHA. Bump TAILWIND_VERSION in both places together,
+# but the musl SHAs here differ from the action's x64 SHA and stay separate.
 ARG TAILWIND_VERSION=v4.2.0
 ARG TAILWIND_SHA256_X64=44b85e87dd1812b5b7e46b6522c80cfa045474c736afa6c9ad2279b7d4944354
 ARG TAILWIND_SHA256_ARM64=2db78c3d59d0b7f75fee28a7ea0d0dc6284761bd039bf633a9f5daac80060829

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -40,7 +40,10 @@ theme:
         icon: material/weather-night
         name: Switch to dark mode
   features:
-    - navigation.instant
+    # navigation.instant is intentionally NOT enabled: the /api/ page is a
+    # standalone Scalar document (see the API Reference nav entry below and
+    # docs/site/build-api-reference.sh) with none of Material's DOM structure,
+    # so instant loading silently fails to mount it (#1760). Do not re-add.
     - navigation.tabs
     - navigation.sections
     - navigation.top
@@ -157,7 +160,8 @@ nav:
       - Worktrees: contributing/worktrees.md
       - Milestone protocol: contributing/milestone-protocol.md
   # /api/ is overwritten at deploy time with the standalone Scalar reference
-  # (see docs/site/build-api-reference.sh). A relative link is correct: clicking
-  # it does a normal full-page load to that document. navigation.instant falls
-  # back to a real navigation for non-Material pages, so it does not break.
+  # (see docs/site/build-api-reference.sh), a document with none of Material's
+  # DOM structure. With navigation.instant disabled (see theme.features above),
+  # clicking this entry does a normal full-page load and Scalar mounts cleanly.
+  # Re-enabling instant loading would intercept the click and break it (#1760).
   - API Reference: api/index.md

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# check-tool-versions.sh -- assert lint/spell tool versions agree across the
+# multiple entrypoints that each pin them independently:
+#
+#   * .githooks/pre-commit        (canonical bash hook; npx pin for markdownlint)
+#   * .pre-commit-config.yaml     (pre-commit framework alternative; rev: pins)
+#   * .github/workflows/ci.yml    (golangci-lint-action version:)
+#   * .github/workflows/docs.yml  (crate-ci/typos SHA pin + "# vX.Y.Z" comment)
+#
+# It also asserts TAILWIND_VERSION parity between the composite action
+# (.github/actions/setup-tailwind, the CI glibc x64 pin) and build/docker/Dockerfile
+# (the musl pins); only the version is shared, the SHAs intentionally differ.
+#
+# A version drift between these is a silent correctness gap: a contributor's
+# local hook can pass while CI fails (or vice versa) on the same tree, and
+# //nolint directives can resolve differently across golangci-lint minor
+# versions (#1560). This guard fails the pre-push gate when any pair drifts.
+#
+# Exit: 0 = all aligned, 1 = drift detected or a pin could not be located.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+errors=0
+
+# Extract the `rev:` value that follows a given repo URL substring in
+# .pre-commit-config.yaml. The pre-commit format lists `- repo: <url>` then a
+# `rev:` line, so track whether we are inside the wanted repo block. Returns
+# empty (handled by the caller) if the repo or its rev is absent.
+precommit_rev() {
+  awk -v want="$1" '
+    /^[[:space:]]*-[[:space:]]*repo:/ { inrepo = (index($0, want) > 0); next }
+    inrepo && /^[[:space:]]*rev:/ {
+      sub(/^[[:space:]]*rev:[[:space:]]*/, "")  # drop the "rev:" key
+      sub(/[[:space:]]*#.*/, "")                # drop any inline comment
+      gsub(/[\042\047\r]/, "")                  # drop quotes (" and ) and CR
+      sub(/[[:space:]]+$/, "")                  # drop trailing whitespace
+      print
+      exit
+    }
+  ' .pre-commit-config.yaml
+}
+
+# require <label> <a> <b> <a-source> <b-source>
+require() {
+  local label="$1" a="$2" b="$3" asrc="$4" bsrc="$5"
+  if [ -z "$a" ]; then
+    echo "FAIL: $label: could not locate version in $asrc" >&2
+    errors=$((errors + 1))
+    return
+  fi
+  if [ -z "$b" ]; then
+    echo "FAIL: $label: could not locate version in $bsrc" >&2
+    errors=$((errors + 1))
+    return
+  fi
+  if [ "$a" != "$b" ]; then
+    echo "FAIL: $label version drift: $asrc=$a vs $bsrc=$b" >&2
+    errors=$((errors + 1))
+  else
+    echo "OK: $label $a ($asrc == $bsrc)"
+  fi
+}
+
+# Each extraction ends in `|| true` so a grep miss (exit 1) does not abort the
+# script under `set -e`/`pipefail`; an empty result is reported by require().
+
+# golangci-lint: ci.yml golangci-lint-action `version:` vs pre-commit-config rev.
+# Bound the scan to the golangci-lint-action step. Steps begin with a `- ` list
+# item (often `- name:` with `uses:` on the next line), so reset in_block at every
+# new list item and set it true on the line naming the action. `version:` is then
+# read only from within that step; if the action ever drops its `version:` input,
+# a later step's `version:` is not silently picked up.
+gci_ci=$(awk '
+  /^[[:space:]]*-[[:space:]]/ { in_block = 0 }
+  /golangci\/golangci-lint-action/ { in_block = 1 }
+  in_block && /^[[:space:]]*version:[[:space:]]*v[0-9]/ {
+    sub(/^[[:space:]]*version:[[:space:]]*/, "")
+    print
+    exit
+  }
+' .github/workflows/ci.yml || true)
+gci_pc=$(precommit_rev 'golangci/golangci-lint' || true)
+require "golangci-lint" "$gci_ci" "$gci_pc" "ci.yml" ".pre-commit-config.yaml"
+
+# typos: docs.yml SHA-pin "# vX.Y.Z" comment vs pre-commit-config rev.
+typos_ci=$(grep -E 'crate-ci/typos@' .github/workflows/docs.yml \
+  | grep -oE '#[[:space:]]*v[0-9.]+' | grep -oE 'v[0-9.]+' | head -1 || true)
+typos_pc=$(precommit_rev 'crate-ci/typos' || true)
+require "typos" "$typos_ci" "$typos_pc" "docs.yml" ".pre-commit-config.yaml"
+
+# markdownlint-cli2: bash-hook npx pin vs pre-commit-config rev. (docs.yml uses
+# the markdownlint-cli2-ACTION, whose version is independent of the bundled
+# tool version, so it is intentionally not compared here.)
+mdl_hook=$(grep -oE 'markdownlint-cli2@v[0-9.]+' .githooks/pre-commit \
+  | grep -oE 'v[0-9.]+' | head -1 || true)
+mdl_pc=$(precommit_rev 'DavidAnson/markdownlint-cli2' || true)
+require "markdownlint-cli2" "$mdl_hook" "$mdl_pc" ".githooks/pre-commit" ".pre-commit-config.yaml"
+
+# Tailwind: the composite action (CI glibc x64 binary) and the Dockerfile (musl
+# binaries) pin the SAME TAILWIND_VERSION but DIFFERENT SHAs. Only the version is
+# a shared invariant, so assert just the version here; the SHAs intentionally
+# differ per libc/arch and are maintained independently.
+tw_action=$(grep -oE 'TAILWIND_VERSION:[[:space:]]*v[0-9.]+' .github/actions/setup-tailwind/action.yml \
+  | grep -oE 'v[0-9.]+' | head -1 || true)
+tw_docker=$(grep -oE 'TAILWIND_VERSION=v[0-9.]+' build/docker/Dockerfile \
+  | grep -oE 'v[0-9.]+' | head -1 || true)
+require "tailwind" "$tw_action" "$tw_docker" ".github/actions/setup-tailwind" "build/docker/Dockerfile"
+
+if [ "$errors" -gt 0 ]; then
+  echo "" >&2
+  echo "$errors tool-version drift error(s). Align the pins listed above." >&2
+  exit 1
+fi
+echo "All tracked tool versions are aligned."

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -122,6 +122,20 @@ fi
 echo "OK"
 
 echo ""
+echo "=== Tool version drift ==="
+# Assert the lint/spell tool versions pinned independently in the bash hook,
+# the pre-commit framework config, and the CI workflows all agree. A drift
+# lets a local hook pass while CI fails on the same tree (and vice versa);
+# golangci-lint minor versions also resolve //nolint differently (#1560).
+# Fast grep-only check, so it fail-fasts before the multi-minute test suite.
+TOOL_VERSIONS_HELPER="$SCRIPT_DIR/check-tool-versions.sh"
+if [ ! -x "$TOOL_VERSIONS_HELPER" ]; then
+  echo "pre-push-gate: check-tool-versions.sh not found or not executable in scripts/" >&2
+  exit 1
+fi
+bash "$TOOL_VERSIONS_HELPER"
+
+echo ""
 echo "=== Tests ==="
 go test -race -count=1 -covermode=atomic -coverprofile="$COVER_OUT" ./...
 


### PR DESCRIPTION
## Summary

- Reduce git-hook/CI duplication and close drift gaps: scope the pre-commit `golangci-lint` to staged packages and gate `govulncheck` on `go.mod`/`go.sum` (full-repo lint/vuln no longer run on every commit); add a tool-version drift guard; extract the CI Tailwind install into a shared composite action.
- Audit `on.*.paths` filters (#1763): `docs.yml` now re-triggers on `.typos.toml`; `docs-drift.yml`'s narrower trigger is documented; `pages.yml` confirmed complete.
- Fix the published API reference (#1760): remove `navigation.instant` so the standalone Scalar `/api/` page loads via full-page navigation instead of Material's instant loader silently failing to mount it. User-visible: the docs-site "API Reference" tab and "Browse the API" link now work in production.
- Reviewers look first at: `gate.yml` (new `tool-versions` job + composite-action swap) and the one-line `mkdocs.yml` change.

## Linked issue

Closes #1763
Closes #1760

Follow-ups filed (not in this PR): #1765 (route-vs-Bruno parity), #1766 (Bruno `-cover` coverage), #1767 (gate `$GITHUB_STEP_SUMMARY`), #1768 (PR reporter bot).

## Pre-flight checklist

- [ ] Pre-push gate runs via the pre-push hook on push (no Go source changed; tool-version + path checks added to the gate).
- [ ] Cloud CodeRabbit review on push (per project default).
- [x] Single clean signed commit.
- [x] Labels set at create.
- [x] Docs label decision: this PR updates `docs/` directly (mkdocs config), so `needs-docs-review` does not apply and `docs: not-required` is inaccurate; no docs-drift label set.
- [ ] No UI screenshot (docs-site behavior verified in-browser; see test plan).
- [x] UAT performed for the user-visible docs fix (built site, clicked through in a browser).
- [ ] OpenAPI: no request/response shape changed (N/A).
- [ ] templ: no `.templ` changed (N/A).

## Test plan

- [ ] `go test -race ./...` and `bash scripts/pre-push-gate.sh` run via the pre-push hook on push (no Go source changed in this PR).
- [x] `actionlint` clean on all edited workflows; `shellcheck`/`bash -n` clean on the hook and new script; `check-tool-versions.sh` passes.
- [x] Manual UAT of the docs fix:
  - [x] Built the site with the pinned toolchain, served `site/` over HTTP.
  - [x] Clicked the "API Reference" nav tab and the home "Browse the API" link: `/api/` loads and Scalar mounts (`.scalar-app` / endpoint list render).
  - [x] Confirmed normal page-to-page navigation still works.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pre-commit checks to regenerate generated outputs and scope lint/vulnerability scans to staged changes.
  * Centralized Tailwind installation into a shared CI action and updated CI workflows to use it.
  * Added automated tool-version drift detection (new check script, CI job, and pre-push gate step).
  * Updated spell-check dependency to v1.46.2.

* **Documentation**
  * Clarified API theme configuration notes for a specific docs page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sydlexius/stillwater/pull/1770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->