### PR TITLE
ci: split settingsio into its own shard (#1876 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       # shard hides real failures in the others if fail-fast is on.
       fail-fast: false
       matrix:
-        shard: [api-1, api-2, rule-1, rule-2, services, providers, scan, rest]
+        shard: [api-1, api-2, rule-1, rule-2, services, settingsio, providers, scan, rest]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -106,7 +106,7 @@ jobs:
           cache: true
 
       # Resolve the package list (and optional -run bucket regex) for this
-      # shard. Named shards (services / providers / scan) come from the SHARDS
+      # shard. Named shards (services / settingsio / providers / scan) come from the SHARDS
       # map below. The partitioned bases (api / rule) are each split into two
       # buckets -- shards api-1/api-2 and rule-1/rule-2 -- by a round-robin over
       # their test names; both were verified isolation-safe under that split
@@ -124,7 +124,10 @@ jobs:
           declare -A SHARDS=(
             [api]="internal/api"
             [rule]="internal/rule"
-            [services]="internal/auth internal/image internal/artist internal/settingsio"
+            [services]="internal/auth internal/image internal/artist"
+            # settingsio is its own shard: its persistence/encryption tests run
+            # ~100s, which made services the matrix long pole when bundled in.
+            [settingsio]="internal/settingsio"
             [providers]="internal/provider internal/connection"
             [scan]="internal/scanner internal/library internal/database internal/scraper internal/foreign internal/watcher"
           )


### PR DESCRIPTION
## Summary

- Follow-up to #1876. Its real per-shard times showed `internal/settingsio`'s persistence/encryption tests run ~100s, which made the `services` shard (auth+image+artist+settingsio) the **219s matrix long pole**. Split `settingsio` into its own shard; `services` returns to ~119s.
- New floor becomes the api buckets (~165s), completing the #1873 -> #1876 CI-speedup arc at roughly **277s -> 165s** long pole (~5m45s -> ~3m15s end to end).
- Mechanical SHARDS-map + matrix change, no logic change - hence `norabbit`.
- Validated: 9 shards cover the module **exactly** (69 packages, no overlap or gap); actionlint clean.

## Linked issue

No dedicated issue - direct rebalance follow-up to #1876.

## Pre-flight checklist

- [x] Pre-push gate green locally (pre-push hook)
- [x] Commits squashed into clean, logical commits (single commit)
- [x] At least one label set (`automation`, `norabbit`, `docs: not-required`)
- [x] Docs label decision made (`docs: not-required` - CI change, no user-visible behavior)
- [ ] Screenshot attached - N/A, no UI change
- [ ] UAT performed - N/A; validation is this PR's own CI run
- [x] OpenAPI spec updated if shapes changed - N/A
- [x] `templ generate` re-run - N/A

## Test plan

- [x] `go test -race ./...` - 0 Go files changed; validated via the 9-shard module-coverage dry-run (69 pkgs, exact cover) + actionlint.
- [x] `bash scripts/pre-push-gate.sh` - ran in the pre-push hook; passed.
- [ ] Reviewer follow-up:
  - [ ] On this PR's run, confirm all 9 shards green, `services` drops to ~119s, `settingsio` ~100s, and the floor lands at the api buckets (~165s).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline configuration by reorganizing test sharding strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->