### PR TITLE
ci(coverage-floor): move enforcement to CI workflow; gate.yml becomes pass-through

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
     name: Coverage Floor
     runs-on: ubuntu-latest
     needs: [changes, test]
-    if: always() && needs.changes.outputs.code == 'true'
+    if: always() && needs.changes.outputs.code == 'true' && needs.test.result == 'success'
     permissions:
       contents: read
     steps:
@@ -394,11 +394,14 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    # Build gates on coverage-floor (which waits for all test shards) so a floor
-    # regression blocks the binary. `Build` and `Test` remain independently
-    # required by branch protection; a test failure still blocks merge via its
-    # own check. Keep the `lint` dependency so a lint-failing PR short-circuits
-    # Build.
+    # The PRIMARY coverage enforcement gate is the required status check
+    # "CI / Coverage Floor" -- branch protection MUST require that check.
+    # The `coverage-floor` dependency here is defense-in-depth only: it means
+    # a floor failure also blocks the Build artifact, but Build is not itself
+    # the gate. Never rely on this dependency as the enforcement path; if
+    # `Build` is ever dropped from required checks, floor enforcement would
+    # silently disappear without the required-check gate in place.
+    # Keep the `lint` dependency so a lint-failing PR short-circuits Build.
     needs: [changes, lint, coverage-floor]
     if: needs.changes.outputs.code == 'true'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,15 +339,67 @@ jobs:
           # Codecov is flaky.
           fail_ci_if_error: false
 
+  coverage-floor:
+    name: Coverage Floor
+    runs-on: ubuntu-latest
+    needs: [changes, test]
+    if: always() && needs.changes.outputs.code == 'true'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: coverage-*
+
+      - name: Merge coverage profiles
+        run: |
+          first=true
+          for f in coverage-*/coverage.out; do
+            if $first; then
+              cat "$f" > merged.out
+              first=false
+            else
+              tail -n +2 "$f" >> merged.out
+            fi
+          done
+
+      - name: Enforce per-package coverage floor
+        run: |
+          output=$(bash scripts/coverage-floor.sh --cover merged.out 2>&1) || {
+            echo "$output"
+            {
+              echo "## Coverage Floor -- FAILED"
+              echo ""
+              echo "One or more packages fell below their coverage floor. Add tests or update"
+              echo "\`testdata/coverage-floor.json\` if the drop is intentional."
+              echo ""
+              echo '```'
+              echo "$output"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+          echo "$output"
+
   build:
     name: Build
     runs-on: ubuntu-latest
-    # Build runs concurrent with the test matrix: compiling the binary does not
-    # depend on tests passing, and `Build` + `Test` are INDEPENDENTLY required by
-    # branch protection, so a test failure still blocks merge via its own check.
-    # Keep the `lint` dependency so a lint-failing PR short-circuits Build (lint
-    # is far shorter than the matrix, so this costs no wall time).
-    needs: [changes, lint]
+    # Build gates on coverage-floor (which waits for all test shards) so a floor
+    # regression blocks the binary. `Build` and `Test` remain independently
+    # required by branch protection; a test failure still blocks merge via its
+    # own check. Keep the `lint` dependency so a lint-failing PR short-circuits
+    # Build.
+    needs: [changes, lint, coverage-floor]
     if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -380,7 +432,7 @@ jobs:
     # `build`, which produces no published artifact and runs on PRs -- decoupling
     # THAT from `test` is the actual wall-time win. Docker never runs on PRs, so
     # gating it on test costs no PR-time latency.) Per CodeRabbit review on #1873.
-    needs: [changes, lint, test]
+    needs: [changes, lint, test, coverage-floor]
     if: needs.changes.outputs.code == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,20 +311,19 @@ jobs:
           # (e.g. coverage-api-1/coverage.out, coverage-rule-2/coverage.out).
           pattern: coverage-*
 
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Merge coverage profiles
-        run: |
-          # Combine per-shard text coverage profiles into one file.
-          # Each profile starts with a "mode:" header line; keep it once
-          # and strip it from all subsequent files to avoid duplicates.
-          first=true
-          for f in coverage-*/coverage.out; do
-            if $first; then
-              cat "$f" > merged-coverage.out
-              first=false
-            else
-              tail -n +2 "$f" >> merged-coverage.out
-            fi
-          done
+        # go tool gocovmerge performs a per-block UNION merge (summing hit
+        # counts), so each statement block appears exactly once in the output.
+        # The naive head-1/tail concat duplicates every block across shards
+        # because each shard runs -coverpkg=./... and emits a full-module
+        # profile; plain concat causes coverage-floor.sh to sum nstmts 9x
+        # while covered stays 1x, collapsing every package to ~1/numShards.
+        run: go tool gocovmerge coverage-*/coverage.out > merged-coverage.out
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -362,16 +361,7 @@ jobs:
           pattern: coverage-*
 
       - name: Merge coverage profiles
-        run: |
-          first=true
-          for f in coverage-*/coverage.out; do
-            if $first; then
-              cat "$f" > merged.out
-              first=false
-            else
-              tail -n +2 "$f" >> merged.out
-            fi
-          done
+        run: go tool gocovmerge coverage-*/coverage.out > merged.out
 
       - name: Enforce per-package coverage floor
         run: |

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -126,22 +126,24 @@ jobs:
           echo "OK: all generated files are current."
 
   # ---------------------------------------------------------------------------
-  # Per-package coverage floor
+  # Per-package coverage floor (pass-through)
   #
-  # Replicates the '=== Per-package coverage floor ===' step in
-  # scripts/pre-push-gate.sh.  Runs go test to produce a coverage profile,
-  # then calls scripts/coverage-floor.sh to enforce the one-way ratchet
-  # recorded in testdata/coverage-floor.json.
+  # Real enforcement has moved to the CI workflow (ci.yml Coverage Floor job),
+  # which consumes the per-shard coverage artifacts uploaded by the test matrix
+  # instead of re-running the full ./internal/... suite.
   #
-  # Uses dorny/paths-filter to skip the expensive test run on PRs that touch
-  # no Go source (e.g. docs-only or workflow-only changes).  The job itself
-  # always runs and always emits a terminal status -- skipping only means
-  # "no Go changed; floor cannot have dropped" which is always correct.
+  # This job is kept here solely to preserve the "Pre-Push Gate / Coverage Floor"
+  # required-status-check entry.  It always runs and always emits a terminal
+  # status without running go test.
+  #
+  # BRANCH PROTECTION NOTE: add "CI / Coverage Floor" as a required status check
+  # in addition to (or replacing) this one so the enforcement in ci.yml is
+  # actually gated.  See docs/pr-workflow.md.
   # ---------------------------------------------------------------------------
   coverage-floor:
     name: Coverage Floor
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -153,43 +155,16 @@ jobs:
           filters: |
             go:
               - '.github/workflows/gate.yml'
+              - '.github/workflows/ci.yml'
               - 'scripts/coverage-floor.sh'
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'
               - 'testdata/coverage-floor.json'
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      - name: Coverage floor enforced by CI workflow
         if: steps.filter.outputs.go == 'true'
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Run tests and collect coverage profile
-        if: steps.filter.outputs.go == 'true'
-        run: |
-          go test -count=1 -covermode=atomic \
-            -coverprofile=coverage-floor.out \
-            ./internal/...
-
-      - name: Enforce per-package coverage floor
-        if: steps.filter.outputs.go == 'true'
-        run: |
-          output=$(bash scripts/coverage-floor.sh --cover coverage-floor.out 2>&1) || {
-            echo "$output"
-            {
-              echo "## Coverage Floor -- FAILED"
-              echo ""
-              echo "One or more packages fell below their coverage floor. Add tests or update"
-              echo "\`testdata/coverage-floor.json\` if the drop is intentional."
-              echo ""
-              echo '```'
-              echo "$output"
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          }
-          echo "$output"
+        run: echo "Coverage floor enforcement runs in the CI workflow (Coverage Floor job); see that check for results."
 
       - name: Skip (no Go changes)
         if: steps.filter.outputs.go != 'true'

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
+	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	modernc.org/libc v1.72.3 // indirect
@@ -55,4 +56,7 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 )
 
-tool github.com/a-h/templ/cmd/templ
+tool (
+	github.com/a-h/templ/cmd/templ
+	github.com/wadey/gocovmerge
+)

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad h1:W0LEBv82YCGEtcmPA3uNZBI33/qF//HAAs3MawDjRa0=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=


### PR DESCRIPTION
## Summary

The `coverage-floor` job in `gate.yml` was re-running the entire `./internal/...` test suite (~2 min) solely to produce a coverage profile, even though the CI `test` matrix already runs those same tests and uploads per-shard coverage artifacts. This PR eliminates the duplicate test run.

- Adds a `coverage-floor` job to `ci.yml` that downloads the per-shard artifacts already uploaded by the `test` matrix, merges them with a simple header-dedup loop, and runs `scripts/coverage-floor.sh` against the merged profile.
- Hollows out the `coverage-floor` job in `gate.yml` to a pass-through: the `go test` run and enforcement step are removed; the job now emits a single echo so the "Pre-Push Gate / Coverage Floor" required-status-check entry is preserved without running tests.
- Reduces per-PR CI compute by ~2 min (one full `./internal/...` pass eliminated).
- Adds `coverage-floor` as a dependency to both `build` and `docker-push` in `ci.yml` so a floor failure still blocks those downstream jobs (defense-in-depth; the required-check is the primary gate).

## What changed

- **`.github/workflows/ci.yml`** - new `coverage-floor` job: `needs: [changes, test]`, downloads `coverage-*` artifacts, merges profiles, runs `scripts/coverage-floor.sh --cover merged.out`; added to `needs` of `build` and `docker-push`.
- **`.github/workflows/gate.yml`** - `coverage-floor` job hollowed to pass-through: removed `setup-go`, `go test -coverprofile`, and enforcement steps; replaced with `echo`; `timeout-minutes` reduced from 20 to 5; `paths-filter` updated to also watch `ci.yml`.

## ⚠️ Required at merge - branch protection change

> **The new enforcement gate is `CI / Coverage Floor` (in the CI workflow).**
> The old gate `Pre-Push Gate / Coverage Floor` is now a pass-through and no longer enforces anything.
>
> Before or immediately after merging, the repo admin **must** add `CI / Coverage Floor` as a required status check in branch protection settings, or a coverage regression could merge through with all required checks green.
>
> See `docs/pr-workflow.md` for branch protection instructions.

## Test plan

- [ ] Push a branch with a Go change and verify `CI / Coverage Floor` appears in the PR's check list and passes.
- [ ] Confirm `Pre-Push Gate / Coverage Floor` still appears and exits 0 (pass-through).
- [ ] Verify `build` is blocked when `coverage-floor` fails (drop a package floor in `testdata/coverage-floor.json` to force a failure, then revert).
- [ ] Confirm no second `go test ./internal/...` run appears in the CI timeline.

Closes #1875


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now enforces per-package code coverage thresholds as a required check before builds and publishing.
  * Coverage reports from parallel test runs are merged for accurate reporting and upload.
  * Pre-push/gate status updated to surface the coverage check result without re-running tests in that gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->