### PR TITLE
ci: make tool-version drift gate dependabot-friendly with --fix sync

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # wired via `core.hooksPath = .githooks` is `.githooks/pre-commit`,
 # which mirrors these checks in plain bash and is what CI expects.
 # Tool version pins below should stay in sync with the canonical hook and CI
-# (notably: markdownlint-cli2 v0.22.1, golangci-lint v2.12.2, typos v1.46.2).
+# (the tracked tools: markdownlint-cli2, golangci-lint, typos, and Tailwind).
 # scripts/check-tool-versions.sh asserts these agree across all entrypoints
 # and runs in the pre-push gate, so a drift here fails before push.
 repos:
@@ -26,7 +26,9 @@ repos:
 
   - repo: https://github.com/crate-ci/typos
     # Keep in sync with .github/workflows/docs.yml (crate-ci/typos SHA pin).
-    rev: v1.46.2
+    # Dependabot bumps the docs.yml pin; run `make sync-tool-versions` to mirror
+    # the new version here (Dependabot cannot edit pre-commit rev: pins itself).
+    rev: v1.47.0
     hooks:
       - id: typos
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-shuffle test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks doctor worktree check-openapi hadolint scan bruno-ci
+.PHONY: build run test test-shuffle test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks doctor worktree check-openapi sync-tool-versions hadolint scan bruno-ci
 
 # Binary name
 BINARY=stillwater
@@ -115,6 +115,13 @@ docker-stop:
 ## check-openapi: Verify OpenAPI spec matches handler implementations
 check-openapi:
 	go test -count=1 -run TestOpenAPIConsistency -v ./internal/api/
+
+## sync-tool-versions: Mirror CI-side tool versions into the pins Dependabot cannot edit
+##   Use after a Dependabot tool bump (e.g. crate-ci/typos) drifts the Tool Version
+##   Drift gate: this rewrites the .pre-commit-config.yaml rev: (and Dockerfile
+##   TAILWIND_VERSION) to match the CI/source side. Review and commit the result.
+sync-tool-versions:
+	@./scripts/check-tool-versions.sh --fix
 
 ## hooks: Install git hooks (pre-commit lint, pre-push gate)
 hooks:

--- a/docs/_generated/make-commands.md
+++ b/docs/_generated/make-commands.md
@@ -24,6 +24,7 @@
 | `make docker-run` | Run Docker container |
 | `make docker-stop` | Stop Docker container |
 | `make check-openapi` | Verify OpenAPI spec matches handler implementations |
+| `make sync-tool-versions` | Mirror CI-side tool versions into the pins Dependabot cannot edit |
 | `make hooks` | Install git hooks (pre-commit lint, pre-push gate) |
 | `make doctor` | Verify hook wiring without modifying anything |
 | `make worktree` | Create a sibling worktree with hooks wired and tracker row inserted into the Active table |

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -16,13 +16,44 @@
 # //nolint directives can resolve differently across golangci-lint minor
 # versions (#1560). This guard fails the pre-push gate when any pair drifts.
 #
-# Exit: 0 = all aligned, 1 = drift detected or a pin could not be located.
+# Dependabot angle: Dependabot updates the CI-side pins (e.g. the crate-ci/typos
+# SHA in docs.yml via its github-actions ecosystem) but has NO pre-commit
+# ecosystem, so it cannot touch the matching `.pre-commit-config.yaml` rev:.
+# A typos bump therefore drifts this gate and stalls the auto-merge pipeline.
+# Run this script with --fix (or `make sync-tool-versions`) to mirror the
+# CI-side version into the pin Dependabot cannot reach, then push the one-line
+# follow-up commit onto the Dependabot branch so its required checks re-run.
+#
+# Usage:
+#   check-tool-versions.sh          verify only (default; used by the gate)
+#   check-tool-versions.sh --fix    rewrite each drifted derived pin to match
+#                                   its canonical (CI/source) side, then report
+#
+# Exit: 0 = all aligned (or, with --fix, all drifts were auto-fixed),
+#       1 = drift detected in verify mode or a pin could not be located.
 set -euo pipefail
+
+FIX=0
+for arg in "$@"; do
+  case "$arg" in
+    --fix) FIX=1 ;;
+    -h | --help)
+      # Reprint the Usage block from this header.
+      sed -n '/^# Usage:/,/^# *$/p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "check-tool-versions.sh: unknown argument '$arg' (try --fix or --help)" >&2
+      exit 2
+      ;;
+  esac
+done
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 errors=0
+fixed=0
 
 # Extract the `rev:` value that follows a given repo URL substring in
 # .pre-commit-config.yaml. The pre-commit format lists `- repo: <url>` then a
@@ -42,9 +73,45 @@ precommit_rev() {
   ' .pre-commit-config.yaml
 }
 
-# require <label> <a> <b> <a-source> <b-source>
+# Rewrite the `rev:` value inside the `.pre-commit-config.yaml` block whose
+# `- repo:` line contains <want>, preserving indentation and any trailing
+# comment. Only the first rev: in the block is touched. Used by --fix to mirror
+# a CI-side version into the pin Dependabot cannot reach.
+fix_precommit_rev() {
+  local want="$1" newver="$2" file=".pre-commit-config.yaml" tmp
+  tmp="$(mktemp)"
+  awk -v want="$want" -v newver="$newver" '
+    /^[[:space:]]*-[[:space:]]*repo:/ { inrepo = (index($0, want) > 0) }
+    inrepo && /^[[:space:]]*rev:/ {
+      match($0, /^[[:space:]]*rev:[[:space:]]*/)   # capture "  rev: " prefix
+      prefix = substr($0, 1, RLENGTH)
+      rest = substr($0, RLENGTH + 1)
+      comment = ""                                  # keep any trailing "# ..."
+      if (match(rest, /[[:space:]]*#.*/)) { comment = substr(rest, RSTART) }
+      print prefix newver comment
+      inrepo = 0                                    # first rev only
+      next
+    }
+    { print }
+  ' "$file" >"$tmp" && mv "$tmp" "$file"
+}
+
+# Rewrite every TAILWIND_VERSION=vX.Y.Z token in the Dockerfile (the musl pins)
+# to <newver>. The SHAs intentionally differ per libc/arch and are left alone.
+fix_dockerfile_tailwind() {
+  local newver="$1" file="build/docker/Dockerfile" tmp
+  tmp="$(mktemp)"
+  sed -E "s/TAILWIND_VERSION=v[0-9.]+/TAILWIND_VERSION=${newver}/g" "$file" >"$tmp" \
+    && mv "$tmp" "$file"
+}
+
+# require <label> <a> <b> <a-source> <b-source> [fixer-fn [fixer-args...]]
+# `a`/`asrc` is the canonical (CI/source) side; `b`/`bsrc` is the derived pin.
+# In --fix mode a drift is repaired by calling: <fixer-fn> [fixer-args...] <a>
+# which rewrites the derived pin's file to the canonical value.
 require() {
   local label="$1" a="$2" b="$3" asrc="$4" bsrc="$5"
+  local fixer=("${@:6}")
   if [ -z "$a" ]; then
     echo "FAIL: $label: could not locate version in $asrc" >&2
     errors=$((errors + 1))
@@ -56,8 +123,14 @@ require() {
     return
   fi
   if [ "$a" != "$b" ]; then
-    echo "FAIL: $label version drift: $asrc=$a vs $bsrc=$b" >&2
-    errors=$((errors + 1))
+    if [ "$FIX" -eq 1 ] && [ "${#fixer[@]}" -gt 0 ]; then
+      "${fixer[@]}" "$a"
+      echo "FIXED: $label $bsrc $b -> $a (mirrored from $asrc)"
+      fixed=$((fixed + 1))
+    else
+      echo "FAIL: $label version drift: $asrc=$a vs $bsrc=$b" >&2
+      errors=$((errors + 1))
+    fi
   else
     echo "OK: $label $a ($asrc == $bsrc)"
   fi
@@ -82,13 +155,15 @@ gci_ci=$(awk '
   }
 ' .github/workflows/ci.yml || true)
 gci_pc=$(precommit_rev 'golangci/golangci-lint' || true)
-require "golangci-lint" "$gci_ci" "$gci_pc" "ci.yml" ".pre-commit-config.yaml"
+require "golangci-lint" "$gci_ci" "$gci_pc" "ci.yml" ".pre-commit-config.yaml" \
+  fix_precommit_rev 'golangci/golangci-lint'
 
 # typos: docs.yml SHA-pin "# vX.Y.Z" comment vs pre-commit-config rev.
 typos_ci=$(grep -E 'crate-ci/typos@' .github/workflows/docs.yml \
   | grep -oE '#[[:space:]]*v[0-9.]+' | grep -oE 'v[0-9.]+' | head -1 || true)
 typos_pc=$(precommit_rev 'crate-ci/typos' || true)
-require "typos" "$typos_ci" "$typos_pc" "docs.yml" ".pre-commit-config.yaml"
+require "typos" "$typos_ci" "$typos_pc" "docs.yml" ".pre-commit-config.yaml" \
+  fix_precommit_rev 'crate-ci/typos'
 
 # markdownlint-cli2: bash-hook npx pin vs pre-commit-config rev. (docs.yml uses
 # the markdownlint-cli2-ACTION, whose version is independent of the bundled
@@ -96,7 +171,8 @@ require "typos" "$typos_ci" "$typos_pc" "docs.yml" ".pre-commit-config.yaml"
 mdl_hook=$(grep -oE 'markdownlint-cli2@v[0-9.]+' .githooks/pre-commit \
   | grep -oE 'v[0-9.]+' | head -1 || true)
 mdl_pc=$(precommit_rev 'DavidAnson/markdownlint-cli2' || true)
-require "markdownlint-cli2" "$mdl_hook" "$mdl_pc" ".githooks/pre-commit" ".pre-commit-config.yaml"
+require "markdownlint-cli2" "$mdl_hook" "$mdl_pc" ".githooks/pre-commit" ".pre-commit-config.yaml" \
+  fix_precommit_rev 'DavidAnson/markdownlint-cli2'
 
 # Tailwind: the composite action (CI glibc x64 binary) and the Dockerfile (musl
 # binaries) pin the SAME TAILWIND_VERSION but DIFFERENT SHAs. Only the version is
@@ -106,11 +182,20 @@ tw_action=$(grep -oE 'TAILWIND_VERSION:[[:space:]]*v[0-9.]+' .github/actions/set
   | grep -oE 'v[0-9.]+' | head -1 || true)
 tw_docker=$(grep -oE 'TAILWIND_VERSION=v[0-9.]+' build/docker/Dockerfile \
   | grep -oE 'v[0-9.]+' | head -1 || true)
-require "tailwind" "$tw_action" "$tw_docker" ".github/actions/setup-tailwind" "build/docker/Dockerfile"
+require "tailwind" "$tw_action" "$tw_docker" ".github/actions/setup-tailwind" "build/docker/Dockerfile" \
+  fix_dockerfile_tailwind
 
 if [ "$errors" -gt 0 ]; then
   echo "" >&2
-  echo "$errors tool-version drift error(s). Align the pins listed above." >&2
+  echo "$errors tool-version drift error(s)." >&2
+  echo "Run 'make sync-tool-versions' to mirror the CI-side versions into the" >&2
+  echo "derived pins, then commit the result. (Dependabot cannot edit pre-commit" >&2
+  echo "rev: pins, so its tool bumps land here as drift -- this is the fix.)" >&2
   exit 1
+fi
+if [ "$fixed" -gt 0 ]; then
+  echo ""
+  echo "$fixed pin(s) synced. Review and commit the changes above."
+  exit 0
 fi
 echo "All tracked tool versions are aligned."


### PR DESCRIPTION
## Summary

- Dependabot updates CI-side tool pins (e.g. the `crate-ci/typos` SHA in `docs.yml` via its github-actions ecosystem) but has **no pre-commit ecosystem**, so it cannot touch the matching `.pre-commit-config.yaml` `rev:`. A typos bump therefore drifts the **Tool Version Drift** gate; that drift landed on `main` via #1814 and was failing the gate on every open PR cut from `main`.
- Aligns the typos pre-commit `rev:` to `v1.47.0` to match `docs.yml`, re-greening `main`.
- Adds a `--fix` mode to `scripts/check-tool-versions.sh` (exposed as `make sync-tool-versions`) that mirrors each canonical CI/source version into the derived pin it drifts against, so the next Dependabot tool bump is a one-command, no-new-credential repair. The gate's failure message now points at it.
- No user-visible behavior change (CI/tooling only). The one-line `docs/_generated/make-commands.md` update is the auto-generated row for the new make target.
- Reviewers: the `--fix` direction is intentionally asymmetric (canonical CI/source side -> derived pin); see the function comments in `check-tool-versions.sh`.

## Linked issue

No tracking issue (the drift was discovered live while Dependabot PRs were merging). Follow-up #1820 covers the contributor-side counterpart (cross-platform dev bootstrap).

## Pre-flight checklist

- [x] Pre-push gate green locally (ran via the pre-push hook on push).
- [ ] Code review pass: relying on the cloud CodeRabbit pass that runs on push rather than the local toolkit.
- [x] Commits squashed into one clean commit before the first push.
- [x] At least one label set (`ci`, `dependencies`, `docs: not-required`).
- [x] Docs label decision made: `docs: not-required` (CI/tooling change, no user-visible behavior).
- [x] Screenshot: N/A (no UI change).
- [x] UAT performed: this is a tooling change; exercised the scripts directly (see Test plan).
- [x] OpenAPI: N/A (no request/response shape change; gate ran `make check-openapi` anyway).
- [x] `templ generate`: N/A (no `.templ` files changed).

## Test plan

- [x] `go test -race ./...` passes locally (via the pre-push gate).
- [x] `bash scripts/pre-push-gate.sh` passes locally (via the pre-push hook).
- [x] Manual validation of the tooling:
  - [x] `check-tool-versions.sh` verify mode reports all four pairs aligned.
  - [x] `--fix` round-trips a deliberately drifted typos `rev:` back to `v1.47.0`, preserving indentation and trailing comments; verify mode then passes.
  - [x] `--fix` round-trips a drifted Dockerfile `TAILWIND_VERSION`.
  - [x] `make sync-tool-versions`, `--help`, and an unknown-arg (exit 2) all behave as intended; `shellcheck` clean.
- [ ] Reviewer follow-ups:
  - [ ] Sanity-check the `fix_precommit_rev` awk against any future multi-`rev:` block shapes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the typo-detection tool to a newer release for improved spell-checking.
  * Added a project command to sync tool/version pins across CI and build files.
  * Enhanced the version-checking utility with an optional auto-fix mode to detect and rewrite drifted tool pins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->