### PR TITLE
docs(m55): terminology sweep vs next/ UI labels (#1872)

### DIFF
--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -140,6 +140,7 @@ nav:
       - Rules catalogue: reference/rules-catalogue.md
       - Providers: reference/providers.md
       - Environment variables: reference/environment-variables.md
+      - UI label glossary: reference/ui-labels.md
   - Troubleshooting:
       - troubleshooting/index.md
       - Platform authentication: troubleshooting/platform-auth.md

--- a/docs/site/src/core-concepts/auto-provisioning.md
+++ b/docs/site/src/core-concepts/auto-provisioning.md
@@ -29,7 +29,7 @@ Two options:
 - **Admins only** -- only users who are administrators on the upstream server qualify. This is the default. If the upstream server marks the user as an admin, Stillwater provisions them as an administrator (ignoring the configured default role for that connection). If the upstream server marks them as a regular user, login is rejected.
 - **Any user** -- any user who can authenticate against the upstream server qualifies. Combined with a permissive Emby or Jellyfin installation, this means anyone on the upstream server can sign in.
 
-The guard rail setting lives under Settings > Auth providers > Emby (or Jellyfin) > Guard rail (see [`settings-auth-providers-auth-emby-guard-rail`](../reference/settings-by-tab.md#settings-auth-providers-auth-emby-guard-rail) and [`settings-auth-providers-auth-jellyfin-guard-rail`](../reference/settings-by-tab.md#settings-auth-providers-auth-jellyfin-guard-rail)).
+The guard rail setting lives under Settings > Auth Providers > Emby (or Jellyfin) > Guard rail (see [`settings-auth-providers-auth-emby-guard-rail`](../reference/settings-by-tab.md#settings-auth-providers-auth-emby-guard-rail) and [`settings-auth-providers-auth-jellyfin-guard-rail`](../reference/settings-by-tab.md#settings-auth-providers-auth-jellyfin-guard-rail)).
 
 ### OIDC guard rails
 
@@ -69,8 +69,8 @@ Stillwater does not delete or deactivate local accounts when the upstream accoun
 
 Auto-provisioning is disabled by default for every provider. To enable it:
 
-- For Emby: Settings > Auth providers > Emby > Enable auto-provisioning (see [`settings-auth-providers-auth-auto-provision-emby`](../reference/settings-by-tab.md#settings-auth-providers-auth-auto-provision-emby))
-- For Jellyfin: Settings > Auth providers > Jellyfin > Enable auto-provisioning (see [`settings-auth-providers-auth-auto-provision-jellyfin`](../reference/settings-by-tab.md#settings-auth-providers-auth-auto-provision-jellyfin))
-- For OIDC: Settings > Auth providers > OIDC > Enable auto-provisioning (see [`settings-auth-providers-auth-auto-provision-oidc`](../reference/settings-by-tab.md#settings-auth-providers-auth-auto-provision-oidc))
+- For Emby: Settings > Auth Providers > Emby > Enable auto-provisioning (see [`settings-auth-providers-auth-auto-provision-emby`](../reference/settings-by-tab.md#settings-auth-providers-auth-auto-provision-emby))
+- For Jellyfin: Settings > Auth Providers > Jellyfin > Enable auto-provisioning (see [`settings-auth-providers-auth-auto-provision-jellyfin`](../reference/settings-by-tab.md#settings-auth-providers-auth-auto-provision-jellyfin))
+- For OIDC: Settings > Auth Providers > OIDC > Enable auto-provisioning (see [`settings-auth-providers-auth-auto-provision-oidc`](../reference/settings-by-tab.md#settings-auth-providers-auth-auto-provision-oidc))
 
 Each provider's auto-provision toggle is independent. You can enable it for Emby without enabling it for Jellyfin or OIDC.

--- a/docs/site/src/getting-started/first-run-oobe.md
+++ b/docs/site/src/getting-started/first-run-oobe.md
@@ -151,7 +151,7 @@ Everything the wizard touched lives under the **Settings** menu, organized by ar
 
 - **Settings** > **Libraries** to add, remove, or reconfigure libraries.
 - **Settings** > **Providers** > **Metadata Language Preferences** for language preferences, and **Settings** > **General** for other account-level defaults.
-- **Settings** > **Platform** to switch platform profiles.
+- **Settings** > **General** to switch platform profiles.
 - **Settings** > **Providers** for API keys and per-provider configuration.
 - **Settings** > **Connections** for media server and Lidarr connections.
 - **Settings** > **Rules** for the rule engine.

--- a/docs/site/src/reference/environment-variables.md
+++ b/docs/site/src/reference/environment-variables.md
@@ -93,7 +93,7 @@ The same configuration in YAML (still supported for existing deployments) uses k
 
 ### Backup numeric parsing
 
-`SW_BACKUP_RETENTION` and `SW_BACKUP_INTERVAL` require a positive integer. **Invalid values silently fall through to the defaults** (no error logged). Set carefully; verify under Settings > Backups after restart.
+`SW_BACKUP_RETENTION` and `SW_BACKUP_INTERVAL` require a positive integer. **Invalid values silently fall through to the defaults** (no error logged). Set carefully; verify under Settings > Maintenance after restart.
 
 ### Backup-enabled accepts only `true` or `1`
 

--- a/docs/site/src/reference/index.md
+++ b/docs/site/src/reference/index.md
@@ -12,7 +12,7 @@ The map for "where do I find the exact list of X?" Each page is a deep enumerati
 
     ---
 
-    A guided tour of every tab in Settings: General, Providers, Connections, Libraries, Automation, Rules, Users, Auth providers, Maintenance, Logs, and Updates.
+    A guided tour of every tab in Settings: General, Providers, Connections, Libraries, Automation, Rules, Users, Auth Providers, Maintenance, Logs, and Updates.
 
     [Read more](settings-by-tab.md)
 
@@ -39,6 +39,14 @@ The map for "where do I find the exact list of X?" Each page is a deep enumerati
     Every `SW_` environment variable Stillwater honors at startup, with defaults and YAML field equivalents.
 
     [Read more](environment-variables.md)
+
+- __UI label glossary__
+
+    ---
+
+    Exact wording for sidebar navigation, Settings tabs, artist page sections, image type names, and key action buttons. Use when writing docs to match what users see.
+
+    [Read more](ui-labels.md)
 
 </div>
 

--- a/docs/site/src/reference/ui-labels.md
+++ b/docs/site/src/reference/ui-labels.md
@@ -1,0 +1,114 @@
+---
+description: Static reference for current Stillwater UI labels -- navigation items, Settings tabs, artist page sections, and image terminology. Use this when writing documentation to match exact wording shown in the interface.
+---
+
+<!-- source: internal/i18n/locales/en.json (hand-derived; not generated). Update when labels change. -->
+
+# UI label glossary
+
+When writing documentation that names a control, section, or tab, use the exact label from this table. Mismatches (for example "Settings > Platform" instead of "Settings > General") confuse users who cannot find what the doc describes.
+
+## Sidebar navigation
+
+These are the top-level items in the left-hand sidebar, as rendered to end users.
+
+| Label | Notes |
+|---|---|
+| Dashboard | Main at-a-glance health view |
+| Artists | The artist list and grid |
+| Reports | Parent item; expands to Compliance, Duplicates, Unmatched Files |
+| Reports > Compliance | Per-artist rule compliance table |
+| Reports > Duplicates | Near-duplicate artist detection |
+| Reports > Unmatched Files | Images without Stillwater provenance |
+| Rules | Top-level nav to the violations / rule-run surface |
+| Activity | Full metadata-change activity feed |
+| Logs | Live log viewer (sidebar shortcut) |
+| Settings | Application configuration |
+| Guide | Built-in user guide |
+| Help | Context-sensitive help panel |
+| Quick Actions | Shortcut panel for common bulk actions |
+| Preferences | Per-user appearance and layout drawer |
+| Log Out | Sign out of the current session |
+
+## Settings tabs
+
+Settings is divided into eleven tabs. Use these exact names when writing "Settings > X" navigation paths.
+
+| Tab label | Key sections inside |
+|---|---|
+| General | Platform Profile, Active Profile Details, TLS Status, Base Path, Behavior, Image Cache, Symlinks, Onboarding |
+| Providers | Provider API Keys, Web Image Search, Provider Priorities, Metadata Language Preferences, Advanced, Name Similarity, Tag Sources |
+| Connections | Server Connections (Emby, Jellyfin, Lidarr) |
+| Libraries | Music Libraries |
+| Automation | Webhooks, Notification Badges, API Tokens |
+| Rules | Rules (by category), Scheduled Evaluation |
+| Users | Multi-User Mode, User Accounts, Pending Invites |
+| Auth Providers | Local, Emby, Jellyfin, OpenID Connect (OIDC) |
+| Maintenance | Confirmation Dialogs, Database Maintenance, Database Backup, Settings Export / Import |
+| Logs | Log Settings, Log Viewer |
+| Updates | Application Updates |
+
+**Common mistakes to avoid:**
+
+- "Settings > Platform" does not exist. Platform Profile is under **Settings > General**.
+- "Settings > Backups" does not exist. Database Backup is under **Settings > Maintenance**.
+- "Settings > Appearance" does not exist. Per-user appearance controls live in the **Preferences** drawer (sidebar).
+- The Auth tab is "Auth Providers" (capital P), not "Auth providers".
+
+## Artist detail page
+
+Tabs on the artist detail page (accessed by clicking any artist in the list):
+
+| Tab label | Contents |
+|---|---|
+| Overview | Biography, Tags (Genres/Styles/Moods), Details panel (Name, Sort Name, Type, Born, Formed, etc.) |
+| Images | Four image slots: Thumb, Fanart, Logo, Banner |
+| Violations | Open rule violations for this artist |
+| Providers | Source attributions showing which provider supplied each field |
+| Discography | Album entries from the artist.nfo |
+| History | Prior values per field (clock icon per field; accessible in edit mode) |
+| Debug | Raw platform API payload (only when "Show platform debug info" is enabled in Settings > General) |
+
+Note: "History" is a per-field in-line feature (clock icon), not a dedicated tab. The standalone History tab was removed. See [edit an artist](../how-to/edit-artist.md) for the revert workflow.
+
+## Image types
+
+Stillwater uses four image slots per artist. Each has a Stillwater-internal name, a display label, and platform-specific aliases.
+
+| Stillwater slot | Display label | Kodi | Emby / Jellyfin |
+|---|---|---|---|
+| thumb | Thumbnail | Folder | Primary |
+| fanart | Fanart | Fanart | Backdrop |
+| logo | Logo | Logo | Logo |
+| banner | Banner | Banner | Banner |
+
+The UI shows the platform-appropriate term when a library is linked to a platform profile. Documentation targeting users (not code) should use the Stillwater display label unless describing platform-specific behavior.
+
+## Key action labels
+
+Common buttons and their exact wording in the UI:
+
+| Action | Label shown |
+|---|---|
+| Start a metadata refresh for one artist | Refresh Metadata |
+| Run rule evaluation for one artist | Run Rules |
+| Link an artist to a MusicBrainz entry | Identify Artist |
+| Re-link an artist (clear existing IDs) | Re-identify Artist |
+| Lock an artist from automated changes | Lock Artist |
+| Fetch images from providers (single slot) | Find (on the slot row) |
+| Fetch images across many artists | Bulk actions > Fetch images |
+| Evaluate rules across many artists | Bulk actions > Run rules |
+| Apply all fixable violations at once | Fix All (N) |
+| Dismiss a violation without fixing it | Dismiss |
+| Undo a recent fix | Undo |
+| Export application settings | Export Settings |
+| Import application settings | (Settings > Maintenance > Settings Export / Import) |
+
+## Automation modes (rules)
+
+Each rule has an automation mode controlling how violations are handled:
+
+| Mode label | Behavior |
+|---|---|
+| Manual (notify only) | Finds violations; fixes wait for you to click |
+| Auto | Finds violations and applies fixes automatically during evaluation |


### PR DESCRIPTION
## Summary

Doc-only terminology sweep reconciling the docs prose against the current next/ UI labels (canonical strings in `internal/i18n/locales/en.json`), plus a new UI-label glossary. Scoped to the CR-free portion of #1872; the docs-as-code drift generator and screenshot refresh are tracked as separate follow-ups (see #1967 for the new-feature docs gap).

## Changes

- Terminology fixes: `Settings > Platform` → `Settings > General`; `Settings > Backups` → `Settings > Maintenance`; `Auth providers` → `Auth Providers` (5 occurrences) — across `getting-started/first-run-oobe.md`, `reference/environment-variables.md`, `reference/index.md`, `core-concepts/auto-provisioning.md`.
- New `docs/site/src/reference/ui-labels.md` glossary (sidebar nav, the 11 settings tabs with a "common mistakes" callout, artist-detail tabs, image-type name mappings, action-button labels, automation modes), wired into `mkdocs.yml` nav + the reference index.

## Verification

- `mkdocs build` succeeds (pre-existing unrelated anchor warnings only).
- Diff is docs-only (no code/templ/go touched).

## Out of scope (flagged follow-ups)

- Docs-as-code generator / CI drift-check (script logic → would need CR; separate issue).
- Screenshot refresh (needs a live next/ render; separate UAT pass).
- New M55 feature docs (prefs drawer / Quick Actions / per-field clock) → filed as #1967.

Closes #1872
