### PR TITLE
fix(docker): bump golang base image to 1.26.4 (unbreak main Docker build)

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage
-FROM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26-alpine@sha256:376f4a381b112a7cfef541ecee0263ece432119fbbdad8d75f2f51fc197287f4 AS builder
 
 RUN apk add --no-cache curl libstdc++ libgcc
 


### PR DESCRIPTION
## Summary

- Unbreaks the **main** Docker Build, which has been failing since #1823 merged. That PR bumped `go.mod` to `go 1.26.4` (to clear two fresh stdlib govuln advisories), but the builder base image was pinned to a 1.26.3-era digest. The build runs `GOTOOLCHAIN=local` (hermetic, no toolchain fetch), so `go mod download` failed:
  ```
  go: go.mod requires go >= 1.26.4 (running go 1.26.3; GOTOOLCHAIN=local)
  ```
- Bumps `golang:1.26-alpine` to the current digest (`376f4a38...`), which is **go1.26.4** (verified by running `go version` in the image and replaying `go mod download` under `GOTOOLCHAIN=local` -> OK).
- This is the manual equivalent of the Dependabot Docker bump. Root cause is a cadence desync: the live-DB govulncheck that forced the go.mod bump lands ahead of Dependabot's Docker schedule, so the base image needed a hand-sync.

## Linked issue

Closes #

(Unblocks main CI; relates to the #1823 Go 1.26.4 bump.)

## Pre-flight checklist

- [X] Pre-push gate green locally (pre-push hook).
- [X] Verified the fix replays the failed step (`go mod download`, `GOTOOLCHAIN=local`) successfully in the new image.
- [X] At least one label set.
- [X] Docs label decision made: `docs: not-required` (build dependency bump, no user-visible change).

## Test plan

- [X] `go version` in `golang:1.26-alpine@sha256:376f4a38...` -> `go1.26.4`.
- [X] `go mod download` under `GOTOOLCHAIN=local` in the new image -> succeeds.
- [ ] CI Docker Build green on this PR (the real gate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker builder configuration to use an updated base image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->