### PR TITLE
fix: preserve file mode on cross-device WriteFileAtomic fallback + flash-free system theme (#1880, #1863)

### DIFF
--- a/internal/filesystem/atomic.go
+++ b/internal/filesystem/atomic.go
@@ -7,6 +7,11 @@ import (
 	"path/filepath"
 )
 
+// osRename is the rename function used by renameSafe. It defaults to os.Rename
+// and can be overridden in tests to simulate cross-device (EXDEV) errors,
+// following the same injectable-hook pattern used by renameFunc in rename.go.
+var osRename = os.Rename
+
 // WriteFileAtomic writes data to the target path using the tmp/bak/rename pattern.
 // This prevents data corruption if the process is interrupted during the write.
 //
@@ -35,17 +40,17 @@ func WriteFileAtomic(target string, data []byte, perm os.FileMode) error {
 
 	// Step 2: Backup existing file if it exists
 	if _, err := os.Stat(target); err == nil {
-		if err := renameSafe(target, bakPath); err != nil {
+		if err := renameSafe(target, bakPath, perm); err != nil {
 			_ = os.Remove(tmpPath)
 			return fmt.Errorf("backing up existing file: %w", err)
 		}
 	}
 
 	// Step 3: Move .tmp to target
-	if err := renameSafe(tmpPath, target); err != nil {
+	if err := renameSafe(tmpPath, target, perm); err != nil {
 		// Attempt to restore backup
 		if _, bakErr := os.Stat(bakPath); bakErr == nil {
-			_ = renameSafe(bakPath, target)
+			_ = renameSafe(bakPath, target, perm)
 		}
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("renaming temp to target: %w", err)
@@ -66,14 +71,16 @@ func WriteReaderAtomic(target string, r io.Reader, perm os.FileMode) error {
 	return WriteFileAtomic(target, data, perm)
 }
 
-// renameSafe attempts os.Rename first, then falls back to copy+delete.
-func renameSafe(oldPath, newPath string) error {
-	err := os.Rename(oldPath, newPath)
+// renameSafe attempts osRename first, then falls back to copy+delete.
+// perm is passed to copyFile so the destination inherits the intended file mode
+// even on the cross-device fallback path (where os.Rename would drop the perm).
+func renameSafe(oldPath, newPath string, perm os.FileMode) error {
+	err := osRename(oldPath, newPath)
 	if err == nil {
 		return nil
 	}
-	// Rename may fail on cross-device moves. Fall back to copy+delete.
-	if copyErr := copyFile(oldPath, newPath); copyErr != nil {
+	// Rename may fail on cross-device moves (EXDEV). Fall back to copy+delete.
+	if copyErr := copyFile(oldPath, newPath, perm); copyErr != nil {
 		return fmt.Errorf("copy fallback: %w (rename error: %w)", copyErr, err)
 	}
 	_ = os.Remove(oldPath)
@@ -119,14 +126,18 @@ func RemoveFileSafe(target string) error {
 }
 
 // copyFile copies a file using io.Copy and flushes with fsync.
-func copyFile(src, dst string) error {
+// perm is applied when creating the destination file so the intended mode
+// is preserved on the cross-device fallback path. Using os.OpenFile with
+// O_WRONLY|O_CREATE|O_TRUNC mirrors what os.Create does, but with the
+// caller-specified mode rather than the default 0666.
+func copyFile(src, dst string, perm os.FileMode) error {
 	in, err := os.Open(src) //nolint:gosec // G304: src is from trusted internal path
 	if err != nil {
 		return err
 	}
 	defer in.Close() //nolint:errcheck // Close error not actionable on read path
 
-	out, err := os.Create(dst) //nolint:gosec // G304: dst is from trusted internal path
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm) //nolint:gosec // G304: dst is from trusted internal path
 	if err != nil {
 		return err
 	}

--- a/internal/filesystem/atomic_additional_test.go
+++ b/internal/filesystem/atomic_additional_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -115,6 +117,31 @@ func TestCopyFile_DestDirNotExist(t *testing.T) {
 	}
 }
 
+// TestCopyFile_SourceIsDirectory covers the io.Copy error branch in copyFile
+// (lines 146-148 in atomic.go). On POSIX, os.Open on a directory succeeds
+// (returns a valid *os.File), but the first Read call on that fd returns
+// EISDIR, causing io.Copy to fail before any bytes are written. This is a
+// clean, deterministic way to exercise the branch without needing a failing
+// device or disk-full condition.
+func TestCopyFile_SourceIsDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory read semantics differ on Windows")
+	}
+
+	dir := t.TempDir()
+	// Use an existing directory (the temp dir itself) as the source path.
+	srcDir := filepath.Join(dir, "srcdir")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "dst.txt")
+
+	err := copyFile(srcDir, dst, 0o644)
+	if err == nil {
+		t.Fatal("expected error when source is a directory (EISDIR on read)")
+	}
+}
+
 // --- renameSafe tests ---
 
 func TestRenameSafe_SameFilesystem(t *testing.T) {
@@ -143,6 +170,49 @@ func TestRenameSafe_SameFilesystem(t *testing.T) {
 	}
 	if !bytes.Equal(got, data) {
 		t.Errorf("content = %q, want %q", got, data)
+	}
+}
+
+// TestRenameSafe_EXDEVCopyFallbackFails covers the error branch inside
+// renameSafe where the copy fallback itself fails (line 83-84 in atomic.go).
+// The test injects an EXDEV error via osRename so the copy path is taken,
+// then points the destination at a read-only directory so os.OpenFile fails
+// inside copyFile, causing renameSafe to return a "copy fallback" error.
+func TestRenameSafe_EXDEVCopyFallbackFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod is not effective on Windows NTFS")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("chmod restrictions do not apply to root")
+	}
+
+	// Mutates package-level osRename; must not run in parallel.
+	orig := osRename
+	t.Cleanup(func() { osRename = orig })
+	osRename = func(old, new string) error { return exdevError(old, new) }
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Destination is inside a directory the process cannot write to. copyFile
+	// will fail at os.OpenFile(dst, O_WRONLY|O_CREATE|...) with EACCES.
+	roDir := filepath.Join(dir, "readonly")
+	if err := os.MkdirAll(roDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	// Restore write permission so TempDir cleanup can remove the directory.
+	t.Cleanup(func() { os.Chmod(roDir, 0o755) })
+
+	dst := filepath.Join(roDir, "dst.txt")
+	err := renameSafe(src, dst, 0o644)
+	if err == nil {
+		t.Fatal("expected error from renameSafe when copy fallback destination is unwritable")
+	}
+	if !strings.Contains(err.Error(), "copy fallback") {
+		t.Errorf("error = %q, want it to contain 'copy fallback'", err.Error())
 	}
 }
 

--- a/internal/filesystem/atomic_additional_test.go
+++ b/internal/filesystem/atomic_additional_test.go
@@ -21,7 +21,7 @@ func TestCopyFile(t *testing.T) {
 		t.Fatalf("writing source: %v", err)
 	}
 
-	if err := copyFile(src, dst); err != nil {
+	if err := copyFile(src, dst, 0o644); err != nil {
 		t.Fatalf("copyFile: %v", err)
 	}
 
@@ -48,7 +48,7 @@ func TestCopyFile_LargeFile(t *testing.T) {
 		t.Fatalf("writing source: %v", err)
 	}
 
-	if err := copyFile(src, dst); err != nil {
+	if err := copyFile(src, dst, 0o644); err != nil {
 		t.Fatalf("copyFile: %v", err)
 	}
 
@@ -70,7 +70,7 @@ func TestCopyFile_EmptyFile(t *testing.T) {
 		t.Fatalf("writing source: %v", err)
 	}
 
-	if err := copyFile(src, dst); err != nil {
+	if err := copyFile(src, dst, 0o644); err != nil {
 		t.Fatalf("copyFile: %v", err)
 	}
 
@@ -88,7 +88,7 @@ func TestCopyFile_SourceNotExist(t *testing.T) {
 	src := filepath.Join(dir, "nonexistent.txt")
 	dst := filepath.Join(dir, "dest.txt")
 
-	err := copyFile(src, dst)
+	err := copyFile(src, dst, 0o644)
 	if err == nil {
 		t.Fatal("expected error for nonexistent source")
 	}
@@ -106,7 +106,7 @@ func TestCopyFile_DestDirNotExist(t *testing.T) {
 		t.Fatalf("writing source: %v", err)
 	}
 
-	err := copyFile(src, dst)
+	err := copyFile(src, dst, 0o644)
 	if err == nil {
 		t.Fatal("expected error when dest directory does not exist")
 	}
@@ -127,7 +127,7 @@ func TestRenameSafe_SameFilesystem(t *testing.T) {
 		t.Fatalf("writing old: %v", err)
 	}
 
-	if err := renameSafe(old, new); err != nil {
+	if err := renameSafe(old, new, 0o644); err != nil {
 		t.Fatalf("renameSafe: %v", err)
 	}
 

--- a/internal/filesystem/atomic_test.go
+++ b/internal/filesystem/atomic_test.go
@@ -178,6 +178,65 @@ func TestWriteFileAtomic_EXDEVFallbackPreservesMode(t *testing.T) {
 	}
 }
 
+// TestWriteFileAtomic_EXDEVFallbackPreservesMode_Overwrite is the overwrite
+// variant of the EXDEV perm regression test. It pre-creates the target with a
+// different mode (0o400, read-only), then calls WriteFileAtomic with perm=0o600
+// under the EXDEV osRename hook. Both the backup-rename step (target -> .bak)
+// and the promotion step (.tmp -> target) travel the copyFile fallback path,
+// and the final file must carry the new perm (0o600), not the pre-existing one.
+//
+// This ensures that perm-threading is correct on BOTH renameSafe call sites
+// inside WriteFileAtomic, not just the new-file path.
+func TestWriteFileAtomic_EXDEVFallbackPreservesMode_Overwrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("EXDEV and Unix permission semantics are POSIX-only")
+	}
+
+	// This test mutates the package-level osRename hook; must not run in parallel.
+	orig := osRename
+	t.Cleanup(func() { osRename = orig })
+
+	osRename = func(oldPath, newPath string) error {
+		return &os.LinkError{
+			Op:  "rename",
+			Old: oldPath,
+			New: newPath,
+			Err: syscall.EXDEV,
+		}
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "secret.key")
+
+	// Pre-create the target with a deliberately different mode so we can
+	// verify the new perm wins, not the pre-existing one.
+	if err := os.WriteFile(target, []byte("old content"), 0o400); err != nil {
+		t.Fatalf("pre-creating target: %v", err)
+	}
+
+	// Write with a new, more-permissive mode. The backup rename path
+	// (target -> .bak) and the promotion path (.tmp -> target) both hit the
+	// copyFile fallback; both must use the caller-supplied perm=0o600.
+	//
+	// Invariant: copyFile uses O_CREATE so the perm is applied at creation
+	// time; subsequent writes to the same fd do not alter the mode, making
+	// this the only place the mode can be enforced.
+	const wantPerm os.FileMode = 0o600
+	if err := WriteFileAtomic(target, []byte("new content"), wantPerm); err != nil {
+		t.Fatalf("WriteFileAtomic: %v", err)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	// The final file must carry the new perm, not the pre-existing 0o400.
+	if gotPerm := info.Mode().Perm(); gotPerm != wantPerm {
+		t.Errorf("file mode = %04o, want %04o (perm lost on cross-device overwrite fallback)", gotPerm, wantPerm)
+	}
+}
+
 func TestWriteFileAtomic_MultipleOverwrites(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "multi.txt")

--- a/internal/filesystem/atomic_test.go
+++ b/internal/filesystem/atomic_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
+	"syscall"
 	"testing"
 )
 
@@ -117,6 +119,62 @@ func TestWriteFileAtomic_LargeFile(t *testing.T) {
 	}
 	if !bytes.Equal(got, data) {
 		t.Error("large file content mismatch")
+	}
+}
+
+// TestWriteFileAtomic_EXDEVFallbackPreservesMode verifies that when the rename
+// step fails with EXDEV (cross-device move), the copy fallback preserves the
+// requested file mode on the destination. This is the regression test for the
+// bug where copyFile used os.Create (mode 0666) instead of os.OpenFile with
+// the caller-specified perm, causing sensitive files (e.g. encryption.key
+// written with 0600) to end up world-readable on cross-device setups.
+//
+// Notes:
+//
+//	(1) This tests the EXDEV copy fallback path by injecting an error via the
+//	    package-level osRename hook.
+//	(2) The mode == perm assertion is POSIX-only: on Windows, Go synthesizes
+//	    FileMode values from FILE_ATTRIBUTE_READONLY and does not enforce Unix
+//	    permission bits, so stat.Mode()&0o777 does not round-trip.
+//	(3) EXDEV (cross-device link) is a Unix/Linux kernel concept; Windows uses
+//	    a different mechanism for cross-volume moves and os.Rename does not
+//	    return syscall.EXDEV.
+func TestWriteFileAtomic_EXDEVFallbackPreservesMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("EXDEV and Unix permission semantics are POSIX-only")
+	}
+
+	// This test mutates the package-level osRename hook; must not run in parallel.
+	orig := osRename
+	t.Cleanup(func() { osRename = orig })
+
+	osRename = func(oldPath, newPath string) error {
+		return &os.LinkError{
+			Op:  "rename",
+			Old: oldPath,
+			New: newPath,
+			Err: syscall.EXDEV,
+		}
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "secret.key")
+	data := []byte("sensitive data")
+
+	// Request a restrictive 0600 mode (owner read/write only).
+	const wantPerm os.FileMode = 0o600
+	if err := WriteFileAtomic(target, data, wantPerm); err != nil {
+		t.Fatalf("WriteFileAtomic: %v", err)
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	// Confirm the file mode survived the cross-device copy fallback.
+	if gotPerm := info.Mode().Perm(); gotPerm != wantPerm {
+		t.Errorf("file mode = %04o, want %04o (perm lost on cross-device copy fallback)", gotPerm, wantPerm)
 	}
 }
 

--- a/internal/filesystem/rename.go
+++ b/internal/filesystem/rename.go
@@ -56,7 +56,15 @@ func RenameFileAtomic(src, dst string) error {
 	// Snapshot dst state so we only clean up our own partial copy on failure.
 	_, statErr := os.Stat(dst)
 
-	if err := copyFile(src, dst); err != nil {
+	// Stat the source to preserve its existing file mode on the copy path.
+	// If the stat fails (narrow race: file removed between rename failure and
+	// here), copyFile will fail at os.Open and we will propagate that error.
+	srcMode := os.FileMode(0o644)
+	if srcInfo, srcStatErr := os.Stat(src); srcStatErr == nil {
+		srcMode = srcInfo.Mode().Perm()
+	}
+
+	if err := copyFile(src, dst, srcMode); err != nil {
 		if os.IsNotExist(statErr) {
 			// dst was created by us; safe to clean up.
 			_ = os.Remove(dst)
@@ -85,7 +93,8 @@ func copyDirRecursive(src, dst string) error {
 		if info.IsDir() {
 			return os.MkdirAll(target, info.Mode())
 		}
-		// Reuse the package-level copyFile from atomic.go.
-		return copyFile(path, target)
+		// Reuse the package-level copyFile from atomic.go, preserving
+		// the source file's mode so directory copies stay permission-faithful.
+		return copyFile(path, target, info.Mode().Perm())
 	})
 }

--- a/web/static/js/preferences.js
+++ b/web/static/js/preferences.js
@@ -162,7 +162,10 @@
       // the first paint, preventing FOUC. The raw value ('dark', 'light', or
       // 'system') is stored -- not the resolved boolean -- so themeInitScript
       // can re-resolve 'system' via matchMedia on each load.
-      localStorage.setItem('theme', value);
+      // Wrapped in try/catch: Safari/Firefox in private-browsing mode throw
+      // QuotaExceededError on any localStorage write; this is non-fatal since
+      // themeInitScript falls back to matchMedia when the key is absent.
+      try { localStorage.setItem('theme', value); } catch (e) { /* private browsing or quota - non-fatal */ }
       // Recompute theme-dependent background color after theme change.
       var cached = readCache() || {};
       var opacityVal = cached.bg_opacity || DEFAULTS.bg_opacity || '85';
@@ -350,8 +353,12 @@
     // Prefer the localStorage value (raw preference: 'dark', 'light', 'system')
     // set by preferences.js on prior loads; fall back to the DOM class that
     // themeInitScript set for the current paint.
-    var domTheme = localStorage.getItem('theme') ||
-      (document.documentElement.classList.contains('dark') ? 'dark' : 'light');
+    // Wrapped in try/catch: localStorage.getItem throws in Safari/Firefox
+    // private-browsing mode; fall back to the DOM class already set by
+    // themeInitScript (which has its own guard in the inline script).
+    var domTheme;
+    try { domTheme = localStorage.getItem('theme'); } catch (e) {}
+    domTheme = domTheme || (document.documentElement.classList.contains('dark') ? 'dark' : 'light');
     var initDefaults = {};
     var initKey;
     for (initKey in DEFAULTS) {

--- a/web/static/js/preferences.js
+++ b/web/static/js/preferences.js
@@ -157,6 +157,12 @@
       } else {
         root.classList.remove('dark');
       }
+      // Sync the raw preference value to localStorage so that themeInitScript
+      // can read it on the next page load and apply the correct class before
+      // the first paint, preventing FOUC. The raw value ('dark', 'light', or
+      // 'system') is stored -- not the resolved boolean -- so themeInitScript
+      // can re-resolve 'system' via matchMedia on each load.
+      localStorage.setItem('theme', value);
       // Recompute theme-dependent background color after theme change.
       var cached = readCache() || {};
       var opacityVal = cached.bg_opacity || DEFAULTS.bg_opacity || '85';
@@ -334,7 +340,27 @@
   if (initCached) {
     applyAll(initCached);
   } else {
-    applyAll(DEFAULTS);
+    // No session cache yet (new tab or cleared sessionStorage). themeInitScript
+    // already applied the correct theme class and data-theme attribute from
+    // localStorage / OS preference before first paint. Preserve that by reading
+    // the current theme back from the DOM rather than blindly applying
+    // DEFAULTS.theme = 'dark', which would flash the page to dark even for
+    // users whose preference is light or system-light.
+    //
+    // Prefer the localStorage value (raw preference: 'dark', 'light', 'system')
+    // set by preferences.js on prior loads; fall back to the DOM class that
+    // themeInitScript set for the current paint.
+    var domTheme = localStorage.getItem('theme') ||
+      (document.documentElement.classList.contains('dark') ? 'dark' : 'light');
+    var initDefaults = {};
+    var initKey;
+    for (initKey in DEFAULTS) {
+      if (DEFAULTS.hasOwnProperty(initKey)) {
+        initDefaults[initKey] = DEFAULTS[initKey];
+      }
+    }
+    initDefaults.theme = domTheme;
+    applyAll(initDefaults);
   }
 
   // Step 2 (async): Fetch fresh preferences from the API once the DOM is ready.

--- a/web/templates/layout.templ
+++ b/web/templates/layout.templ
@@ -1022,13 +1022,25 @@ templ tourI18nJSON() {
 // On the very first visit (no localStorage entry), the script falls back to
 // the OS color-scheme preference via matchMedia.
 //
+// localStorage.getItem is wrapped in try/catch because Safari and Firefox in
+// private-browsing mode throw QuotaExceededError on any localStorage access.
+// When it throws we fall back to matchMedia so the page still renders correctly.
+//
+// data-theme is set to the RAW preference value ('dark', 'light', 'system')
+// when one is known, matching the value preferences.js writes via ATTR_MAP.
+// This keeps the attribute consistent across the initial paint and after
+// hydration, preventing a 'dark' -> 'system' flip on first preferences.js run.
+// When no preference is stored the fallback is the resolved value ('dark' or
+// 'light') derived from matchMedia.
+//
 // Middleware was evaluated but rejected: it only benefits the very first
 // request before any JS has run, and adds server complexity that is not
 // justified for that narrow edge case.
 templ themeInitScript() {
 	<script>
 		(function() {
-			var pref = localStorage.getItem('theme');
+			var pref;
+			try { pref = localStorage.getItem('theme'); } catch (e) {}
 			var isDark;
 			if (pref === 'dark') {
 				isDark = true;
@@ -1038,9 +1050,15 @@ templ themeInitScript() {
 				// 'system', null, or any unrecognized value: follow OS preference.
 				isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 			}
-			var resolvedTheme = isDark ? 'dark' : 'light';
 			document.documentElement.classList.toggle('dark', isDark);
-			document.documentElement.setAttribute('data-theme', resolvedTheme);
+			// Set data-theme to the raw pref so it stays consistent with the value
+			// preferences.js writes after hydration. Fall back to the resolved value
+			// when no stored preference exists (first visit or private browsing).
+			if (pref === 'dark' || pref === 'light' || pref === 'system') {
+				document.documentElement.setAttribute('data-theme', pref);
+			} else {
+				document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
+			}
 		})();
 	</script>
 }

--- a/web/templates/layout.templ
+++ b/web/templates/layout.templ
@@ -117,6 +117,7 @@ templ LayoutHead(title string, assets AssetPaths) {
 		<meta charset="UTF-8"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 		<title>{ tf(ctx, "layout.page_title", title) }</title>
+		@themeInitScript()
 		<link rel="stylesheet" href={ assets.CSS }/>
 		if assets.DriverCSS != "" {
 			<link rel="stylesheet" href={ assets.DriverCSS }/>
@@ -126,7 +127,6 @@ templ LayoutHead(title string, assets AssetPaths) {
 		<link rel="icon" type="image/png" sizes="16x16" href={ assets.BasePath + "/static/img/favicon-16x16.png" }/>
 		<link rel="apple-touch-icon" sizes="180x180" href={ assets.BasePath + "/static/img/apple-touch-icon.png" }/>
 		<link rel="manifest" href={ assets.BasePath + "/static/site.webmanifest" }/>
-		@themeInitScript()
 		<script src={ assets.HTMX }></script>
 		// htmx-base-path provides the base path to JavaScript at runtime. The
 		// htmx:configRequest listener uses it to prefix every absolute HTMX
@@ -1012,15 +1012,35 @@ templ tourI18nJSON() {
 	<div id="tour-i18n" hidden data-i18n={ tourStepsJSON(ctx) }></div>
 }
 
-// themeInitScript applies the dark class before first paint to prevent FOUC.
-// Must be placed in <head> before any stylesheets take effect.
+// themeInitScript applies the dark/light class and data-theme attribute before
+// first paint to prevent FOUC (flash of unstyled content). It is positioned
+// before all stylesheets in <head> so Tailwind dark: utilities and CSS custom
+// properties resolve correctly on the very first paint.
+//
+// localStorage is populated by preferences.js on every theme change so
+// subsequent page loads have the user's explicit preference available here.
+// On the very first visit (no localStorage entry), the script falls back to
+// the OS color-scheme preference via matchMedia.
+//
+// Middleware was evaluated but rejected: it only benefits the very first
+// request before any JS has run, and adds server complexity that is not
+// justified for that narrow edge case.
 templ themeInitScript() {
 	<script>
 		(function() {
 			var pref = localStorage.getItem('theme');
-			if (pref === 'dark' || (pref !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-				document.documentElement.classList.add('dark');
+			var isDark;
+			if (pref === 'dark') {
+				isDark = true;
+			} else if (pref === 'light') {
+				isDark = false;
+			} else {
+				// 'system', null, or any unrecognized value: follow OS preference.
+				isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 			}
+			var resolvedTheme = isDark ? 'dark' : 'light';
+			document.documentElement.classList.toggle('dark', isDark);
+			document.documentElement.setAttribute('data-theme', resolvedTheme);
 		})();
 	</script>
 }

--- a/web/templates/layout_templ.go
+++ b/web/templates/layout_templ.go
@@ -795,6 +795,17 @@ func tourI18nJSON() templ.Component {
 // On the very first visit (no localStorage entry), the script falls back to
 // the OS color-scheme preference via matchMedia.
 //
+// localStorage.getItem is wrapped in try/catch because Safari and Firefox in
+// private-browsing mode throw QuotaExceededError on any localStorage access.
+// When it throws we fall back to matchMedia so the page still renders correctly.
+//
+// data-theme is set to the RAW preference value ('dark', 'light', 'system')
+// when one is known, matching the value preferences.js writes via ATTR_MAP.
+// This keeps the attribute consistent across the initial paint and after
+// hydration, preventing a 'dark' -> 'system' flip on first preferences.js run.
+// When no preference is stored the fallback is the resolved value ('dark' or
+// 'light') derived from matchMedia.
+//
 // Middleware was evaluated but rejected: it only benefits the very first
 // request before any JS has run, and adds server complexity that is not
 // justified for that narrow edge case.
@@ -819,7 +830,7 @@ func themeInitScript() templ.Component {
 			templ_7745c5c3_Var35 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<script>\n\t\t(function() {\n\t\t\tvar pref = localStorage.getItem('theme');\n\t\t\tvar isDark;\n\t\t\tif (pref === 'dark') {\n\t\t\t\tisDark = true;\n\t\t\t} else if (pref === 'light') {\n\t\t\t\tisDark = false;\n\t\t\t} else {\n\t\t\t\t// 'system', null, or any unrecognized value: follow OS preference.\n\t\t\t\tisDark = window.matchMedia('(prefers-color-scheme: dark)').matches;\n\t\t\t}\n\t\t\tvar resolvedTheme = isDark ? 'dark' : 'light';\n\t\t\tdocument.documentElement.classList.toggle('dark', isDark);\n\t\t\tdocument.documentElement.setAttribute('data-theme', resolvedTheme);\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<script>\n\t\t(function() {\n\t\t\tvar pref;\n\t\t\ttry { pref = localStorage.getItem('theme'); } catch (e) {}\n\t\t\tvar isDark;\n\t\t\tif (pref === 'dark') {\n\t\t\t\tisDark = true;\n\t\t\t} else if (pref === 'light') {\n\t\t\t\tisDark = false;\n\t\t\t} else {\n\t\t\t\t// 'system', null, or any unrecognized value: follow OS preference.\n\t\t\t\tisDark = window.matchMedia('(prefers-color-scheme: dark)').matches;\n\t\t\t}\n\t\t\tdocument.documentElement.classList.toggle('dark', isDark);\n\t\t\t// Set data-theme to the raw pref so it stays consistent with the value\n\t\t\t// preferences.js writes after hydration. Fall back to the resolved value\n\t\t\t// when no stored preference exists (first visit or private browsing).\n\t\t\tif (pref === 'dark' || pref === 'light' || pref === 'system') {\n\t\t\t\tdocument.documentElement.setAttribute('data-theme', pref);\n\t\t\t} else {\n\t\t\t\tdocument.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');\n\t\t\t}\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/templates/layout_templ.go
+++ b/web/templates/layout_templ.go
@@ -215,108 +215,7 @@ func LayoutHead(title string, assets AssetPaths) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</title><link rel=\"stylesheet\" href=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var4 templ.SafeURL
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(assets.CSS)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 120, Col: 42}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if assets.DriverCSS != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<link rel=\"stylesheet\" href=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var5 templ.SafeURL
-			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(assets.DriverCSS)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 122, Col: 49}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<link rel=\"icon\" type=\"image/svg+xml\" href=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var6 templ.SafeURL
-		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/static/img/favicon.svg")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 124, Col: 90}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\"><link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var7 templ.SafeURL
-		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/static/img/favicon-32x32.png")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 125, Col: 106}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\"><link rel=\"icon\" type=\"image/png\" sizes=\"16x16\" href=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var8 templ.SafeURL
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/static/img/favicon-16x16.png")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 126, Col: 106}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\"><link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var9 templ.SafeURL
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/static/img/apple-touch-icon.png")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 127, Col: 106}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\"><link rel=\"manifest\" href=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var10 templ.SafeURL
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/static/site.webmanifest")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 128, Col: 74}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</title>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -324,7 +223,108 @@ func LayoutHead(title string, assets AssetPaths) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<script src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<link rel=\"stylesheet\" href=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var4 templ.SafeURL
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(assets.CSS)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 121, Col: 42}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if assets.DriverCSS != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<link rel=\"stylesheet\" href=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var5 templ.SafeURL
+			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(assets.DriverCSS)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 123, Col: 49}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<link rel=\"icon\" type=\"image/svg+xml\" href=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var6 templ.SafeURL
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/static/img/favicon.svg")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 125, Col: 90}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\"><link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var7 templ.SafeURL
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/static/img/favicon-32x32.png")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 126, Col: 106}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\"><link rel=\"icon\" type=\"image/png\" sizes=\"16x16\" href=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var8 templ.SafeURL
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/static/img/favicon-16x16.png")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 127, Col: 106}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\"><link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var9 templ.SafeURL
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/static/img/apple-touch-icon.png")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 128, Col: 106}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\"><link rel=\"manifest\" href=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var10 templ.SafeURL
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinURLErrs(assets.BasePath + "/static/site.webmanifest")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/templates/layout.templ`, Line: 129, Col: 74}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\"><script src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -785,8 +785,19 @@ func tourI18nJSON() templ.Component {
 	})
 }
 
-// themeInitScript applies the dark class before first paint to prevent FOUC.
-// Must be placed in <head> before any stylesheets take effect.
+// themeInitScript applies the dark/light class and data-theme attribute before
+// first paint to prevent FOUC (flash of unstyled content). It is positioned
+// before all stylesheets in <head> so Tailwind dark: utilities and CSS custom
+// properties resolve correctly on the very first paint.
+//
+// localStorage is populated by preferences.js on every theme change so
+// subsequent page loads have the user's explicit preference available here.
+// On the very first visit (no localStorage entry), the script falls back to
+// the OS color-scheme preference via matchMedia.
+//
+// Middleware was evaluated but rejected: it only benefits the very first
+// request before any JS has run, and adds server complexity that is not
+// justified for that narrow edge case.
 func themeInitScript() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -808,7 +819,7 @@ func themeInitScript() templ.Component {
 			templ_7745c5c3_Var35 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<script>\n\t\t(function() {\n\t\t\tvar pref = localStorage.getItem('theme');\n\t\t\tif (pref === 'dark' || (pref !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {\n\t\t\t\tdocument.documentElement.classList.add('dark');\n\t\t\t}\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<script>\n\t\t(function() {\n\t\t\tvar pref = localStorage.getItem('theme');\n\t\t\tvar isDark;\n\t\t\tif (pref === 'dark') {\n\t\t\t\tisDark = true;\n\t\t\t} else if (pref === 'light') {\n\t\t\t\tisDark = false;\n\t\t\t} else {\n\t\t\t\t// 'system', null, or any unrecognized value: follow OS preference.\n\t\t\t\tisDark = window.matchMedia('(prefers-color-scheme: dark)').matches;\n\t\t\t}\n\t\t\tvar resolvedTheme = isDark ? 'dark' : 'light';\n\t\t\tdocument.documentElement.classList.toggle('dark', isDark);\n\t\t\tdocument.documentElement.setAttribute('data-theme', resolvedTheme);\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

Two independent fixes bundled per maintainer request. Second PR of an orchestrated parallel-PR batch (lands after the CI-hygiene PR #1885).

Closes #1880
Closes #1863

## #1880 - WriteFileAtomic cross-device fallback dropped file mode (bug / security)

When `os.Rename` failed with `EXDEV` (target on a different filesystem), the copy fallback created the destination with `os.Create`, which uses 0644 and ignores the caller's requested mode. A file written with 0600 (e.g. a secret) could land world-readable after the fallback.

- Threaded the caller's `perm` through `renameSafe` and `copyFile`; `copyFile` now uses `os.OpenFile(dst, O_WRONLY|O_CREATE|O_TRUNC, perm)`.
- Fixed `RenameFileAtomic` to stat the source for its mode before the copy fallback (defaults 0644 only if stat fails), and `copyDirRecursive` to pass `info.Mode().Perm()`.
- Added an injectable `osRename` hook and two race-tested regression tests that force `EXDEV` and assert the final mode is 0600: the new-file case and the overwrite case (exercising both the backup-rename and promotion-rename fallback paths).

## #1863 - Flash-free auto/system theme resolution (enhancement / ux)

Eliminates the light/dark flash (FOUC) on load when the theme is `system`/`auto`.

- Moved `@themeInitScript()` ahead of all stylesheets so the resolved theme class is applied before the browser parses CSS.
- `themeInitScript` now resolves a concrete light/dark from `dark`/`light`/`system`/null and sets both `classList.toggle('dark', ...)` and `data-theme` for first paint.
- `preferences.js` persists the raw theme preference to `localStorage` (so `system` is re-resolved via `matchMedia` on the next load) and, on a cache miss, reads the DOM-resolved theme instead of blindly defaulting. All `localStorage` reads/writes are wrapped in try/catch (private-browsing / quota safe).

## Testing
- `go test -race ./internal/filesystem/`: pass, including both new EXDEV regression tests.
- Deterministic pre-push gate: GREEN (65 packages with -race, lint, OpenAPI, generated-file check; patch coverage 76.47% vs 75% floor; per-package floors clear).
- Independent hostile review: PASS after addressing a localStorage-without-try/catch regression and a test-coverage gap (both fixed and re-verified).
- Theme UAT: `system`/`light`/`dark` all resolve correctly on first paint, pre- and post-auth; both themes render; `preferences.js`/`styles.css` serve 200.

## Notes
The two changes touch disjoint subsystems (`internal/filesystem` vs `web/`); regenerated `layout_templ.go` is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File saves now reliably preserve requested file permissions even when cross-device fallbacks are used.
  * Improved robustness of atomic save operations (better cleanup and fallback behavior).

* **New Features**
  * Theme preference handling now reads/stores raw preference and applies it earlier to prevent flash-of-incorrect-theme.
  * Adds a data-theme attribute for consistent theme tracking.

* **Tests**
  * Added regression tests validating permission-preserving atomic saves and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->