### PR TITLE
chore(ci): eliminate tool-version drift by removing redundant pre-commit pins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,16 @@
 # pre-commit framework (https://pre-commit.com). The canonical hook
 # wired via `core.hooksPath = .githooks` is `.githooks/pre-commit`,
 # which mirrors these checks in plain bash and is what CI expects.
-# Tool version pins below should stay in sync with the canonical hook and CI
-# (the tracked tools: markdownlint-cli2, golangci-lint, typos, and Tailwind).
-# scripts/check-tool-versions.sh asserts these agree across all entrypoints
-# and runs in the pre-push gate, so a drift here fails before push.
+#
+# The lint/spell tools that CI and the canonical hook already run
+# (golangci-lint, crate-ci/typos, markdownlint-cli2) are intentionally NOT
+# duplicated here. Their `rev:` pins used to live in this file as a redundant
+# second copy, but Dependabot's github-actions ecosystem could never sync them
+# (Dependabot has no pre-commit ecosystem), so every tool bump landed as a
+# tool-version-drift gate failure and stalled the auto-merge pipeline. Those
+# tools are enforced by .githooks/pre-commit and CI instead; only generic file
+# hygiene, secret/action linting, conventional commits, and the repo-local
+# generate hooks remain here.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -24,34 +30,15 @@ repos:
         args: ["--maxkb=500"]
       - id: check-merge-conflict
 
-  - repo: https://github.com/crate-ci/typos
-    # Keep in sync with .github/workflows/docs.yml (crate-ci/typos SHA pin).
-    # Dependabot bumps the docs.yml pin; run `make sync-tool-versions` to mirror
-    # the new version here (Dependabot cannot edit pre-commit rev: pins itself).
-    rev: v1.47.0
-    hooks:
-      - id: typos
-
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.0
     hooks:
       - id: gitleaks
 
-  - repo: https://github.com/golangci/golangci-lint
-    # rev must match the version pinned in .github/workflows/ci.yml's golangci-lint-action step to prevent cross-version //nolint drift; see #1560
-    rev: v2.12.2
-    hooks:
-      - id: golangci-lint
-
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12
     hooks:
       - id: actionlint
-
-  - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.22.1
-    hooks:
-      - id: markdownlint-cli2
 
   - repo: local
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -120,10 +120,10 @@ docker-stop:
 check-openapi:
 	go test -count=1 -run TestOpenAPIConsistency -v ./internal/api/
 
-## sync-tool-versions: Mirror CI-side tool versions into the pins Dependabot cannot edit
-##   Use after a Dependabot tool bump (e.g. crate-ci/typos) drifts the Tool Version
-##   Drift gate: this rewrites the .pre-commit-config.yaml rev: (and Dockerfile
-##   TAILWIND_VERSION) to match the CI/source side. Review and commit the result.
+## sync-tool-versions: Mirror the CI-side Tailwind version into the Dockerfile pin
+##   Use when the Tool Version Drift gate reports the setup-tailwind action and
+##   build/docker/Dockerfile TAILWIND_VERSION disagree: this rewrites the
+##   Dockerfile pin to match the action. Review and commit the result.
 sync-tool-versions:
 	@./scripts/check-tool-versions.sh --fix
 

--- a/docs/_generated/make-commands.md
+++ b/docs/_generated/make-commands.md
@@ -25,7 +25,7 @@
 | `make docker-run` | Run Docker container |
 | `make docker-stop` | Stop Docker container |
 | `make check-openapi` | Verify OpenAPI spec matches handler implementations |
-| `make sync-tool-versions` | Mirror CI-side tool versions into the pins Dependabot cannot edit |
+| `make sync-tool-versions` | Mirror the CI-side Tailwind version into the Dockerfile pin |
 | `make hooks` | Install git hooks (pre-commit lint, pre-push gate) |
 | `make doctor` | Verify hook wiring without modifying anything |
 | `make worktree` | Create a sibling worktree with hooks wired and tracker row inserted into the Active table |

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -1,35 +1,32 @@
 #!/usr/bin/env bash
-# check-tool-versions.sh -- assert lint/spell tool versions agree across the
-# multiple entrypoints that each pin them independently:
+# check-tool-versions.sh -- assert the Tailwind version pinned for CI agrees
+# with the version pinned for the Docker image:
 #
-#   * .githooks/pre-commit        (canonical bash hook; npx pin for markdownlint)
-#   * .pre-commit-config.yaml     (pre-commit framework alternative; rev: pins)
-#   * .github/workflows/ci.yml    (golangci-lint-action version:)
-#   * .github/workflows/docs.yml  (crate-ci/typos SHA pin + "# vX.Y.Z" comment)
+#   * .github/actions/setup-tailwind (the CI glibc x64 pin)
+#   * build/docker/Dockerfile         (the musl pins)
 #
-# It also asserts TAILWIND_VERSION parity between the composite action
-# (.github/actions/setup-tailwind, the CI glibc x64 pin) and build/docker/Dockerfile
-# (the musl pins); only the version is shared, the SHAs intentionally differ.
+# Only the version is the shared invariant; the SHAs intentionally differ per
+# libc/arch and are maintained independently. A version drift between these two
+# is a silent correctness gap (CI lints with one Tailwind, the shipped image
+# builds with another), so this guard fails the pre-push gate when they differ.
 #
-# A version drift between these is a silent correctness gap: a contributor's
-# local hook can pass while CI fails (or vice versa) on the same tree, and
-# //nolint directives can resolve differently across golangci-lint minor
-# versions (#1560). This guard fails the pre-push gate when any pair drifts.
-#
-# Dependabot angle: Dependabot updates the CI-side pins (e.g. the crate-ci/typos
-# SHA in docs.yml via its github-actions ecosystem) but has NO pre-commit
-# ecosystem, so it cannot touch the matching `.pre-commit-config.yaml` rev:.
-# A typos bump therefore drifts this gate and stalls the auto-merge pipeline.
-# Run this script with --fix (or `make sync-tool-versions`) to mirror the
-# CI-side version into the pin Dependabot cannot reach, then push the one-line
-# follow-up commit onto the Dependabot branch so its required checks re-run.
+# History: this script previously also asserted that the lint/spell tool
+# versions (golangci-lint, crate-ci/typos, markdownlint-cli2) matched between
+# the CI side and the `rev:` pins in .pre-commit-config.yaml. Those pre-commit
+# `rev:` pins were a redundant second copy: the canonical hook
+# (.githooks/pre-commit, wired via core.hooksPath) and CI already run those
+# tools, and Dependabot has no pre-commit ecosystem, so it could never sync the
+# `rev:` side -- every github-actions tool bump landed here as drift and stalled
+# the auto-merge pipeline. The redundant lint hooks were removed from
+# .pre-commit-config.yaml so there is nothing left to drift; only the Tailwind
+# parity (which Dependabot does not touch) remains.
 #
 # Usage:
 #   check-tool-versions.sh          verify only (default; used by the gate)
-#   check-tool-versions.sh --fix    rewrite each drifted derived pin to match
-#                                   its canonical (CI/source) side, then report
+#   check-tool-versions.sh --fix    rewrite the Dockerfile TAILWIND_VERSION to
+#                                   match the CI/source side, then report
 #
-# Exit: 0 = all aligned (or, with --fix, all drifts were auto-fixed),
+# Exit: 0 = aligned (or, with --fix, the drift was auto-fixed),
 #       1 = drift detected in verify mode or a pin could not be located.
 set -euo pipefail
 
@@ -54,47 +51,6 @@ cd "$REPO_ROOT"
 
 errors=0
 fixed=0
-
-# Extract the `rev:` value that follows a given repo URL substring in
-# .pre-commit-config.yaml. The pre-commit format lists `- repo: <url>` then a
-# `rev:` line, so track whether we are inside the wanted repo block. Returns
-# empty (handled by the caller) if the repo or its rev is absent.
-precommit_rev() {
-  awk -v want="$1" '
-    /^[[:space:]]*-[[:space:]]*repo:/ { inrepo = (index($0, want) > 0); next }
-    inrepo && /^[[:space:]]*rev:/ {
-      sub(/^[[:space:]]*rev:[[:space:]]*/, "")  # drop the "rev:" key
-      sub(/[[:space:]]*#.*/, "")                # drop any inline comment
-      gsub(/[\042\047\r]/, "")                  # drop quotes (" and ) and CR
-      sub(/[[:space:]]+$/, "")                  # drop trailing whitespace
-      print
-      exit
-    }
-  ' .pre-commit-config.yaml
-}
-
-# Rewrite the `rev:` value inside the `.pre-commit-config.yaml` block whose
-# `- repo:` line contains <want>, preserving indentation and any trailing
-# comment. Only the first rev: in the block is touched. Used by --fix to mirror
-# a CI-side version into the pin Dependabot cannot reach.
-fix_precommit_rev() {
-  local want="$1" newver="$2" file=".pre-commit-config.yaml" tmp
-  tmp="$(mktemp)"
-  awk -v want="$want" -v newver="$newver" '
-    /^[[:space:]]*-[[:space:]]*repo:/ { inrepo = (index($0, want) > 0) }
-    inrepo && /^[[:space:]]*rev:/ {
-      match($0, /^[[:space:]]*rev:[[:space:]]*/)   # capture "  rev: " prefix
-      prefix = substr($0, 1, RLENGTH)
-      rest = substr($0, RLENGTH + 1)
-      comment = ""                                  # keep any trailing "# ..."
-      if (match(rest, /[[:space:]]*#.*/)) { comment = substr(rest, RSTART) }
-      print prefix newver comment
-      inrepo = 0                                    # first rev only
-      next
-    }
-    { print }
-  ' "$file" >"$tmp" && mv "$tmp" "$file"
-}
 
 # Rewrite every TAILWIND_VERSION=vX.Y.Z token in the Dockerfile (the musl pins)
 # to <newver>. The SHAs intentionally differ per libc/arch and are left alone.
@@ -139,41 +95,6 @@ require() {
 # Each extraction ends in `|| true` so a grep miss (exit 1) does not abort the
 # script under `set -e`/`pipefail`; an empty result is reported by require().
 
-# golangci-lint: ci.yml golangci-lint-action `version:` vs pre-commit-config rev.
-# Bound the scan to the golangci-lint-action step. Steps begin with a `- ` list
-# item (often `- name:` with `uses:` on the next line), so reset in_block at every
-# new list item and set it true on the line naming the action. `version:` is then
-# read only from within that step; if the action ever drops its `version:` input,
-# a later step's `version:` is not silently picked up.
-gci_ci=$(awk '
-  /^[[:space:]]*-[[:space:]]/ { in_block = 0 }
-  /golangci\/golangci-lint-action/ { in_block = 1 }
-  in_block && /^[[:space:]]*version:[[:space:]]*v[0-9]/ {
-    sub(/^[[:space:]]*version:[[:space:]]*/, "")
-    print
-    exit
-  }
-' .github/workflows/ci.yml || true)
-gci_pc=$(precommit_rev 'golangci/golangci-lint' || true)
-require "golangci-lint" "$gci_ci" "$gci_pc" "ci.yml" ".pre-commit-config.yaml" \
-  fix_precommit_rev 'golangci/golangci-lint'
-
-# typos: docs.yml SHA-pin "# vX.Y.Z" comment vs pre-commit-config rev.
-typos_ci=$(grep -E 'crate-ci/typos@' .github/workflows/docs.yml \
-  | grep -oE '#[[:space:]]*v[0-9.]+' | grep -oE 'v[0-9.]+' | head -1 || true)
-typos_pc=$(precommit_rev 'crate-ci/typos' || true)
-require "typos" "$typos_ci" "$typos_pc" "docs.yml" ".pre-commit-config.yaml" \
-  fix_precommit_rev 'crate-ci/typos'
-
-# markdownlint-cli2: bash-hook npx pin vs pre-commit-config rev. (docs.yml uses
-# the markdownlint-cli2-ACTION, whose version is independent of the bundled
-# tool version, so it is intentionally not compared here.)
-mdl_hook=$(grep -oE 'markdownlint-cli2@v[0-9.]+' .githooks/pre-commit \
-  | grep -oE 'v[0-9.]+' | head -1 || true)
-mdl_pc=$(precommit_rev 'DavidAnson/markdownlint-cli2' || true)
-require "markdownlint-cli2" "$mdl_hook" "$mdl_pc" ".githooks/pre-commit" ".pre-commit-config.yaml" \
-  fix_precommit_rev 'DavidAnson/markdownlint-cli2'
-
 # Tailwind: the composite action (CI glibc x64 binary) and the Dockerfile (musl
 # binaries) pin the SAME TAILWIND_VERSION but DIFFERENT SHAs. Only the version is
 # a shared invariant, so assert just the version here; the SHAs intentionally
@@ -188,9 +109,8 @@ require "tailwind" "$tw_action" "$tw_docker" ".github/actions/setup-tailwind" "b
 if [ "$errors" -gt 0 ]; then
   echo "" >&2
   echo "$errors tool-version drift error(s)." >&2
-  echo "Run 'make sync-tool-versions' to mirror the CI-side versions into the" >&2
-  echo "derived pins, then commit the result. (Dependabot cannot edit pre-commit" >&2
-  echo "rev: pins, so its tool bumps land here as drift -- this is the fix.)" >&2
+  echo "Run 'make sync-tool-versions' to mirror the CI-side Tailwind version into" >&2
+  echo "the Dockerfile pin, then commit the result." >&2
   exit 1
 fi
 if [ "$fixed" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- Stop the Tool Version Drift gate from flagging Dependabot `github-actions` bumps. The matching `.pre-commit-config.yaml` `rev:` pins (typos, golangci-lint, markdownlint-cli2) were a redundant second copy Dependabot could never sync (no pre-commit ecosystem), so every bump landed as drift and needed a manual `make sync-tool-versions` follow-up. (Live example: #1905 bumped `crate-ci/typos` 1.47.0 -> 1.47.2 on `main`.)
- Those tools are already enforced by the canonical `.githooks/pre-commit` (wired via `core.hooksPath`, what CI runs) and by CI directly, so the pre-commit copies were redundant. Removing them eliminates the drift at the source: nothing left to sync.
- The gate now asserts only the legitimate Tailwind action-vs-Dockerfile version parity, which Dependabot never touches.

## Linked issue

None. (The companion permission fix originally bundled here, #1896, already landed on `main` via #1897, so it was dropped during rebase.)

## Pre-flight checklist

- [x] Pre-push gate green locally (ran on push via the pre-push hook).
- [x] Code review pass: N/A for this change set (yaml/bash/docs only); local CR explicitly skipped by maintainer.
- [x] Commits squashed into a single commit.
- [x] At least one label set.
- [x] Docs label decision made: `docs: not-required` (CI/refactor, no user-visible behavior change).
- [ ] Screenshot attached for any UI change. (N/A.)
- [ ] UAT performed for user-visible changes. (N/A - CI/tooling only.)
- [x] OpenAPI spec updated if shapes changed. (N/A.)
- [x] `templ generate` re-run. (N/A - no `.templ` change.)

## Test plan

- [x] `bash scripts/pre-push-gate.sh` passes locally (via pre-push hook on push).
- [x] `bash scripts/check-tool-versions.sh` -> `OK: tailwind v4.2.0`, aligned.
- [ ] Reviewer follow-ups:
  - [ ] Confirm dropping typos/golangci/markdownlint from the pre-commit *framework* config is acceptable (still enforced by `.githooks/pre-commit` + CI; framework-only users lose those local runs).

## Notes

A pre-existing flaky test (`TestRunBulkAction_TerminalCanceledWithFailures`, `internal/api`) surfaced during this PR's gate run and is tracked separately in #1908. It is unrelated to this diff (passes 5/5 in isolation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified development configuration by removing duplicate tool version checks already enforced in CI and canonical pre-commit hooks.
  * Consolidated tool version enforcement to focus on critical dependency alignment between deployment and development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->