### PR TITLE
chore(build): add -trimpath across all build paths + dual-Dockerfile drift guards (#1879)

### DIFF
--- a/.github/workflows/bruno-ci.yml
+++ b/.github/workflows/bruno-ci.yml
@@ -96,6 +96,7 @@ jobs:
           DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           PKG=github.com/sydlexius/stillwater/internal/version
           CGO_ENABLED=0 go build \
+            -trimpath \
             -ldflags="-s -w -X ${PKG}.Version=${VERSION} -X ${PKG}.Commit=${COMMIT} -X ${PKG}.Date=${DATE}" \
             -o stillwater ./cmd/stillwater
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,6 +414,7 @@ jobs:
           DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           PKG=github.com/sydlexius/stillwater/internal/version
           CGO_ENABLED=0 go build \
+            -trimpath \
             -ldflags="-s -w -X ${PKG}.Version=${VERSION} -X ${PKG}.Commit=${COMMIT} -X ${PKG}.Date=${DATE}" \
             -o stillwater ./cmd/stillwater
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,7 @@ jobs:
           DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           PKG=github.com/sydlexius/stillwater/internal/version
           CGO_ENABLED=0 go build \
+            -trimpath \
             -ldflags="-s -w -X ${PKG}.Version=${VERSION} -X ${PKG}.Commit=${COMMIT} -X ${PKG}.Date=${DATE}" \
             -o stillwater ./cmd/stillwater
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,7 @@ jobs:
           fi
 
           go build \
+            -trimpath \
             -ldflags "-s -w \
               -X github.com/sydlexius/stillwater/internal/version.Version=${VERSION} \
               -X github.com/sydlexius/stillwater/internal/version.Commit=${SHORT_COMMIT} \

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -68,6 +68,8 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
+    flags:
+      - -trimpath
     ldflags:
       - -s -w
       - -X github.com/sydlexius/stillwater/internal/version.Version={{ .Version }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,8 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
+    flags:
+      - -trimpath
     ldflags:
       - -s -w
       - -X github.com/sydlexius/stillwater/internal/version.Version={{ .Version }}

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -40,7 +40,19 @@ COPY . .
 
 # Build Tailwind CSS and Go binary in a single layer (hadolint DL3059).
 RUN tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minify \
-    && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /bin/stillwater ./cmd/stillwater
+    && CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /bin/stillwater ./cmd/stillwater
+
+# --- SYNC with Dockerfile.goreleaser runtime stanza ---
+# The runtime stage below must stay in sync with Dockerfile.goreleaser.
+# Allowed intentional differences (do not "fix" these):
+#   - LABEL block: present here (for `docker build` / CI); absent in
+#     Dockerfile.goreleaser (goreleaser injects OCI labels via .goreleaser.yml).
+#   - Binary COPY source: `--from=builder /bin/stillwater` here; in
+#     Dockerfile.goreleaser it is `ARG TARGETPLATFORM` + `COPY $TARGETPLATFORM/stillwater`
+#     (goreleaser's multi-platform buildx context, no builder stage).
+# Any other runtime change (base image digest, apk packages, users, ports,
+# healthcheck, volumes, entrypoint) MUST be mirrored in Dockerfile.goreleaser.
+# --- END SYNC ---
 
 # Runtime stage
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11

--- a/build/docker/Dockerfile.goreleaser
+++ b/build/docker/Dockerfile.goreleaser
@@ -1,3 +1,15 @@
+# --- SYNC with runtime stanza of Dockerfile ---
+# This file is the goreleaser runtime image (copies a pre-built binary; no
+# builder stage). Its content must stay in sync with the runtime stage of
+# Dockerfile. Allowed intentional differences (do not "fix" these):
+#   - No LABEL block here; goreleaser injects OCI labels via .goreleaser.yml.
+#   - ARG TARGETPLATFORM + COPY $TARGETPLATFORM/stillwater (goreleaser multi-
+#     platform buildx context); Dockerfile uses `--from=builder /bin/stillwater`.
+# Any other runtime change (base image digest, apk packages, users, ports,
+# healthcheck, volumes, entrypoint) MUST be mirrored in the runtime stage of
+# Dockerfile.
+# --- END SYNC ---
+
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 RUN apk add --no-cache ca-certificates tzdata su-exec && \


### PR DESCRIPTION
## Summary

Adds `-trimpath` to every artifact-producing Go build path so released binaries no longer embed the build machine's absolute source paths (reproducible-build parity / SLSA-provenance posture), and guards the dual-Dockerfile drift risk with cross-reference comments.

## Changes

- `-trimpath` added to every shipped build path:
  - `.goreleaser.yml` and `.goreleaser.nightly.yml` (`flags: [-trimpath]` under `builds:`, adjacent to `ldflags`)
  - `build/docker/Dockerfile` (`go build -trimpath -ldflags="-s -w" ...`)
  - `.github/workflows/ci.yml`, `codeql.yml`, `bruno-ci.yml`, and `release.yml` (the latter builds the signed/attested GitHub Release archives)
- `build/docker/Dockerfile.goreleaser` intentionally unchanged (copies a pre-built binary; no `go build`)
- Cross-reference comments added to **both** Dockerfiles documenting the runtime-stanza sync requirement and the allowed intentional differences (the `LABEL` block, and the binary `COPY` source / `TARGETPLATFORM` mechanism)

## Verification

- `go build ./...` and `go vet ./...` clean.
- `-trimpath` proven to strip source paths via a direct-build side-by-side: **with** `-trimpath`, `strings | grep -E '/Users/|/home/runner'` returns 0 source-file paths (the only `/Users/` matches are intentional Emby API endpoint string literals like `/Users/%s/Items/%s`); **without** it, dozens of `/Users/.../internal/...` source paths appear.
- Local `goreleaser release --snapshot --clean` is not run here (a pre-existing macOS-arm64 limitation: the tailwind `before_hook` downloads a linux-x64 binary); CI runs goreleaser on Linux and validates version-ldflag injection there.

Closes #1879
