### PR TITLE
test(api): assert i18n ctx + user id on companion-pill sub-request (#1948)

### DIFF
--- a/internal/api/handlers_conflict_foreign_test.go
+++ b/internal/api/handlers_conflict_foreign_test.go
@@ -71,8 +71,12 @@ func TestHandleGetConflictBanner_NoForeignFilesStateWhenFilesPresent(t *testing.
 
 	// Companion: the sidebar pill (next channel) still renders the count, so
 	// foreign-file presence remains discoverable -- just not via the banner.
-	pillReq := httptest.NewRequest(http.MethodGet, "/api/v1/foreign-files/count?ch=next", nil)
-	pillReq = pillReq.WithContext(middleware.WithTestRole(pillReq.Context(), "administrator"))
+	// Apply the same three-step context chain used by sibling tests in
+	// handlers_foreign_files_test.go: i18n first, then user ID, then role.
+	pillReq := withI18nCtx(t, httptest.NewRequest(http.MethodGet, "/api/v1/foreign-files/count?ch=next", nil))
+	pillCtx := middleware.WithTestUserID(pillReq.Context(), "admin-1")
+	pillCtx = middleware.WithTestRole(pillCtx, "administrator")
+	pillReq = pillReq.WithContext(pillCtx)
 	pillRec := httptest.NewRecorder()
 	r.handleForeignFilesCount(pillRec, pillReq)
 	if pillRec.Code != http.StatusOK {


### PR DESCRIPTION
## Summary
- Harden `TestHandleGetConflictBanner_NoForeignFilesStateWhenFilesPresent`: the companion-pill sub-request now applies the same i18n-ctx + user-id + role chain its sibling tests use (`withI18nCtx` + `middleware.WithTestUserID` + `middleware.WithTestRole`), asserting the sub-request carries i18n context and the user id.
- Test-only; no production code touched. Per the issue there is no correctness bug — this closes a test-coverage gap.

## Linked issue
Closes #1948

## Pre-flight checklist
- [x] Pre-push gate green locally (pre-push hook runs on push)
- [x] Commits squashed (single commit)
- [x] Label(s) set
- [x] Docs label decision made (docs: not-required)
- [ ] Screenshot for UI change (N/A - no UI)
- [ ] UAT performed (N/A - test-only, non-UX surface)
- [x] OpenAPI spec updated if shapes changed (no API change)
- [x] `templ generate` re-run (no .templ changes)

## Test plan
- [x] `go test -count=1 ./internal/api/` passes
- [x] `go build ./...` clean
