### PR TITLE
test(bruno): add API test coverage for preferences endpoints (#1762)

### DIFF
--- a/api/bruno/preferences/get-all-preferences.bru
+++ b/api/bruno/preferences/get-all-preferences.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Get All Preferences
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{apiBase}}/preferences
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is an object", function() {
+    expect(res.body).to.be.an("object");
+  });
+
+  test("known keys are present with default values", function() {
+    expect(res.body.theme).to.be.a("string");
+    expect(res.body.font_size).to.be.a("string");
+    expect(res.body.thumbnail_size).to.be.a("string");
+    expect(res.body.page_size).to.be.a("string");
+    expect(res.body.density).to.be.a("string");
+  });
+}

--- a/api/bruno/preferences/get-one-preference.bru
+++ b/api/bruno/preferences/get-one-preference.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Get One Preference
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{apiBase}}/preferences/theme
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response contains key and value", function() {
+    expect(res.body.key).to.equal("theme");
+    expect(res.body.value).to.be.a("string");
+  });
+
+  test("value is a valid theme option", function() {
+    const valid = ["dark", "light", "system"];
+    expect(valid).to.include(res.body.value);
+  });
+}

--- a/api/bruno/preferences/get-unknown-preference.bru
+++ b/api/bruno/preferences/get-unknown-preference.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Get Unknown Preference (400)
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{apiBase}}/preferences/nonexistent_key
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 400 for unknown key", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("error field is present", function() {
+    expect(res.body.error).to.be.a("string");
+  });
+}

--- a/api/bruno/preferences/patch-preferences-merge.bru
+++ b/api/bruno/preferences/patch-preferences-merge.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Patch Preferences (merge semantics)
+  type: http
+  seq: 6
+}
+
+patch {
+  url: {{apiBase}}/preferences
+  body: json
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "theme": "light",
+    "sidebar_state": "icon-only"
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response echoes canonical values for patched keys", function() {
+    expect(res.body.theme).to.equal("light");
+    expect(res.body.sidebar_state).to.equal("icon-only");
+  });
+
+  test("response only contains the patched keys (merge not replace)", function() {
+    // PATCH must not clobber unmentioned keys: the response body only
+    // echoes the keys that were written, not the full preference map.
+    const keys = Object.keys(res.body);
+    expect(keys).to.have.lengthOf(2);
+    expect(keys).to.include("theme");
+    expect(keys).to.include("sidebar_state");
+  });
+}

--- a/api/bruno/preferences/patch-preferences-unknown-key-rejects.bru
+++ b/api/bruno/preferences/patch-preferences-unknown-key-rejects.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Patch Preferences Unknown Key Rejects All (400)
+  type: http
+  seq: 7
+}
+
+patch {
+  url: {{apiBase}}/preferences
+  body: json
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "theme": "dark",
+    "nonexistent_key": "any-value"
+  }
+}
+
+tests {
+  test("should return 400 when any key is unknown", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("error field identifies the bad key", function() {
+    expect(res.body.error).to.be.a("string");
+    expect(res.body.error).to.include("nonexistent_key");
+  });
+}

--- a/api/bruno/preferences/patch-then-get-roundtrip.bru
+++ b/api/bruno/preferences/patch-then-get-roundtrip.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Patch Then Get Round-Trip
+  type: http
+  seq: 8
+}
+
+patch {
+  url: {{apiBase}}/preferences
+  body: json
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "thumbnail_size": "small"
+  }
+}
+
+tests {
+  test("patch returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("patch echoes canonical stored value", function() {
+    expect(res.body.thumbnail_size).to.equal("small");
+  });
+}

--- a/api/bruno/preferences/patch-then-get-roundtrip.bru
+++ b/api/bruno/preferences/patch-then-get-roundtrip.bru
@@ -1,7 +1,7 @@
 meta {
   name: Patch Then Get Round-Trip
   type: http
-  seq: 8
+  seq: 9
 }
 
 patch {

--- a/api/bruno/preferences/patch-then-get-verify.bru
+++ b/api/bruno/preferences/patch-then-get-verify.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Patch Then Get Round-Trip Verify
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{apiBase}}/preferences
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("previously patched thumbnail_size persists in GET-all", function() {
+    // Verifies merge semantics: the value written by the preceding PATCH
+    // (seq 8) is returned by GET-all in its canonical form.
+    expect(res.body.thumbnail_size).to.equal("small");
+  });
+
+  test("unpatched keys are still present (merge not replace)", function() {
+    // Keys not touched by the PATCH are not wiped out.
+    expect(res.body.theme).to.be.a("string");
+    expect(res.body.font_size).to.be.a("string");
+    expect(res.body.sidebar_state).to.be.a("string");
+  });
+}

--- a/api/bruno/preferences/patch-then-get-verify.bru
+++ b/api/bruno/preferences/patch-then-get-verify.bru
@@ -1,7 +1,7 @@
 meta {
   name: Patch Then Get Round-Trip Verify
   type: http
-  seq: 9
+  seq: 10
 }
 
 get {

--- a/api/bruno/preferences/patch-unknown-key-no-partial-write.bru
+++ b/api/bruno/preferences/patch-unknown-key-no-partial-write.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Patch Unknown Key - No Partial Write (atomic rejection)
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{apiBase}}/preferences
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("rejected PATCH did not write the valid key (atomic rejection)", function() {
+    // The preceding test (seq 7) sent {"theme": "dark", "nonexistent_key": "any-value"}
+    // and received a 400. The rejection must be atomic: the valid key "theme"
+    // must NOT have been written. seq 6 set theme to "light", so it must
+    // still be "light" here.
+    expect(res.body.theme).to.equal("light");
+  });
+}

--- a/api/bruno/preferences/put-preference-invalid-value.bru
+++ b/api/bruno/preferences/put-preference-invalid-value.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Put Preference Invalid Value (400)
+  type: http
+  seq: 5
+}
+
+put {
+  url: {{apiBase}}/preferences/theme
+  body: json
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "value": "invalid-theme-value"
+  }
+}
+
+tests {
+  test("should return 400 for invalid value", function() {
+    expect(res.status).to.equal(400);
+  });
+
+  test("error field is present", function() {
+    expect(res.body.error).to.be.a("string");
+  });
+}

--- a/api/bruno/preferences/put-preference.bru
+++ b/api/bruno/preferences/put-preference.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Put Preference (upsert)
+  type: http
+  seq: 4
+}
+
+put {
+  url: {{apiBase}}/preferences/font_size
+  body: json
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "value": "large"
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response echoes key and canonical value", function() {
+    expect(res.body.key).to.equal("font_size");
+    expect(res.body.value).to.equal("large");
+  });
+}


### PR DESCRIPTION
## Summary
- Add Bruno API test coverage for the preferences endpoints: GET all, GET one, GET unknown-key, PUT, PUT invalid-value, PATCH merge, PATCH unknown-key-rejects, patch-then-get roundtrip and verify.
- Test-only change; no runtime/Go code touched. `make bruno-ci` green (117/117 requests, 229/229 assertions).

## Linked issue
Closes #1762

## Pre-flight checklist
- [x] Pre-push gate green locally (pre-push hook ran on push)
- [x] Commits squashed (single commit)
- [x] Label(s) set
- [x] Docs label decision made (docs: not-required)
- [ ] Screenshot for UI change (N/A - no UI)
- [ ] UAT performed for user-visible changes (N/A - test-only)
- [x] OpenAPI spec updated if shapes changed (no API shape change)
- [x] `templ generate` re-run (no .templ changes)

## Test plan
- [x] `make bruno-ci` passes (117/117 requests, 229/229 assertions)
- [x] `go test -race ./...` via pre-push gate
