### PR TITLE
chore(docker): drop curl from runtime image, retire grype curl/nghttp2 ignores (#1914)

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -4,46 +4,4 @@
 # Remove entries once the upstream fix lands in Alpine stable.
 # The grype-ignore-expiry job in security.yml fails when entries expire.
 
-ignore:
-  # curl 8.17.0 -- no fix in Alpine 3.23-main as of 2026-05-11.
-  # v3.23 still carries 8.17.0-r1; fix is 8.19.0-r0 in edge-main only.
-  # Upstream: https://security.alpinelinux.org/vuln/CVE-2026-3805
-  - vulnerability: CVE-2026-3805
-    package:
-      name: curl
-      type: apk
-    review-by: "2026-06-09"
-    reason: "Alpine 3.23 still on 8.17.0-r1; fix 8.19.0-r0 not yet backported"
-
-  # nghttp2 1.68.0 -- no fix in Alpine 3.23-main as of 2026-05-11.
-  # v3.23 still carries 1.68.0-r0; fix 1.68.1 not yet released in this branch.
-  # Upstream: https://security.alpinelinux.org/vuln/CVE-2026-27135
-  - vulnerability: CVE-2026-27135
-    package:
-      name: nghttp2-libs
-      type: apk
-    review-by: "2026-06-09"
-    reason: "Alpine 3.23 still on 1.68.0-r0; fix 1.68.1 not yet backported"
-
-  # curl 8.19.0-r0 -- no fix in Alpine 3.23-main as of 2026-05-19.
-  # v3.23 still carries 8.19.0-r0; fix is 8.20.0-r0 in edge-main only.
-  # Practical reachability is nil: curl ships in the runtime image only to
-  # back the Docker HEALTHCHECK, which probes a fixed localhost URL with
-  # no attacker-controllable input. Stillwater itself does not invoke curl.
-  # Upstream: https://security.alpinelinux.org/vuln/CVE-2026-5773
-  - vulnerability: CVE-2026-5773
-    package:
-      name: curl
-      type: apk
-    review-by: "2026-06-19"
-    reason: "Alpine 3.23 still on 8.19.0-r0; fix 8.20.0-r0 in edge-main only. Used only by Docker healthcheck."
-
-  # curl 8.19.0-r0 -- no fix in Alpine 3.23-main as of 2026-05-19.
-  # Same upstream-lag situation and reachability assessment as CVE-2026-5773.
-  # Upstream: https://security.alpinelinux.org/vuln/CVE-2026-6276
-  - vulnerability: CVE-2026-6276
-    package:
-      name: curl
-      type: apk
-    review-by: "2026-06-19"
-    reason: "Alpine 3.23 still on 8.19.0-r0; fix 8.20.0-r0 in edge-main only. Used only by Docker healthcheck."
+ignore: []

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -49,7 +49,7 @@ LABEL org.opencontainers.image.source="https://github.com/sydlexius/stillwater" 
       org.opencontainers.image.description="Artist metadata and image manager for Emby, Jellyfin, and Kodi" \
       org.opencontainers.image.licenses="GPL-3.0"
 
-RUN apk add --no-cache ca-certificates tzdata su-exec curl && \
+RUN apk add --no-cache ca-certificates tzdata su-exec && \
     apk upgrade --no-cache
 
 # Create app user (guarded: GID/UID may already be claimed after apk upgrade)
@@ -81,10 +81,10 @@ EXPOSE ${SW_TLS_PORT}/udp
 
 # Healthcheck. The shell-expanded URL lets the entrypoint override
 # SW_HEALTH_URL when SW_TLS_CERT_FILE is set so the probe targets HTTPS on
-# the right port. -k is intentional: a localhost healthcheck against a
-# self-signed cert is acceptable.
+# the right port. --no-check-certificate is intentional: a localhost
+# healthcheck against a self-signed cert is acceptable.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD sh -c 'curl -fsk "${SW_HEALTH_URL:-http://localhost:${SW_PORT:-1973}${SW_BASE_PATH:-}/api/v1/health}" || exit 1'
+  CMD wget -q -O /dev/null --no-check-certificate "${SW_HEALTH_URL:-http://localhost:${SW_PORT:-1973}${SW_BASE_PATH:-}/api/v1/health}" || exit 1
 
 VOLUME ["/config", "/music"]
 

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -1,6 +1,6 @@
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
-RUN apk add --no-cache ca-certificates tzdata su-exec curl && \
+RUN apk add --no-cache ca-certificates tzdata su-exec && \
     apk upgrade --no-cache
 
 # Create app user (guarded: GID/UID may already be claimed after apk upgrade)
@@ -34,7 +34,7 @@ EXPOSE 1973/udp
 EXPOSE ${SW_TLS_PORT}/udp
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD sh -c 'curl -fsk "${SW_HEALTH_URL:-http://localhost:${SW_PORT:-1973}${SW_BASE_PATH:-}/api/v1/health}" || exit 1'
+  CMD wget -q -O /dev/null --no-check-certificate "${SW_HEALTH_URL:-http://localhost:${SW_PORT:-1973}${SW_BASE_PATH:-}/api/v1/health}" || exit 1
 
 VOLUME ["/config", "/music"]
 

--- a/docs/site/src/how-to/direct-tls-setup.md
+++ b/docs/site/src/how-to/direct-tls-setup.md
@@ -77,7 +77,7 @@ Once Stillwater detects a TLS connection, it automatically sets a strict `Strict
 
 ## Docker healthcheck
 
-The container's healthcheck targets `localhost` over the configured protocol. When `SW_TLS_CERT_FILE` is set, the entrypoint exports `SW_HEALTH_URL` so the probe uses HTTPS on the right port. The probe runs with `curl -k` to skip cert verification -- this is intentional, because a localhost healthcheck against a self-signed cert would otherwise fail for the wrong reason. You do not need to set `SW_HEALTH_URL` yourself; setting `SW_TLS_CERT_FILE` is enough.
+The container's healthcheck targets `localhost` over the configured protocol. When `SW_TLS_CERT_FILE` is set, the entrypoint exports `SW_HEALTH_URL` so the probe uses HTTPS on the right port. The probe runs with `wget --no-check-certificate` to skip cert verification -- this is intentional, because a localhost healthcheck against a self-signed cert would otherwise fail for the wrong reason. You do not need to set `SW_HEALTH_URL` yourself; setting `SW_TLS_CERT_FILE` is enough.
 
 ## ACME and HTTP redirect
 


### PR DESCRIPTION
`curl` was present in the Stillwater runtime Docker image solely as the `HEALTHCHECK` client, which introduced CVE-tracked surface area (curl + nghttp2) that required ongoing grype ignore entries. This PR replaces the `HEALTHCHECK` with busybox `wget --no-check-certificate`, removes `curl` from both Dockerfiles, and deletes all 4 grype ignore entries that were covering curl and nghttp2. The direct-tls-setup.md documentation reference to curl is also updated.

Note: the issue described 3 grype ignore entries but the file contained 4 - all 4 have been removed.

Closes #1914

## Verification

- `curl` removed from both Dockerfiles; `HEALTHCHECK` uses `busybox wget --no-check-certificate`
- Docker build completes; container reaches healthy state
- `grype` scan clean at `--fail-on high` with all 4 ignore entries removed
- `hadolint` clean; pre-push gate GREEN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Re-enabled vulnerability scanning by clearing previous CVE ignore list.

* **Chores**
  * Removed curl dependency from Docker images.
  * Updated container healthcheck mechanism to use wget instead of curl.

* **Documentation**
  * Updated Docker TLS setup guide with revised healthcheck details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->