### PR TITLE
fix(settings): distinguish absent key from DB error in get*Setting helpers (#1594)

### DIFF
--- a/internal/api/handlers_settings.go
+++ b/internal/api/handlers_settings.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -275,10 +276,14 @@ func (r *Router) handleUpdateSettings(w http.ResponseWriter, req *http.Request) 
 
 // getBoolSetting reads a boolean setting from the key-value table.
 // Returns the fallback value if the key does not exist or cannot be parsed.
+// Logs a warning for genuine DB errors (i.e. anything other than a missing row).
 func (r *Router) getBoolSetting(ctx context.Context, key string, fallback bool) bool {
 	var v string
 	err := r.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
 	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			r.logger.Warn("reading bool setting", "key", key, "error", err)
+		}
 		return fallback
 	}
 	return v == "true" || v == "1"
@@ -286,10 +291,18 @@ func (r *Router) getBoolSetting(ctx context.Context, key string, fallback bool) 
 
 // getIntSetting reads an integer setting from the key-value table.
 // Returns the fallback value if the key does not exist or cannot be parsed.
+// Logs a warning for genuine DB errors (i.e. anything other than a missing row).
+// Parse errors from a stored non-integer value are silently ignored.
 func (r *Router) getIntSetting(ctx context.Context, key string, fallback int) int {
 	var v string
 	err := r.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
-	if err != nil || v == "" {
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			r.logger.Warn("reading int setting", "key", key, "error", err)
+		}
+		return fallback
+	}
+	if v == "" {
 		return fallback
 	}
 	n, err2 := strconv.Atoi(v)
@@ -326,11 +339,19 @@ func (r *Router) ruleScheduleMinutes(ctx context.Context) int {
 }
 
 // getStringSetting reads a string setting from the key-value table.
-// Returns the fallback value if the key does not exist.
+// Returns the fallback value if the key does not exist or the stored value is
+// empty. Logs a warning for genuine DB errors (i.e. anything other than a
+// missing row).
 func (r *Router) getStringSetting(ctx context.Context, key string, fallback string) string {
 	var v string
 	err := r.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
-	if err != nil || v == "" {
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			r.logger.Warn("reading string setting", "key", key, "error", err)
+		}
+		return fallback
+	}
+	if v == "" {
 		return fallback
 	}
 	return v

--- a/internal/api/handlers_settings.go
+++ b/internal/api/handlers_settings.go
@@ -292,7 +292,7 @@ func (r *Router) getBoolSetting(ctx context.Context, key string, fallback bool) 
 // getIntSetting reads an integer setting from the key-value table.
 // Returns the fallback value if the key does not exist or cannot be parsed.
 // Logs a warning for genuine DB errors (i.e. anything other than a missing row).
-// Parse errors from a stored non-integer value are silently ignored.
+// Logs a warning when a stored value is not a valid integer.
 func (r *Router) getIntSetting(ctx context.Context, key string, fallback int) int {
 	var v string
 	err := r.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
@@ -307,6 +307,7 @@ func (r *Router) getIntSetting(ctx context.Context, key string, fallback int) in
 	}
 	n, err2 := strconv.Atoi(v)
 	if err2 != nil {
+		r.logger.Warn("int setting value is not a valid integer", "key", key, "stored_value", v, "fallback", fallback)
 		return fallback
 	}
 	return n

--- a/internal/api/handlers_settings_helpers_test.go
+++ b/internal/api/handlers_settings_helpers_test.go
@@ -8,6 +8,19 @@ import (
 	"testing"
 )
 
+// insertSetting is a test helper that writes a key/value pair into the
+// settings table of the test router's DB.
+func insertSetting(t *testing.T, r *Router, key, value string) {
+	t.Helper()
+	_, err := r.db.ExecContext(context.Background(),
+		`INSERT INTO settings (key, value) VALUES (?, ?)`, key, value)
+	if err != nil {
+		t.Fatalf("insertSetting(%q=%q): %v", key, value, err)
+	}
+}
+
+// -- getStringSetting ---------------------------------------------------------
+
 // TestGetStringSetting_AbsentKey verifies that a missing settings row
 // returns the fallback without emitting a log line.
 func TestGetStringSetting_AbsentKey(t *testing.T) {
@@ -23,6 +36,32 @@ func TestGetStringSetting_AbsentKey(t *testing.T) {
 	}
 	if buf.Len() != 0 {
 		t.Errorf("getStringSetting absent key: expected no log output, got %q", buf.String())
+	}
+}
+
+// TestGetStringSetting_StoredValue verifies that a present, non-empty stored
+// value is returned directly (happy path).
+func TestGetStringSetting_StoredValue(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+	insertSetting(t, r, "test.str", "hello")
+
+	got := r.getStringSetting(context.Background(), "test.str", "fallback")
+	if got != "hello" {
+		t.Errorf("getStringSetting stored value: got %q, want %q", got, "hello")
+	}
+}
+
+// TestGetStringSetting_EmptyStoredValue verifies that a stored empty string
+// returns the fallback (empty string is treated as absent).
+func TestGetStringSetting_EmptyStoredValue(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+	insertSetting(t, r, "test.empty", "")
+
+	got := r.getStringSetting(context.Background(), "test.empty", "fallback")
+	if got != "fallback" {
+		t.Errorf("getStringSetting empty stored value: got %q, want %q", got, "fallback")
 	}
 }
 
@@ -53,6 +92,8 @@ func TestGetStringSetting_DBError(t *testing.T) {
 	}
 }
 
+// -- getBoolSetting -----------------------------------------------------------
+
 // TestGetBoolSetting_AbsentKey verifies that a missing settings row
 // returns the fallback without emitting a log line.
 func TestGetBoolSetting_AbsentKey(t *testing.T) {
@@ -68,6 +109,34 @@ func TestGetBoolSetting_AbsentKey(t *testing.T) {
 	}
 	if buf.Len() != 0 {
 		t.Errorf("getBoolSetting absent key: expected no log output, got %q", buf.String())
+	}
+}
+
+// TestGetBoolSetting_True verifies that stored "true" and "1" both parse to true.
+func TestGetBoolSetting_True(t *testing.T) {
+	t.Parallel()
+	for _, stored := range []string{"true", "1"} {
+		stored := stored
+		t.Run(stored, func(t *testing.T) {
+			t.Parallel()
+			r, _ := testRouter(t)
+			insertSetting(t, r, "test.bool.on", stored)
+			got := r.getBoolSetting(context.Background(), "test.bool.on", false)
+			if !got {
+				t.Errorf("getBoolSetting(%q): got false, want true", stored)
+			}
+		})
+	}
+}
+
+// TestGetBoolSetting_False verifies that stored "false" parses to false.
+func TestGetBoolSetting_False(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+	insertSetting(t, r, "test.bool.off", "false")
+	got := r.getBoolSetting(context.Background(), "test.bool.off", true)
+	if got {
+		t.Errorf("getBoolSetting(\"false\"): got true, want false")
 	}
 }
 
@@ -97,6 +166,8 @@ func TestGetBoolSetting_DBError(t *testing.T) {
 	}
 }
 
+// -- getIntSetting ------------------------------------------------------------
+
 // TestGetIntSetting_AbsentKey verifies that a missing settings row
 // returns the fallback without emitting a log line.
 func TestGetIntSetting_AbsentKey(t *testing.T) {
@@ -112,6 +183,55 @@ func TestGetIntSetting_AbsentKey(t *testing.T) {
 	}
 	if buf.Len() != 0 {
 		t.Errorf("getIntSetting absent key: expected no log output, got %q", buf.String())
+	}
+}
+
+// TestGetIntSetting_StoredValue verifies that a stored valid integer is
+// returned correctly (happy path, previously untested).
+func TestGetIntSetting_StoredValue(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+	insertSetting(t, r, "test.int", "42")
+
+	got := r.getIntSetting(context.Background(), "test.int", 0)
+	if got != 42 {
+		t.Errorf("getIntSetting stored value: got %d, want 42", got)
+	}
+}
+
+// TestGetIntSetting_EmptyStoredValue verifies that a stored empty string
+// returns the fallback (empty is treated as absent).
+func TestGetIntSetting_EmptyStoredValue(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+	insertSetting(t, r, "test.int.empty", "")
+
+	got := r.getIntSetting(context.Background(), "test.int.empty", 7)
+	if got != 7 {
+		t.Errorf("getIntSetting empty stored value: got %d, want 7 (fallback)", got)
+	}
+}
+
+// TestGetIntSetting_InvalidValue verifies that a stored non-integer returns
+// the fallback AND emits a Warn log line (Item 2 observability).
+func TestGetIntSetting_InvalidValue(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+	insertSetting(t, r, "test.int.bad", "bad")
+
+	var buf bytes.Buffer
+	r.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	got := r.getIntSetting(context.Background(), "test.int.bad", 99)
+	if got != 99 {
+		t.Errorf("getIntSetting invalid value: got %d, want 99 (fallback)", got)
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "int setting value is not a valid integer") {
+		t.Errorf("getIntSetting invalid value: expected warn log, got %q", logged)
+	}
+	if !strings.Contains(logged, "level=WARN") {
+		t.Errorf("getIntSetting invalid value: expected WARN level, got %q", logged)
 	}
 }
 

--- a/internal/api/handlers_settings_helpers_test.go
+++ b/internal/api/handlers_settings_helpers_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestGetStringSetting_AbsentKey verifies that a missing settings row
+// returns the fallback without emitting a log line.
+func TestGetStringSetting_AbsentKey(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+
+	var buf bytes.Buffer
+	r.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	got := r.getStringSetting(context.Background(), "nonexistent.key", "default-val")
+	if got != "default-val" {
+		t.Errorf("getStringSetting absent key: got %q, want %q", got, "default-val")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("getStringSetting absent key: expected no log output, got %q", buf.String())
+	}
+}
+
+// TestGetStringSetting_DBError verifies that a real DB error (closed connection)
+// returns the fallback AND emits a Warn log line.
+func TestGetStringSetting_DBError(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+
+	var buf bytes.Buffer
+	r.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	// Force every subsequent DB call to fail.
+	if err := r.db.Close(); err != nil {
+		t.Fatalf("closing db: %v", err)
+	}
+
+	got := r.getStringSetting(context.Background(), "some.key", "fallback")
+	if got != "fallback" {
+		t.Errorf("getStringSetting DB error: got %q, want %q", got, "fallback")
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "reading string setting") {
+		t.Errorf("getStringSetting DB error: expected warn log, got %q", logged)
+	}
+	if !strings.Contains(logged, "level=WARN") {
+		t.Errorf("getStringSetting DB error: expected WARN level, got %q", logged)
+	}
+}
+
+// TestGetBoolSetting_AbsentKey verifies that a missing settings row
+// returns the fallback without emitting a log line.
+func TestGetBoolSetting_AbsentKey(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+
+	var buf bytes.Buffer
+	r.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	got := r.getBoolSetting(context.Background(), "nonexistent.bool", true)
+	if !got {
+		t.Errorf("getBoolSetting absent key: got %v, want true (fallback)", got)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("getBoolSetting absent key: expected no log output, got %q", buf.String())
+	}
+}
+
+// TestGetBoolSetting_DBError verifies that a real DB error returns the fallback
+// and emits a Warn log line.
+func TestGetBoolSetting_DBError(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+
+	var buf bytes.Buffer
+	r.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	if err := r.db.Close(); err != nil {
+		t.Fatalf("closing db: %v", err)
+	}
+
+	got := r.getBoolSetting(context.Background(), "some.bool", false)
+	if got != false {
+		t.Errorf("getBoolSetting DB error: got %v, want false (fallback)", got)
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "reading bool setting") {
+		t.Errorf("getBoolSetting DB error: expected warn log, got %q", logged)
+	}
+	if !strings.Contains(logged, "level=WARN") {
+		t.Errorf("getBoolSetting DB error: expected WARN level, got %q", logged)
+	}
+}
+
+// TestGetIntSetting_AbsentKey verifies that a missing settings row
+// returns the fallback without emitting a log line.
+func TestGetIntSetting_AbsentKey(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+
+	var buf bytes.Buffer
+	r.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	got := r.getIntSetting(context.Background(), "nonexistent.int", 42)
+	if got != 42 {
+		t.Errorf("getIntSetting absent key: got %d, want 42 (fallback)", got)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("getIntSetting absent key: expected no log output, got %q", buf.String())
+	}
+}
+
+// TestGetIntSetting_DBError verifies that a real DB error returns the fallback
+// and emits a Warn log line.
+func TestGetIntSetting_DBError(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+
+	var buf bytes.Buffer
+	r.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	if err := r.db.Close(); err != nil {
+		t.Fatalf("closing db: %v", err)
+	}
+
+	got := r.getIntSetting(context.Background(), "some.int", 99)
+	if got != 99 {
+		t.Errorf("getIntSetting DB error: got %d, want 99 (fallback)", got)
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "reading int setting") {
+		t.Errorf("getIntSetting DB error: expected warn log, got %q", logged)
+	}
+	if !strings.Contains(logged, "level=WARN") {
+		t.Errorf("getIntSetting DB error: expected WARN level, got %q", logged)
+	}
+}

--- a/internal/maintenance/maintenance.go
+++ b/internal/maintenance/maintenance.go
@@ -3,6 +3,7 @@ package maintenance
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -103,6 +104,8 @@ func (s *Service) Status(ctx context.Context) (*Status, error) {
 		`SELECT value FROM settings WHERE key = 'db_maintenance.last_optimize_at'`).Scan(&lastOpt)
 	if err == nil {
 		st.LastOptimizeAt = lastOpt
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		s.logger.Warn("reading last_optimize_at", "error", err)
 	}
 
 	// Schedule config
@@ -358,24 +361,39 @@ func (s *Service) StartScheduler(ctx context.Context, interval time.Duration) {
 }
 
 // getBoolSetting reads a boolean setting from the key-value table.
+// Returns the fallback value if the key does not exist or cannot be parsed.
+// Logs a warning for genuine DB errors (i.e. anything other than a missing row).
 func (s *Service) getBoolSetting(ctx context.Context, key string, fallback bool) bool {
 	var v string
 	err := s.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
 	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			s.logger.Warn("reading bool setting", "key", key, "error", err)
+		}
 		return fallback
 	}
 	return v == "true" || v == "1"
 }
 
 // getIntSetting reads an integer setting from the key-value table.
+// Returns the fallback value if the key does not exist or cannot be parsed.
+// Logs a warning for genuine DB errors (i.e. anything other than a missing row).
+// Logs a warning when a stored value is not a valid integer.
 func (s *Service) getIntSetting(ctx context.Context, key string, fallback int) int {
 	var v string
 	err := s.db.QueryRowContext(ctx, `SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
-	if err != nil || v == "" {
+	if err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			s.logger.Warn("reading int setting", "key", key, "error", err)
+		}
+		return fallback
+	}
+	if v == "" {
 		return fallback
 	}
 	var n int
 	if _, err := fmt.Sscanf(v, "%d", &n); err != nil {
+		s.logger.Warn("int setting value is not a valid integer", "key", key, "stored_value", v, "fallback", fallback)
 		return fallback
 	}
 	return n

--- a/internal/maintenance/maintenance.go
+++ b/internal/maintenance/maintenance.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/sydlexius/stillwater/internal/foreign"
@@ -391,8 +392,8 @@ func (s *Service) getIntSetting(ctx context.Context, key string, fallback int) i
 	if v == "" {
 		return fallback
 	}
-	var n int
-	if _, err := fmt.Sscanf(v, "%d", &n); err != nil {
+	n, err := strconv.Atoi(v)
+	if err != nil {
 		s.logger.Warn("int setting value is not a valid integer", "key", key, "stored_value", v, "fallback", fallback)
 		return fallback
 	}

--- a/internal/maintenance/maintenance_test.go
+++ b/internal/maintenance/maintenance_test.go
@@ -748,28 +748,48 @@ func TestGetIntSetting_AbsentKey(t *testing.T) {
 
 // TestGetIntSetting_InvalidValue verifies that a stored non-integer value
 // returns the fallback AND emits a Warn log line (Item 2 observability).
+// TestGetIntSetting_InvalidValue verifies that a stored value that is not a
+// valid integer returns the fallback and logs a Warn. The cases cover both a
+// fully non-numeric value and a partial-numeric value (e.g. "12abc"): the
+// latter is the case strconv.Atoi rejects but the old fmt.Sscanf(v, "%d", &n)
+// would silently accept (parsing the leading "12" and ignoring the rest).
 func TestGetIntSetting_InvalidValue(t *testing.T) {
 	t.Parallel()
-	db, dbPath := setupTestDB(t)
-	ctx := context.Background()
-	if _, err := db.ExecContext(ctx,
-		`INSERT INTO settings (key, value) VALUES ('test.bad', 'notanint')`); err != nil {
-		t.Fatalf("seeding bad int: %v", err)
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"non_numeric", "notanint"},
+		{"leading_numeric_trailing_garbage", "12abc"},
+		{"float_like", "3.14"},
+		{"whitespace_padded", " 12 "},
 	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			db, dbPath := setupTestDB(t)
+			ctx := context.Background()
+			if _, err := db.ExecContext(ctx,
+				`INSERT INTO settings (key, value) VALUES ('test.bad', ?)`, tc.value); err != nil {
+				t.Fatalf("seeding bad int: %v", err)
+			}
 
-	buf, lg := warnLogger()
-	svc := NewService(db, dbPath, "", lg)
+			buf, lg := warnLogger()
+			svc := NewService(db, dbPath, "", lg)
 
-	got := svc.getIntSetting(ctx, "test.bad", 33)
-	if got != 33 {
-		t.Errorf("getIntSetting invalid value: got %d, want 33 (fallback)", got)
-	}
-	logged := buf.String()
-	if !strings.Contains(logged, "int setting value is not a valid integer") {
-		t.Errorf("getIntSetting invalid value: expected warn log, got %q", logged)
-	}
-	if !strings.Contains(logged, "level=WARN") {
-		t.Errorf("getIntSetting invalid value: expected WARN level, got %q", logged)
+			got := svc.getIntSetting(ctx, "test.bad", 33)
+			if got != 33 {
+				t.Errorf("getIntSetting(%q): got %d, want 33 (fallback)", tc.value, got)
+			}
+			logged := buf.String()
+			if !strings.Contains(logged, "int setting value is not a valid integer") {
+				t.Errorf("getIntSetting(%q): expected warn log, got %q", tc.value, logged)
+			}
+			if !strings.Contains(logged, "level=WARN") {
+				t.Errorf("getIntSetting(%q): expected WARN level, got %q", tc.value, logged)
+			}
+		})
 	}
 }
 

--- a/internal/maintenance/maintenance_test.go
+++ b/internal/maintenance/maintenance_test.go
@@ -1,6 +1,7 @@
 package maintenance
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -648,4 +650,151 @@ func TestStartForeignFileScanner_NilListerNoOp(t *testing.T) {
 	svc := NewService(db, dbPath, "", slog.New(slog.NewTextHandler(os.Stderr, nil)))
 	// Passing nil should return immediately without panicking.
 	svc.StartForeignFileScanner(context.Background(), nil, 0, 0)
+}
+
+// -- get*Setting error-discrimination tests -----------------------------------
+
+// warnLogger returns a bytes.Buffer and a *slog.Logger that writes WARN+ to it.
+// This lets tests assert that the right Warn log line was (or was not) emitted.
+func warnLogger() (*bytes.Buffer, *slog.Logger) {
+	var buf bytes.Buffer
+	lg := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	return &buf, lg
+}
+
+// TestGetBoolSetting_DBError verifies that a genuine DB error (closed connection)
+// returns the fallback AND emits a Warn log line.
+func TestGetBoolSetting_DBError(t *testing.T) {
+	t.Parallel()
+	db, dbPath := setupTestDB(t)
+	buf, lg := warnLogger()
+	svc := NewService(db, dbPath, "", lg)
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing db: %v", err)
+	}
+
+	got := svc.getBoolSetting(context.Background(), "any.key", false)
+	if got {
+		t.Errorf("getBoolSetting DB error: got true, want false (fallback)")
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "reading bool setting") {
+		t.Errorf("getBoolSetting DB error: expected warn log, got %q", logged)
+	}
+	if !strings.Contains(logged, "level=WARN") {
+		t.Errorf("getBoolSetting DB error: expected WARN level, got %q", logged)
+	}
+}
+
+// TestGetBoolSetting_AbsentKey verifies that a missing row returns the
+// fallback without emitting any log line.
+func TestGetBoolSetting_AbsentKey(t *testing.T) {
+	t.Parallel()
+	db, dbPath := setupTestDB(t)
+	buf, lg := warnLogger()
+	svc := NewService(db, dbPath, "", lg)
+
+	got := svc.getBoolSetting(context.Background(), "no.such.key", true)
+	if !got {
+		t.Errorf("getBoolSetting absent key: got false, want true (fallback)")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("getBoolSetting absent key: expected no log, got %q", buf.String())
+	}
+}
+
+// TestGetIntSetting_DBError verifies that a genuine DB error returns the
+// fallback AND emits a Warn log line.
+func TestGetIntSetting_DBError(t *testing.T) {
+	t.Parallel()
+	db, dbPath := setupTestDB(t)
+	buf, lg := warnLogger()
+	svc := NewService(db, dbPath, "", lg)
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing db: %v", err)
+	}
+
+	got := svc.getIntSetting(context.Background(), "any.key", 77)
+	if got != 77 {
+		t.Errorf("getIntSetting DB error: got %d, want 77 (fallback)", got)
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "reading int setting") {
+		t.Errorf("getIntSetting DB error: expected warn log, got %q", logged)
+	}
+	if !strings.Contains(logged, "level=WARN") {
+		t.Errorf("getIntSetting DB error: expected WARN level, got %q", logged)
+	}
+}
+
+// TestGetIntSetting_AbsentKey verifies that a missing row returns the
+// fallback without emitting any log line.
+func TestGetIntSetting_AbsentKey(t *testing.T) {
+	t.Parallel()
+	db, dbPath := setupTestDB(t)
+	buf, lg := warnLogger()
+	svc := NewService(db, dbPath, "", lg)
+
+	got := svc.getIntSetting(context.Background(), "no.such.key", 55)
+	if got != 55 {
+		t.Errorf("getIntSetting absent key: got %d, want 55 (fallback)", got)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("getIntSetting absent key: expected no log, got %q", buf.String())
+	}
+}
+
+// TestGetIntSetting_InvalidValue verifies that a stored non-integer value
+// returns the fallback AND emits a Warn log line (Item 2 observability).
+func TestGetIntSetting_InvalidValue(t *testing.T) {
+	t.Parallel()
+	db, dbPath := setupTestDB(t)
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO settings (key, value) VALUES ('test.bad', 'notanint')`); err != nil {
+		t.Fatalf("seeding bad int: %v", err)
+	}
+
+	buf, lg := warnLogger()
+	svc := NewService(db, dbPath, "", lg)
+
+	got := svc.getIntSetting(ctx, "test.bad", 33)
+	if got != 33 {
+		t.Errorf("getIntSetting invalid value: got %d, want 33 (fallback)", got)
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "int setting value is not a valid integer") {
+		t.Errorf("getIntSetting invalid value: expected warn log, got %q", logged)
+	}
+	if !strings.Contains(logged, "level=WARN") {
+		t.Errorf("getIntSetting invalid value: expected WARN level, got %q", logged)
+	}
+}
+
+// TestStatus_LastOptimizeAt_DBError verifies that when the last_optimize_at
+// query hits a non-ErrNoRows DB error, Status() logs a Warn and returns
+// an empty LastOptimizeAt rather than silently swallowing the error.
+func TestStatus_LastOptimizeAt_DBError(t *testing.T) {
+	t.Parallel()
+	db, dbPath := setupTestDB(t)
+	buf, lg := warnLogger()
+	svc := NewService(db, dbPath, "", lg)
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing db: %v", err)
+	}
+
+	st, err := svc.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status returned error (should tolerate DB failures): %v", err)
+	}
+	if st.LastOptimizeAt != "" {
+		t.Errorf("Status DB error: LastOptimizeAt = %q, want empty", st.LastOptimizeAt)
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "reading last_optimize_at") {
+		t.Errorf("Status DB error: expected 'reading last_optimize_at' warn, got %q", logged)
+	}
 }


### PR DESCRIPTION
## Summary

`getStringSetting` / `getBoolSetting` / `getIntSetting` previously collapsed two distinct conditions into one: a setting genuinely absent, and a real DB read error (DB locked, I/O error, context cancellation, schema drift). Both returned the caller's fallback with no log line, so a transient DB error was indistinguishable from "never configured" — an unreproducible "my setting randomly stopped working" class of bug.

This applies the established `errors.Is(err, sql.ErrNoRows)` discrimination (the pattern from `getUserBoolPreference`) so genuine DB errors are logged at `Warn` while `sql.ErrNoRows` still falls back silently. Function signatures are unchanged (`getStringSetting` remains the `SettingReader` callback for `middleware.RequireMultiUser`).

## Changes

- `internal/api/handlers_settings.go`: all three `get*Setting` helpers now log non-`ErrNoRows` errors via `r.logger.Warn`, falling back silently only on `ErrNoRows`. The `getIntSetting` non-integer parse path now also logs a `Warn` (`"int setting value is not a valid integer"`) rather than failing silently.
- `internal/maintenance/maintenance.go`: the duplicate `getBoolSetting` / `getIntSetting` copies (the maintenance scheduler's `db_maintenance.enabled` / `interval_hours` reads) get the same discrimination + `Warn` (`maintenance.Service` has a wired `*slog.Logger`), and `Status()`'s `last_optimize_at` read now logs a `Warn` on a genuine error instead of swallowing it.
- New/expanded tests (`handlers_settings_helpers_test.go`, `maintenance_test.go`) covering happy path, empty-string fallback, absent key (no log), DB error (asserts the `Warn`), and invalid-integer (asserts the `Warn`).

## Verification

- `go build ./...` / `go vet ./...` clean; `go test` + `-race` on `./internal/api/...` and `./internal/maintenance/...` all pass.
- Patch coverage **96.43%** (handlers_settings.go 100%, maintenance.go 91.7%).
- Independent hostile review (PASS) verified all three findings resolved and that the new `Warn` never fires on the legitimate empty/absent paths.

A follow-up for the unrelated cross-subsystem `errors.Is` robustness sweep is tracked in #1958.

Closes #1594


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of settings retrieval with better handling of database errors versus missing settings
  * Added warning logs for database errors to provide better diagnostics and troubleshooting information

* **Tests**
  * Expanded test coverage for settings retrieval functions with comprehensive error scenario testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->