### PR TITLE
fix: deterministic internal/connection coverage + make vulncheck + golang 1.26.4 docker base (#1759)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-shuffle test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks doctor worktree check-openapi sync-tool-versions hadolint scan bruno-ci
+.PHONY: build run test test-shuffle test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks doctor worktree check-openapi sync-tool-versions hadolint vulncheck scan bruno-ci
 
 # Binary name
 BINARY=stillwater
@@ -54,6 +54,10 @@ lint:
 ## hadolint: Lint Dockerfile for best practices
 hadolint:
 	hadolint build/docker/Dockerfile
+
+## vulncheck: Scan for known vulnerabilities (govulncheck, pinned to the CI version)
+vulncheck:
+	go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
 
 ## fmt: Format all Go and Templ files
 fmt:

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage
-FROM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26-alpine@sha256:376f4a381b112a7cfef541ecee0263ece432119fbbdad8d75f2f51fc197287f4 AS builder
 
 RUN apk add --no-cache curl libstdc++ libgcc
 

--- a/docs/_generated/make-commands.md
+++ b/docs/_generated/make-commands.md
@@ -11,6 +11,7 @@
 | `make test-cover` | Run tests with coverage |
 | `make lint` | Run golangci-lint |
 | `make hadolint` | Lint Dockerfile for best practices |
+| `make vulncheck` | Scan for known vulnerabilities (govulncheck, pinned to the CI version) |
 | `make fmt` | Format all Go and Templ files |
 | `make templ` | Generate Go code from Templ templates |
 | `make tailwind` | Build Tailwind CSS |

--- a/internal/connection/locksync_test.go
+++ b/internal/connection/locksync_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/database"
@@ -336,26 +337,72 @@ func TestLockSync_UnlockErrorIsLoggedAndSkipped(t *testing.T) {
 	}
 }
 
-// TestLockSync_StartSchedulerStopsOnCancel verifies the scheduler
-// loop exits cleanly when the context is canceled, including a
-// canceled initial-delay path.
+// TestLockSync_StartSchedulerStopsOnCancel verifies the scheduler loop exits
+// cleanly when the context is canceled after the main ticker loop has started.
+//
+// The test runs inside a testing/synctest bubble so the fake clock provides
+// deterministic synchronization without time.Sleep or test-support hooks in
+// production code. Inside the bubble, time.After and time.NewTicker use the
+// fake clock, which only advances when every goroutine in the bubble is
+// durably blocked:
+//
+//  1. time.Sleep(2ms) blocks the test goroutine on a fake 2ms timer.
+//  2. The scheduler goroutine is blocked on time.After(1ms) - the startup delay.
+//  3. All goroutines are durably blocked, so the fake clock advances to 1ms.
+//  4. Scheduler wakes, runs its initial Run() (fast in-memory SQLite), then
+//     blocks on time.NewTicker(1h) in the main loop.
+//  5. All goroutines are again durably blocked, so the clock advances to 2ms.
+//  6. Test goroutine wakes. The scheduler is GUARANTEED to be in its ticker
+//     select at this point (the fake clock could not have reached 2ms otherwise).
+//  7. cancel() fires ctx.Done(), scheduler logs "stopped" and returns.
 func TestLockSync_StartSchedulerStopsOnCancel(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		lockSync, _, _, _, _ := setupLockSyncDB(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			lockSync.StartScheduler(ctx, time.Hour, time.Millisecond)
+			close(done)
+		}()
+
+		// The return from time.Sleep guarantees the scheduler is in its main
+		// ticker loop (see function comment for the full reasoning).
+		time.Sleep(2 * time.Millisecond)
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("scheduler did not exit within 5s of cancel")
+		}
+	})
+}
+
+// TestLockSync_StartSchedulerExitsOnPreCanceledCtx covers the early-exit
+// branch of StartScheduler's startup-delay select: when the context is already
+// canceled before the startup delay fires, the scheduler must return without
+// running the initial sweep. This pins the case <-ctx.Done(): return branch
+// that the sibling test above never reaches (the sibling always lets the
+// startup delay fire first).
+func TestLockSync_StartSchedulerExitsOnPreCanceledCtx(t *testing.T) {
+	t.Parallel()
 	lockSync, _, _, _, _ := setupLockSyncDB(t)
+
 	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel: startup-delay select must fire ctx.Done immediately
+
 	done := make(chan struct{})
 	go func() {
-		// Long enough that the test cancel beats the first tick.
-		lockSync.StartScheduler(ctx, time.Hour, time.Millisecond)
+		// Long startup delay ensures only ctx.Done() can win the select.
+		lockSync.StartScheduler(ctx, time.Hour, time.Hour)
 		close(done)
 	}()
-	// Give the scheduler a moment to enter its loop, then cancel.
-	time.Sleep(50 * time.Millisecond)
-	cancel()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("scheduler did not exit within 2s of cancel")
+		t.Fatal("scheduler did not exit with a pre-canceled context within 2s")
 	}
 }
 

--- a/testdata/coverage-floor.json
+++ b/testdata/coverage-floor.json
@@ -6,7 +6,7 @@
   "internal/backup": 62,
   "internal/config": 94,
   "internal/conflict": 79,
-  "internal/connection": 83,
+  "internal/connection": 84,
   "internal/connection/emby": 79,
   "internal/connection/httpclient": 68,
   "internal/connection/jellyfin": 79,


### PR DESCRIPTION
## Summary

Three small CI/build-hardening changes, bundled into one PR to conserve CodeRabbit review budget.

1. **#1759 - deterministic `internal/connection` coverage (test-only).** `TestLockSync_StartSchedulerStopsOnCancel` used `time.Sleep(50ms)` to wait for the scheduler goroutine to reach its ticker-loop select before cancelling the context. Under full-suite `-race` contention the goroutine could be starved past 50ms and take the early `case <-ctx.Done(): return` branch instead, flipping ~6 statements and dropping `internal/connection` from 83% to 82% - below its 83% floor. The coverage-floor gate then failed **intermittently on PRs that don't touch `internal/connection` at all**. Rewritten to run inside a `testing/synctest` bubble: the fake clock advances only when all goroutines are durably blocked, which deterministically guarantees the scheduler reached its select before the test cancels - no timing race, **zero production-code change** (only `locksync_test.go` + the floor json). Floor bumped 83 -> 84 (now a deterministic 84.1%).

2. **`make vulncheck`** - new Makefile target wrapping `go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...` (the version the Security CI job installs), so a local run mirrors CI byte-for-byte. Wired into `/prep-pr` as a blocking gate; deliberately NOT added to the pre-push hook - govulncheck is a live-DB query whose result can flip with no code change, which would spuriously block unrelated pushes.

3. **Docker `golang:1.26-alpine` digest -> go1.26.4** - unbreaks **main**'s Docker Build, which has been failing since #1823 bumped `go.mod` to `go 1.26.4` while the builder base image was still go1.26.3. The build runs `GOTOOLCHAIN=local` (hermetic), so `go mod download` failed: `go: go.mod requires go >= 1.26.4 (running go 1.26.3; GOTOOLCHAIN=local)`. New digest verified (`go version` -> go1.26.4, and `go mod download` succeeds under `GOTOOLCHAIN=local`). Manual equivalent of the Dependabot Docker bump (the live-DB govulncheck that forced the go.mod bump lands ahead of Dependabot's schedule).

## Linked issue

Closes #1759

## Pre-flight checklist

- [X] Pre-push gate green locally (pre-push hook).
- [X] `make vulncheck` clean ("No vulnerabilities found.").
- [X] At least one label set.
- [X] Docs label decision: `docs: not-required` (test/CI/build hardening; no user-visible behavior change).

## Test plan

- [X] #1759: `testing/synctest` rewrite is deterministic by construction; `internal/connection` 84.1% on go 1.26.4, floor gate OK; 10/10 prior `-race` runs clean before the rebase.
- [X] `make vulncheck` -> "No vulnerabilities found."
- [X] Docker: `go version` = go1.26.4 and `go mod download` succeeds under `GOTOOLCHAIN=local` in the new base image.
- [ ] CI green on this PR (the real gate, including Docker Build).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added vulnerability scanning to the build process for enhanced security
  * Enhanced test infrastructure for improved reliability and deterministic behavior
  * Updated build dependencies and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->