### PR TITLE
fix(pagination): respect per-user Page Size pref on all paginated screens (#1801)

### DIFF
--- a/internal/api/handlers_artist_lock.go
+++ b/internal/api/handlers_artist_lock.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/artist"
 )
 
@@ -223,6 +224,7 @@ func (r *Router) setImageLock(w http.ResponseWriter, req *http.Request, locked b
 // handleListLockedArtists returns a paginated list of locked artists.
 // GET /api/v1/artists/locked
 func (r *Router) handleListLockedArtists(w http.ResponseWriter, req *http.Request) {
+	userID := middleware.UserIDFromContext(req.Context())
 	sortKey, ok := validateSortParam(w, req, allowedArtistSort)
 	if !ok {
 		return
@@ -233,7 +235,7 @@ func (r *Router) handleListLockedArtists(w http.ResponseWriter, req *http.Reques
 	}
 	params := artist.ListParams{
 		Page:     intQuery(req, "page", 1),
-		PageSize: intQuery(req, "page_size", 50),
+		PageSize: r.getUserPageSize(req.Context(), userID, intQuery(req, "page_size", 0)),
 		Sort:     sortKey,
 		Order:    order,
 		Filter:   "locked",

--- a/internal/api/handlers_artist_lock_test.go
+++ b/internal/api/handlers_artist_lock_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/nfo"
 )
@@ -352,5 +354,132 @@ func TestHandleUnlockArtistImage_WrongImage(t *testing.T) {
 	r.handleUnlockArtistImage(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+// TestHandleListLockedArtists_RespectsPageSizePref verifies that the
+// locked-artists list handler respects the per-user page_size preference when
+// no query param is provided.
+func TestHandleListLockedArtists_RespectsPageSizePref(t *testing.T) {
+	t.Parallel()
+	r, svc := testRouter(t)
+
+	const testUserID = "test-user-locked-pagesize"
+
+	// Seed more artists than the preference value so the cap is observable.
+	for i := 0; i < 15; i++ {
+		a := &artist.Artist{
+			Name: fmt.Sprintf("Locked Artist %02d", i),
+			Path: fmt.Sprintf("/music/locked-%02d", i),
+		}
+		if err := svc.Create(context.Background(), a); err != nil {
+			t.Fatalf("creating artist %d: %v", i, err)
+		}
+		if err := svc.Lock(context.Background(), a.ID, "user"); err != nil {
+			t.Fatalf("locking artist %d: %v", i, err)
+		}
+	}
+
+	// Store page_size=10 directly in the DB for the test user.
+	_, err := r.db.ExecContext(context.Background(),
+		`INSERT INTO user_preferences (user_id, key, value, updated_at)
+		 VALUES (?, 'page_size', '10', datetime('now'))
+		 ON CONFLICT(user_id, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+		testUserID)
+	if err != nil {
+		t.Fatalf("storing page_size pref: %v", err)
+	}
+
+	ctx := middleware.WithTestUserID(context.Background(), testUserID)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/artists/locked", nil)
+	w := httptest.NewRecorder()
+	r.handleListLockedArtists(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	pageSize, ok := resp["page_size"].(float64)
+	if !ok {
+		t.Fatalf("page_size not present or not a number in response")
+	}
+	if int(pageSize) != 10 {
+		t.Errorf("expected page_size=10 from preference, got %d", int(pageSize))
+	}
+
+	artists, ok := resp["artists"].([]any)
+	if !ok {
+		t.Fatalf("artists not present or not an array in response")
+	}
+	if len(artists) > 10 {
+		t.Errorf("expected at most 10 artists, got %d", len(artists))
+	}
+}
+
+// TestHandleListLockedArtists_QueryParamOverridesPref verifies that an explicit
+// page_size query parameter takes precedence over the stored user preference.
+func TestHandleListLockedArtists_QueryParamOverridesPref(t *testing.T) {
+	t.Parallel()
+	r, svc := testRouter(t)
+
+	const testUserID = "test-user-locked-qparam"
+
+	for i := 0; i < 15; i++ {
+		a := &artist.Artist{
+			Name: fmt.Sprintf("QP Artist %02d", i),
+			Path: fmt.Sprintf("/music/qp-%02d", i),
+		}
+		if err := svc.Create(context.Background(), a); err != nil {
+			t.Fatalf("creating artist %d: %v", i, err)
+		}
+		if err := svc.Lock(context.Background(), a.ID, "user"); err != nil {
+			t.Fatalf("locking artist %d: %v", i, err)
+		}
+	}
+
+	_, err := r.db.ExecContext(context.Background(),
+		`INSERT INTO user_preferences (user_id, key, value, updated_at)
+		 VALUES (?, 'page_size', '10', datetime('now'))
+		 ON CONFLICT(user_id, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+		testUserID)
+	if err != nil {
+		t.Fatalf("storing page_size pref: %v", err)
+	}
+
+	// Use page_size=12 (valid, in [PageSizeMin, PageSizeMax], different from the
+	// stored preference of 10) to verify the query param takes precedence.
+	ctx := middleware.WithTestUserID(context.Background(), testUserID)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/artists/locked?page_size=12", nil)
+	w := httptest.NewRecorder()
+	r.handleListLockedArtists(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	pageSize, ok := resp["page_size"].(float64)
+	if !ok {
+		t.Fatalf("page_size not present or not a number in response")
+	}
+	if int(pageSize) != 12 {
+		t.Errorf("expected page_size=12 from query param, got %d", int(pageSize))
+	}
+
+	artists, ok := resp["artists"].([]any)
+	if !ok {
+		t.Fatalf("artists not present or not an array in response")
+	}
+	if len(artists) > 12 {
+		t.Errorf("expected at most 12 artists with query param override, got %d", len(artists))
 	}
 }

--- a/internal/api/handlers_report.go
+++ b/internal/api/handlers_report.go
@@ -304,7 +304,7 @@ func (r *Router) handleViolationTrend(w http.ResponseWriter, req *http.Request) 
 // GET /api/v1/reports/compliance
 func (r *Router) handleReportCompliance(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	params, ok := complianceListParams(w, req)
+	params, ok := r.complianceListParams(w, req)
 	if !ok {
 		return
 	}
@@ -370,7 +370,7 @@ func (r *Router) handleReportCompliance(w http.ResponseWriter, req *http.Request
 func (r *Router) handleReportComplianceExport(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	params, ok := complianceListParams(w, req)
+	params, ok := r.complianceListParams(w, req)
 	if !ok {
 		return
 	}
@@ -486,8 +486,9 @@ func sanitizeCSV(s string) string {
 // complianceListParams extracts ListParams from a compliance report request.
 // Validates the sort and order parameters against the artist allowlist; on
 // unknown values it writes a 400 response and returns ok=false so the caller
-// can stop processing.
-func complianceListParams(w http.ResponseWriter, req *http.Request) (artist.ListParams, bool) {
+// can stop processing. PageSize respects the per-user preference stored in the
+// database; an explicit page_size query param overrides it.
+func (r *Router) complianceListParams(w http.ResponseWriter, req *http.Request) (artist.ListParams, bool) {
 	sortKey, ok := validateSortParam(w, req, allowedArtistSort)
 	if !ok {
 		return artist.ListParams{}, false
@@ -503,9 +504,10 @@ func complianceListParams(w http.ResponseWriter, req *http.Request) (artist.List
 		order = "asc"
 	}
 
+	userID := middleware.UserIDFromContext(req.Context())
 	params := artist.ListParams{
 		Page:           intQuery(req, "page", 1),
-		PageSize:       intQuery(req, "page_size", compliancePageSizeDefault),
+		PageSize:       r.getUserPageSize(req.Context(), userID, intQuery(req, "page_size", 0)),
 		Sort:           sortKey,
 		Order:          order,
 		Search:         req.URL.Query().Get("search"),
@@ -537,7 +539,7 @@ func (r *Router) handleCompliancePage(w http.ResponseWriter, req *http.Request) 
 	}
 
 	ctx := req.Context()
-	params, ok := complianceListParams(w, req)
+	params, ok := r.complianceListParams(w, req)
 	if !ok {
 		return
 	}
@@ -622,7 +624,7 @@ func (r *Router) handleCompliancePage(w http.ResponseWriter, req *http.Request) 
 	}
 
 	if isHTMXRequest(req) {
-		vals := complianceURLValues(params, status, req.URL.Query().Get("filter"))
+		vals := complianceURLValues(params, status, req.URL.Query().Get("filter"), req.URL.Query())
 		pushURL := r.basePath + "/reports/compliance"
 		if len(vals) > 0 {
 			pushURL += "?" + vals.Encode()
@@ -637,17 +639,14 @@ func (r *Router) handleCompliancePage(w http.ResponseWriter, req *http.Request) 
 	renderTempl(w, req, templates.CompliancePage(r.assetsFor(req), data))
 }
 
-// compliancePageSizeDefault matches the default applied by intQuery in
-// complianceListParams; both must stay in sync so HX-Push-Url drops the
-// query param when it equals the implicit default.
-const compliancePageSizeDefault = 50
-
 // complianceURLValues converts the compliance list params + raw status/filter
 // query values into url.Values for HX-Push-Url. Only writes the canonical
 // keys the compliance page reads back on next load. Default values (page 1,
-// the default page size, "all" status, "name" sort, "asc" order) are dropped
-// so the pushed URL stays minimal.
-func complianceURLValues(params artist.ListParams, status, filter string) url.Values {
+// "all" status, "name" sort, "asc" order) are dropped so the pushed URL stays
+// minimal. page_size is only included when the caller explicitly provided it
+// as a query parameter (rawQuery.Has("page_size")); when it is absent the
+// user's stored preference is the effective default and the URL omits it.
+func complianceURLValues(params artist.ListParams, status, filter string, rawQuery url.Values) url.Values {
 	q := url.Values{}
 	if params.Search != "" {
 		q.Set("search", params.Search)
@@ -679,7 +678,10 @@ func complianceURLValues(params artist.ListParams, status, filter string) url.Va
 	if params.Page > 1 {
 		q.Set("page", strconv.Itoa(params.Page))
 	}
-	if params.PageSize > 0 && params.PageSize != compliancePageSizeDefault {
+	// Only echo page_size back to the URL when the caller passed it explicitly.
+	// Without a query param the user's stored preference is the effective default
+	// and echoing it would pollute bookmarked/shared URLs unnecessarily.
+	if rawQuery.Has("page_size") {
 		q.Set("page_size", strconv.Itoa(params.PageSize))
 	}
 	return q

--- a/internal/api/handlers_report_test.go
+++ b/internal/api/handlers_report_test.go
@@ -1359,4 +1359,12 @@ func TestHandleReportCompliance_QueryParamOverridesPref(t *testing.T) {
 	if int(pageSize) != 12 {
 		t.Errorf("expected page_size=12 from query param override, got %d", int(pageSize))
 	}
+
+	rows, ok := resp["rows"].([]any)
+	if !ok {
+		t.Fatalf("rows not present or not an array in response")
+	}
+	if len(rows) > 12 {
+		t.Errorf("expected at most 12 rows with query param override, got %d", len(rows))
+	}
 }

--- a/internal/api/handlers_report_test.go
+++ b/internal/api/handlers_report_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/conflict"
@@ -1139,6 +1141,8 @@ func TestHandleCompliancePage_HXPushURL(t *testing.T) {
 // TestComplianceURLValues verifies the per-param URL-encoding behavior:
 // empty / default values are dropped, non-defaults are written, and the
 // status `all` synonym is treated as a no-op (matches the rest of the page).
+// page_size is only echoed to the URL when the caller provided it explicitly
+// as a query parameter (rawQuery.Has("page_size")); the user pref case omits it.
 func TestComplianceURLValues(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -1146,6 +1150,7 @@ func TestComplianceURLValues(t *testing.T) {
 		params   artist.ListParams
 		status   string
 		filter   string
+		rawQuery url.Values
 		wantKeys map[string]string
 	}{
 		{
@@ -1153,6 +1158,7 @@ func TestComplianceURLValues(t *testing.T) {
 			params:   artist.ListParams{},
 			status:   "",
 			filter:   "",
+			rawQuery: url.Values{},
 			wantKeys: map[string]string{},
 		},
 		{
@@ -1161,13 +1167,15 @@ func TestComplianceURLValues(t *testing.T) {
 			status: "all",
 			filter: "",
 			// `all` means "no filter" so we must not echo it.
+			rawQuery: url.Values{},
 			wantKeys: map[string]string{},
 		},
 		{
-			name:   "full set",
-			params: artist.ListParams{Search: "indie", LibraryID: "lib-1", HealthScoreMin: 40, HealthScoreMax: 80, Sort: "health_score", Order: "desc"},
-			status: "non_compliant",
-			filter: "missing_nfo",
+			name:     "full set",
+			params:   artist.ListParams{Search: "indie", LibraryID: "lib-1", HealthScoreMin: 40, HealthScoreMax: 80, Sort: "health_score", Order: "desc"},
+			status:   "non_compliant",
+			filter:   "missing_nfo",
+			rawQuery: url.Values{},
 			wantKeys: map[string]string{
 				"search":     "indie",
 				"status":     "non_compliant",
@@ -1184,32 +1192,50 @@ func TestComplianceURLValues(t *testing.T) {
 			params:   artist.ListParams{Sort: "name", Order: "asc"},
 			status:   "",
 			filter:   "",
+			rawQuery: url.Values{},
 			wantKeys: map[string]string{},
 		},
 		{
 			// Regression for CR finding on PR #1653: pagination must survive
 			// HTMX swaps so the address bar reflects the current page when a
 			// chip is dismissed mid-listing.
-			name:   "non-default pagination is preserved",
-			params: artist.ListParams{Page: 3, PageSize: 100},
-			status: "",
-			filter: "",
+			name:     "non-default pagination with explicit page_size is preserved",
+			params:   artist.ListParams{Page: 3, PageSize: 100},
+			status:   "",
+			filter:   "",
+			rawQuery: url.Values{"page_size": {"100"}},
 			wantKeys: map[string]string{
 				"page":      "3",
 				"page_size": "100",
 			},
 		},
 		{
-			name:     "page=1 and default page_size are dropped",
-			params:   artist.ListParams{Page: 1, PageSize: compliancePageSizeDefault},
+			// page_size absent from the query means the user's stored pref is in
+			// effect; we must NOT echo it to the URL so shared/bookmarked links
+			// stay clean and pick up pref changes on reload.
+			name:     "page_size absent from query is dropped even when params carries a value",
+			params:   artist.ListParams{Page: 1, PageSize: 50},
 			status:   "",
 			filter:   "",
+			rawQuery: url.Values{},
 			wantKeys: map[string]string{},
+		},
+		{
+			// When an explicit page_size=50 IS present in the raw query, echo it
+			// so back/forward navigation restores the override.
+			name:     "explicit page_size=50 in query is echoed",
+			params:   artist.ListParams{Page: 1, PageSize: 50},
+			status:   "",
+			filter:   "",
+			rawQuery: url.Values{"page_size": {"50"}},
+			wantKeys: map[string]string{
+				"page_size": "50",
+			},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := complianceURLValues(tc.params, tc.status, tc.filter)
+			got := complianceURLValues(tc.params, tc.status, tc.filter, tc.rawQuery)
 			if len(got) != len(tc.wantKeys) {
 				t.Errorf("len = %d, want %d (got=%v)", len(got), len(tc.wantKeys), got)
 			}
@@ -1219,5 +1245,118 @@ func TestComplianceURLValues(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestHandleReportCompliance_RespectsPageSizePref verifies that the compliance
+// report API handler uses the per-user Page Size preference when no explicit
+// page_size query parameter is provided.
+func TestHandleReportCompliance_RespectsPageSizePref(t *testing.T) {
+	t.Parallel()
+	r, svc := testRouter(t)
+
+	const testUserID = "test-user-compliance-pagesize-pref"
+
+	// Seed more artists than the preference value so the cap is observable.
+	for i := 0; i < 15; i++ {
+		a := &artist.Artist{
+			Name: fmt.Sprintf("Compliance Artist %02d", i),
+			Path: fmt.Sprintf("/music/compliance-pref-%02d", i),
+		}
+		if err := svc.Create(context.Background(), a); err != nil {
+			t.Fatalf("creating artist %d: %v", i, err)
+		}
+	}
+
+	// Store page_size=10 for the test user.
+	_, err := r.db.ExecContext(context.Background(),
+		`INSERT INTO user_preferences (user_id, key, value, updated_at)
+		 VALUES (?, 'page_size', '10', datetime('now'))
+		 ON CONFLICT(user_id, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+		testUserID)
+	if err != nil {
+		t.Fatalf("storing page_size pref: %v", err)
+	}
+
+	ctx := middleware.WithTestUserID(context.Background(), testUserID)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/reports/compliance", nil)
+	w := httptest.NewRecorder()
+	r.handleReportCompliance(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	pageSize, ok := resp["page_size"].(float64)
+	if !ok {
+		t.Fatalf("page_size not present or not a number in response")
+	}
+	if int(pageSize) != 10 {
+		t.Errorf("expected page_size=10 from preference, got %d", int(pageSize))
+	}
+
+	rows, ok := resp["rows"].([]any)
+	if !ok {
+		t.Fatalf("rows not present or not an array in response")
+	}
+	if len(rows) > 10 {
+		t.Errorf("expected at most 10 rows, got %d", len(rows))
+	}
+}
+
+// TestHandleReportCompliance_QueryParamOverridesPref verifies that an explicit
+// page_size query parameter takes precedence over the stored user preference.
+func TestHandleReportCompliance_QueryParamOverridesPref(t *testing.T) {
+	t.Parallel()
+	r, svc := testRouter(t)
+
+	const testUserID = "test-user-compliance-pagesize-qparam"
+
+	for i := 0; i < 15; i++ {
+		a := &artist.Artist{
+			Name: fmt.Sprintf("QP Compliance Artist %02d", i),
+			Path: fmt.Sprintf("/music/compliance-qparam-%02d", i),
+		}
+		if err := svc.Create(context.Background(), a); err != nil {
+			t.Fatalf("creating artist %d: %v", i, err)
+		}
+	}
+
+	// Store page_size=10 for the test user.
+	_, err := r.db.ExecContext(context.Background(),
+		`INSERT INTO user_preferences (user_id, key, value, updated_at)
+		 VALUES (?, 'page_size', '10', datetime('now'))
+		 ON CONFLICT(user_id, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+		testUserID)
+	if err != nil {
+		t.Fatalf("storing page_size pref: %v", err)
+	}
+
+	// Request with ?page_size=12 should override the stored pref of 10.
+	ctx := middleware.WithTestUserID(context.Background(), testUserID)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/reports/compliance?page_size=12", nil)
+	w := httptest.NewRecorder()
+	r.handleReportCompliance(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	pageSize, ok := resp["page_size"].(float64)
+	if !ok {
+		t.Fatalf("page_size not present or not a number in response")
+	}
+	if int(pageSize) != 12 {
+		t.Errorf("expected page_size=12 from query param override, got %d", int(pageSize))
 	}
 }

--- a/internal/api/handlers_rule.go
+++ b/internal/api/handlers_rule.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/rule"
 )
@@ -196,6 +197,7 @@ func (r *Router) handleUpdateRule(w http.ResponseWriter, req *http.Request) {
 //
 // GET /api/v1/rules/{id}/results
 func (r *Router) handleRuleResults(w http.ResponseWriter, req *http.Request) {
+	userID := middleware.UserIDFromContext(req.Context())
 	ruleID, ok := RequirePathParam(w, req, "id")
 	if !ok {
 		return
@@ -205,13 +207,7 @@ func (r *Router) handleRuleResults(w http.ResponseWriter, req *http.Request) {
 	if page < 1 {
 		page = 1
 	}
-	pageSize := intQuery(req, "page_size", 50)
-	if _, ok := req.URL.Query()["page_size"]; ok && pageSize < 1 {
-		pageSize = 1
-	}
-	if pageSize > 200 {
-		pageSize = 200
-	}
+	pageSize := r.getUserPageSize(req.Context(), userID, intQuery(req, "page_size", 0))
 	// Clamp page so (page-1)*pageSize cannot overflow int. The bound
 	// matters in principle (a hostile or buggy caller could pass an
 	// enormous page value); in practice no real client gets near it.

--- a/internal/api/handlers_rule_results_test.go
+++ b/internal/api/handlers_rule_results_test.go
@@ -71,7 +71,10 @@ func TestHandleRuleResults_ReturnsPaginatedRows(t *testing.T) {
 		t.Fatalf("seed fail c: %v", err)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/rules/rule-d/results?page=1&page_size=2", nil)
+	// page_size=10 is the minimum accepted value; use it to get exactly 2 of the
+	// 3 rows back (page=1 returns the first 2 but we only have 3 total so page=2
+	// is needed to see the third). Use page_size=10 and assert on total/page.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rules/rule-d/results?page=1&page_size=10", nil)
 	req.SetPathValue("id", "rule-d")
 	w := httptest.NewRecorder()
 	r.handleRuleResults(w, req)
@@ -91,11 +94,12 @@ func TestHandleRuleResults_ReturnsPaginatedRows(t *testing.T) {
 	if env.Total != 3 {
 		t.Errorf("total: got %d, want 3", env.Total)
 	}
-	if env.Page != 1 || env.PageSize != 2 {
-		t.Errorf("page/size: got %d/%d, want 1/2", env.Page, env.PageSize)
+	if env.Page != 1 || env.PageSize != 10 {
+		t.Errorf("page/size: got %d/%d, want 1/10", env.Page, env.PageSize)
 	}
-	if len(env.Rows) != 2 {
-		t.Fatalf("rows len: got %d, want 2", len(env.Rows))
+	// All 3 rows fit within page_size=10, so we expect all three in order.
+	if len(env.Rows) != 3 {
+		t.Fatalf("rows len: got %d, want 3", len(env.Rows))
 	}
 	if env.Rows[0].ArtistID != "p-a" || env.Rows[1].ArtistID != "p-b" {
 		t.Errorf("ordering: got [%s %s], want [p-a p-b]", env.Rows[0].ArtistID, env.Rows[1].ArtistID)
@@ -178,9 +182,10 @@ func TestHandleRuleResults_UnknownRuleReturns200WithEmptyRows(t *testing.T) {
 // TestHandleRuleResults_PageAndPageSizeClamps exercises the clamp
 // branches around page / page_size. Covers:
 //   - page < 1 normalizes to 1
-//   - page_size < 1 (explicitly provided) clamps to 1, NOT the default 50
-//     (this distinction matters: the absent-param case keeps the default)
-//   - page_size > 200 clamps to 200
+//   - page_size=0 (explicit zero) falls through to the user-preference path
+//     and returns PageSizeDefault (50) when no preference is stored
+//   - page_size > PageSizeMax (500) clamps to PageSizeMax via getUserPageSize
+//   - page_size below PageSizeMin (10) clamps to PageSizeMin via getUserPageSize
 //
 // The body shape is checked rather than the row payload; the seed has
 // one passing artist, so the row count is at most 1 in every case.
@@ -200,8 +205,13 @@ func TestHandleRuleResults_PageAndPageSizeClamps(t *testing.T) {
 		wantPageSize int
 	}{
 		{"page<1 normalizes to 1", "page=0&page_size=10", 1, 10},
-		{"page_size<1 explicit clamps to 1", "page=1&page_size=0", 1, 1},
-		{"page_size>200 clamps to 200", "page=1&page_size=500", 1, 200},
+		// page_size=0 signals "no override" to getUserPageSize; no stored
+		// preference means PageSizeDefault (50) is returned.
+		{"page_size=0 falls through to default", "page=1&page_size=0", 1, PageSizeDefault},
+		// getUserPageSize clamps above PageSizeMax (500) to PageSizeMax.
+		{"page_size>PageSizeMax clamps to PageSizeMax", "page=1&page_size=999", 1, PageSizeMax},
+		// getUserPageSize clamps below PageSizeMin (10) to PageSizeMin.
+		{"page_size<PageSizeMin clamps to PageSizeMin", "page=1&page_size=1", 1, PageSizeMin},
 		// page > math.MaxInt/pageSize triggers the overflow guard;
 		// pick a value comfortably above the clamp for pageSize=10.
 		{"page overflow clamps to maxPage", "page=999999999999999999&page_size=10", math.MaxInt / 10, 10},

--- a/internal/api/handlers_rule_test.go
+++ b/internal/api/handlers_rule_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/rule"
 )
@@ -617,5 +619,141 @@ func TestHandleBulkJobStatus_WithJob(t *testing.T) {
 	}
 	if _, ok := resp["items"]; !ok {
 		t.Error("response missing items field")
+	}
+}
+
+// TestHandleRuleResults_RespectsPageSizePref verifies that the rule-results
+// handler respects the per-user page_size preference when no query param is
+// provided.
+func TestHandleRuleResults_RespectsPageSizePref(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouter(t)
+
+	const testUserID = "test-user-rule-pagesize"
+
+	ruleID := firstRuleID(t, r.ruleService)
+
+	// Seed more artists with rule results than the preference value so the cap
+	// is observable.
+	evaluatedAt := time.Now().UTC()
+	for i := 0; i < 15; i++ {
+		a := &artist.Artist{
+			Name: fmt.Sprintf("Rule Artist %02d", i),
+			Path: fmt.Sprintf("/music/rule-%02d", i),
+		}
+		if err := artistSvc.Create(context.Background(), a); err != nil {
+			t.Fatalf("creating artist %d: %v", i, err)
+		}
+		if err := r.ruleService.UpsertRuleResultPass(context.Background(), a.ID, ruleID, evaluatedAt); err != nil {
+			t.Fatalf("upserting rule result %d: %v", i, err)
+		}
+	}
+
+	// Store page_size=10 directly in the DB for the test user.
+	_, err := r.db.ExecContext(context.Background(),
+		`INSERT INTO user_preferences (user_id, key, value, updated_at)
+		 VALUES (?, 'page_size', '10', datetime('now'))
+		 ON CONFLICT(user_id, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+		testUserID)
+	if err != nil {
+		t.Fatalf("storing page_size pref: %v", err)
+	}
+
+	ctx := middleware.WithTestUserID(context.Background(), testUserID)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/rules/"+ruleID+"/results", nil)
+	req.SetPathValue("id", ruleID)
+	w := httptest.NewRecorder()
+	r.handleRuleResults(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	pageSize, ok := resp["page_size"].(float64)
+	if !ok {
+		t.Fatalf("page_size not present or not a number in response")
+	}
+	if int(pageSize) != 10 {
+		t.Errorf("expected page_size=10 from preference, got %d", int(pageSize))
+	}
+
+	rows, ok := resp["rows"].([]any)
+	if !ok {
+		t.Fatalf("rows not present or not an array in response")
+	}
+	if len(rows) > 10 {
+		t.Errorf("expected at most 10 rows, got %d", len(rows))
+	}
+}
+
+// TestHandleRuleResults_QueryParamOverridesPref verifies that an explicit
+// page_size query parameter takes precedence over the stored user preference.
+func TestHandleRuleResults_QueryParamOverridesPref(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouter(t)
+
+	const testUserID = "test-user-rule-qparam"
+
+	ruleID := firstRuleID(t, r.ruleService)
+
+	evaluatedAt := time.Now().UTC()
+	for i := 0; i < 15; i++ {
+		a := &artist.Artist{
+			Name: fmt.Sprintf("QP Rule Artist %02d", i),
+			Path: fmt.Sprintf("/music/qp-rule-%02d", i),
+		}
+		if err := artistSvc.Create(context.Background(), a); err != nil {
+			t.Fatalf("creating artist %d: %v", i, err)
+		}
+		if err := r.ruleService.UpsertRuleResultPass(context.Background(), a.ID, ruleID, evaluatedAt); err != nil {
+			t.Fatalf("upserting rule result %d: %v", i, err)
+		}
+	}
+
+	_, err := r.db.ExecContext(context.Background(),
+		`INSERT INTO user_preferences (user_id, key, value, updated_at)
+		 VALUES (?, 'page_size', '10', datetime('now'))
+		 ON CONFLICT(user_id, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+		testUserID)
+	if err != nil {
+		t.Fatalf("storing page_size pref: %v", err)
+	}
+
+	// Use page_size=12 (valid, in [PageSizeMin, PageSizeMax], different from the
+	// stored preference of 10) to verify the query param takes precedence.
+	ctx := middleware.WithTestUserID(context.Background(), testUserID)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/rules/"+ruleID+"/results?page_size=12", nil)
+	req.SetPathValue("id", ruleID)
+	w := httptest.NewRecorder()
+	r.handleRuleResults(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	pageSize, ok := resp["page_size"].(float64)
+	if !ok {
+		t.Fatalf("page_size not present or not a number in response")
+	}
+	if int(pageSize) != 12 {
+		t.Errorf("expected page_size=12 from query param, got %d", int(pageSize))
+	}
+
+	rows, ok := resp["rows"].([]any)
+	if !ok {
+		t.Fatalf("rows not present or not an array in response")
+	}
+	if len(rows) > 12 {
+		t.Errorf("expected at most 12 rows with query param override, got %d", len(rows))
 	}
 }

--- a/internal/api/testdata/openapi-coverage-baseline.json
+++ b/internal/api/testdata/openapi-coverage-baseline.json
@@ -39,7 +39,6 @@
   "listAPITokens",
   "listAliases",
   "listFanart",
-  "listLockedArtists",
   "listLogFiles",
   "listNotifications",
   "listPlatforms",

--- a/internal/api/testdata/openapi-coverage.json
+++ b/internal/api/testdata/openapi-coverage.json
@@ -1033,7 +1033,7 @@
     "method": "GET",
     "path": "/artists/locked",
     "handler": "handleListLockedArtists",
-    "covered": false
+    "covered": true
   },
   {
     "operationId": "listLogFiles",


### PR DESCRIPTION
## Summary

Makes all paginated list screens respect the per-user **Page Size** preference instead of hardcoding 50. Applies the established `getUserPageSize` pattern (already used by the artists list and dashboard) to the three screens named in the issue that were still hardcoding their page size.

Fixes:
- **Locked artists** (`handleListLockedArtists`)
- **Rule results** (`handleRuleResults`) — also drops the now-redundant inline `page_size` clamping (`getUserPageSize` clamps to `[PageSizeMin, PageSizeMax]`); the page-number overflow guard is retained.
- **Compliance report** (`handleComplianceReport` / `complianceListParams`) — this one was missed by the original plan; surfaced by a sweep of all paginated handlers. `complianceListParams` became a `(r *Router)` method so it can read the pref, and `complianceURLValues` now echoes `page_size` to the HX-Push-Url **only when the user explicitly overrides** their pref (`rawQuery.Has("page_size")`), keeping the URL minimal at the default. The now-unused `compliancePageSizeDefault` const was removed.

## Testing

- New relational-assertion tests per screen (seed > pref items, set the pref small, assert the returned count/`page_size` respects the pref, not 50) plus query-param-override tests.
- `complianceURLValues` unit test updated to cover the new "omit at pref / echo on explicit override" behavior.
- `go build ./...` clean; `go test ./internal/api/...` passes.
- No UAT: these are legacy (stable) UX screens; the next/ screens reuse the now-compliant shared handlers.

## Notes

- No new endpoints, routes, or OpenAPI changes (the openapi-coverage ratchet baseline was updated since `listLockedArtists` is now covered).
- `internal/api/handlers_identify.go`'s `const pageSize = 200` loops are internal full-scans, not user pagination — intentionally left as-is.

Closes #1801


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Listing and report pages now respect per-user pagination preferences and still allow an explicit page_size query to override the stored value.
  * Canonical/pushed URLs now omit implicit default page_size (they only echo page_size if it was explicitly present in the request).

* **Tests**
  * Added tests covering pagination-preference behavior and query-parameter overrides across reports, rules, and locked-artist listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->