### PR TITLE
chore(github): add chore/CI PR template (#1909)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/chore.md
+++ b/.github/PULL_REQUEST_TEMPLATE/chore.md
@@ -1,0 +1,25 @@
+## Summary
+
+- What changed and why (focus on the why; 1-3 bullets).
+- Note anything reviewers should look at first.
+
+## Linked issue
+
+Closes #
+
+(Use `Part of #N` for a slice of a larger issue that is not yet fully resolved.)
+
+## Pre-flight checklist
+
+- [ ] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`), or run via `/prep-pr` / `/pr-review-toolkit:review-pr` which invokes it.
+- [ ] Code review pass complete (`/prep-pr` or `/pr-review-toolkit:review-pr`); critical and important findings fixed before pushing.
+- [ ] Commits squashed into clean, logical commits before the first push.
+- [ ] At least one label set on `gh pr create --label ...` (the CI label gate fails without one).
+- [ ] Docs label decision made: `docs: not-required` for chore/CI/refactor PRs with no user-visible behavioral change.
+
+## Test plan
+
+- [ ] `go test -race ./...` passes locally.
+- [ ] `bash scripts/pre-push-gate.sh` passes locally.
+- [ ] Reviewer follow-ups (anything you want a second pair of eyes on):
+  - [ ]

--- a/docs/pr-workflow.md
+++ b/docs/pr-workflow.md
@@ -56,6 +56,24 @@ When creating a GitHub issue with `gh issue create`:
    ```
 4. Delete the temp file after creation.
 
+## PR templates
+
+Two PR templates are available:
+
+- **Default** (`.github/pull_request_template.md`) -- for feature, bug, and user-visible change PRs. Applied automatically when opening a PR via `gh pr create` with no `--body`/`--body-file` flag, or via the GitHub compare URL without a `?template=` parameter.
+- **Chore** (`.github/PULL_REQUEST_TEMPLATE/chore.md`) -- for chore, CI, refactor, and dependency PRs. Omits screenshot, UAT, OpenAPI, and `templ generate` rows. Select it with:
+
+  ```bash
+  # gh pr create: pass the template file as the body
+  gh pr create --body-file .github/PULL_REQUEST_TEMPLATE/chore.md --label chore
+  ```
+
+  In a browser, append `?template=chore.md&expand=1` to the compare URL:
+
+  ```
+  https://github.com/sydlexius/stillwater/compare/main...<branch>?expand=1&template=chore.md
+  ```
+
 ## Reading PR comments (gh API)
 
 The `!` character triggers bash history expansion inside double quotes. **Never use `!=` in `--jq` expressions.** Use `select(.field == "value" | not)` instead:


### PR DESCRIPTION
Adds `.github/PULL_REQUEST_TEMPLATE/chore.md`, a lightweight checklist for chore/CI/refactor PRs that drops the feature-centric rows (screenshots, UAT, OpenAPI, `templ generate`) while keeping the essentials (gate-green, squash, label, docs-decision). The root `pull_request_template.md` default is unchanged - the new template is opt-in via the `?template=chore.md&expand=1` query parameter. `docs/pr-workflow.md` is updated to document both templates and the selection mechanism for humans opening PRs in the browser.

Closes #1909

## Verification

- [ ] `.github/PULL_REQUEST_TEMPLATE/chore.md` present with trimmed checklist
- [ ] Root `.github/pull_request_template.md` unchanged (still the default)
- [ ] `docs/pr-workflow.md` documents both templates and the `?template=` selector
- [ ] Markdown-only change; pre-commit clean