### PR TITLE
refactor(scanner): extract hasNumericSuffix to cut isCanonicalArtistFile complexity (#1553)

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -672,6 +672,19 @@ func preserveDimensions(existing *artist.Artist, detected *detectedFiles) {
 	}
 }
 
+// hasNumericSuffix reports whether s is non-empty and consists entirely of ASCII digits.
+func hasNumericSuffix(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, ch := range s {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // publishArtistUpdated publishes an ArtistUpdated event if the event bus is
 // configured. It is a no-op when no bus is set.
 func (s *Service) publishArtistUpdated(artistID string) {
@@ -985,8 +998,6 @@ var errFastPathFileTouched = fmt.Errorf("fast path: canonical file mtime advance
 // isCanonicalArtistFile reports whether lower (a lowercase filename) matches
 // any pattern the scanner reads on the artist hot path: NFO, thumb/folder,
 // fanart (including numbered variants), logo, banner.
-//
-//nolint:gocognit // Pattern-family fan-out across NFO + thumb/fanart/logo/banner pattern slices plus the numbered-fanart variant check that requires the suffix to be purely numeric (DiscoverFanart only recognizes the numeric form so unrelated files like fanart-old.jpg must stay off the fast path). The hot-path predicate is called per directory entry during scans, so an allocation-free implementation matters more than a few cog points; refactor tracked in #1553.
 func isCanonicalArtistFile(lower string) bool {
 	if lower == "artist.nfo" {
 		return true
@@ -1013,17 +1024,7 @@ func isCanonicalArtistFile(lower string) bool {
 				continue
 			}
 			suffix := strings.TrimSuffix(strings.TrimPrefix(lower, base), ext)
-			if suffix == "" {
-				continue
-			}
-			numeric := true
-			for _, ch := range suffix {
-				if ch < '0' || ch > '9' {
-					numeric = false
-					break
-				}
-			}
-			if numeric {
+			if hasNumericSuffix(suffix) {
 				return true
 			}
 		}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1985,3 +1985,27 @@ func TestScan_ExistingArtistGainsFilesystemMembership(t *testing.T) {
 		t.Errorf("after scan 2 emby membership = %q, want 'emby'", after2["lib-emby"])
 	}
 }
+
+func TestHasNumericSuffix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"", false},
+		{"1", true},
+		{"42", true},
+		{"007", true},
+		{"a", false},
+		{"1a", false},
+		{"a1", false},
+		{"1-2", false},
+		{"!", false},
+	}
+	for _, tc := range tests {
+		got := hasNumericSuffix(tc.input)
+		if got != tc.want {
+			t.Errorf("hasNumericSuffix(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Reduce the cognitive complexity of `isCanonicalArtistFile` by extracting a `hasNumericSuffix` helper, dropping it below the gocognit threshold and removing the `//nolint:gocognit` suppression.
- Behavior-preserving refactor (same inputs -> same outputs); added a table-driven `TestHasNumericSuffix`. Scoped to `internal/scanner`.

## Linked issue
Closes #1553

## Pre-flight checklist
- [x] Pre-push gate green locally (pre-push hook runs on push)
- [x] Commits squashed
- [x] Label(s) set
- [x] Docs label decision made (docs: not-required)
- [ ] Screenshot for UI change (N/A)
- [ ] UAT performed (N/A - non-UX backend refactor)
- [x] OpenAPI spec updated if shapes changed (no API change)
- [x] `templ generate` re-run (no .templ changes)

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/scanner/` passes (behavior preserved)
- [x] `golangci-lint run ./internal/scanner/` 0 issues (gocognit warning on `isCanonicalArtistFile` cleared)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for fanart file processing utilities.

* **Tests**
  * Added test coverage for numeric string validation in scanner operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->