### PR TITLE
fix(scanner): record filesystem membership for existing artists (#1780)

### DIFF
--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -467,6 +467,23 @@ func (s *Service) AddLibraryMembership(ctx context.Context, artistID, libraryID,
 	return s.memberships.Add(ctx, artistID, libraryID, source)
 }
 
+// EnsureLibraryMembership guarantees the artist holds a membership row for the
+// given library, deriving the source from the library's connection (or
+// 'filesystem' when the library has no connection). Idempotent: a repeat call
+// preserves the existing row's source and added_at. No-op when no membership
+// repository is configured or when the target library does not exist.
+//
+// The filesystem scanner calls this on every visit to an existing artist so an
+// on-disk artist first created by a connection import (Emby/Jellyfin) still
+// acquires its filesystem membership, healing the missing-from-local-filter and
+// missing-folder-badge symptoms of issue #1780.
+func (s *Service) EnsureLibraryMembership(ctx context.Context, artistID, libraryID string) error {
+	if s.memberships == nil {
+		return nil
+	}
+	return s.memberships.AddDerivingSource(ctx, artistID, libraryID)
+}
+
 // RemoveLibraryMembership removes a single (artist, library) pair from the
 // membership table
 func (s *Service) RemoveLibraryMembership(ctx context.Context, artistID, libraryID string) error {

--- a/internal/artist/service_mn_test.go
+++ b/internal/artist/service_mn_test.go
@@ -290,6 +290,9 @@ func TestMembershipMethods_NoMembershipRepo(t *testing.T) {
 	if err := svc.AddLibraryMembership(ctx, "any", "any", "filesystem"); err != nil {
 		t.Errorf("AddLibraryMembership returned err with nil repo: %v", err)
 	}
+	if err := svc.EnsureLibraryMembership(ctx, "any", "any"); err != nil {
+		t.Errorf("EnsureLibraryMembership returned err with nil repo: %v", err)
+	}
 	if err := svc.RemoveLibraryMembership(ctx, "any", "any"); err != nil {
 		t.Errorf("RemoveLibraryMembership returned err with nil repo: %v", err)
 	}
@@ -306,5 +309,65 @@ func TestMembershipMethods_NoMembershipRepo(t *testing.T) {
 	}
 	if got != 0 {
 		t.Errorf("CountLibrariesForArtist with nil repo = %d, want 0", got)
+	}
+}
+
+// TestEnsureLibraryMembership covers the issue #1780 healing path: an artist
+// whose initial membership is for a different library gains a filesystem
+// membership for the scanned library when EnsureLibraryMembership runs, and a
+// repeat call is idempotent (no duplicate row).
+func TestEnsureLibraryMembership(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	seedLibForMNTests(t, ctx, db, "lib-other", "manual")
+	seedLibForMNTests(t, ctx, db, "lib-fs", "manual")
+
+	// Create the artist with its initial membership pointing at lib-other, so
+	// lib-fs is genuinely absent at the start (mirrors a connection-first
+	// artist that has no filesystem membership yet).
+	a := testArtist("Portishead", "/music/Portishead")
+	a.LibraryID = "lib-other"
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got, err := svc.CountLibrariesForArtist(ctx, a.ID); err != nil {
+		t.Fatalf("baseline count: %v", err)
+	} else if got != 1 {
+		t.Fatalf("baseline count = %d, want 1", got)
+	}
+
+	// Ensure adds the filesystem membership for lib-fs.
+	if err := svc.EnsureLibraryMembership(ctx, a.ID, "lib-fs"); err != nil {
+		t.Fatalf("EnsureLibraryMembership: %v", err)
+	}
+	// Idempotent: a repeat call must not add a duplicate row.
+	if err := svc.EnsureLibraryMembership(ctx, a.ID, "lib-fs"); err != nil {
+		t.Fatalf("EnsureLibraryMembership (idempotent): %v", err)
+	}
+
+	libs, err := svc.LibrariesForArtist(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("LibrariesForArtist: %v", err)
+	}
+	if len(libs) != 2 {
+		t.Fatalf("LibrariesForArtist = %d rows, want 2", len(libs))
+	}
+	var fsSource string
+	found := false
+	for _, m := range libs {
+		if m.LibraryID == "lib-fs" {
+			found = true
+			fsSource = m.Source
+		}
+	}
+	if !found {
+		t.Fatalf("no membership for lib-fs after EnsureLibraryMembership")
+	}
+	// lib-fs has no connection_id, so the derived source is filesystem.
+	if fsSource != "filesystem" {
+		t.Errorf("lib-fs membership source = %q, want filesystem", fsSource)
 	}
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -381,7 +381,7 @@ func (s *Service) processDirectory(ctx context.Context, dirPath, name, libraryID
 	if existing == nil {
 		return s.processNewArtist(ctx, dirPath, name, libraryID, excluded, detected, preloadedKeys, result)
 	}
-	return s.processExistingArtist(ctx, dirPath, existing, excluded, detected, result)
+	return s.processExistingArtist(ctx, dirPath, libraryID, existing, excluded, detected, result)
 }
 
 // processNewArtist creates a new artist record for a directory not yet in the
@@ -502,7 +502,23 @@ func (s *Service) processNewArtist(ctx context.Context, dirPath, name, libraryID
 // the current filesystem state. It preserves placeholders and dimensions on
 // transient probe failures, applies NFO re-import for unlocked artists, and
 // falls back to a lightweight ReconcileImages call when nothing has changed.
-func (s *Service) processExistingArtist(ctx context.Context, dirPath string, existing *artist.Artist, excluded bool, detected detectedFiles, result *ScanResult) error {
+func (s *Service) processExistingArtist(ctx context.Context, dirPath, libraryID string, existing *artist.Artist, excluded bool, detected detectedFiles, result *ScanResult) error {
+	// Heal the artist_libraries membership on EVERY visit, before any
+	// early-return branch below. An artist first created by a connection
+	// import (Emby/Jellyfin) and matched here by path would otherwise never
+	// acquire the filesystem-library membership for the library being
+	// scanned, so it would be absent from local-library filtering and show
+	// no folder badge (issue #1780). EnsureLibraryMembership is idempotent
+	// and derives the source from the library's connection (filesystem when
+	// none), so re-running a scan does not duplicate or move the row. Placed
+	// ahead of the quiet-rescan early return so steady-state libraries (which
+	// take that early-return path) still self-heal.
+	if libraryID != "" {
+		if err := s.artistService.EnsureLibraryMembership(ctx, existing.ID, libraryID); err != nil {
+			return fmt.Errorf("ensuring library membership: %w", err)
+		}
+	}
+
 	// Protect existing placeholders from transient I/O failures: if the image
 	// file still exists on disk but placeholder generation failed (returned
 	// empty), preserve the existing placeholder.

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1841,3 +1841,147 @@ func TestScan_NearDuplicateDetected(t *testing.T) {
 		t.Error("expected AC-DC artist row to be created despite the duplicate flag")
 	}
 }
+
+// membershipSources returns the set of source strings on the artist_libraries
+// rows for the given artist, keyed by library_id, so a test can assert which
+// library/source pairs exist after a scan.
+func membershipSources(t *testing.T, db *sql.DB, artistID string) map[string]string {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(),
+		`SELECT library_id, source FROM artist_libraries WHERE artist_id = ?`, artistID)
+	if err != nil {
+		t.Fatalf("querying memberships: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[string]string)
+	for rows.Next() {
+		var lib, src string
+		if err := rows.Scan(&lib, &src); err != nil {
+			t.Fatalf("scanning membership: %v", err)
+		}
+		out[lib] = src
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterating memberships: %v", err)
+	}
+	return out
+}
+
+// TestScan_ExistingArtistGainsFilesystemMembership proves the issue #1780 fix:
+// an artist first created by a connection import (so it holds only an
+// emby-sourced membership) and whose path matches a directory under a manual
+// filesystem library acquires a 'filesystem'-sourced artist_libraries row after
+// that library is scanned. Re-scanning is idempotent (no duplicate row, the
+// added_at timestamp does not move), and an artist that already holds the
+// filesystem membership is left untouched.
+func TestScan_ExistingArtistGainsFilesystemMembership(t *testing.T) {
+	t.Parallel()
+	libDir := t.TempDir()
+	svc, artistSvc, db := setupScannerWithDB(t, libDir)
+	ctx := context.Background()
+
+	// Seed an emby connection plus a connection-backed library, and a manual
+	// (connection_id NULL) filesystem library that points at libDir. The
+	// filesystem library is the one we scan.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO connections (id, name, type, url, encrypted_api_key)
+		 VALUES ('conn-emby', 'Emby', 'emby', 'http://emby.local', 'x')`); err != nil {
+		t.Fatalf("seeding connection: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO libraries (id, name, path, type, source, connection_id, created_at, updated_at)
+		 VALUES ('lib-emby', 'Emby Music', '', 'regular', 'emby', 'conn-emby', datetime('now'), datetime('now'))`); err != nil {
+		t.Fatalf("seeding emby library: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)
+		 VALUES ('lib-fs', 'FS Music', ?, 'regular', 'manual', datetime('now'), datetime('now'))`,
+		libDir); err != nil {
+		t.Fatalf("seeding filesystem library: %v", err)
+	}
+
+	// Create the artist as a connection import would: LibraryID points at the
+	// emby library, so Create records an 'emby'-sourced membership only. Its
+	// path matches a directory under the filesystem library.
+	artistPath := filepath.Join(libDir, "Pink Floyd")
+	a := &artist.Artist{
+		Name:      "Pink Floyd",
+		SortName:  "Pink Floyd",
+		Path:      artistPath,
+		LibraryID: "lib-emby",
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// Sanity: only the emby membership exists pre-scan.
+	pre := membershipSources(t, db, a.ID)
+	if pre["lib-emby"] != "emby" {
+		t.Fatalf("pre-scan emby membership = %q, want 'emby'", pre["lib-emby"])
+	}
+	if _, ok := pre["lib-fs"]; ok {
+		t.Fatalf("pre-scan should not yet hold a filesystem membership, got %v", pre)
+	}
+
+	createArtistDir(t, libDir, "Pink Floyd")
+	svc.SetLibraryLister(&stubLibraryLister{
+		libs: []library.Library{
+			{ID: "lib-fs", Name: "FS Music", Path: libDir, Type: library.TypeRegular},
+		},
+	})
+
+	// Scan 1: the existing artist is matched by path and must gain the
+	// filesystem membership.
+	if _, err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run 1: %v", err)
+	}
+	waitForScan(t, svc, 5*time.Second)
+
+	after1 := membershipSources(t, db, a.ID)
+	if after1["lib-emby"] != "emby" {
+		t.Errorf("after scan 1 emby membership = %q, want 'emby'", after1["lib-emby"])
+	}
+	if after1["lib-fs"] != "filesystem" {
+		t.Errorf("after scan 1 filesystem membership = %q, want 'filesystem'", after1["lib-fs"])
+	}
+
+	// Capture the filesystem row's added_at to prove idempotency below.
+	var addedAt1 string
+	if err := db.QueryRowContext(ctx,
+		`SELECT added_at FROM artist_libraries WHERE artist_id = ? AND library_id = 'lib-fs'`,
+		a.ID).Scan(&addedAt1); err != nil {
+		t.Fatalf("reading filesystem added_at: %v", err)
+	}
+
+	// Scan 2: idempotent. Exactly one filesystem membership, added_at unchanged.
+	if _, err := svc.Run(ctx); err != nil {
+		t.Fatalf("Run 2: %v", err)
+	}
+	waitForScan(t, svc, 5*time.Second)
+
+	var fsCount int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM artist_libraries WHERE artist_id = ? AND library_id = 'lib-fs'`,
+		a.ID).Scan(&fsCount); err != nil {
+		t.Fatalf("counting filesystem memberships: %v", err)
+	}
+	if fsCount != 1 {
+		t.Errorf("after scan 2 filesystem membership count = %d, want 1", fsCount)
+	}
+
+	var addedAt2 string
+	if err := db.QueryRowContext(ctx,
+		`SELECT added_at FROM artist_libraries WHERE artist_id = ? AND library_id = 'lib-fs'`,
+		a.ID).Scan(&addedAt2); err != nil {
+		t.Fatalf("reading filesystem added_at after scan 2: %v", err)
+	}
+	if addedAt2 != addedAt1 {
+		t.Errorf("filesystem added_at moved on rescan: %q -> %q", addedAt1, addedAt2)
+	}
+
+	// The emby membership must be untouched throughout.
+	after2 := membershipSources(t, db, a.ID)
+	if after2["lib-emby"] != "emby" {
+		t.Errorf("after scan 2 emby membership = %q, want 'emby'", after2["lib-emby"])
+	}
+}


### PR DESCRIPTION
## Summary

- The filesystem scanner recorded an `artist_libraries` membership **only when creating a new artist**. When it re-encountered an artist that already existed (matched by path), `processExistingArtist` updated the row but never recorded the membership for the library being scanned -- it wasn't even passed `libraryID`.
- So an on-disk artist first created by a connection import (Emby/Jellyfin) never gained the filesystem membership. Both the artist-list **library filter** and the **`HasFilesystem`** flag derive solely from `artist_libraries`, so the artist was missing from local-library filtering and showed no folder badge. **Regression from #1004** (the M:N migration wired only the create path).
- Fix: thread `libraryID` into `processExistingArtist` and ensure the membership idempotently via a new `artist.Service.EnsureLibraryMembership` (delegating to the existing `AddDerivingSource`), placed **above** the quiet-rescan early return so steady-state libraries self-heal on the next scan. Additive, **no schema change**.
- Reviewers: look first at the placement of the `EnsureLibraryMembership` call in `processExistingArtist` (must run before the early return) and the `EnsureLibraryMembership` method.

## Linked issue

Closes #1780

## Pre-flight checklist

- [x] Pre-push gate green locally (ran automatically via the pre-push hook on push).
- [ ] Code review pass: relying on cloud CodeRabbit on push (no local review pass run).
- [x] Commits squashed into one clean commit before the first push.
- [x] At least one label set (`bug`, `scanner`, `scope: small`, `docs: not-required`).
- [x] Docs label decision: `docs: not-required` -- bug fix restoring intended behavior; no new user-facing concept to document.
- [ ] Screenshot: N/A -- backend-only change (no template/UI code); the folder badge is a data-layer consequence (UAT evidence below).
- [x] UAT performed (ran the binary end-to-end, not just the test suite -- see Test plan).
- [x] OpenAPI: N/A -- no request/response shape change.
- [x] `templ generate`: N/A -- no `.templ` files changed.

## Test plan

- [x] `go test -race ./...` passes locally (via the pre-push gate).
- [x] `bash scripts/pre-push-gate.sh` passes locally (ran via the pre-push hook).
- [x] New unit tests:
  - `TestEnsureLibraryMembership` (artist) -- an artist whose initial membership is for a different library gains a `filesystem`-sourced membership for the scanned library; repeat call is idempotent (no duplicate row).
  - `TestScan_ExistingArtistGainsFilesystemMembership` (scanner) -- an existing connection-only artist found on disk in a filesystem library gains the fs membership after a scan; re-scan idempotent; `added_at` preserved.
- [x] Manual UAT against the dev DB:
  - Built and ran the fixed binary, `POST /api/v1/scanner/run`.
  - "2nd Chapter of Acts" (path `/Users/jesse/media/music/...`, previously only an `emby` membership) gained a `filesystem -> Local Music` membership; the original `emby` row and its `added_at` were preserved.
  - It now matches the Local Music library filter, and its grid card renders the folder badge ("Found in /Users/jesse/media/music/..." alongside "Present in Emby").
  - Broader: 603 artists gained filesystem memberships from the single scan (the whole previously-affected on-disk population self-healed).
- [ ] Reviewer follow-ups:
  - [ ] Confirm the ensure-before-early-return placement is the right call vs only ensuring when something changed (intentional: steady-state libraries take the early-return path on every recurring scan, so the ensure must precede it to heal them).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed artist library associations during filesystem scans. Existing artists matched during scanning now properly gain memberships with the scanned library, ensuring accurate local library filtering and UI badges. The reconciliation is idempotent and preserves existing library associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->