### PR TITLE
feat(images): non-destructive crop/auto-trim with revert + close conflict-gate gaps (#1336 4B backend)

### DIFF
--- a/api/bruno/artists/revert-image.bru
+++ b/api/bruno/artists/revert-image.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Revert Image
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{apiBase}}/artists/00000000-0000-0000-0000-000000000000/images/thumb/revert
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("returns 404 for sentinel artistId", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope reports artist not found", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.equal("artist not found");
+  });
+}

--- a/internal/api/handlers_backdrop.go
+++ b/internal/api/handlers_backdrop.go
@@ -404,6 +404,10 @@ func (r *Router) handleFanartSlotDelete(w http.ResponseWriter, req *http.Request
 	if !ok {
 		return
 	}
+	// Destructive (deletes bytes): fail CLOSED if the gate cannot be evaluated.
+	if !r.gateImageWriteStrict(w, req) {
+		return
+	}
 
 	a, err := r.artistService.GetByID(req.Context(), artistID)
 	if err != nil {
@@ -510,6 +514,13 @@ func (r *Router) handleFanartSlotDelete(w http.ResponseWriter, req *http.Request
 func (r *Router) handleFanartReorder(w http.ResponseWriter, req *http.Request) {
 	artistID, ok := RequirePathParam(w, req, "id")
 	if !ok {
+		return
+	}
+	// Reorder renames on-disk fanart files (destructive, no backup), so it must
+	// fail CLOSED if the conflict gate cannot be evaluated - matching slot-delete
+	// and batch-delete. A fail-open gate-eval error could otherwise fall through
+	// into the staged rename and mutate ordering anyway (CR #1839).
+	if !r.gateImageWriteStrict(w, req) {
 		return
 	}
 

--- a/internal/api/handlers_backdrop_test.go
+++ b/internal/api/handlers_backdrop_test.go
@@ -959,3 +959,146 @@ func TestIsValidPermutation(t *testing.T) {
 		}
 	}
 }
+
+// seedBlockedFanartArtist creates an artist rooted at a temp dir with two seeded
+// fanart slots and returns the artist plus the slot paths, so a blocked
+// destructive op can assert the bytes were left untouched.
+func seedBlockedFanartArtist(t *testing.T, artistSvc *artist.Service, name string) (*artist.Artist, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	a := &artist.Artist{Name: name, SortName: name, Type: "group", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist %s: %v", name, err)
+	}
+	p0 := filepath.Join(dir, "fanart.jpg")
+	p1 := filepath.Join(dir, "fanart1.jpg")
+	writeJPEG(t, p0, 1920, 1080)
+	writeJPEG(t, p1, 1920, 1080)
+	return a, p0, p1
+}
+
+// assertSlotsUnchanged asserts both seeded slot files still exist after a
+// blocked destructive op.
+func assertSlotsUnchanged(t *testing.T, paths ...string) {
+	t.Helper()
+	for _, p := range paths {
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("blocked op must leave %s on disk: %v", filepath.Base(p), err)
+		}
+	}
+}
+
+// assertConflictWriteBlock asserts a gated 409 body carries the shared
+// ConflictWriteBlock payload (error/axis/reason/ledger) rather than a bare
+// error, so a regression dropping the conflict fields fails the test (CR #1839).
+func assertConflictWriteBlock(t *testing.T, body []byte) {
+	t.Helper()
+	var blocked map[string]any
+	if err := json.Unmarshal(body, &blocked); err != nil {
+		t.Fatalf("decoding 409 body: %v; body = %s", err, string(body))
+	}
+	if blocked["axis"] != "image" {
+		t.Errorf("409 axis = %v, want image", blocked["axis"])
+	}
+	if s, _ := blocked["error"].(string); s == "" {
+		t.Errorf("409 error code must be non-empty, got %v", blocked["error"])
+	}
+	if s, _ := blocked["reason"].(string); s == "" {
+		t.Errorf("409 reason must be non-empty, got %v", blocked["reason"])
+	}
+	if _, ok := blocked["ledger"].(map[string]any); !ok {
+		t.Errorf("409 ledger should be a JSON object, got %T (%v)", blocked["ledger"], blocked["ledger"])
+	}
+}
+
+func TestHandleFanartSlotDelete_Blocked409(t *testing.T) {
+	t.Parallel()
+	d := conflict.NewBlockingForTest(testDiscardLogger())
+	r, artistSvc := testRouterForBackdrops(t)
+	r.conflictDetector = d
+	r.conflictGate = conflict.NewGate(d)
+	a, p0, p1 := seedBlockedFanartArtist(t, artistSvc, "Blocked Slot")
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/artists/"+a.ID+"/images/fanart/0", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("slot", "0")
+	w := httptest.NewRecorder()
+	r.handleFanartSlotDelete(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	assertConflictWriteBlock(t, w.Body.Bytes()) // 409 must carry the conflict payload
+	assertSlotsUnchanged(t, p0, p1)             // T1: blocked delete must not remove bytes
+}
+
+// TestHandleFanartSlotDelete_RemoveFailureKeepsSlots proves T5: when the file
+// remover fails, slot-delete returns 500 and BOTH seeded slots remain on disk.
+func TestHandleFanartSlotDelete_RemoveFailureKeepsSlots(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterForBackdrops(t)
+	r.fileRemover = failingRemover{err: fmt.Errorf("permission denied")}
+	a, p0, p1 := seedBlockedFanartArtist(t, artistSvc, "Remove Fail Slot")
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/artists/"+a.ID+"/images/fanart/0", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("slot", "0")
+	w := httptest.NewRecorder()
+	r.handleFanartSlotDelete(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+	assertSlotsUnchanged(t, p0, p1) // remove failed -> nothing deleted
+}
+
+func TestHandleFanartReorder_Blocked409(t *testing.T) {
+	t.Parallel()
+	d := conflict.NewBlockingForTest(testDiscardLogger())
+	r, artistSvc := testRouterForBackdrops(t)
+	r.conflictDetector = d
+	r.conflictGate = conflict.NewGate(d)
+	a, p0, p1 := seedBlockedFanartArtist(t, artistSvc, "Blocked Reorder")
+	// Distinct per-slot contents so a blocked reorder that nevertheless swapped
+	// bytes before returning 409 would be caught (matching filenames alone is not
+	// enough - both slots keep the same names through a reorder). The gate blocks
+	// before any file read, so non-image marker bytes are fine here.
+	if err := os.WriteFile(p0, []byte("SLOT0-CONTENT"), 0o644); err != nil {
+		t.Fatalf("seeding slot 0 content: %v", err)
+	}
+	if err := os.WriteFile(p1, []byte("SLOT1-CONTENT"), 0o644); err != nil {
+		t.Fatalf("seeding slot 1 content: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fanart/reorder",
+		bytes.NewReader([]byte(`{"order":[1,0]}`)))
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+	r.handleFanartReorder(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	assertConflictWriteBlock(t, w.Body.Bytes()) // 409 must carry the conflict payload
+	assertSlotsUnchanged(t, p0, p1)             // T1: blocked reorder must not rename files
+	// Bytes must stay put per slot: a blocked reorder must not swap contents.
+	if got, _ := os.ReadFile(p0); string(got) != "SLOT0-CONTENT" {
+		t.Errorf("slot 0 content changed after blocked reorder: %q", got)
+	}
+	if got, _ := os.ReadFile(p1); string(got) != "SLOT1-CONTENT" {
+		t.Errorf("slot 1 content changed after blocked reorder: %q", got)
+	}
+}
+
+func TestHandleFanartBatchDelete_Blocked409(t *testing.T) {
+	t.Parallel()
+	d := conflict.NewBlockingForTest(testDiscardLogger())
+	r, artistSvc := testRouterForBackdrops(t)
+	r.conflictDetector = d
+	r.conflictGate = conflict.NewGate(d)
+	a, p0, p1 := seedBlockedFanartArtist(t, artistSvc, "Blocked Batch")
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/artists/"+a.ID+"/images/fanart/batch",
+		bytes.NewReader([]byte(`{"indices":[0]}`)))
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+	r.handleFanartBatchDelete(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	assertConflictWriteBlock(t, w.Body.Bytes()) // 409 must carry the conflict payload
+	assertSlotsUnchanged(t, p0, p1)             // T1: blocked batch-delete must not remove bytes
+}

--- a/internal/api/handlers_conflict.go
+++ b/internal/api/handlers_conflict.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -481,6 +482,34 @@ func (r *Router) gateImageWrite(w http.ResponseWriter, req *http.Request) bool {
 		// Non-blocked error means the ledger failed to compute; fail open
 		// rather than blocking every write on a transient detector problem.
 		r.logger.Warn("image write gate check failed; falling through", "error", err)
+	}
+	return true
+}
+
+// gateImageWriteStrict is the fail-CLOSED variant of gateImageWrite for
+// genuinely DESTRUCTIVE image ops that delete bytes (fanart slot-delete, fanart
+// batch-delete, revert). Unlike gateImageWrite, which fails OPEN on a non-blocked
+// ledger-compute error (acceptable for backup-creating overwrite paths), this
+// variant writes HTTP 500 and returns false on such an error: if we cannot
+// determine whether a conflict gate would block, we must not delete
+// source-of-truth bytes. BlockedError still maps to 409 identically.
+func (r *Router) gateImageWriteStrict(w http.ResponseWriter, req *http.Request) bool {
+	if r.conflictGate == nil {
+		return true
+	}
+	if err := r.conflictGate.AllowImageWrite(req.Context()); err != nil {
+		if be, ok := conflict.AsBlocked(err); ok {
+			writeConflictError(w, be)
+			return false
+		}
+		// Non-blocked error means the ledger failed to compute. For a
+		// destructive op we fail CLOSED rather than risk deleting an original.
+		r.logger.Error("image write gate check failed on destructive op; failing closed",
+			slog.String("method", req.Method),
+			slog.String("path", req.URL.Path),
+			slog.String("error", err.Error()))
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "conflict gate check failed; destructive operation aborted"})
+		return false
 	}
 	return true
 }

--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -695,6 +695,19 @@ func (r *Router) processAndSaveImage(ctx context.Context, dir string, imageType 
 
 	naming, useSymlinks := r.getActiveNamingAndSymlinks(ctx, imageType)
 
+	// Non-destructive: keep a one-deep peer-inert backup of the current
+	// canonical single-slot image before we overwrite it, so the edit is
+	// revertible (#1837). Fanart is multi-slot (a new slot is appended
+	// elsewhere) and is never backed up here. BackupSingleSlot probes strictly
+	// (#1161): a transient stat error or a backup-write failure returns an error
+	// and we ABORT the destructive save so the source-of-truth original is never
+	// overwritten without a recoverable backup.
+	if imageType != "fanart" {
+		if bErr := img.BackupSingleSlot(dir, imageType, naming); bErr != nil {
+			return nil, fmt.Errorf("backing up original before overwrite (aborting destructive save): %w", bErr)
+		}
+	}
+
 	// Register expected write paths so the filesystem watcher can
 	// distinguish Stillwater's own writes from external ones.
 	if r.expectedWrites != nil {
@@ -1200,13 +1213,20 @@ func (r *Router) handleImageInfo(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// backup_exists lets the UI conditionally surface a "Revert" affordance for
+	// single-slot kinds (thumb/logo/banner): true when a one-deep .sw-backup
+	// original is present. Fanart is multi-slot and has no single-slot backup,
+	// so it is always false here (#1336 cross-plan delta, #1837).
+	backupExists := imageType != "fanart" && img.HasBackup(dir, imageType)
+
 	writeJSON(w, http.StatusOK, map[string]any{
-		"type":     imageType,
-		"filename": filepath.Base(filePath),
-		"width":    width,
-		"height":   height,
-		"size":     stat.Size(),
-		"modified": stat.ModTime().UTC().Format(time.RFC3339),
+		"type":          imageType,
+		"filename":      filepath.Base(filePath),
+		"width":         width,
+		"height":        height,
+		"size":          stat.Size(),
+		"modified":      stat.ModTime().UTC().Format(time.RFC3339),
+		"backup_exists": backupExists,
 	})
 }
 
@@ -1521,6 +1541,9 @@ func (r *Router) handleLogoTrim(w http.ResponseWriter, req *http.Request) {
 	if !ok {
 		return
 	}
+	if !r.gateImageWrite(w, req) {
+		return
+	}
 
 	a, err := r.artistService.GetByID(req.Context(), artistID)
 	if err != nil {
@@ -1569,6 +1592,17 @@ func (r *Router) handleLogoTrim(w http.ResponseWriter, req *http.Request) {
 	trimMeta.Mode = "user"
 	trimMeta.DHash = "" // Force recomputation from the trimmed image data.
 
+	// Non-destructive: preserve the pre-trim original (#1837). On a backup
+	// failure (transient stat error or write error) ABORT the trim with 500 and
+	// do NOT call Save, so the original logo is never destroyed without a
+	// recoverable backup.
+	if bErr := img.BackupSingleSlot(r.imageDir(a), "logo", patterns); bErr != nil {
+		r.logger.Error("backing up logo before trim; aborting",
+			slog.String("artist_id", artistID), slog.String("error", bErr.Error()))
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to preserve pre-trim original; trim aborted"})
+		return
+	}
+
 	_, useSymlinks := r.getActiveNamingAndSymlinks(req.Context(), "logo")
 	if _, err := img.Save(r.imageDir(a), "logo", trimmed, patterns, useSymlinks, trimMeta, r.logger); err != nil {
 		r.logger.Error("saving trimmed logo", "artist_id", artistID, "error", err)
@@ -1601,6 +1635,109 @@ func (r *Router) handleLogoTrim(w http.ResponseWriter, req *http.Request) {
 		"status":        "ok",
 		"sync_warnings": warnings,
 	})
+}
+
+// handleImageRevert restores the most recent pre-edit original for a single-slot
+// kind (thumb/logo/banner) from the peer-inert backup in the .sw-backup subdir,
+// or drops the newest derived fanart slot for the multi-slot fanart kind. It is a
+// write, so it goes through the conflict gate. #1837.
+// POST /api/v1/artists/{id}/images/{type}/revert
+func (r *Router) handleImageRevert(w http.ResponseWriter, req *http.Request) {
+	artistID, ok := RequirePathParam(w, req, "id")
+	if !ok {
+		return
+	}
+	// Destructive (drops the newest fanart slot or rebuilds over the canonical):
+	// fail CLOSED if the gate cannot be evaluated.
+	if !r.gateImageWriteStrict(w, req) {
+		return
+	}
+
+	imageType := req.PathValue("type")
+	if !validImageTypes[imageType] {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid image type"})
+		return
+	}
+
+	a, err := r.artistService.GetByID(req.Context(), artistID)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "artist not found"})
+		return
+	}
+	if !r.requireImageDir(w, req, a) {
+		return
+	}
+	dir := r.imageDir(a)
+
+	if imageType == "fanart" {
+		// Multi-slot: revert == drop the newest derived slot (highest index),
+		// leaving the original slot 0 intact. 404 when only the original exists.
+		primary := r.getActiveFanartPrimary(req.Context())
+		paths, discErr := img.DiscoverFanart(dir, primary)
+		if discErr != nil {
+			r.logger.Error("discovering fanart for revert", slog.String("artist_id", artistID), slog.String("error", discErr.Error()))
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to read fanart directory"})
+			return
+		}
+		if len(paths) < 2 {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "no derived fanart slot to revert"})
+			return
+		}
+		newest := paths[len(paths)-1]
+		if rmErr := r.fileRemover.Remove(newest); rmErr != nil {
+			r.logger.Error("dropping derived fanart slot", slog.String("artist_id", artistID), slog.String("path", newest), slog.String("error", rmErr.Error()))
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to revert fanart"})
+			return
+		}
+		r.updateArtistFanartCount(req.Context(), a)
+		warnings := r.revertSideEffects(req.Context(), a, imageType)
+		writeJSON(w, http.StatusOK, map[string]any{"status": "reverted", "type": imageType, "count": a.FanartCount, "sync_warnings": warnings})
+		return
+	}
+
+	// Single-slot: restore the original from its one-deep backup. RestoreSingleSlot
+	// routes the backup bytes through img.Save so ALL configured names + symlinks
+	// are rebuilt and the post-edit format (e.g. a jpg written over a png crop)
+	// is cleaned up. The backup is keyed by image TYPE, so a format-changing edit
+	// is still revertible (#1837).
+	naming, useSymlinks := r.getActiveNamingAndSymlinks(req.Context(), imageType)
+	if restoreErr := img.RestoreSingleSlot(dir, imageType, naming, useSymlinks, nil, r.logger); restoreErr != nil {
+		if os.IsNotExist(restoreErr) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "no backup to revert"})
+			return
+		}
+		r.logger.Error("reverting single-slot image", slog.String("artist_id", artistID), slog.String("type", imageType), slog.String("error", restoreErr.Error()))
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to revert image"})
+		return
+	}
+	// DB bookkeeping (exists flag, low-res, placeholder) is intentionally
+	// best-effort on the revert path: setArtistImageFlag logs any Update failure
+	// at Warn and the on-disk file is already the source of truth, so a stale
+	// flag self-heals on the next scan. This matches every other image write
+	// path; we do not fail the revert on a DB hiccup (#1837, F7).
+	r.updateArtistImageFlag(req.Context(), a, imageType)
+	warnings := r.revertSideEffects(req.Context(), a, imageType)
+	writeJSON(w, http.StatusOK, map[string]any{"status": "reverted", "type": imageType, "sync_warnings": warnings})
+}
+
+// revertSideEffects performs the post-write bookkeeping shared by both revert
+// branches: cache eviction, event publish, health invalidation, rule re-eval,
+// and platform sync of the now-canonical image. It RETURNS the platform-sync
+// warnings so both revert responses can surface them under "sync_warnings",
+// matching every other write path (#1837).
+func (r *Router) revertSideEffects(ctx context.Context, a *artist.Artist, imageType string) []string {
+	r.enforceCacheLimitIfNeeded(ctx, a)
+	if r.eventBus != nil {
+		r.eventBus.Publish(event.Event{Type: event.ArtistUpdated, Data: map[string]any{"artist_id": a.ID}})
+	}
+	r.InvalidateHealthCache()
+	r.runRulesAfterRefresh(ctx, a)
+	syncCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if imageType == "fanart" {
+		return r.publisher.SyncAllFanartToPlatforms(syncCtx, a)
+	}
+	return r.publisher.SyncImageToPlatforms(syncCtx, a, imageType)
 }
 
 // imageTypeLabel returns a human-readable label for an image type.
@@ -1841,6 +1978,10 @@ func (r *Router) handleServeFanartByIndex(w http.ResponseWriter, req *http.Reque
 func (r *Router) handleFanartBatchDelete(w http.ResponseWriter, req *http.Request) {
 	artistID, ok := RequirePathParam(w, req, "id")
 	if !ok {
+		return
+	}
+	// Destructive (deletes bytes): fail CLOSED if the gate cannot be evaluated.
+	if !r.gateImageWriteStrict(w, req) {
 		return
 	}
 

--- a/internal/api/handlers_image_revert_errors_test.go
+++ b/internal/api/handlers_image_revert_errors_test.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/event"
+	img "github.com/sydlexius/stillwater/internal/image"
+)
+
+// TestHandleImageRevert_ArtistNotFound404 covers the GetByID-error branch: a
+// revert for a non-existent artist ID returns 404 with the artist-not-found body.
+func TestHandleImageRevert_ArtistNotFound404(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouterWithPlatform(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/does-not-exist/images/thumb/revert", nil)
+	req.SetPathValue("id", "does-not-exist")
+	req.SetPathValue("type", "thumb")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleImageRevert_MissingID400 covers the RequirePathParam-fail branch:
+// a request with no "id" path value is rejected with 400 before any work.
+func TestHandleImageRevert_MissingID400(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouterWithPlatform(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists//images/thumb/revert", nil)
+	// Deliberately do NOT set the "id" path value.
+	req.SetPathValue("type", "thumb")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleImageRevert_NoImageDir422 covers the requireImageDir-fail branch: an
+// artist with no filesystem path and no image cache dir has no image directory,
+// so revert is rejected before any disk access.
+func TestHandleImageRevert_NoImageDir422(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	// Empty Path + empty imageCacheDir => imageDir() == "" => requireImageDir false.
+	a := &artist.Artist{Name: "No Dir", SortName: "No Dir", Path: ""}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/thumb/revert", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "thumb")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleImageRevert_FanartDiscoverError500 covers the DiscoverFanart-error
+// branch: the artist directory path points at a regular file, so reading it as a
+// directory fails and the fanart revert returns 500.
+func TestHandleImageRevert_FanartDiscoverError500(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	// Path is a regular FILE, not a directory; os.ReadDir on it errors.
+	f := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seeding file path: %v", err)
+	}
+	a := &artist.Artist{Name: "Bad Dir", SortName: "Bad Dir", Path: f}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fanart/revert", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "fanart")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleImageRevert_FanartRemoveError500 covers the fileRemover.Remove-error
+// branch: there are two fanart slots (so a derived slot exists to drop) but the
+// remover fails, so the fanart revert returns 500.
+func TestHandleImageRevert_FanartRemoveError500(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	r.fileRemover = failingRemover{err: fmt.Errorf("permission denied")}
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Remove Fail", SortName: "Remove Fail", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	writeJPEG(t, filepath.Join(dir, "fanart.jpg"), 1920, 1080)
+	writeJPEG(t, filepath.Join(dir, "fanart1.jpg"), 1920, 1080)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fanart/revert", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "fanart")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+	// The slot must remain on disk since the remove failed.
+	if _, err := os.Stat(filepath.Join(dir, "fanart1.jpg")); err != nil {
+		t.Errorf("fanart1.jpg should still exist after a failed remove: %v", err)
+	}
+}
+
+// TestHandleImageRevert_SingleSlotRestoreError500 covers the RestoreSingleSlot
+// non-NotExist error branch: a backup file with undecodable bytes makes the
+// internal img.Save fail, so the single-slot revert returns 500 (not 404).
+func TestHandleImageRevert_SingleSlotRestoreError500(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Restore Fail", SortName: "Restore Fail", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	// Seed a current canonical thumb so we can prove the failed restore is
+	// fail-closed on disk (the canonical must NOT be clobbered when Save errors).
+	canonical := filepath.Join(dir, "folder.jpg")
+	writeJPEG(t, canonical, 70, 70)
+	canonicalBefore, _ := os.ReadFile(canonical)
+
+	// Seed a corrupt backup so RestoreSingleSlot finds it but img.Save rejects it.
+	typeDir := filepath.Join(dir, img.BackupDirName, "thumb")
+	if err := os.MkdirAll(typeDir, 0o750); err != nil {
+		t.Fatalf("creating backup type dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(typeDir, "stale.png"), []byte("not-an-image"), 0o644); err != nil {
+		t.Fatalf("seeding corrupt backup: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/thumb/revert", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "thumb")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+	// Fail-closed: a restore error must not have overwritten the canonical thumb.
+	canonicalAfter, _ := os.ReadFile(canonical)
+	if !bytes.Equal(canonicalBefore, canonicalAfter) {
+		t.Error("failed single-slot restore must not clobber the canonical image on disk")
+	}
+}
+
+// TestHandleImageRevert_NilGateProceeds covers the gateImageWriteStrict nil-gate
+// branch: with no conflict gate configured the destructive revert proceeds (no
+// 409), here dropping the newest fanart slot.
+func TestHandleImageRevert_NilGateProceeds(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	// No gate configured -> strict gate returns true without evaluating.
+	r.conflictGate = nil
+	// Wire an event bus so revertSideEffects publishes the ArtistUpdated event
+	// (exercises the eventBus-non-nil branch).
+	bus := event.NewBus(r.logger, 1024)
+	go bus.Start()
+	t.Cleanup(bus.Stop)
+	r.eventBus = bus
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Nil Gate", SortName: "Nil Gate", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	writeJPEG(t, filepath.Join(dir, "fanart.jpg"), 1920, 1080)
+	writeJPEG(t, filepath.Join(dir, "fanart1.jpg"), 1920, 1080)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fanart/revert", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "fanart")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "fanart1.jpg")); !os.IsNotExist(err) {
+		t.Errorf("newest fanart slot should be dropped, stat err = %v", err)
+	}
+}

--- a/internal/api/handlers_image_revert_test.go
+++ b/internal/api/handlers_image_revert_test.go
@@ -1,0 +1,424 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/conflict"
+	img "github.com/sydlexius/stillwater/internal/image"
+)
+
+func TestHandleImageRevert_SingleSlotRestoresBackup(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Revert Artist", SortName: "Revert Artist", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	canonical := filepath.Join(dir, "folder.jpg")
+	writeJPEG(t, canonical, 64, 64)
+	orig, _ := os.ReadFile(canonical)
+	if err := img.BackupSingleSlot(dir, "thumb", thumbNaming); err != nil {
+		t.Fatalf("seed backup: %v", err)
+	}
+	// Simulate a destructive edit (different image content).
+	writeJPEG(t, canonical, 96, 96)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/thumb/revert", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "thumb")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	// Assert the single-slot 200 contract explicitly (status/type), not just the
+	// file restore: a handler regression emitting the wrong JSON while still
+	// restoring the file on disk would otherwise pass.
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding revert body: %v; body=%s", err, w.Body.String())
+	}
+	if body["status"] != "reverted" {
+		t.Errorf("status field = %v, want reverted", body["status"])
+	}
+	if body["type"] != "thumb" {
+		t.Errorf("type field = %v, want thumb", body["type"])
+	}
+	got, _ := os.ReadFile(canonical)
+	if !bytes.Equal(got, orig) {
+		t.Errorf("canonical after revert does not match original (%d vs %d bytes)", len(got), len(orig))
+	}
+	// sync_warnings must be present in the response (F5).
+	if _, ok := body["sync_warnings"]; !ok {
+		t.Errorf("revert response missing sync_warnings: %s", w.Body.String())
+	}
+}
+
+// thumbNaming is the thumb filename list the test router resolves to (no active
+// platform profile -> image.DefaultFileNames).
+var thumbNaming = img.DefaultFileNames["thumb"]
+
+func TestHandleImageRevert_SingleSlotNoBackup404(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "NoBackup", SortName: "NoBackup", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	writeJPEG(t, filepath.Join(dir, "folder.jpg"), 100, 100)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/thumb/revert", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "thumb")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleImageRevert_FanartDropsNewestSlot(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Fanart Revert", SortName: "Fanart Revert", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	// Three fanart slots: fanart.jpg, fanart1.jpg, fanart2.jpg (T6).
+	writeJPEG(t, filepath.Join(dir, "fanart.jpg"), 1920, 1080)
+	writeJPEG(t, filepath.Join(dir, "fanart1.jpg"), 1920, 1080)
+	writeJPEG(t, filepath.Join(dir, "fanart2.jpg"), 1920, 1080)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fanart/revert", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "fanart")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	// Assert the user-visible 200 contract (status/type/count), not just the file
+	// side effect: a regression in these fields is an API-contract break.
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decoding revert body: %v; body=%s", err, w.Body.String())
+	}
+	if body["status"] != "reverted" {
+		t.Errorf("status field = %v, want reverted", body["status"])
+	}
+	if body["type"] != "fanart" {
+		t.Errorf("type field = %v, want fanart", body["type"])
+	}
+	if got, ok := body["count"].(float64); !ok || int(got) != 2 {
+		t.Errorf("count field = %v, want 2", body["count"])
+	}
+	// Only the newest (fanart2.jpg) is dropped; fanart.jpg + fanart1.jpg remain.
+	if _, err := os.Stat(filepath.Join(dir, "fanart2.jpg")); !os.IsNotExist(err) {
+		t.Errorf("newest fanart slot (fanart2.jpg) should be dropped, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "fanart1.jpg")); err != nil {
+		t.Errorf("fanart1.jpg must remain: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "fanart.jpg")); err != nil {
+		t.Errorf("original fanart slot must remain: %v", err)
+	}
+	// sync_warnings must be present in the fanart revert response (F5).
+	if _, ok := body["sync_warnings"]; !ok {
+		t.Errorf("fanart revert response missing sync_warnings: %s", w.Body.String())
+	}
+}
+
+func TestHandleImageRevert_FanartNoExtraSlot404(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Single Fanart", SortName: "Single Fanart", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	writeJPEG(t, filepath.Join(dir, "fanart.jpg"), 1920, 1080) // only the original slot
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/fanart/revert", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "fanart")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleImageRevert_InvalidType400(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	a := &artist.Artist{Name: "BadType", SortName: "BadType", Path: t.TempDir()}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/poster/revert", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "poster")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleImageRevert_Blocked409(t *testing.T) {
+	t.Parallel()
+	d := conflict.NewBlockingForTest(testDiscardLogger())
+	r, artistSvc := testRouterWithPlatform(t)
+	r.conflictDetector = d
+	r.conflictGate = conflict.NewGate(d)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Blocked Revert", SortName: "Blocked Revert", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	canonical := filepath.Join(dir, "folder.jpg")
+	writeJPEG(t, canonical, 64, 64)
+	canonicalBefore, _ := os.ReadFile(canonical)
+	if err := img.BackupSingleSlot(dir, "thumb", thumbNaming); err != nil {
+		t.Fatalf("seed backup: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/thumb/revert", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "thumb")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	// The gated 409 must carry the shared ConflictWriteBlock payload, not a bare
+	// error - otherwise a regression dropping the conflict fields slips through.
+	assertConflictWriteBlock(t, w.Body.Bytes())
+	// T1: a blocked revert must not touch disk - backup survives, canonical unchanged.
+	if !img.HasBackup(dir, "thumb") {
+		t.Error("blocked revert must leave the backup intact")
+	}
+	canonicalAfter, _ := os.ReadFile(canonical)
+	if !bytes.Equal(canonicalBefore, canonicalAfter) {
+		t.Error("blocked revert must not overwrite the canonical image")
+	}
+}
+
+func TestHandleImageInfo_ReportsBackupExists(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Info Backup", SortName: "Info Backup", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	canonical := filepath.Join(dir, "folder.jpg")
+	writeJPEG(t, canonical, 64, 64)
+
+	infoBackupExists := func(imageType string) bool {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/images/"+imageType+"/info", nil)
+		req.SetPathValue("id", a.ID)
+		req.SetPathValue("type", imageType)
+		w := httptest.NewRecorder()
+		r.handleImageInfo(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("info status = %d, want 200; body: %s", w.Code, w.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decoding info body: %v; body=%s", err, w.Body.String())
+		}
+		v, ok := body["backup_exists"].(bool)
+		if !ok {
+			t.Fatalf("backup_exists missing or not a bool in %s", w.Body.String())
+		}
+		return v
+	}
+
+	// No backup yet -> backup_exists false (typed bool, T7).
+	if infoBackupExists("thumb") {
+		t.Error("want backup_exists=false before any backup")
+	}
+
+	// After a backup exists -> backup_exists true.
+	if err := img.BackupSingleSlot(dir, "thumb", thumbNaming); err != nil {
+		t.Fatalf("seed backup: %v", err)
+	}
+	if !infoBackupExists("thumb") {
+		t.Error("want backup_exists=true after backup")
+	}
+
+	// T7: fanart info reports backup_exists=false even with a stray .sw-backup
+	// entry, because fanart is multi-slot and has no single-slot backup.
+	writeJPEG(t, filepath.Join(dir, "fanart.jpg"), 1920, 1080)
+	strayDir := filepath.Join(dir, img.BackupDirName, "fanart")
+	if err := os.MkdirAll(strayDir, 0o750); err != nil {
+		t.Fatalf("creating stray backup dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(strayDir, "fanart.jpg"), []byte("stray"), 0o644); err != nil {
+		t.Fatalf("writing stray backup: %v", err)
+	}
+	if infoBackupExists("fanart") {
+		t.Error("fanart info must report backup_exists=false even with a stray backup entry")
+	}
+}
+
+// TestHandleImageRevert_CropRoundTrip exercises the full crop -> revert flow
+// through the handlers and asserts the post-revert canonical matches the
+// pre-crop original (T3), including a png->jpg variant proving F4.
+func TestHandleImageRevert_CropRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		origName string
+		origFmt  string
+		cropFmt  string
+		// staleName is the post-crop canonical written under the crop format's
+		// name when it differs from origName (format-changing crop). Revert must
+		// remove it via CleanupConflictingFormats. Empty when crop keeps origName.
+		staleName string
+	}{
+		{"jpg-to-jpg", "folder.jpg", "jpeg", "jpeg", ""},
+		{"png-to-jpg", "folder.png", "png", "jpeg", "folder.jpg"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r, artistSvc := testRouterWithPlatform(t)
+			dir := t.TempDir()
+			a := &artist.Artist{Name: "RoundTrip", SortName: "RoundTrip", Path: dir}
+			if err := artistSvc.Create(context.Background(), a); err != nil {
+				t.Fatalf("creating artist: %v", err)
+			}
+			origPath := filepath.Join(dir, tc.origName)
+			writeImageFmt(t, origPath, tc.origFmt, 80, 80)
+			orig, _ := os.ReadFile(origPath)
+
+			// Crop: process+save a different-content image of the crop format.
+			cropData := encodeImageFmt(t, tc.cropFmt, 120, 120)
+			if _, err := r.processAndSaveImage(context.Background(), dir, "thumb", cropData, nil); err != nil {
+				t.Fatalf("crop save: %v", err)
+			}
+
+			// Revert through the handler.
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/thumb/revert", nil)
+			req.SetPathValue("id", a.ID)
+			req.SetPathValue("type", "thumb")
+			w := httptest.NewRecorder()
+			r.handleImageRevert(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("revert status = %d, want 200; body: %s", w.Code, w.Body.String())
+			}
+			// Original basename + format must be restored byte-for-byte.
+			got, err := os.ReadFile(origPath)
+			if err != nil {
+				t.Fatalf("reading restored original at %s: %v", origPath, err)
+			}
+			if !bytes.Equal(got, orig) {
+				t.Errorf("post-revert canonical does not equal pre-crop original (%d vs %d bytes)", len(got), len(orig))
+			}
+			// Format-changing revert must also CLEAN UP the stale post-crop file
+			// (e.g. the folder.jpg written over a png original); leaving it behind
+			// would let two canonical formats coexist (F4).
+			if tc.staleName != "" {
+				if _, err := os.Stat(filepath.Join(dir, tc.staleName)); !os.IsNotExist(err) {
+					t.Errorf("stale post-crop file %s must be removed on revert, stat err = %v", tc.staleName, err)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleImageRevert_OneDeep crops twice and asserts exactly one backup
+// remains holding the FIRST crop's output, and revert returns to that
+// intermediate state (T4).
+func TestHandleImageRevert_OneDeep(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "OneDeep", SortName: "OneDeep", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	origPath := filepath.Join(dir, "folder.jpg")
+	writeJPEG(t, origPath, 60, 60)
+
+	// First crop: backs up the original; canonical becomes crop1.
+	crop1 := encodeImageFmt(t, "jpeg", 100, 100)
+	if _, err := r.processAndSaveImage(context.Background(), dir, "thumb", crop1, nil); err != nil {
+		t.Fatalf("crop1: %v", err)
+	}
+	intermediate, _ := os.ReadFile(origPath)
+
+	// Second crop: backs up crop1 (one-deep replaces the original backup).
+	crop2 := encodeImageFmt(t, "jpeg", 140, 140)
+	if _, err := r.processAndSaveImage(context.Background(), dir, "thumb", crop2, nil); err != nil {
+		t.Fatalf("crop2: %v", err)
+	}
+
+	// Exactly one backup file remains.
+	typeDir := filepath.Join(dir, img.BackupDirName, "thumb")
+	entries, err := os.ReadDir(typeDir)
+	if err != nil {
+		t.Fatalf("read backup dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly one backup after two crops, got %d", len(entries))
+	}
+
+	// Revert returns to the intermediate (first-crop) state, not the original.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/thumb/revert", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("type", "thumb")
+	w := httptest.NewRecorder()
+	r.handleImageRevert(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("revert status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+	got, _ := os.ReadFile(origPath)
+	if !bytes.Equal(got, intermediate) {
+		t.Errorf("one-deep revert should restore the FIRST crop, got %d bytes want %d", len(got), len(intermediate))
+	}
+}
+
+// encodeImageFmt returns encoded image bytes of the given format and size.
+func encodeImageFmt(t *testing.T, format string, w, h int) []byte {
+	t.Helper()
+	m := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			m.Set(x, y, color.RGBA{R: uint8(x % 256), G: uint8(y % 256), B: 64, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	var err error
+	if format == "png" {
+		err = png.Encode(&buf, m)
+	} else {
+		err = jpeg.Encode(&buf, m, &jpeg.Options{Quality: 90})
+	}
+	if err != nil {
+		t.Fatalf("encoding %s: %v", format, err)
+	}
+	return buf.Bytes()
+}
+
+// writeImageFmt writes an encoded image of the given format to path.
+func writeImageFmt(t *testing.T, path, format string, w, h int) {
+	t.Helper()
+	if err := os.WriteFile(path, encodeImageFmt(t, format, w, h), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -10,6 +10,7 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
+	"image/png"
 	"io"
 	"log/slog"
 	"mime/multipart"
@@ -23,6 +24,7 @@ import (
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/artist"
+	"github.com/sydlexius/stillwater/internal/conflict"
 	"github.com/sydlexius/stillwater/internal/httpsafe"
 	img "github.com/sydlexius/stillwater/internal/image"
 	"github.com/sydlexius/stillwater/internal/platform"
@@ -78,6 +80,25 @@ func writeJPEG(t *testing.T, path string, w, h int) {
 	var buf bytes.Buffer
 	if err := jpeg.Encode(&buf, m, nil); err != nil {
 		t.Fatalf("encoding JPEG: %v", err)
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+// writePNG creates a PNG file at path with the given dimensions. Used where the
+// image type requires PNG (logos) so tests do not seed mismatched bytes.
+func writePNG(t *testing.T, path string, w, h int) {
+	t.Helper()
+	m := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := range h {
+		for x := range w {
+			m.Set(x, y, color.RGBA{R: 200, G: 100, B: 50, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, m); err != nil {
+		t.Fatalf("encoding PNG: %v", err)
 	}
 	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
 		t.Fatalf("writing %s: %v", path, err)
@@ -2546,5 +2567,249 @@ func TestFetchImageFromURL_CancelledContext(t *testing.T) {
 		}
 	case <-time.After(1 * time.Second):
 		t.Fatal("fetchImageFromURL did not return within 1s after ctx cancellation; ctx is not being honored")
+	}
+}
+
+func TestHandleImageCrop_PreservesBackup(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Backup Artist", SortName: "Backup Artist", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	// Seed an existing canonical thumb (Kodi default profile uses folder.jpg).
+	writeJPEG(t, filepath.Join(dir, "folder.jpg"), 600, 600)
+	originalBytes, err := os.ReadFile(filepath.Join(dir, "folder.jpg"))
+	if err != nil {
+		t.Fatalf("reading seed: %v", err)
+	}
+
+	// Build a fresh 500x500 JPEG to crop in.
+	var imgBuf bytes.Buffer
+	if err := jpeg.Encode(&imgBuf, image.NewRGBA(image.Rect(0, 0, 500, 500)), nil); err != nil {
+		t.Fatalf("encoding crop input: %v", err)
+	}
+	reqBody, _ := json.Marshal(map[string]any{
+		"image_data": base64.StdEncoding.EncodeToString(imgBuf.Bytes()),
+		"type":       "thumb",
+		"x":          0, "y": 0, "width": 500, "height": 500,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/crop", bytes.NewReader(reqBody))
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+
+	r.handleImageCrop(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
+	// Backup of the pre-crop original must exist (keyed by image TYPE) and match
+	// the seed bytes (#1837: per-type, format-independent backup identity).
+	backup := filepath.Join(dir, img.BackupDirName, "thumb", "folder.jpg")
+	gotBackup, err := os.ReadFile(backup)
+	if err != nil {
+		t.Fatalf("expected backup at %s: %v", backup, err)
+	}
+	if !bytes.Equal(gotBackup, originalBytes) {
+		t.Error("backup bytes do not match the pre-crop original")
+	}
+}
+
+func TestHandleLogoTrim_GatedAndBacksUp(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Logo Artist", SortName: "Logo Artist", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	// Seed a PNG logo with a transparent border so TrimAlpha changes it.
+	logoPath := filepath.Join(dir, "logo.png")
+	m := image.NewRGBA(image.Rect(0, 0, 200, 100))
+	for y := 20; y < 80; y++ {
+		for x := 20; x < 180; x++ {
+			m.Set(x, y, color.RGBA{R: 10, G: 20, B: 30, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, m); err != nil {
+		t.Fatalf("encoding logo: %v", err)
+	}
+	if err := os.WriteFile(logoPath, buf.Bytes(), 0o644); err != nil {
+		t.Fatalf("seeding logo: %v", err)
+	}
+	originalBytes, _ := os.ReadFile(logoPath)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/logo/trim", nil)
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+	r.handleLogoTrim(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
+	backup := filepath.Join(dir, img.BackupDirName, "logo", "logo.png")
+	gotBackup, err := os.ReadFile(backup)
+	if err != nil {
+		t.Fatalf("expected logo backup at %s: %v", backup, err)
+	}
+	if !bytes.Equal(gotBackup, originalBytes) {
+		t.Error("logo backup bytes do not match the pre-trim original")
+	}
+}
+
+func TestHandleLogoTrim_Blocked409(t *testing.T) {
+	t.Parallel()
+	d := conflict.NewBlockingForTest(testDiscardLogger())
+	r, artistSvc := testRouterWithPlatform(t)
+	r.conflictDetector = d
+	r.conflictGate = conflict.NewGate(d)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Blocked Logo", SortName: "Blocked Logo", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	// T8: seed a real PNG (logos are PNG) so the blocked test cannot pass for
+	// the wrong reason.
+	logoPath := filepath.Join(dir, "logo.png")
+	writePNG(t, logoPath, 200, 100)
+	before, _ := os.ReadFile(logoPath)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/logo/trim", nil)
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+	r.handleLogoTrim(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409; body: %s", w.Code, w.Body.String())
+	}
+	// CR #1839: the gated 409 must carry the shared ConflictWriteBlock payload
+	// (error/axis/reason/ledger), not a bare error. Asserting the shape here
+	// catches a regression to a generic 409 that would silently break the
+	// UI/OpenAPI contract.
+	assertConflictWriteBlock(t, w.Body.Bytes())
+	// T1: a blocked trim must not touch disk - no backup, canonical unchanged.
+	if img.HasBackup(dir, "logo") {
+		t.Error("blocked logo-trim must not create a backup")
+	}
+	after, _ := os.ReadFile(logoPath)
+	if !bytes.Equal(before, after) {
+		t.Error("blocked logo-trim must not modify the canonical logo")
+	}
+}
+
+// TestHandleImageInfo_BackupExistsContract pins the JSON contract for the
+// backup_exists field that drives the UI's revert affordance (CR #1839): it is
+// true for a single-slot kind (thumb/logo/banner) that has a one-deep
+// .sw-backup original, and always false for fanart (multi-slot, no single-slot
+// backup) even when an unrelated backup dir is present. This guards against
+// OpenAPI/UI drift that the on-disk-only backup tests would not catch.
+func TestHandleImageInfo_BackupExistsContract(t *testing.T) {
+	t.Parallel()
+	r, svc := newImageHandlerTestServer(t)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "InfoBackupExists", SortName: "InfoBackupExists", Path: dir}
+	if err := svc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	// Canonical thumb + fanart + logo on disk so the info handler can stat each.
+	writeJPEG(t, filepath.Join(dir, "folder.jpg"), 600, 600)
+	writeJPEG(t, filepath.Join(dir, "fanart.jpg"), 1920, 1080)
+	writePNG(t, filepath.Join(dir, "logo.png"), 400, 200) // single-slot, NO backup seeded
+	// A one-deep backup under .sw-backup/thumb -> img.HasBackup(dir,"thumb") true.
+	thumbBackupDir := filepath.Join(dir, img.BackupDirName, "thumb")
+	if err := os.MkdirAll(thumbBackupDir, 0o750); err != nil {
+		t.Fatalf("creating thumb backup dir: %v", err)
+	}
+	writeJPEG(t, filepath.Join(thumbBackupDir, "folder.jpg"), 600, 600)
+
+	backupExists := func(t *testing.T, imageType string) bool {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/images/"+imageType+"/info", nil)
+		req.SetPathValue("id", a.ID)
+		req.SetPathValue("type", imageType)
+		w := serveValidated(t, http.HandlerFunc(r.handleImageInfo), req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("type=%s status = %d, want 200; body: %s", imageType, w.Code, w.Body.String())
+		}
+		var resp struct {
+			BackupExists bool `json:"backup_exists"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("type=%s decoding: %v", imageType, err)
+		}
+		return resp.BackupExists
+	}
+
+	if !backupExists(t, "thumb") {
+		t.Error("backup_exists must be true for a single-slot type with a one-deep backup")
+	}
+	if backupExists(t, "fanart") {
+		t.Error("backup_exists must always be false for fanart (multi-slot, no single-slot backup)")
+	}
+	// Single-slot kind present on disk but with NO one-deep backup -> false. Pins
+	// the "false unless a backup exists" contract (guards a regression that would
+	// return true for every single-slot type).
+	if backupExists(t, "logo") {
+		t.Error("backup_exists must be false for a single-slot type with no backup present")
+	}
+}
+
+// TestProcessAndSaveImage_BackupFailureAborts proves F2/T2: when the backup
+// cannot be written (here, .sw-backup pre-exists as a FILE so MkdirAll fails),
+// the destructive crop save is aborted and the canonical original is preserved.
+func TestProcessAndSaveImage_BackupFailureAborts(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouterWithPlatform(t)
+	dir := t.TempDir()
+	origPath := filepath.Join(dir, "folder.jpg")
+	writeJPEG(t, origPath, 80, 80)
+	orig, _ := os.ReadFile(origPath)
+
+	// Block backup-dir creation: .sw-backup is a regular file, so MkdirAll fails.
+	if err := os.WriteFile(filepath.Join(dir, img.BackupDirName), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seeding .sw-backup as a file: %v", err)
+	}
+
+	crop := encodeImageFmt(t, "jpeg", 120, 120)
+	if _, err := r.processAndSaveImage(context.Background(), dir, "thumb", crop, nil); err == nil {
+		t.Fatal("processAndSaveImage must abort when the backup cannot be written")
+	}
+	// The original must be intact (the destructive Save never ran).
+	after, _ := os.ReadFile(origPath)
+	if !bytes.Equal(orig, after) {
+		t.Error("canonical original must be preserved when backup fails")
+	}
+}
+
+// TestHandleLogoTrim_BackupFailureAborts proves F3/T2: a backup-write failure
+// aborts the trim with 500 and leaves the original logo intact.
+func TestHandleLogoTrim_BackupFailureAborts(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouterWithPlatform(t)
+	dir := t.TempDir()
+	a := &artist.Artist{Name: "Trim Abort", SortName: "Trim Abort", Path: dir}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+	logoPath := filepath.Join(dir, "logo.png")
+	writePNG(t, logoPath, 200, 100)
+	orig, _ := os.ReadFile(logoPath)
+
+	// Block backup-dir creation.
+	if err := os.WriteFile(filepath.Join(dir, img.BackupDirName), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seeding .sw-backup as a file: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/images/logo/trim", nil)
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+	r.handleLogoTrim(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body: %s", w.Code, w.Body.String())
+	}
+	after, _ := os.ReadFile(logoPath)
+	if !bytes.Equal(orig, after) {
+		t.Error("original logo must be preserved when pre-trim backup fails")
 	}
 }

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -11593,6 +11593,79 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /artists/{id}/images/{type}/revert:
+    post:
+      tags: [Images]
+      summary: Revert the most recent image edit
+      description: >-
+        For single-slot kinds (thumb, logo, banner) restores the pre-edit
+        original from the peer-inert backup. For fanart, drops the newest
+        derived slot, leaving the original slot intact. Gated by the conflict
+        gate. One-deep: a second revert with no backup returns 404.
+      operationId: revertImage
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: type
+          in: path
+          required: true
+          description: Image kind (thumb, fanart, logo, banner).
+          schema:
+            type: string
+            enum: [thumb, fanart, logo, banner]
+      responses:
+        "200":
+          description: Image reverted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    description: Always "reverted" on success.
+                  type:
+                    type: string
+                    description: The image kind that was reverted.
+                  count:
+                    type: integer
+                    description: Remaining fanart count (fanart kind only).
+                  sync_warnings:
+                    type: array
+                    items:
+                      type: string
+                    description: Non-fatal warnings from syncing the reverted image to connected platforms.
+                required: [status, type, sync_warnings]
+        "400":
+          description: Invalid image type
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "404":
+          description: Artist not found, or no backup / no derived slot to revert
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Write blocked by the conflict gate
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConflictWriteBlock"
+        "500":
+          description: >-
+            Server error, including a fail-closed abort when the conflict gate
+            could not be evaluated for this destructive operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /artists/{id}/images/fanart/list:
     get:
       tags: [Images]
@@ -11719,7 +11792,15 @@ paths:
                       type: string
                     description: Warnings from batch deletion, including file removal failures, renumbering issues, and platform sync errors. Empty only when there are no warnings.
         "409":
-          description: No filesystem path
+          description: Write blocked by the conflict gate
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConflictWriteBlock"
+        "500":
+          description: >-
+            Server error, including a fail-closed abort when the conflict gate
+            could not be evaluated for this destructive delete.
           content:
             application/json:
               schema:
@@ -11831,6 +11912,20 @@ paths:
                       type: string
         "400":
           description: Invalid permutation or length mismatch
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Write blocked by the conflict gate
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConflictWriteBlock"
+        "500":
+          description: >-
+            Server error, including a fail-closed abort when the conflict gate
+            could not be evaluated for this destructive reorder.
           content:
             application/json:
               schema:
@@ -11948,6 +12043,20 @@ paths:
                       type: string
         "400":
           description: Slot out of range
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "409":
+          description: Write blocked by the conflict gate
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConflictWriteBlock"
+        "500":
+          description: >-
+            Server error, including a fail-closed abort when the conflict gate
+            could not be evaluated for this destructive delete.
           content:
             application/json:
               schema:
@@ -12158,6 +12267,13 @@ paths:
                     type: string
                     format: date-time
                     description: When the file was last modified (UTC, RFC 3339).
+                  backup_exists:
+                    type: boolean
+                    description: >-
+                      Whether a one-deep peer-inert backup of the pre-edit
+                      original exists for this single-slot kind, so the UI can
+                      conditionally offer Revert. Always false for fanart.
+                required: [backup_exists]
             text/html:
               schema:
                 type: string

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -711,6 +711,7 @@ func (r *Router) Handler(ctx context.Context) http.Handler {
 	mux.HandleFunc("GET "+bp+"/api/v1/artists/{id}/images/websearch", wrapAuth(r.handleWebImageSearch, authMw))
 	mux.HandleFunc("POST "+bp+"/api/v1/artists/{id}/images/crop", wrapAuth(r.handleImageCrop, authMw))
 	mux.HandleFunc("POST "+bp+"/api/v1/artists/{id}/images/logo/trim", wrapAuth(r.handleLogoTrim, authMw))
+	mux.HandleFunc("POST "+bp+"/api/v1/artists/{id}/images/{type}/revert", wrapAuth(r.handleImageRevert, authMw))
 	// Multi-fanart routes
 	mux.HandleFunc("GET "+bp+"/api/v1/artists/{id}/images/fanart/list", wrapAuth(r.handleFanartList, authMw))
 	mux.HandleFunc("GET "+bp+"/api/v1/artists/{id}/images/fanart/{index}/file", wrapAuth(r.handleServeFanartByIndex, authMw))

--- a/internal/api/testdata/openapi-coverage.json
+++ b/internal/api/testdata/openapi-coverage.json
@@ -1351,6 +1351,13 @@
     "covered": true
   },
   {
+    "operationId": "revertImage",
+    "method": "POST",
+    "path": "/artists/{id}/images/{type}/revert",
+    "handler": "handleImageRevert",
+    "covered": true
+  },
+  {
     "operationId": "revokeAPIToken",
     "method": "DELETE",
     "path": "/auth/tokens/{id}",

--- a/internal/image/backup.go
+++ b/internal/image/backup.go
@@ -1,0 +1,183 @@
+package image
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/sydlexius/stillwater/internal/filesystem"
+)
+
+// BackupDirName is the hidden subdirectory inside an artist folder where the
+// pre-edit original of a single-slot image (thumb/logo/banner) is kept so a
+// destructive edit (crop, auto-trim, replace) is revertible exactly one step.
+//
+// It is a dotfile-prefixed SUBDIRECTORY, not a sibling file, which makes it
+// peer-inert: Emby, Jellyfin, and Kodi scan the artist folder's top level for a
+// fixed allowlist of artwork basenames and never recurse into a hidden subdir,
+// so the backup is never picked up as artwork. A subdir also cannot collide with
+// the atomic writer's transient "<target>.tmp"/".bak"/".removing" temporaries,
+// which are always written next to the target file, never inside this dir.
+const BackupDirName = ".sw-backup"
+
+// backupTypeDir returns the per-type backup subdirectory for an image type. Each
+// single-slot kind (thumb/logo/banner) gets its own subdir so the backup
+// identity is keyed by image TYPE, not by the file's basename-with-extension.
+// This makes the backup format-INDEPENDENT: a png->jpg crop still finds its
+// backup after Save deletes the old png and writes a jpg (#1837).
+func backupTypeDir(dir, imageType string) string {
+	return filepath.Join(dir, BackupDirName, imageType)
+}
+
+// findBackupFile returns the single backup file path for an image type, or "" if
+// none exists. Exactly one file lives in the per-type dir (one-deep), so the
+// first regular entry found is the backup. The returned path preserves the
+// ORIGINAL basename (and thus the original format).
+func findBackupFile(dir, imageType string) (string, error) {
+	typeDir := backupTypeDir(dir, imageType)
+	entries, err := os.ReadDir(typeDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("reading backup dir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		return filepath.Join(typeDir, e.Name()), nil
+	}
+	return "", nil
+}
+
+// pruneBackupFiles removes backup file(s) for an image type, except the file
+// whose basename equals keep, so exactly one backup remains (one-deep,
+// format-independent). Pass keep == "" to remove every backup file (the
+// post-restore consume path). A missing per-type dir is not an error.
+func pruneBackupFiles(dir, imageType, keep string) error {
+	typeDir := backupTypeDir(dir, imageType)
+	entries, err := os.ReadDir(typeDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading backup dir for cleanup: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || e.Name() == keep {
+			continue
+		}
+		if rmErr := os.Remove(filepath.Join(typeDir, e.Name())); rmErr != nil && !os.IsNotExist(rmErr) {
+			return fmt.Errorf("removing prior backup: %w", rmErr)
+		}
+	}
+	return nil
+}
+
+// BackupSingleSlot copies the current PRIMARY original of a single-slot image
+// type into the hidden per-type backup subdirectory, preserving the original
+// basename (and thus the original format). It is keyed by image TYPE so the
+// backup survives a format-changing edit (e.g. png->jpg crop). It is one-deep
+// PER TYPE: any prior backup file for this type (in any format) is removed first
+// so exactly one remains.
+//
+// It is a no-op (returns nil) when no original file exists yet for the type, so
+// a first write of a kind that had no prior image leaves no backup to revert to.
+//
+// naming is the configured filename list for imageType (the type's canonical
+// names); the PRIMARY existing original is located by probing those names plus
+// alternate extensions, matching FindExistingImageStrict semantics.
+func BackupSingleSlot(dir, imageType string, naming []string) error {
+	// Strict probe: a transient stat error must not be mistaken for "absent",
+	// which would silently skip the backup and let the destructive caller
+	// overwrite a still-present original (#1161).
+	existing, found, statErr := FindExistingImageStrict(dir, naming)
+	if statErr != nil {
+		return fmt.Errorf("probing original for backup: %w", statErr)
+	}
+	if !found {
+		return nil
+	}
+
+	data, err := os.ReadFile(existing) //nolint:gosec // existing built from trusted naming patterns
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading original for backup: %w", err)
+	}
+
+	backup := filepath.Join(backupTypeDir(dir, imageType), filepath.Base(existing))
+	if mkErr := os.MkdirAll(filepath.Dir(backup), 0o750); mkErr != nil {
+		return fmt.Errorf("creating backup dir: %w", mkErr)
+	}
+	// Write the fresh backup BEFORE pruning any prior backup. If the write fails
+	// (disk full, permission, transient IO) the caller aborts the destructive
+	// save, and because the previous backup is still present the edit keeps a
+	// valid revert path. Pruning first would delete the only recoverable original
+	// on a failed refresh, leaving nothing to revert to (Qodo #1839 reliability).
+	if writeErr := filesystem.WriteFileAtomic(backup, data, 0o644); writeErr != nil {
+		return fmt.Errorf("writing backup: %w", writeErr)
+	}
+	// One-deep: now that the fresh backup is durable, drop any other (older,
+	// possibly different-format) backup files for this type so exactly one remains.
+	if rmErr := pruneBackupFiles(dir, imageType, filepath.Base(backup)); rmErr != nil {
+		return rmErr
+	}
+	return nil
+}
+
+// HasBackup reports whether a one-deep backup exists for the image type.
+func HasBackup(dir, imageType string) bool {
+	path, err := findBackupFile(dir, imageType)
+	return err == nil && path != ""
+}
+
+// RestoreSingleSlot restores the most recent pre-edit original for a single-slot
+// image type by routing the backup bytes back through Save, so ALL configured
+// names and symlinks are rebuilt and Save's CleanupConflictingFormats drops the
+// now-stale post-edit format (e.g. the jpg written over a png-original crop).
+// After a successful restore it removes the backup so revert is one-shot (a
+// second revert finds no backup).
+//
+// Returns the bare os.ErrNotExist sentinel when no backup exists, so callers can
+// map it to 404 via errors.Is / os.IsNotExist.
+func RestoreSingleSlot(dir, imageType string, naming []string, useSymlinks bool, meta *ExifMeta, logger *slog.Logger) error {
+	backup, err := findBackupFile(dir, imageType)
+	if err != nil {
+		return fmt.Errorf("locating backup: %w", err)
+	}
+	if backup == "" {
+		return os.ErrNotExist
+	}
+
+	data, err := os.ReadFile(backup) //nolint:gosec // backup path derived from trusted naming patterns
+	if err != nil {
+		if os.IsNotExist(err) {
+			return os.ErrNotExist
+		}
+		return fmt.Errorf("reading backup: %w", err)
+	}
+
+	// Route through Save so every canonical name + symlink is rebuilt from the
+	// original bytes and CleanupConflictingFormats removes the post-edit format.
+	if _, saveErr := Save(dir, imageType, data, naming, useSymlinks, meta, logger); saveErr != nil {
+		return fmt.Errorf("restoring via save: %w", saveErr)
+	}
+
+	// Consume the backup (and drop any siblings, defensively) so a repeat revert
+	// is a clean no-backup case. This is BEST-EFFORT: Save above has already
+	// rewritten the canonical image, so the revert has succeeded on disk. Failing
+	// here would make the handler return 500 and skip sync/event side effects even
+	// though the file already changed. A leftover backup is harmless (a repeat
+	// revert just re-restores the same original), so we log and continue (CR #1839).
+	if rmErr := pruneBackupFiles(dir, imageType, ""); rmErr != nil && logger != nil {
+		logger.Warn("consuming backup after successful restore failed (revert already applied on disk)",
+			slog.String("dir", dir),
+			slog.String("image_type", imageType),
+			slog.String("error", rmErr.Error()))
+	}
+	return nil
+}

--- a/internal/image/backup_errors_test.go
+++ b/internal/image/backup_errors_test.go
@@ -1,0 +1,196 @@
+package image
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// thumbNaming is the canonical filename list used across the backup error-path
+// tests below. The first name is the primary the strict probe locates.
+var errPathThumbNaming = []string{"folder.jpg", "folder.png"}
+
+// seedOriginal writes a valid JPEG primary so BackupSingleSlot's strict probe
+// finds an original to back up (the no-original case short-circuits before the
+// error branches under test).
+func seedOriginal(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "folder.jpg"), makeImageBytes(t, "jpeg"), 0o644); err != nil {
+		t.Fatalf("seeding original: %v", err)
+	}
+}
+
+// TestBackupSingleSlot_BackupDirIsFile covers the error branches that fire when
+// the per-type backup directory cannot be read or created because a non-directory
+// already occupies the path: removeBackupFiles' ReadDir error (not os.IsNotExist)
+// and MkdirAll's failure.
+func TestBackupSingleSlot_BackupDirIsFile(t *testing.T) {
+	dir := t.TempDir()
+	seedOriginal(t, dir)
+
+	// Make the top-level .sw-backup a regular FILE so MkdirAll of
+	// .sw-backup/thumb cannot create the parent and ReadDir of the type dir
+	// surfaces a non-NotExist error during cleanup.
+	if err := os.WriteFile(filepath.Join(dir, BackupDirName), []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("seeding .sw-backup as file: %v", err)
+	}
+
+	err := BackupSingleSlot(dir, "thumb", errPathThumbNaming)
+	if err == nil {
+		t.Fatal("BackupSingleSlot must error when .sw-backup is a regular file")
+	}
+}
+
+// TestBackupSingleSlot_FailedWritePreservesPriorBackup proves the Qodo #1839
+// reliability fix: BackupSingleSlot writes the fresh backup BEFORE pruning prior
+// backups, so when the write fails the previous backup survives and the edit
+// still has a revert path. A read-only per-type dir makes WriteFileAtomic fail
+// (it cannot create its tmp sibling) while MkdirAll of the existing dir succeeds.
+func TestBackupSingleSlot_FailedWritePreservesPriorBackup(t *testing.T) {
+	// Root (UID 0, e.g. Docker/root CI) bypasses the read-only-dir permission
+	// check, so WriteFileAtomic would succeed and the intended failure path would
+	// not be exercised - skip rather than fail spuriously.
+	if os.Getuid() == 0 {
+		t.Skip("chmod-based write-failure path is not enforced for root (UID 0)")
+	}
+	dir := t.TempDir()
+	seedOriginal(t, dir)
+
+	// Seed a prior backup with a DIFFERENT basename than the primary, so the old
+	// order (prune-first) would have deleted it before the failing write.
+	typeDir := filepath.Join(dir, BackupDirName, "thumb")
+	if err := os.MkdirAll(typeDir, 0o750); err != nil {
+		t.Fatalf("creating type dir: %v", err)
+	}
+	priorBackup := filepath.Join(typeDir, "stale.png")
+	if err := os.WriteFile(priorBackup, []byte("prior-backup-bytes"), 0o644); err != nil {
+		t.Fatalf("seeding prior backup: %v", err)
+	}
+
+	// Make the type dir read-only so WriteFileAtomic of the fresh backup fails
+	// (cannot create the tmp file) while the existing prior backup stays readable.
+	if err := os.Chmod(typeDir, 0o500); err != nil {
+		t.Fatalf("chmod type dir read-only: %v", err)
+	}
+	// Restore perms so t.TempDir's RemoveAll can clean up.
+	t.Cleanup(func() { _ = os.Chmod(typeDir, 0o750) })
+
+	err := BackupSingleSlot(dir, "thumb", errPathThumbNaming)
+	if err == nil {
+		t.Fatal("BackupSingleSlot must error when the fresh backup write fails")
+	}
+
+	// The prior backup must STILL exist: the failed write must not have pruned it.
+	if _, statErr := os.Stat(priorBackup); statErr != nil {
+		t.Errorf("prior backup must survive a failed write, stat err = %v", statErr)
+	}
+}
+
+// TestRestoreSingleSlot_BackupDirIsFile covers findBackupFile's ReadDir error
+// branch (a non-NotExist error) reached through RestoreSingleSlot when the
+// per-type backup directory path is occupied by a regular file.
+func TestRestoreSingleSlot_BackupDirIsFile(t *testing.T) {
+	dir := t.TempDir()
+	// .sw-backup/thumb is a regular file, so os.ReadDir of it errors with a
+	// non-NotExist error rather than reporting "no backup".
+	typeParent := filepath.Join(dir, BackupDirName)
+	if err := os.MkdirAll(typeParent, 0o750); err != nil {
+		t.Fatalf("creating .sw-backup: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(typeParent, "thumb"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seeding type dir as file: %v", err)
+	}
+
+	err := RestoreSingleSlot(dir, "thumb", errPathThumbNaming, false, nil, testLogger(t))
+	if err == nil {
+		t.Fatal("RestoreSingleSlot must error when the type backup dir is a regular file")
+	}
+	// It is a real ReadDir error, NOT the no-backup sentinel.
+	if errors.Is(err, os.ErrNotExist) {
+		t.Errorf("err = %v, want a non-NotExist ReadDir error", err)
+	}
+}
+
+// TestRestoreSingleSlot_CorruptBackupSaveFails covers the Save-error branch of
+// RestoreSingleSlot: a backup file whose bytes are not a decodable image makes
+// img.Save fail, so the restore returns a wrapped (non-NotExist) error.
+func TestRestoreSingleSlot_CorruptBackupSaveFails(t *testing.T) {
+	dir := t.TempDir()
+	typeDir := filepath.Join(dir, BackupDirName, "thumb")
+	if err := os.MkdirAll(typeDir, 0o750); err != nil {
+		t.Fatalf("creating type dir: %v", err)
+	}
+	// A backup file that Save cannot decode (DetectFormat fails on junk bytes).
+	if err := os.WriteFile(filepath.Join(typeDir, "folder.jpg"), []byte("not-an-image"), 0o644); err != nil {
+		t.Fatalf("seeding corrupt backup: %v", err)
+	}
+
+	err := RestoreSingleSlot(dir, "thumb", errPathThumbNaming, false, nil, testLogger(t))
+	if err == nil {
+		t.Fatal("RestoreSingleSlot must error when the backup bytes are not a valid image")
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		t.Errorf("err = %v, want a Save error, not the no-backup sentinel", err)
+	}
+}
+
+// TestFindBackupFile_SkipsSubdirectories covers the entry.IsDir() skip branch in
+// findBackupFile: a stray subdirectory inside the per-type backup dir is ignored
+// and the regular backup file is still located. The subdir is named to sort
+// BEFORE the backup file so the IsDir() continue is actually exercised before the
+// file is returned.
+func TestFindBackupFile_SkipsSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	typeDir := filepath.Join(dir, BackupDirName, "thumb")
+	// A stray subdirectory ("0-stray" sorts before "folder.jpg") that must be
+	// skipped before the real backup file is found.
+	if err := os.MkdirAll(filepath.Join(typeDir, "0-stray"), 0o750); err != nil {
+		t.Fatalf("creating stray subdir: %v", err)
+	}
+	// The real backup file.
+	if err := os.WriteFile(filepath.Join(typeDir, "folder.jpg"), []byte("backup"), 0o644); err != nil {
+		t.Fatalf("seeding backup file: %v", err)
+	}
+
+	got, err := findBackupFile(dir, "thumb")
+	if err != nil {
+		t.Fatalf("findBackupFile: %v", err)
+	}
+	want := filepath.Join(typeDir, "folder.jpg")
+	if got != want {
+		t.Errorf("findBackupFile = %q, want %q (subdir must be skipped)", got, want)
+	}
+}
+
+// TestRemoveBackupFiles_SkipsSubdirectories covers the entry.IsDir() skip branch
+// in pruneBackupFiles (reached via BackupSingleSlot's one-deep cleanup): a stray
+// subdirectory in the per-type backup dir is left untouched while the prior
+// backup file is removed and replaced. The subdir sorts first so the skip runs
+// before the file is removed.
+func TestRemoveBackupFiles_SkipsSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	seedOriginal(t, dir)
+	typeDir := filepath.Join(dir, BackupDirName, "thumb")
+	if err := os.MkdirAll(filepath.Join(typeDir, "0-stray"), 0o750); err != nil {
+		t.Fatalf("creating stray subdir: %v", err)
+	}
+	// A prior backup file that pruneBackupFiles should clear on the next backup.
+	if err := os.WriteFile(filepath.Join(typeDir, "stale.jpg"), []byte("stale"), 0o644); err != nil {
+		t.Fatalf("seeding stale backup: %v", err)
+	}
+
+	// BackupSingleSlot writes a fresh backup, then runs pruneBackupFiles (one-deep).
+	if err := BackupSingleSlot(dir, "thumb", errPathThumbNaming); err != nil {
+		t.Fatalf("BackupSingleSlot: %v", err)
+	}
+
+	// The stray subdirectory must survive the cleanup.
+	if info, err := os.Stat(filepath.Join(typeDir, "0-stray")); err != nil || !info.IsDir() {
+		t.Errorf("stray subdir must be preserved by pruneBackupFiles, err=%v", err)
+	}
+	// The stale prior backup file must be gone (replaced one-deep).
+	if _, err := os.Stat(filepath.Join(typeDir, "stale.jpg")); !os.IsNotExist(err) {
+		t.Errorf("stale backup should be removed, stat err = %v", err)
+	}
+}

--- a/internal/image/backup_test.go
+++ b/internal/image/backup_test.go
@@ -1,0 +1,220 @@
+package image
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeImageBytes returns encoded image bytes in the requested format ("jpeg" or
+// "png") so backup tests exercise the real Save path (which detects format).
+func makeImageBytes(t *testing.T, format string) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	for y := 0; y < 8; y++ {
+		for x := 0; x < 8; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x * 16), G: uint8(y * 16), B: 64, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	var err error
+	switch format {
+	case "png":
+		err = png.Encode(&buf, img)
+	default:
+		err = jpeg.Encode(&buf, img, &jpeg.Options{Quality: 90})
+	}
+	if err != nil {
+		t.Fatalf("encoding %s: %v", format, err)
+	}
+	return buf.Bytes()
+}
+
+func TestBackupSingleSlot_CreatesPeerInertCopy(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "folder.jpg")
+	orig := []byte("original-bytes")
+	if err := os.WriteFile(canonical, orig, 0o644); err != nil {
+		t.Fatalf("seeding canonical: %v", err)
+	}
+
+	if err := BackupSingleSlot(dir, "thumb", []string{"folder.jpg", "folder.png"}); err != nil {
+		t.Fatalf("BackupSingleSlot: %v", err)
+	}
+
+	// Backup lives inside the hidden per-type subdir, keyed by image TYPE,
+	// preserving the original basename (and format).
+	want := filepath.Join(dir, BackupDirName, "thumb", "folder.jpg")
+	got, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("reading backup at %s: %v", want, err)
+	}
+	if !bytes.Equal(got, orig) {
+		t.Errorf("backup bytes = %q, want %q", got, orig)
+	}
+	// Canonical file is untouched by the backup op.
+	if _, err := os.Stat(canonical); err != nil {
+		t.Errorf("canonical must still exist after backup: %v", err)
+	}
+}
+
+func TestBackupSingleSlot_OneDeepOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "logo.png")
+	if err := os.WriteFile(canonical, []byte("v1"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := BackupSingleSlot(dir, "logo", []string{"logo.png", "logo-white.png"}); err != nil {
+		t.Fatalf("backup v1: %v", err)
+	}
+	// Second edit overwrites the canonical, then re-backs-up.
+	if err := os.WriteFile(canonical, []byte("v2"), 0o644); err != nil {
+		t.Fatalf("write v2: %v", err)
+	}
+	if err := BackupSingleSlot(dir, "logo", []string{"logo.png", "logo-white.png"}); err != nil {
+		t.Fatalf("backup v2: %v", err)
+	}
+	// Exactly one backup file should remain (one-deep) and it should hold v2.
+	typeDir := filepath.Join(dir, BackupDirName, "logo")
+	entries, err := os.ReadDir(typeDir)
+	if err != nil {
+		t.Fatalf("read backup dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly one backup, got %d", len(entries))
+	}
+	got, err := os.ReadFile(filepath.Join(typeDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if string(got) != "v2" {
+		t.Errorf("one-deep backup = %q, want most-recent pre-edit %q", got, "v2")
+	}
+}
+
+func TestRestoreSingleSlot_RoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	naming := []string{"folder.jpg", "folder.png"}
+	canonical := filepath.Join(dir, "folder.jpg")
+	orig := makeImageBytes(t, "jpeg")
+	if err := os.WriteFile(canonical, orig, 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := BackupSingleSlot(dir, "thumb", naming); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	// Simulate a destructive edit.
+	if err := os.WriteFile(canonical, makeImageBytes(t, "png"), 0o644); err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	if err := RestoreSingleSlot(dir, "thumb", naming, false, nil, testLogger(t)); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	got, err := os.ReadFile(canonical)
+	if err != nil {
+		t.Fatalf("read restored: %v", err)
+	}
+	// Save re-encodes via WriteFileAtomic of the original bytes (no transform for
+	// jpeg input), so the canonical must decode to the same dimensions as orig.
+	if !sameDecodedSize(t, got, orig) {
+		t.Errorf("restored image does not match original dimensions")
+	}
+	// Restore consumes the backup so a second revert is a no-backup error.
+	if HasBackup(dir, "thumb") {
+		t.Error("backup should be consumed after restore")
+	}
+}
+
+// TestRestoreSingleSlot_FormatChangeRevertible proves the F4 fix: a png original
+// cropped to jpg is still revertible (backup is keyed by type, not basename) and
+// restore drops the post-edit jpg, leaving the original png.
+func TestRestoreSingleSlot_FormatChangeRevertible(t *testing.T) {
+	dir := t.TempDir()
+	naming := []string{"folder.jpg", "folder.png"}
+	origPNG := makeImageBytes(t, "png")
+	if err := os.WriteFile(filepath.Join(dir, "folder.png"), origPNG, 0o644); err != nil {
+		t.Fatalf("seed png: %v", err)
+	}
+	// Back up the png original.
+	if err := BackupSingleSlot(dir, "thumb", naming); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	// Simulate the crop: Save jpg data, which deletes folder.png and writes folder.jpg.
+	if _, err := Save(dir, "thumb", makeImageBytes(t, "jpeg"), naming, false, nil, testLogger(t)); err != nil {
+		t.Fatalf("save jpg crop: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "folder.png")); !os.IsNotExist(err) {
+		t.Fatalf("expected folder.png removed after jpg save, err=%v", err)
+	}
+	// Backup must still be findable even though the on-disk format changed.
+	if !HasBackup(dir, "thumb") {
+		t.Fatal("backup must survive a format-changing edit")
+	}
+	// Revert: should rebuild folder.png and drop folder.jpg.
+	if err := RestoreSingleSlot(dir, "thumb", naming, false, nil, testLogger(t)); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "folder.png")); err != nil {
+		t.Errorf("folder.png should be restored: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "folder.jpg")); !os.IsNotExist(err) {
+		t.Errorf("post-edit folder.jpg should be cleaned up, err=%v", err)
+	}
+	if HasBackup(dir, "thumb") {
+		t.Error("backup should be consumed after restore")
+	}
+}
+
+func TestRestoreSingleSlot_NoBackupReturnsNotExist(t *testing.T) {
+	dir := t.TempDir()
+	if err := RestoreSingleSlot(dir, "thumb", []string{"folder.jpg"}, false, nil, testLogger(t)); !os.IsNotExist(err) {
+		t.Errorf("RestoreSingleSlot with no backup err = %v, want os.IsNotExist", err)
+	}
+}
+
+func TestHasBackup(t *testing.T) {
+	dir := t.TempDir()
+	if HasBackup(dir, "banner") {
+		t.Fatal("no backup expected initially")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "banner.jpg"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := BackupSingleSlot(dir, "banner", []string{"banner.jpg", "banner.png"}); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	if !HasBackup(dir, "banner") {
+		t.Error("HasBackup should report true after backup")
+	}
+}
+
+// TestBackupSingleSlot_NoOriginalNoOp confirms a first write (no prior original)
+// leaves no backup.
+func TestBackupSingleSlot_NoOriginalNoOp(t *testing.T) {
+	dir := t.TempDir()
+	if err := BackupSingleSlot(dir, "thumb", []string{"folder.jpg", "folder.png"}); err != nil {
+		t.Fatalf("BackupSingleSlot no-original: %v", err)
+	}
+	if HasBackup(dir, "thumb") {
+		t.Error("no backup should exist when there was no original")
+	}
+}
+
+// sameDecodedSize reports whether two encoded images decode to the same bounds.
+func sameDecodedSize(t *testing.T, a, b []byte) bool {
+	t.Helper()
+	ca, _, err := image.DecodeConfig(bytes.NewReader(a))
+	if err != nil {
+		t.Fatalf("decode a: %v", err)
+	}
+	cb, _, err := image.DecodeConfig(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("decode b: %v", err)
+	}
+	return ca.Width == cb.Width && ca.Height == cb.Height
+}


### PR DESCRIPTION
## Summary

- Make artist-image crop and logo auto-trim **non-destructive**: single-slot kinds (thumb/logo/banner) keep a one-deep, peer-inert pre-edit copy under a hidden `.sw-backup/<type>/` subdir before the canonical file is overwritten; fanart (multi-slot) writes a new slot and leaves existing slots intact.
- Add a gated `POST /api/v1/artists/{id}/images/{type}/revert` that restores the original (routed through `img.Save` so all configured names/symlinks rebuild and the post-edit format is cleaned up) or drops the newest fanart slot, plus a `backup_exists` flag on the image-info endpoint so the UI can show Revert only when there is something to revert.
- Close conflict-gate gaps: logo-trim, fanart slot-delete, batch-delete, reorder, and revert now route through the conflict gate. Destructive deletes and revert **fail closed** (HTTP 500) on a non-blocked gate error; backup-creating overwrite paths keep their existing fail-open behavior.
- **Reviewers look first at:** the fail-open vs fail-closed split in `handlers_conflict.go` / `handlers_image.go`, and the peer-inertness argument for `.sw-backup/` (it must stay invisible to Emby/Jellyfin/Kodi scanners and never collide with the atomic writer's `.tmp`/`.bak` siblings).

User-visible behavior change: image edits are now recoverable and a revert API exists. The user-facing UI that surfaces Revert lands with the #1336 4B artwork modal; this PR is the backend slice.

## Linked issue

Closes #1837
Part of #1336

## Pre-flight checklist

- [x] Pre-push gate green locally (ran via the pre-push hook on push; race suite + OpenAPI + generated-files + lint + patch-coverage + provider-failure smoke 9/9).
- [ ] Code review pass: cloud CodeRabbit reviews on push per repo workflow (no local CR run).
- [x] Commits squashed into one clean logical commit before first push (`d65aec83`).
- [x] At least one label set.
- [x] Docs label decision: `needs-docs-review` (user-visible behavior; prose docs slated for the #1336 4B UI PR, OpenAPI spec updated here).
- [ ] Screenshot: N/A (no UI in this slice).
- [ ] UAT against a running binary: not yet performed for the revert flow (covered by integration tests + a new Bruno collection, not exercised against a live instance). Manual UAT will accompany the #1336 4B UI.
- [x] OpenAPI spec updated (`internal/api/openapi.yaml`; `make check-openapi` runs in the gate).
- [ ] `templ generate`: N/A (no `.templ` changes).

## Test plan

- [x] `go test -race ./...` passes locally (pre-push hook).
- [x] `bash scripts/pre-push-gate.sh` passes locally (pre-push hook).
- [x] Diff-scoped patch coverage 85.45% (threshold 75%); per-package coverage floor holds.
- Manual UAT flows: deferred to the #1336 4B UI PR (revert exercised here via httptest + real-SQLite integration tests and `api/bruno/artists/revert-image.bru`).
- Reviewer follow-ups:
  - [ ] Two branches left intentionally uncovered (no production refactor to chase them): `gateImageWriteStrict` fail-closed 500 arm (unreachable because `conflictGate` is a concrete type returning only nil/`*BlockedError`), and a few `backup.go` FS-error paths that need non-deterministic stat/write failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image revert endpoint for thumbnails, logos, banners, and fanart (fanart reverts drop the newest slot).
  * Image info now reports backup availability for single-slot kinds.

* **Behavior & Safety**
  * Edits create one-deep backups so reverts restore prior images.
  * Destructive image ops fail closed when blocked or on backup/save errors, preserving existing files and returning appropriate error responses.

* **Tests**
  * Expanded tests for revert, backup, gating, and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->