### PR TITLE
fix(api): fetch biography in the user's metadata language on field-providers refresh (#1848)

### DIFF
--- a/internal/api/handlers_field.go
+++ b/internal/api/handlers_field.go
@@ -431,6 +431,11 @@ func (r *Router) handleFieldProviders(w http.ResponseWriter, req *http.Request) 
 	artistID := req.PathValue("id")
 	field := req.PathValue("field")
 
+	if !artist.IsEditableField(field) {
+		writeError(w, req, http.StatusBadRequest, "unknown or non-editable field: "+field)
+		return
+	}
+
 	a, err := r.artistService.GetByID(req.Context(), artistID)
 	if err != nil {
 		writeError(w, req, http.StatusNotFound, "artist not found")

--- a/internal/api/handlers_field.go
+++ b/internal/api/handlers_field.go
@@ -437,8 +437,12 @@ func (r *Router) handleFieldProviders(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
+	// Inject language preferences so providers receive the user's locale
+	// settings and return biography text in the correct language.
+	ctx := r.injectMetadataLanguages(req.Context())
+
 	results, err := r.orchestrator.FetchFieldFromProviders(
-		req.Context(), a.MusicBrainzID, a.Name, field, a.ProviderIDMap(),
+		ctx, a.MusicBrainzID, a.Name, field, a.ProviderIDMap(),
 	)
 	if err != nil {
 		r.logger.Error("fetching field from providers",

--- a/internal/api/handlers_field_providers_test.go
+++ b/internal/api/handlers_field_providers_test.go
@@ -81,6 +81,10 @@ func TestHandleFieldProviders_LanguageContextInjected(t *testing.T) {
 
 	r.handleFieldProviders(w, req)
 
+	if w.Code != http.StatusOK {
+		t.Fatalf("handleFieldProviders status = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+	}
+
 	// The mock must have been called, proving FetchFieldFromProviders proceeded
 	// to the provider level (i.e., did not fail before reaching it).
 	if cap.capturedCtx == nil {
@@ -96,5 +100,26 @@ func TestHandleFieldProviders_LanguageContextInjected(t *testing.T) {
 	}
 	if langs[0] != "fr" {
 		t.Errorf("first language preference = %q, want %q", langs[0], "fr")
+	}
+}
+
+// TestHandleFieldProviders_InvalidField verifies that handleFieldProviders
+// rejects an unknown or non-editable field value with 400 Bad Request.
+func TestHandleFieldProviders_InvalidField(t *testing.T) {
+	t.Parallel()
+
+	r, _ := testRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/any-id/fields/__invalid__/providers", nil)
+	req.SetPathValue("id", "any-id")
+	req.SetPathValue("field", "__invalid__")
+	req = withUserCtx(req, "test-user")
+	w := httptest.NewRecorder()
+
+	r.handleFieldProviders(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("handleFieldProviders with invalid field: status = %d, want %d; body=%s",
+			w.Code, http.StatusBadRequest, w.Body.String())
 	}
 }

--- a/internal/api/handlers_field_providers_test.go
+++ b/internal/api/handlers_field_providers_test.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/provider"
+)
+
+// contextCapturingProvider is a minimal Provider implementation that records
+// the context passed to GetArtist so tests can verify that language preferences
+// were injected by the handler before the orchestrator reaches the provider.
+type contextCapturingProvider struct {
+	capturedCtx context.Context
+}
+
+func (p *contextCapturingProvider) Name() provider.ProviderName { return provider.NameAudioDB }
+func (p *contextCapturingProvider) RequiresAuth() bool          { return false }
+func (p *contextCapturingProvider) SearchArtist(_ context.Context, _ string) ([]provider.ArtistSearchResult, error) {
+	return nil, nil
+}
+func (p *contextCapturingProvider) GetArtist(ctx context.Context, _ string) (*provider.ArtistMetadata, error) {
+	p.capturedCtx = ctx
+	return &provider.ArtistMetadata{Name: "Test Artist", Biography: "Test biography."}, nil
+}
+func (p *contextCapturingProvider) GetImages(_ context.Context, _ string) ([]provider.ImageResult, error) {
+	return nil, nil
+}
+
+// TestHandleFieldProviders_LanguageContextInjected verifies that
+// handleFieldProviders injects language preferences into the context before
+// calling FetchFieldFromProviders (#1848). Before the fix the handler passed
+// req.Context() directly; after the fix it calls r.injectMetadataLanguages
+// first so each provider receives the user's locale settings.
+func TestHandleFieldProviders_LanguageContextInjected(t *testing.T) {
+	t.Parallel()
+
+	r, artistSvc := testRouter(t)
+
+	// Use a synthetic user ID. user_preferences has no FK constraint to users,
+	// so we can store preferences for any ID without creating a real user row.
+	const userID = "field-providers-lang-test-user"
+
+	// Store a French language preference via the preferences handler. This
+	// writes a row that injectMetadataLanguages will read when the user is in
+	// context.
+	body := `{"value":"[\"fr\"]"}`
+	prefReq := httptest.NewRequest(http.MethodPut, "/api/v1/preferences/metadata_languages", strings.NewReader(body))
+	prefReq.SetPathValue("key", "metadata_languages")
+	prefReq = withUserCtx(prefReq, userID)
+	prefW := httptest.NewRecorder()
+	r.handleUpdatePreference(prefW, prefReq)
+	if prefW.Code != http.StatusOK {
+		t.Fatalf("storing language preference: expected 200, got %d: %s", prefW.Code, prefW.Body.String())
+	}
+
+	// Wire a context-capturing mock provider as AudioDB. AudioDB does not
+	// require an API key and is not excluded for the "biography" field, so
+	// FetchFieldFromProviders will call it when it appears in the priority list.
+	cap := &contextCapturingProvider{}
+	reg := provider.NewRegistry()
+	reg.Register(cap)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	providerSettings := provider.NewSettingsService(r.db, nil)
+	orch := provider.NewOrchestrator(reg, providerSettings, logger)
+	r.orchestrator = orch
+
+	a := addTestArtist(t, artistSvc, "Language Injection Test Artist")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/fields/biography/providers", nil)
+	req.SetPathValue("id", a.ID)
+	req.SetPathValue("field", "biography")
+	req = withUserCtx(req, userID)
+	w := httptest.NewRecorder()
+
+	r.handleFieldProviders(w, req)
+
+	// The mock must have been called, proving FetchFieldFromProviders proceeded
+	// to the provider level (i.e., did not fail before reaching it).
+	if cap.capturedCtx == nil {
+		t.Fatal("provider GetArtist was not called; FetchFieldFromProviders may have failed before reaching the AudioDB provider")
+	}
+
+	// Verify the context carries the stored language preference.
+	// Before the fix, req.Context() was passed directly and would have had no
+	// preferences. With the fix, r.injectMetadataLanguages enriches it from DB.
+	langs := provider.MetadataLanguages(cap.capturedCtx)
+	if len(langs) == 0 {
+		t.Fatal("no language preferences in provider context; injectMetadataLanguages was not called or failed to inject")
+	}
+	if langs[0] != "fr" {
+		t.Errorf("first language preference = %q, want %q", langs[0], "fr")
+	}
+}

--- a/internal/api/testdata/openapi-coverage-baseline.json
+++ b/internal/api/testdata/openapi-coverage-baseline.json
@@ -19,7 +19,6 @@
   "getAPIDocs",
   "getArtist",
   "getConnectionScraperConfig",
-  "getFieldProviders",
   "getHealth",
   "getLogging",
   "getMaintenanceStatus",

--- a/internal/api/testdata/openapi-coverage.json
+++ b/internal/api/testdata/openapi-coverage.json
@@ -606,7 +606,7 @@
     "method": "GET",
     "path": "/artists/{id}/fields/{field}/providers",
     "handler": "handleFieldProviders",
-    "covered": false
+    "covered": true
   },
   {
     "operationId": "getFieldsEditAll",

--- a/internal/provider/audiodb/audiodb.go
+++ b/internal/provider/audiodb/audiodb.go
@@ -281,8 +281,15 @@ func mapArtist(ctx context.Context, art *AudioDBArtist) *provider.ArtistMetadata
 	// AudioDB provides per-language biography fields for a fixed set of languages.
 	// strBiography is the API's own default/locale-specific value; it is used as a
 	// final fallback when no preference-ordered field matches.
+	// AudioDB's strBiographyEN is frequently null even for artists that have
+	// English content; in those cases strBiography carries the English text.
+	// Treat strBiography as the English candidate so it ranks correctly against
+	// other language candidates (e.g. strBiographyFR) when the user's first
+	// preference is "en". Without this, an empty strBiographyEN causes
+	// SelectLocalizedBiography to skip "en" and return the next non-empty
+	// language (e.g. French) instead of the English text in strBiography.
 	bioCandidates := map[string]string{
-		"en": art.BiographyEN,
+		"en": firstNonEmpty(art.BiographyEN, art.Biography),
 		"de": art.BiographyDE,
 		"fr": art.BiographyFR,
 		"ja": art.BiographyJA,
@@ -298,9 +305,10 @@ func mapArtist(ctx context.Context, art *AudioDBArtist) *provider.ArtistMetadata
 		"nl": art.BiographyNL,
 		"es": art.BiographyES,
 	}
-	// Prefer the explicit English field as the no-preference fallback so that
-	// callers without a language context receive English rather than whatever
-	// locale AudioDB happens to return in the generic strBiography slot.
+	// No-preference fallback: prefer the explicit English field, then the
+	// generic strBiography. The bioCandidates["en"] entry already covers this
+	// ordering for preference-aware callers; the fallback serves callers that
+	// pass no language context at all.
 	fallbackBio := firstNonEmpty(art.BiographyEN, art.Biography)
 
 	langPrefs := provider.MetadataLanguages(ctx)

--- a/internal/provider/audiodb/audiodb.go
+++ b/internal/provider/audiodb/audiodb.go
@@ -298,7 +298,10 @@ func mapArtist(ctx context.Context, art *AudioDBArtist) *provider.ArtistMetadata
 		"nl": art.BiographyNL,
 		"es": art.BiographyES,
 	}
-	fallbackBio := firstNonEmpty(art.Biography, art.BiographyEN)
+	// Prefer the explicit English field as the no-preference fallback so that
+	// callers without a language context receive English rather than whatever
+	// locale AudioDB happens to return in the generic strBiography slot.
+	fallbackBio := firstNonEmpty(art.BiographyEN, art.Biography)
 
 	langPrefs := provider.MetadataLanguages(ctx)
 	bio := provider.SelectLocalizedBiography(bioCandidates, langPrefs, fallbackBio)

--- a/internal/provider/audiodb/audiodb_test.go
+++ b/internal/provider/audiodb/audiodb_test.go
@@ -510,6 +510,24 @@ func TestMapArtist_BiographyExtendedLanguages(t *testing.T) {
 			langPrefs: []string{"he"},
 			wantBio:   "\u05d1\u05d9\u05d5\u05d2\u05e8\u05e4\u05d9\u05d4 \u05d1\u05e2\u05d1\u05e8\u05d9\u05ea.",
 		},
+		{
+			// Regression test for the Adele scenario: AudioDB's strBiographyEN is
+			// null for many artists (the English text lives in strBiography instead).
+			// When the user prefers ["en","fr"] and strBiographyEN is empty but
+			// strBiographyFR is populated, we must return English (strBiography)
+			// rather than French. The fix is to treat strBiography as the "en"
+			// candidate when strBiographyEN is absent/empty.
+			name: "English strBiography used as EN candidate when strBiographyEN is absent",
+			art: AudioDBArtist{
+				IDArtist:    "19",
+				Artist:      "S",
+				Biography:   "English text from strBiography.",
+				BiographyEN: "", // null/absent in AudioDB v2 response
+				BiographyFR: "Texte en francais.",
+			},
+			langPrefs: []string{"en", "fr"},
+			wantBio:   "English text from strBiography.",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/provider/audiodb/audiodb_test.go
+++ b/internal/provider/audiodb/audiodb_test.go
@@ -241,11 +241,14 @@ func TestMapArtist_BiographyLocalization(t *testing.T) {
 			wantBio:   "English biography.",
 		},
 		{
-			name:      "Non-English preference falls back to default bio",
+			// User prefers German but BiographyDE is not set; fallback order is
+			// now firstNonEmpty(BiographyEN, Biography) so English is returned
+			// rather than the ambiguous locale-default strBiography field.
+			name:      "Non-English preference without that language falls back to EN",
 			bio:       "Biographie auf Deutsch.",
 			bioEN:     "English biography.",
 			langPrefs: []string{"de"},
-			wantBio:   "Biographie auf Deutsch.",
+			wantBio:   "English biography.",
 		},
 		{
 			name:      "Empty English bio falls back to default bio",
@@ -255,11 +258,13 @@ func TestMapArtist_BiographyLocalization(t *testing.T) {
 			wantBio:   "Biographie par default.",
 		},
 		{
-			name:      "No preferences uses fallback",
+			// After swapping the fallback to firstNonEmpty(BiographyEN, Biography),
+			// the English field is preferred when no language preference is set.
+			name:      "No preferences prefers English bio over locale default",
 			bio:       "Default bio.",
 			bioEN:     "English bio.",
 			langPrefs: nil,
-			wantBio:   "Default bio.",
+			wantBio:   "English bio.",
 		},
 		{
 			name:      "No preferences and empty EN falls back to strBiography",


### PR DESCRIPTION
## Summary
- Inject the user's metadata-language preference into the **field-providers** biography fetch path (`handlers_field.go`), so single-field "fetch from providers" honors language prefs (Last.fm now requests the preferred language). This mirrors the full-refresh and provider paths, which already did this.
- Fix AudioDB biography language selection: AudioDB's `strBiographyEN` is effectively always `null` and the **no-suffix `strBiography` holds the English text**, so the `"en"` candidate is keyed to `firstNonEmpty(BiographyEN, Biography)`. Previously the empty `EN` candidate was skipped and a non-English bio (e.g. French for Adele) won despite an `en`-first preference.
- Regression tests: field-providers language-context injection, and AudioDB `en`-candidate selection (an `["en","fr"]` pref returns the English no-suffix bio).

## Linked issue
Closes #1848

## Pre-flight checklist
- [x] Pre-push gate green locally (pre-push hook runs on push)
- [x] Code review pass complete (independent hostile review CLEAN)
- [x] Commits squashed
- [x] Label(s) set
- [x] Docs label decision made (docs: not-required)
- [ ] Screenshot for UI change (N/A - no layout/CSS change)
- [x] UAT performed for user-visible changes (maintainer confirmed Adele's biography now returns English, was French, on the live field-providers fetch)
- [x] OpenAPI spec updated if shapes changed (no shape change; coverage baseline updated)
- [x] `templ generate` re-run (no .templ changes)

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/api/ ./internal/provider/audiodb/` pass
- [x] Live UAT: Adele biography fetch returns English (en-first pref) - maintainer-confirmed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Provider-sourced content (such as artist biographies) now respects user language preferences for localization.

* **Bug Fixes**
  * Improved biography selection logic to better handle language fallbacks when preferred language content is unavailable.

* **Tests**
  * Added and updated test coverage for language preference handling in provider data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->