### PR TITLE
test(api): make bulk-action SSE terminal-event tests deterministic (#1908)

### DIFF
--- a/internal/api/handlers_bulk_actions_test.go
+++ b/internal/api/handlers_bulk_actions_test.go
@@ -707,10 +707,11 @@ func TestRunBulkAction_StartEmit(t *testing.T) {
 		t.Fatalf("status = %d, want 202; body: %s", w.Code, w.Body.String())
 	}
 	waitBulkActionCompleted(t, r)
-	// Allow the terminal publish to drain through the bus's worker.
-	time.Sleep(50 * time.Millisecond)
-
-	evts := rec.snapshot()
+	// Poll for the terminal publish to drain through the bus's worker
+	// instead of racing a fixed sleep (flaky under load, #1908).
+	evts := rec.waitUntil(t, func(evts []event.Event) bool {
+		return len(evts) > 0 && evts[len(evts)-1].Data["status"] == "completed"
+	}, "terminal completed event")
 	if len(evts) < 2 {
 		t.Fatalf("emitted events = %d, want at least 2 (start + terminal); got %+v", len(evts), evts)
 	}
@@ -769,8 +770,18 @@ func TestRunBulkAction_ThrottleBoundaries(t *testing.T) {
 				t.Fatalf("status = %d, want 202; body: %s", w.Code, w.Body.String())
 			}
 			waitBulkActionCompleted(t, r)
-			time.Sleep(100 * time.Millisecond)
-			got := extractProcessedIndices(rec.snapshot())
+			// Poll for a terminal event rather than racing a fixed sleep (#1908).
+			evts := rec.waitUntil(t, func(evts []event.Event) bool {
+				if len(evts) == 0 {
+					return false
+				}
+				switch evts[len(evts)-1].Data["status"] {
+				case "completed", "failed", "canceled":
+					return true
+				}
+				return false
+			}, "terminal event")
+			got := extractProcessedIndices(evts)
 			if !equalInts(got, tc.want) {
 				t.Errorf("running indices = %v, want %v", got, tc.want)
 			}
@@ -806,8 +817,10 @@ func TestRunBulkAction_TerminalCompleted(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.handleBulkAction(w, req)
 	waitBulkActionCompleted(t, r)
-	time.Sleep(50 * time.Millisecond)
-	evts := rec.snapshot()
+	// Poll for the terminal event rather than racing a fixed sleep (#1908).
+	evts := rec.waitUntil(t, func(evts []event.Event) bool {
+		return len(evts) > 0 && evts[len(evts)-1].Data["status"] == "completed"
+	}, "terminal completed event")
 	last := evts[len(evts)-1]
 	if last.Data["status"] != "completed" {
 		t.Errorf("terminal status = %v, want completed; events=%+v", last.Data["status"], evts)
@@ -837,8 +850,10 @@ func TestRunBulkAction_TerminalFailed(t *testing.T) {
 	// The progress reaches Status=completed even when every per-artist
 	// run failed (the goroutine fully processed every ID). Wait on that.
 	waitBulkActionCompleted(t, r)
-	time.Sleep(50 * time.Millisecond)
-	evts := rec.snapshot()
+	// Poll for the terminal event rather than racing a fixed sleep (#1908).
+	evts := rec.waitUntil(t, func(evts []event.Event) bool {
+		return len(evts) > 0 && evts[len(evts)-1].Data["status"] == "failed"
+	}, "terminal failed event")
 	last := evts[len(evts)-1]
 	if last.Data["status"] != "failed" {
 		t.Errorf("terminal status = %v, want failed; events=%+v", last.Data["status"], evts)
@@ -938,11 +953,12 @@ func TestRunBulkAction_TerminalCanceledWithFailures(t *testing.T) {
 		t.Errorf("progress.Failed = %d, want >= 1 (first artist failed before cancel)", failed)
 	}
 
-	time.Sleep(100 * time.Millisecond)
-	evts := rec.snapshot()
-	if len(evts) == 0 {
-		t.Fatal("no events recorded")
-	}
+	// Poll for the terminal canceled event rather than racing a fixed sleep:
+	// the in-memory Status flips to canceled slightly before the terminal SSE
+	// event is published and recorded, so a fixed wait flaked under load (#1908).
+	evts := rec.waitUntil(t, func(evts []event.Event) bool {
+		return len(evts) > 0 && evts[len(evts)-1].Data["status"] == "canceled"
+	}, "terminal canceled event")
 	last := evts[len(evts)-1]
 	if last.Data["status"] != "canceled" {
 		t.Errorf("terminal event status = %v, want canceled (cancel supersedes failed); events=%+v", last.Data["status"], evts)


### PR DESCRIPTION
## Summary

- Fix five flaky bulk-action SSE tests in `internal/api/handlers_bulk_actions_test.go`. Each waited for the terminal SSE event with a fixed `time.Sleep(50/100ms)` before snapshotting the event recorder.
- The in-memory progress `Status` flips to its terminal value slightly *before* the terminal SSE event is published and recorded, so under `-race` / CI load the fixed wait could expire first and the snapshot would still end on a `status:running` progress event. This flake reds-out unrelated PR gates (it blocked #1907's first push).
- Each fixed sleep is replaced with the existing `waitUntil(t, pred, what)` helper (polls every 5ms to a 1s deadline) with a predicate asserting the last recorded event carries the expected terminal status. Deterministic, and returns the instant the event lands instead of always waiting the full fixed duration (a small, free speedup as a side effect).

## Linked issue

Closes #1908

## Pre-flight checklist

- [x] Pre-push gate green locally (ran on push via the pre-push hook).
- [x] Code review pass: change is test-only and self-contained.
- [x] Commits squashed into a single commit.
- [x] At least one label set.
- [x] Docs label decision made: `docs: not-required` (test-only, no user-visible behavior change).
- [ ] Screenshot for UI change. (N/A.)
- [ ] UAT for user-visible changes. (N/A - test-only.)
- [x] OpenAPI spec updated if shapes changed. (N/A.)
- [x] `templ generate` re-run. (N/A.)

## Test plan

- [x] `go test -race -count=20 -run TestRunBulkAction ./internal/api/` -> clean (`ok`, 31.7s), no flake across 20 iterations.
- [x] `go vet ./internal/api/` clean; gofmt + golangci-lint green in pre-commit.

## Scope note

This converts the five sleep-then-snapshot sites in this file. The same anti-pattern in ~10 other test files (and a small DRY cleanup of the two in-memory-progress poll loops here) is tracked separately in #1910 (Milestone 55.5), not bundled here.