### PR TITLE
refactor: use errors.Is for sql.ErrNoRows comparisons (#1958)

### DIFF
--- a/internal/artist/sqlite_history.go
+++ b/internal/artist/sqlite_history.go
@@ -3,6 +3,7 @@ package artist
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -50,7 +51,7 @@ func (r *sqliteHistoryRepo) GetByID(ctx context.Context, id string) (*MetadataCh
 		&c.ID, &c.ArtistID, &c.Field, &c.OldValue, &c.NewValue, &c.Source, &createdAtStr,
 	)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("%w: %s", ErrChangeNotFound, id)
 		}
 		return nil, fmt.Errorf("querying metadata change: %w", err)

--- a/internal/artist/sqlite_platform.go
+++ b/internal/artist/sqlite_platform.go
@@ -63,7 +63,7 @@ func (r *sqlitePlatformIDRepo) Get(ctx context.Context, artistID, connectionID s
 		WHERE artist_id = ? AND connection_id = ?
 	`, artistID, connectionID).Scan(&platformArtistID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return "", nil
 		}
 		return "", fmt.Errorf("getting platform id: %w", err)

--- a/internal/provider/settings.go
+++ b/internal/provider/settings.go
@@ -169,7 +169,7 @@ func (s *SettingsService) GetKeyStatus(ctx context.Context, name ProviderName) (
 	key := keyStatusSettingKey(name)
 	var value string
 	err := s.db.QueryRowContext(ctx, "SELECT value FROM settings WHERE key = ?", key).Scan(&value)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
 	}
 	if err != nil {
@@ -375,7 +375,7 @@ func (s *SettingsService) GetPriorities(ctx context.Context) ([]FieldPriority, e
 		key := prioritySettingKey(d.Field)
 		var value string
 		err := s.db.QueryRowContext(ctx, "SELECT value FROM settings WHERE key = ?", key).Scan(&value)
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			result[i] = d
 		} else if err != nil {
 			return nil, fmt.Errorf("reading priority for %s: %w", d.Field, err)
@@ -574,7 +574,7 @@ func (s *SettingsService) IsWebSearchEnabled(ctx context.Context, name ProviderN
 	key := webSearchEnabledKey(name)
 	var value string
 	err := s.db.QueryRowContext(ctx, "SELECT value FROM settings WHERE key = ?", key).Scan(&value)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
 	}
 	if err != nil {
@@ -647,7 +647,7 @@ func (s *SettingsService) GetBaseURL(ctx context.Context, name ProviderName) (st
 	key := baseURLSettingKey(name)
 	var value string
 	err := s.db.QueryRowContext(ctx, "SELECT value FROM settings WHERE key = ?", key).Scan(&value)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
 	}
 	if err != nil {

--- a/internal/scraper/service.go
+++ b/internal/scraper/service.go
@@ -96,7 +96,7 @@ func (s *Service) SaveConfig(ctx context.Context, scope string, cfg *ScraperConf
 		err := s.db.QueryRowContext(ctx,
 			"SELECT id FROM scraper_config WHERE scope = ?", scope,
 		).Scan(&existingID)
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			cfg.ID = uuid.New().String()
 		} else if err != nil {
 			return fmt.Errorf("checking existing config: %w", err)


### PR DESCRIPTION
## Summary

Converts the 7 remaining direct `err == sql.ErrNoRows` sentinel comparisons to the wrap-safe `errors.Is(err, sql.ErrNoRows)` form, so the "no rows" branch stays correct even if an intermediate layer wraps the error (`fmt.Errorf("...: %w", err)`). Behavior-preserving: `modernc.org/sqlite` returns the sentinel unwrapped today, so all current comparisons already behave correctly — this is a robustness/consistency change matching the pattern in `internal/api/handlers_settings.go`.

## Changes

- `internal/scraper/service.go` (1 site)
- `internal/provider/settings.go` (4 sites: lines 172 / 378 / 577 / 650)
- `internal/artist/sqlite_history.go` (1 site; added the `errors` import)
- `internal/artist/sqlite_platform.go` (1 site)

A final `grep` confirms **0 remaining** direct `== sql.ErrNoRows` / `!= sql.ErrNoRows` comparisons outside test files.

## Verification

- `go build ./...` and `go vet ./...` clean
- `go test ./internal/scraper/... ./internal/provider/... ./internal/artist/...` all pass (no behavior change)

Surfaced by the adversarial review during #1594. Mechanical / no behavior change → `norabbit`.

Closes #1958
