### PR TITLE
docs(claude): add decompose-before-building PR convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,8 @@ See `docs/pr-workflow.md` for full details including the gh `!=` bash history wo
 
 **Review comment scope:** Default: fix now. Defer only for architectural changes or unrelated subsystems. Never defer without creating a tracking issue.
 
+**Decompose before building.** Land shared/foundation refactors (extractions, exported helpers, new shared components) as their own small PR *before* building features on them; the feature PR then targets a clean base. When the foundation is not known up front, spike a throwaway rough-cut (delegate it to a subagent that returns a "foundation manifest") to discover what needs sharing, then split. If a feature cannot fit under the ~800 hand-written-LOC / 10-file size gate, that is a signal it bundles a foundation refactor that should have landed first. For complex multi-session screens/features, run the main session as an orchestrator (delegate implementation, tests, RCA, and UAT-evidence gathering to subagents), gate per chunk rather than once at the end, and never report work "done" without the verifying evidence in the same message. See the screen-build playbook in the M55 plan and the `feedback_screen_build_playbook` memory.
+
 ## Worktrees
 
 Use git worktrees for concurrent issue/agent work. Naming: `../stillwater-{issue}/`, `../stillwater-m{N}-{issue}/`. Track in `~/.claude/projects/<project>/memory/worktrees.md`.


### PR DESCRIPTION
Land shared/foundation refactors as their own small PR before building features on them; spike to discover the foundation when unknown; orchestrate complex work via subagents and gate per chunk. Distilled from the M55 #1335 3-session slog (see feedback_screen_build_playbook).

## Summary

- What changed and why (focus on the why; 1-3 bullets).
- Note any user-visible behavior change.
- Call out anything reviewers should look at first.

## Linked issue

Closes #

(Use `Part of #N` for a slice of a larger issue that is not yet fully resolved.)

## Pre-flight checklist

- [ ] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`), or run via `/prep-pr` / `/pr-review-toolkit:review-pr` which invokes it.
- [ ] Code review pass complete (`/prep-pr` or `/pr-review-toolkit:review-pr`); critical and important findings fixed before pushing.
- [ ] Commits squashed into clean, logical commits before the first push (Copilot reviews the diff at PR open).
- [ ] At least one label set on `gh pr create --label ...` (the CI label gate fails without one).
- [ ] Docs label decision made: `needs-docs-review` for user-visible changes, `docs: not-required` for test, CI, or refactor PRs with no user-visible behavioral change.
- [ ] Screenshot attached for any UI change.
- [ ] UAT performed for user-visible changes (run the binary, not just the test suite).
- [ ] OpenAPI spec updated if any request or response shape changed (`make check-openapi`).
- [ ] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed.

## Test plan

- [ ] `go test -race ./...` passes locally.
- [ ] `bash scripts/pre-push-gate.sh` passes locally.
- [ ] Manual UAT steps (list the specific flows exercised):
  - [ ]
  - [ ]
- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
  - [ ]
