### PR TITLE
chore(security): address Scorecard TokenPermissions + PinnedDependencies alerts

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,8 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+permissions: {}
+
 jobs:
   claude-review:
     # Optional: Filter by PR author
@@ -27,13 +29,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   claude:
     if: |
@@ -26,13 +28,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@70a6e5256e9e2366a1ed5c041904a982ba3a328f # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Hardens the two Claude Code workflows added in #1844 to clear the new Scorecard alerts: adds a top-level `permissions: {}` to `claude.yml` and `claude-code-review.yml` (alerts #106/#107), and SHA-pins `actions/checkout@v4` and `anthropics/claude-code-action@v1` in both files (alerts #108-#111).
- No behavior change; follows the repo's existing pin-to-SHA + minimal-permissions conventions. actionlint clean.
- Scorecard #104 (dependabot-merge) and #105 (sbom release-asset upload) were dismissed as won't-fix: their `contents: write` is genuinely required and already job-scoped under a top-level `permissions: {}`.

## Linked issue

Addresses GitHub code-scanning Scorecard alerts #106-#111 directly (no tracking issue).

## Pre-flight checklist

- [x] Pre-push gate green (ran on push)
- [x] At least one label set (`chore`, `norabbit`, `docs: not-required`)
- [N/A] Screenshot / UAT / OpenAPI / templ-generate - workflow YAML only

## Test plan

- [x] `actionlint` clean on both changed workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened GitHub Actions permissions to reduce CI token scope and improve security.
  * Pinned workflow actions to specific references for more consistent and reproducible CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->