### PR TITLE
test(next): JS test harness (node:test + jsdom) + CI job for next/ artist-detail client JS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      js: ${{ steps.filter.outputs.js }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -44,6 +45,12 @@ jobs:
               - '.golangci.yml'
               - '.spectral.yaml'
               - 'internal/api/openapi.yaml'
+            js:
+              - 'web/static/js/**'
+              - 'tests/unit/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/ci.yml'
 
   lint:
     name: Lint
@@ -85,6 +92,29 @@ jobs:
 
       - name: Validate OpenAPI spec
         run: npx --yes @stoplight/spectral-cli@6.15.0 lint internal/api/openapi.yaml --ruleset .spectral.yaml --fail-severity=warn
+
+  js-test:
+    name: JS Unit Tests
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.js == 'true'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run JS unit tests
+        run: npm test
 
   test:
     # Per-shard display names render as "Test Shard (api)", "Test Shard (rule)",

--- a/.gitignore
+++ b/.gitignore
@@ -48,11 +48,15 @@ setupdocker.sh
 
 # Node (Tailwind v4, MCP servers)
 node_modules/
+npm-debug.log*
 package.json
 package-lock.json
 # Exception: Bruno CLI is a real pinned npm project consumed by bruno-ci workflow
 !.github/bruno/package.json
 !.github/bruno/package-lock.json
+# Exception: JS unit test harness (tests/unit/) uses the root package.json
+!/package.json
+!/package-lock.json
 
 # Ephemeral docs (plans, specs)
 # Milestone plans, design prototypes, and similar working notes live

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-shuffle test-race test-cover lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks doctor worktree check-openapi sync-tool-versions hadolint vulncheck scan bruno-ci
+.PHONY: build run test test-shuffle test-race test-cover test-js lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks doctor worktree check-openapi sync-tool-versions hadolint vulncheck scan bruno-ci
 
 # Binary name
 BINARY=stillwater
@@ -46,6 +46,14 @@ test-race:
 test-cover:
 	go test -count=1 -v -race -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
+
+## test-js: Install JS dev dependencies and run Node.js unit tests for client-side JS modules.
+# Uses Node's built-in test runner (node:test, Node 18+) and jsdom (the only npm dep).
+# No server required; tests exercise fanart-manage.js, lightbox.js, and artwork-modal.js
+# in an isolated jsdom environment. Run command: make test-js
+test-js:
+	npm ci
+	node --test tests/unit/fanart-manage.test.js tests/unit/lightbox.test.js tests/unit/artwork-modal.test.js
 
 ## lint: Run golangci-lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test-cover:
 # in an isolated jsdom environment. Run command: make test-js
 test-js:
 	npm ci
-	node --test tests/unit/fanart-manage.test.js tests/unit/lightbox.test.js tests/unit/artwork-modal.test.js
+	npm test
 
 ## lint: Run golangci-lint
 lint:

--- a/docs/_generated/make-commands.md
+++ b/docs/_generated/make-commands.md
@@ -9,6 +9,7 @@
 | `make test-shuffle` | Run tests with random ordering to surface order-dependent tests (local hygiene; reproduce a failure with -shuffle=<seed>) |
 | `make test-race` | Run tests with race detector (native; CGO required for the race instrumentation) |
 | `make test-cover` | Run tests with coverage |
+| `make test-js` | Install JS dev dependencies and run Node.js unit tests for client-side JS modules. |
 | `make lint` | Run golangci-lint |
 | `make hadolint` | Lint Dockerfile for best practices |
 | `make vulncheck` | Scan for known vulnerabilities (govulncheck, pinned to the CI version) |

--- a/internal/api/handlers_next_artist_detail.go
+++ b/internal/api/handlers_next_artist_detail.go
@@ -58,6 +58,8 @@ func (r *Router) handleNextArtistDetailPage(w http.ResponseWriter, req *http.Req
 
 // artworkKindToType maps a next/ Manage-artwork modal kind (the plain-language
 // switcher label) to the API image-type segment the editor uses.
+// NOTE: tests/unit/artwork-modal.test.js mirrors these constants in GO_KIND_TO_TYPE;
+// keep both in sync when adding or changing cases.
 func artworkKindToType(kind string) string {
 	switch kind {
 	case "logo":

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,542 @@
+{
+  "name": "stillwater-m55-1893-jstest",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "jsdom": "^26.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "scripts": {
-    "test": "node --test tests/unit/fanart-manage.test.js tests/unit/lightbox.test.js tests/unit/artwork-modal.test.js"
+    "test": "node --test tests/unit/*.test.js"
   },
   "devDependencies": {
     "jsdom": "^26.1.0"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "type": "module",
+  "scripts": {
+    "test": "node --test tests/unit/fanart-manage.test.js tests/unit/lightbox.test.js tests/unit/artwork-modal.test.js"
+  },
+  "devDependencies": {
+    "jsdom": "^26.1.0"
+  }
+}

--- a/tests/unit/artwork-modal.test.js
+++ b/tests/unit/artwork-modal.test.js
@@ -1,0 +1,211 @@
+// Unit tests for web/static/js/artist-detail/artwork-modal.js
+// Covers:
+//   - KIND_TO_TYPE parity with Go's artworkKindToType (handlers_next_artist_detail.go)
+//   - doRevert: HTTP status branching (200, 404, 409) and CSRF guard
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createDom, makeFetchMock, flush } from './helpers/dom-harness.js';
+
+// ---------------------------------------------------------------------------
+// Go source of truth for kind -> image-type (handlers_next_artist_detail.go).
+// artworkKindToType switch: logo->logo, banner->banner, backdrops->fanart,
+// default (primary / unknown) -> thumb.
+// Update this constant when the Go function changes; the tests will then fail,
+// which is the intended signal.
+// ---------------------------------------------------------------------------
+const GO_KIND_TO_TYPE = {
+  primary:   'thumb',
+  logo:      'logo',
+  banner:    'banner',
+  backdrops: 'fanart',
+};
+
+// Minimal modal DOM. refreshRevert needs artwork-revert-row, artwork-modal
+// (with data-artist-id), and the kind-tab buttons. doRevert additionally needs
+// artwork-revert-btn and artwork-gate-banner / artwork-gate-reason.
+const MODAL_HTML = `<!doctype html><html><body>
+<button id="outside-btn">Outside</button>
+<div id="artwork-modal" class="hidden" data-artist-id="artist456" tabindex="-1">
+  <div id="artwork-modal-body"></div>
+  <button id="artwork-revert-btn">Revert</button>
+  <div id="artwork-revert-row"></div>
+  <div id="artwork-gate-banner" class="hidden">
+    <span id="artwork-gate-reason"></span>
+  </div>
+  <button data-sw-artwork-kind-tab data-artwork-kind="primary" aria-pressed="true">Primary</button>
+  <button data-sw-artwork-kind-tab data-artwork-kind="logo"    aria-pressed="false">Logo</button>
+  <button data-sw-artwork-kind-tab data-artwork-kind="banner"  aria-pressed="false">Banner</button>
+  <button data-sw-artwork-kind-tab data-artwork-kind="backdrops" aria-pressed="false">Backdrops</button>
+  <button data-sw-artwork-close>Close</button>
+</div>
+</body></html>`;
+
+// ---------------------------------------------------------------------------
+// KIND_TO_TYPE parity: JS map vs Go artworkKindToType
+//
+// Strategy: open the modal for a given kind and observe what image-type segment
+// appears in the /info fetch URL that refreshRevert dispatches. This tests the
+// live code path rather than parsing source text, so a renamed variable or a
+// wrong value both fail the assertion.
+// ---------------------------------------------------------------------------
+describe('artwork-modal: KIND_TO_TYPE parity with Go artworkKindToType', () => {
+  for (const [kind, expectedType] of Object.entries(GO_KIND_TO_TYPE)) {
+    it(`kind "${kind}" resolves to image type "${expectedType}"`, async () => {
+      const fetchMock = makeFetchMock({ ok: true, json: { backup_exists: false } });
+      const dom = createDom({ html: MODAL_HTML, modules: ['artworkModal'], csrfToken: 'tok' });
+      dom.window.fetch = fetchMock;
+
+      dom.window.swArtworkModal.open(kind);
+      await flush();
+
+      if (expectedType === 'fanart') {
+        // fanart is the multi-slot kind: refreshRevert hides the row immediately
+        // and returns without fetching /info (no single-slot backup applies).
+        const row = dom.window.document.getElementById('artwork-revert-row');
+        assert.ok(
+          row.classList.contains('hidden'),
+          `kind "${kind}" (type fanart): revert row must be hidden (no single-slot backup)`,
+        );
+        const infoFetches = fetchMock.calls.filter(c => String(c.url).includes('/info'));
+        assert.equal(infoFetches.length, 0,
+          `kind "${kind}" (type fanart): must not fetch /info`);
+      } else {
+        const infoFetches = fetchMock.calls.filter(c => String(c.url).includes('/info'));
+        assert.equal(infoFetches.length, 1,
+          `kind "${kind}": expected exactly one /info fetch, got ${infoFetches.length}`);
+        assert.ok(
+          String(infoFetches[0].url).includes(`/images/${expectedType}/info`),
+          `kind "${kind}": expected URL to contain /images/${expectedType}/info, got: ${infoFetches[0].url}`,
+        );
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// doRevert: HTTP status branching
+// ---------------------------------------------------------------------------
+describe('artwork-modal: doRevert HTTP status branching', () => {
+  it('200 ok: reloads the modal body (htmx.ajax called)', async () => {
+    // doRevert POST returns 200: expects loadBody() to be called,
+    // which calls window.htmx.ajax.
+    const ajaxCalls = [];
+    const dom = createDom({ html: MODAL_HTML, modules: ['artworkModal'], csrfToken: 'tok' });
+    dom.window.htmx = { ajax: (...args) => { ajaxCalls.push(args); return Promise.resolve(); } };
+    // First call (from open()) is loadBody; we'll count only POST-200 induced calls.
+    dom.window.fetch = makeFetchMock({ ok: true, status: 200, json: { backup_exists: true } });
+
+    dom.window.swArtworkModal.open('logo');
+    await flush();
+    const callsAfterOpen = ajaxCalls.length;
+
+    // Now trigger revert (POST /revert returns 200)
+    dom.window.fetch = makeFetchMock({ ok: true, status: 200 });
+    dom.window.document.getElementById('artwork-revert-btn').click();
+    await flush();
+
+    assert.ok(ajaxCalls.length > callsAfterOpen,
+      'a successful revert (200) must reload the modal body via htmx.ajax');
+  });
+
+  it('409: shows the gate banner with the reason from the response body', async () => {
+    const dom = createDom({ html: MODAL_HTML, modules: ['artworkModal'], csrfToken: 'tok' });
+    dom.window.fetch = makeFetchMock({ ok: false, status: 409, json: { reason: 'test conflict' } });
+
+    dom.window.swArtworkModal.open('logo');
+    await flush();
+
+    // Re-assign fetch for the revert call so it returns 409
+    dom.window.fetch = makeFetchMock({ ok: false, status: 409, json: { reason: 'test conflict' } });
+    dom.window.document.getElementById('artwork-revert-btn').click();
+    await flush();
+
+    const banner = dom.window.document.getElementById('artwork-gate-banner');
+    assert.ok(!banner.classList.contains('hidden'),
+      '409 must show the gate banner');
+    assert.equal(
+      dom.window.document.getElementById('artwork-gate-reason').textContent,
+      'test conflict',
+      '409 must populate the banner with the reason from the response',
+    );
+  });
+
+  it('404: hides the revert row (backup is gone)', async () => {
+    const dom = createDom({ html: MODAL_HTML, modules: ['artworkModal'], csrfToken: 'tok' });
+    dom.window.fetch = makeFetchMock({ ok: false, status: 404 });
+
+    dom.window.swArtworkModal.open('logo');
+    await flush();
+
+    dom.window.fetch = makeFetchMock({ ok: false, status: 404 });
+    dom.window.document.getElementById('artwork-revert-btn').click();
+    await flush();
+
+    const row = dom.window.document.getElementById('artwork-revert-row');
+    assert.ok(row.classList.contains('hidden'),
+      '404 must hide the revert row (backup no longer exists)');
+  });
+
+  it('CSRF guard: empty token skips the POST and logs a warning', async () => {
+    const fetchMock = makeFetchMock({ ok: true });
+    const warnings = [];
+    const dom = createDom({ html: MODAL_HTML, modules: ['artworkModal'], csrfToken: '' });
+    dom.window.fetch = fetchMock;
+    dom.window.console = { warn: msg => warnings.push(msg) };
+
+    dom.window.swArtworkModal.open('logo');
+    await flush();
+
+    const callsAfterOpen = fetchMock.calls.length;
+
+    // Attempt revert with empty CSRF
+    dom.window.document.getElementById('artwork-revert-btn').click();
+    await flush();
+
+    assert.equal(fetchMock.calls.length, callsAfterOpen,
+      'doRevert must not call fetch when CSRF token is empty');
+    assert.ok(warnings.some(w => /csrf/i.test(w)),
+      'doRevert must log a CSRF warning when token is empty');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// close / focus-restore
+// ---------------------------------------------------------------------------
+describe('artwork-modal: open and close', () => {
+  it('open makes the modal visible', () => {
+    const dom = createDom({ html: MODAL_HTML, modules: ['artworkModal'] });
+    dom.window.swArtworkModal.open('primary');
+    const m = dom.window.document.getElementById('artwork-modal');
+    assert.ok(!m.classList.contains('hidden'), 'modal must not have hidden class when open');
+    assert.ok(m.classList.contains('flex'), 'modal must have flex class when open');
+  });
+
+  it('close hides the modal and restores focus to opener', () => {
+    const dom = createDom({ html: MODAL_HTML, modules: ['artworkModal'] });
+    const outsideBtn = dom.window.document.getElementById('outside-btn');
+    outsideBtn.focus();
+
+    dom.window.swArtworkModal.open('primary');
+    dom.window.swArtworkModal.close();
+
+    const m = dom.window.document.getElementById('artwork-modal');
+    assert.ok(m.classList.contains('hidden'), 'modal must be hidden after close');
+    assert.equal(dom.window.document.activeElement, outsideBtn,
+      'focus must return to the opener element after close');
+  });
+
+  it('Escape key closes the modal', () => {
+    const dom = createDom({ html: MODAL_HTML, modules: ['artworkModal'] });
+    dom.window.swArtworkModal.open('primary');
+    const m = dom.window.document.getElementById('artwork-modal');
+
+    const evt = new dom.window.KeyboardEvent('keydown', {
+      key: 'Escape', bubbles: true, cancelable: true,
+    });
+    dom.window.document.dispatchEvent(evt);
+
+    assert.ok(m.classList.contains('hidden'), 'Escape must close the artwork modal');
+    assert.ok(evt.defaultPrevented, 'Escape must call preventDefault');
+  });
+});

--- a/tests/unit/artwork-modal.test.js
+++ b/tests/unit/artwork-modal.test.js
@@ -7,11 +7,11 @@ import assert from 'node:assert/strict';
 import { createDom, makeFetchMock, flush } from './helpers/dom-harness.js';
 
 // ---------------------------------------------------------------------------
-// Go source of truth for kind -> image-type (handlers_next_artist_detail.go).
-// artworkKindToType switch: logo->logo, banner->banner, backdrops->fanart,
-// default (primary / unknown) -> thumb.
-// Update this constant when the Go function changes; the tests will then fail,
-// which is the intended signal.
+// Go source of truth for kind -> image-type (handlers_next_artist_detail.go,
+// artworkKindToType). This constant is MANUALLY maintained: when Go's
+// artworkKindToType gains or changes a case, update GO_KIND_TO_TYPE here.
+// The tests then catch JS drift from this constant -- they do NOT
+// auto-detect Go-side changes on their own.
 // ---------------------------------------------------------------------------
 const GO_KIND_TO_TYPE = {
   primary:   'thumb',

--- a/tests/unit/fanart-manage.test.js
+++ b/tests/unit/fanart-manage.test.js
@@ -1,0 +1,177 @@
+// Unit tests for web/static/js/artist-detail/fanart-manage.js
+// Covers: reorder swap-index math, setFanartPrimary order construction, and
+// the empty-CSRF guards that gate every mutating call.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createDom, makeFetchMock, flush } from './helpers/dom-harness.js';
+
+// Minimal gallery HTML: 3 fanart slots + move/primary buttons.
+// The reorder logic counts .fanart-cb checkboxes to derive `total`.
+const GALLERY_HTML = `<!doctype html><html><body>
+<div id="gallery" data-sw-fanart-gallery data-artist-id="artist123">
+  <input type="checkbox" class="fanart-cb" value="0">
+  <input type="checkbox" class="fanart-cb" value="1">
+  <input type="checkbox" class="fanart-cb" value="2">
+
+  <button class="fanart-move-btn" id="btn-up-1"
+    data-index="1" data-direction="up" data-artist-id="artist123"></button>
+  <button class="fanart-move-btn" id="btn-down-0"
+    data-index="0" data-direction="down" data-artist-id="artist123"></button>
+  <button class="fanart-move-btn" id="btn-up-0"
+    data-index="0" data-direction="up" data-artist-id="artist123"></button>
+  <button class="fanart-move-btn" id="btn-down-last"
+    data-index="2" data-direction="down" data-artist-id="artist123"></button>
+
+  <button id="set-primary-2"
+    data-set-primary-index="2"
+    data-set-primary-count="3"
+    data-set-primary-artist="artist123"></button>
+  <button id="set-primary-0"
+    data-set-primary-index="0"
+    data-set-primary-count="3"
+    data-set-primary-artist="artist123"></button>
+</div>
+</body></html>`;
+
+// ---------------------------------------------------------------------------
+// Reorder swap-index math
+// ---------------------------------------------------------------------------
+describe('fanart-manage: reorder swap-index math', () => {
+  it('move-up on index 1 swaps with index 0 → order [1, 0, 2]', async () => {
+    const fetchMock = makeFetchMock({ ok: true });
+    const dom = createDom({ html: GALLERY_HTML, modules: ['fanartManage'], csrfToken: 'tok' });
+    dom.window.fetch = fetchMock;
+
+    dom.window.document.getElementById('btn-up-1').click();
+    await flush();
+
+    assert.equal(fetchMock.calls.length, 1);
+    assert.deepEqual(JSON.parse(fetchMock.calls[0].options.body).order, [1, 0, 2]);
+  });
+
+  it('move-down on index 0 swaps with index 1 → order [1, 0, 2]', async () => {
+    const fetchMock = makeFetchMock({ ok: true });
+    const dom = createDom({ html: GALLERY_HTML, modules: ['fanartManage'], csrfToken: 'tok' });
+    dom.window.fetch = fetchMock;
+
+    dom.window.document.getElementById('btn-down-0').click();
+    await flush();
+
+    assert.equal(fetchMock.calls.length, 1);
+    assert.deepEqual(JSON.parse(fetchMock.calls[0].options.body).order, [1, 0, 2]);
+  });
+
+  it('move-up on index 0 is a no-op (lower boundary guard)', async () => {
+    const fetchMock = makeFetchMock({ ok: true });
+    const dom = createDom({ html: GALLERY_HTML, modules: ['fanartManage'], csrfToken: 'tok' });
+    dom.window.fetch = fetchMock;
+
+    dom.window.document.getElementById('btn-up-0').click();
+    await flush();
+
+    assert.equal(fetchMock.calls.length, 0, 'move-up at index 0 must not call fetch');
+  });
+
+  it('move-down on last index is a no-op (upper boundary guard)', async () => {
+    const fetchMock = makeFetchMock({ ok: true });
+    const dom = createDom({ html: GALLERY_HTML, modules: ['fanartManage'], csrfToken: 'tok' });
+    dom.window.fetch = fetchMock;
+
+    dom.window.document.getElementById('btn-down-last').click();
+    await flush();
+
+    assert.equal(fetchMock.calls.length, 0, 'move-down on last index must not call fetch');
+  });
+
+  it('reorder call targets the fanart reorder endpoint', async () => {
+    const fetchMock = makeFetchMock({ ok: true });
+    const dom = createDom({ html: GALLERY_HTML, modules: ['fanartManage'], csrfToken: 'tok' });
+    dom.window.fetch = fetchMock;
+
+    dom.window.document.getElementById('btn-up-1').click();
+    await flush();
+
+    assert.ok(
+      fetchMock.calls[0].url.includes('/images/fanart/reorder'),
+      `expected reorder URL, got: ${fetchMock.calls[0].url}`,
+    );
+    assert.equal(fetchMock.calls[0].options.method, 'POST');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setFanartPrimary order construction
+// ---------------------------------------------------------------------------
+describe('fanart-manage: setFanartPrimary order construction', () => {
+  it('set-primary at index 2 builds order [2, 0, 1] (chosen index first)', async () => {
+    const fetchMock = makeFetchMock({ ok: true });
+    const dom = createDom({ html: GALLERY_HTML, modules: ['fanartManage'], csrfToken: 'tok' });
+    dom.window.fetch = fetchMock;
+    dom.window.confirm = () => true;
+
+    dom.window.document.getElementById('set-primary-2').click();
+    await flush();
+
+    assert.equal(fetchMock.calls.length, 1);
+    assert.deepEqual(JSON.parse(fetchMock.calls[0].options.body).order, [2, 0, 1],
+      'chosen index goes first, remaining indices follow in original order');
+  });
+
+  it('set-primary at index 0 builds order [0, 1, 2] (no effective reorder)', async () => {
+    const fetchMock = makeFetchMock({ ok: true });
+    const dom = createDom({ html: GALLERY_HTML, modules: ['fanartManage'], csrfToken: 'tok' });
+    dom.window.fetch = fetchMock;
+    dom.window.confirm = () => true;
+
+    dom.window.document.getElementById('set-primary-0').click();
+    await flush();
+
+    assert.deepEqual(JSON.parse(fetchMock.calls[0].options.body).order, [0, 1, 2]);
+  });
+
+  it('cancelled confirm does not call fetch', async () => {
+    const fetchMock = makeFetchMock({ ok: true });
+    const dom = createDom({ html: GALLERY_HTML, modules: ['fanartManage'], csrfToken: 'tok' });
+    dom.window.fetch = fetchMock;
+    dom.window.confirm = () => false;
+
+    dom.window.document.getElementById('set-primary-2').click();
+    await flush();
+
+    assert.equal(fetchMock.calls.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CSRF guards
+// ---------------------------------------------------------------------------
+describe('fanart-manage: CSRF guards', () => {
+  it('reorder alerts and skips fetch when CSRF token is empty', async () => {
+    const fetchMock = makeFetchMock({ ok: true });
+    const alerts = [];
+    const dom = createDom({ html: GALLERY_HTML, modules: ['fanartManage'], csrfToken: '' });
+    dom.window.fetch = fetchMock;
+    dom.window.alert = msg => alerts.push(msg);
+
+    dom.window.document.getElementById('btn-up-1').click();
+    await flush();
+
+    assert.equal(fetchMock.calls.length, 0, 'fetch must not be called with empty CSRF');
+    assert.equal(alerts.length, 1, 'an alert must be shown when CSRF is missing');
+  });
+
+  it('setFanartPrimary alerts and skips fetch when CSRF token is empty', async () => {
+    const fetchMock = makeFetchMock({ ok: true });
+    const alerts = [];
+    const dom = createDom({ html: GALLERY_HTML, modules: ['fanartManage'], csrfToken: '' });
+    dom.window.fetch = fetchMock;
+    dom.window.alert = msg => alerts.push(msg);
+    dom.window.confirm = () => true;
+
+    dom.window.document.getElementById('set-primary-2').click();
+    await flush();
+
+    assert.equal(fetchMock.calls.length, 0, 'fetch must not be called with empty CSRF');
+    assert.equal(alerts.length, 1, 'an alert must be shown when CSRF is missing');
+  });
+});

--- a/tests/unit/helpers/dom-harness.js
+++ b/tests/unit/helpers/dom-harness.js
@@ -51,8 +51,8 @@ export function createDom({ html, modules = [], csrfToken = null } = {}) {
 }
 
 /**
- * makeFetchMock returns { mock, calls }.
- * mock is a fetch-compatible function that records every call.
+ * makeFetchMock returns a fetch-compatible mock function with a `.calls` array
+ * property that records every call made to it.
  * responseSpec can be an object or a function(url, options) => object.
  * Response shape: { ok, status, json, text }.
  */

--- a/tests/unit/helpers/dom-harness.js
+++ b/tests/unit/helpers/dom-harness.js
@@ -1,0 +1,87 @@
+// dom-harness.js - shared utilities for loading ES5 IIFE modules into a fresh
+// jsdom context. Each test gets its own JSDOM instance so there is no shared
+// state between cases.
+import { JSDOM } from 'jsdom';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../..');
+
+export const MODULE_PATHS = {
+  lightbox:     join(REPO_ROOT, 'web/static/js/artist-detail/lightbox.js'),
+  fanartManage: join(REPO_ROOT, 'web/static/js/artist-detail/fanart-manage.js'),
+  artworkModal: join(REPO_ROOT, 'web/static/js/artist-detail/artwork-modal.js'),
+};
+
+/**
+ * createDom creates a fresh jsdom window and optionally loads module scripts.
+ *
+ * @param {object} opts
+ * @param {string}   [opts.html]       - initial HTML (defaults to blank page)
+ * @param {string[]} [opts.modules]    - keys from MODULE_PATHS to eval in order
+ * @param {string|null} [opts.csrfToken] - if set, stubs window.swCsrfToken
+ * @returns {import('jsdom').JSDOM}
+ */
+export function createDom({ html, modules = [], csrfToken = null } = {}) {
+  const dom = new JSDOM(
+    html || '<!doctype html><html><body></body></html>',
+    { runScripts: 'dangerously', url: 'http://localhost:1973/' },
+  );
+  const win = dom.window;
+
+  win.confirm = () => true;
+  win.alert   = () => {};
+  win.htmx    = { ajax: () => Promise.resolve() };
+
+  // Default fetch stub; tests override dom.window.fetch per-case.
+  win.fetch = makeFetchMock();
+
+  if (csrfToken !== null) {
+    win.swCsrfToken = () => csrfToken;
+  }
+
+  for (const key of modules) {
+    const path = MODULE_PATHS[key] ?? key;
+    win.eval(readFileSync(path, 'utf-8'));
+  }
+
+  return dom;
+}
+
+/**
+ * makeFetchMock returns { mock, calls }.
+ * mock is a fetch-compatible function that records every call.
+ * responseSpec can be an object or a function(url, options) => object.
+ * Response shape: { ok, status, json, text }.
+ */
+export function makeFetchMock(responseSpec = { ok: true, status: 200 }) {
+  const calls = [];
+  function mock(url, options) {
+    calls.push({ url, options });
+    const spec = typeof responseSpec === 'function'
+      ? responseSpec(url, options)
+      : responseSpec;
+    const jsonValue = spec.json ?? {};
+    const textValue = spec.text ?? '';
+    const response = {
+      ok:     spec.ok !== undefined ? spec.ok : true,
+      status: spec.status ?? 200,
+      json:  () => Promise.resolve(jsonValue),
+      text:  () => Promise.resolve(textValue),
+      clone: () => ({
+        json: () => Promise.resolve(jsonValue),
+        text: () => Promise.resolve(textValue),
+      }),
+    };
+    return Promise.resolve(response);
+  }
+  mock.calls = calls;
+  return mock;
+}
+
+/** flush drains all pending microtasks + one macrotask turn. */
+export function flush() {
+  return new Promise(r => setTimeout(r, 0));
+}

--- a/tests/unit/lightbox.test.js
+++ b/tests/unit/lightbox.test.js
@@ -1,0 +1,186 @@
+// Unit tests for web/static/js/artist-detail/lightbox.js
+// Covers: open/close state, focus management, and the Tab/Shift+Tab focus-trap
+// (WCAG 2.1 SC 2.4.3 keyboard focus containment).
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createDom } from './helpers/dom-harness.js';
+
+// Lightbox overlay + two focusable elements inside it.
+// The module queries for focusable elements using its own selector list;
+// buttons are natively in that list so no tabindex is required.
+const LIGHTBOX_HTML = `<!doctype html><html><body>
+<button id="outside-btn">Trigger</button>
+<div id="sw-lightbox" class="hidden">
+  <button data-lightbox-close id="close-btn">Close</button>
+  <button id="extra-btn">Extra action</button>
+  <img id="sw-lightbox-img" src="" alt="">
+</div>
+</body></html>`;
+
+function openedDom() {
+  const dom = createDom({ html: LIGHTBOX_HTML, modules: ['lightbox'] });
+  dom.window.swLightbox.open('http://example.com/img.jpg', 'test alt');
+  return dom;
+}
+
+// ---------------------------------------------------------------------------
+// open / close lifecycle
+// ---------------------------------------------------------------------------
+describe('lightbox: open and close lifecycle', () => {
+  it('open removes hidden class and adds flex class', () => {
+    const dom = openedDom();
+    const lb = dom.window.document.getElementById('sw-lightbox');
+    assert.ok(!lb.classList.contains('hidden'), 'lightbox must not have hidden class when open');
+    assert.ok(lb.classList.contains('flex'), 'lightbox must have flex class when open');
+  });
+
+  it('open sets the img src and alt', () => {
+    const dom = openedDom();
+    const img = dom.window.document.getElementById('sw-lightbox-img');
+    assert.equal(img.src, 'http://example.com/img.jpg');
+    assert.equal(img.alt, 'test alt');
+  });
+
+  it('open moves focus to the close button', () => {
+    const dom = openedDom();
+    const closeBtn = dom.window.document.getElementById('close-btn');
+    assert.equal(dom.window.document.activeElement, closeBtn,
+      'focus must move to [data-lightbox-close] when lightbox opens');
+  });
+
+  it('close adds hidden class and removes flex class', () => {
+    const dom = openedDom();
+    dom.window.swLightbox.close();
+    const lb = dom.window.document.getElementById('sw-lightbox');
+    assert.ok(lb.classList.contains('hidden'), 'lightbox must have hidden class when closed');
+    assert.ok(!lb.classList.contains('flex'), 'lightbox must not have flex class when closed');
+  });
+
+  it('close clears the img src attribute', () => {
+    const dom = openedDom();
+    dom.window.swLightbox.close();
+    const img = dom.window.document.getElementById('sw-lightbox-img');
+    // Check the raw attribute rather than the resolved .src property;
+    // jsdom resolves an empty string to the base URL in the .src getter.
+    assert.equal(img.getAttribute('src'), '', 'img src attribute must be cleared on close');
+  });
+
+  it('close restores focus to the element that was active before open', () => {
+    const dom = createDom({ html: LIGHTBOX_HTML, modules: ['lightbox'] });
+    const outsideBtn = dom.window.document.getElementById('outside-btn');
+    outsideBtn.focus();
+
+    dom.window.swLightbox.open('img.jpg', '');
+    dom.window.swLightbox.close();
+
+    assert.equal(dom.window.document.activeElement, outsideBtn,
+      'focus must return to the opener element after close');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard: Escape
+// ---------------------------------------------------------------------------
+describe('lightbox: Escape key closes the lightbox', () => {
+  it('Escape closes the lightbox and prevents default', () => {
+    const dom = openedDom();
+    const lb = dom.window.document.getElementById('sw-lightbox');
+
+    const evt = new dom.window.KeyboardEvent('keydown', {
+      key: 'Escape', bubbles: true, cancelable: true,
+    });
+    dom.window.document.dispatchEvent(evt);
+
+    assert.ok(lb.classList.contains('hidden'), 'Escape must close the lightbox');
+    assert.ok(evt.defaultPrevented, 'Escape must call preventDefault');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard: Tab focus-trap
+// ---------------------------------------------------------------------------
+describe('lightbox: Tab focus-trap', () => {
+  it('Tab on last focusable element wraps focus to first', () => {
+    const dom = openedDom();
+    const lb = dom.window.document.getElementById('sw-lightbox');
+
+    // Find the same focusables the module finds.
+    const focusables = lb.querySelectorAll(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]),' +
+      ' textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusables[0];
+    const last  = focusables[focusables.length - 1];
+
+    last.focus();
+    assert.equal(dom.window.document.activeElement, last, 'precondition: last element is focused');
+
+    const evt = new dom.window.KeyboardEvent('keydown', {
+      key: 'Tab', shiftKey: false, bubbles: true, cancelable: true,
+    });
+    dom.window.document.dispatchEvent(evt);
+
+    assert.equal(dom.window.document.activeElement, first,
+      'Tab on last element must wrap focus to first');
+    assert.ok(evt.defaultPrevented, 'Tab wrap must call preventDefault');
+  });
+
+  it('Shift+Tab on first focusable element wraps focus to last', () => {
+    const dom = openedDom();
+    const lb = dom.window.document.getElementById('sw-lightbox');
+
+    const focusables = lb.querySelectorAll(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]),' +
+      ' textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusables[0];
+    const last  = focusables[focusables.length - 1];
+
+    first.focus();
+    assert.equal(dom.window.document.activeElement, first, 'precondition: first element is focused');
+
+    const evt = new dom.window.KeyboardEvent('keydown', {
+      key: 'Tab', shiftKey: true, bubbles: true, cancelable: true,
+    });
+    dom.window.document.dispatchEvent(evt);
+
+    assert.equal(dom.window.document.activeElement, last,
+      'Shift+Tab on first element must wrap focus to last');
+    assert.ok(evt.defaultPrevented, 'Shift+Tab wrap must call preventDefault');
+  });
+
+  it('Tab on a middle element does not trap (natural order continues)', () => {
+    const dom = openedDom();
+    const lb = dom.window.document.getElementById('sw-lightbox');
+
+    const focusables = lb.querySelectorAll(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]),' +
+      ' textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    // Only two buttons; skip this case when there are not enough elements.
+    if (focusables.length < 2) return;
+
+    // Focus the first element (not the last), Tab should NOT preventDefault.
+    const first = focusables[0];
+    first.focus();
+
+    const evt = new dom.window.KeyboardEvent('keydown', {
+      key: 'Tab', shiftKey: false, bubbles: true, cancelable: true,
+    });
+    dom.window.document.dispatchEvent(evt);
+
+    // The module only prevents default when wrapping; Tab from first (not last) passes through.
+    assert.ok(!evt.defaultPrevented,
+      'Tab from first element (not last) must not call preventDefault');
+  });
+
+  it('Tab key outside open lightbox is not intercepted', () => {
+    const dom = createDom({ html: LIGHTBOX_HTML, modules: ['lightbox'] });
+    // Lightbox is NOT opened — no keydown listener should be active.
+    const evt = new dom.window.KeyboardEvent('keydown', {
+      key: 'Tab', bubbles: true, cancelable: true,
+    });
+    dom.window.document.dispatchEvent(evt);
+    assert.ok(!evt.defaultPrevented, 'Tab must not be intercepted when lightbox is closed');
+  });
+});

--- a/tests/unit/lightbox.test.js
+++ b/tests/unit/lightbox.test.js
@@ -17,6 +17,12 @@ const LIGHTBOX_HTML = `<!doctype html><html><body>
 </div>
 </body></html>`;
 
+// Selector used by lightbox.js to enumerate focusable elements inside the overlay.
+// Mirrors the production module; defined once here so test changes stay in sync.
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]),' +
+  ' textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
 function openedDom() {
   const dom = createDom({ html: LIGHTBOX_HTML, modules: ['lightbox'] });
   dom.window.swLightbox.open('http://example.com/img.jpg', 'test alt');
@@ -105,10 +111,7 @@ describe('lightbox: Tab focus-trap', () => {
     const lb = dom.window.document.getElementById('sw-lightbox');
 
     // Find the same focusables the module finds.
-    const focusables = lb.querySelectorAll(
-      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]),' +
-      ' textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    );
+    const focusables = lb.querySelectorAll(FOCUSABLE_SELECTOR);
     const first = focusables[0];
     const last  = focusables[focusables.length - 1];
 
@@ -129,10 +132,7 @@ describe('lightbox: Tab focus-trap', () => {
     const dom = openedDom();
     const lb = dom.window.document.getElementById('sw-lightbox');
 
-    const focusables = lb.querySelectorAll(
-      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]),' +
-      ' textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    );
+    const focusables = lb.querySelectorAll(FOCUSABLE_SELECTOR);
     const first = focusables[0];
     const last  = focusables[focusables.length - 1];
 
@@ -153,10 +153,7 @@ describe('lightbox: Tab focus-trap', () => {
     const dom = openedDom();
     const lb = dom.window.document.getElementById('sw-lightbox');
 
-    const focusables = lb.querySelectorAll(
-      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]),' +
-      ' textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    );
+    const focusables = lb.querySelectorAll(FOCUSABLE_SELECTOR);
     // Only two buttons; skip this case when there are not enough elements.
     if (focusables.length < 2) return;
 


### PR DESCRIPTION
## Summary

Add a JavaScript test harness (`node:test` + `jsdom`) with coverage for the new next/ artist-detail client JS, plus a CI job to run it. Deferred from #1336 (4B/4C, item H4) where the client JS shipped without unit coverage.

## Changes

- `tests/unit/`: `node:test` + `jsdom` harness, 32 tests covering the next/ artist-detail client JS.
- `.github/workflows/ci.yml`: new `js-test` job - actions pinned to commit SHAs (with `# vX` comments), `persist-credentials: false`, job-level `contents: read`; `actionlint` clean.

## Testing

- `npm test` -> 32/32 pass.
- Go gate green (no Go changes in this PR).

Closes #1893


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  - Added unit tests for fanart management, lightbox modal, and artwork modal functionality

* **Chores**
  - Enhanced continuous integration to automatically detect and run JavaScript tests
  - Updated build configuration and tooling for test execution support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->