### PR TITLE
fix(scraper): guard empty provider ordering before ordered[0] (#1963)

### DIFF
--- a/internal/scraper/executor.go
+++ b/internal/scraper/executor.go
@@ -775,6 +775,13 @@ func effectiveFieldOrdering(field FieldConfig, chain FallbackChain, priority []p
 		ordered = append(ordered, p)
 	}
 
+	// Guard: if every input list was empty, ordered is empty and indexed access
+	// below would panic. Return the originals unchanged so downstream callers
+	// simply find no providers and skip normally.
+	if len(ordered) == 0 {
+		return field, chain
+	}
+
 	effField := field
 	effField.Primary = ordered[0]
 

--- a/internal/scraper/executor_test.go
+++ b/internal/scraper/executor_test.go
@@ -1437,3 +1437,64 @@ func TestFieldAppliers_VocabFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestEffectiveFieldOrdering_EmptyProviders_NoPanic(t *testing.T) {
+	// Regression test for #1963: ordered[0] panics when all provider lists
+	// (priority, field.Primary, chain.Providers) contribute nothing.
+	// The function must return the original field and chain unchanged.
+	field := FieldConfig{
+		Field:    "biography",
+		Category: "metadata",
+		Primary:  "",
+	}
+	chain := FallbackChain{
+		Category:  "metadata",
+		Providers: nil,
+	}
+
+	// hasPriority=true with empty priority list triggers the empty-ordered path.
+	// (The call site skips the call when hasPriority && len(priority)==0, but the
+	// function must still not panic if called directly or from a future code path.)
+	gotField, gotChain := effectiveFieldOrdering(field, chain, nil, true)
+
+	if gotField.Field != field.Field {
+		t.Errorf("expected original field %q, got %q", field.Field, gotField.Field)
+	}
+	if gotField.Primary != field.Primary {
+		t.Errorf("expected original Primary %q, got %q", field.Primary, gotField.Primary)
+	}
+	if len(gotChain.Providers) != 0 {
+		t.Errorf("expected empty Providers, got %v", gotChain.Providers)
+	}
+}
+
+func TestEffectiveFieldOrdering_NonEmpty_Unchanged(t *testing.T) {
+	// Non-empty priority list must still produce the correct ordered output.
+	field := FieldConfig{
+		Field:    "biography",
+		Category: "metadata",
+		Primary:  "fanart",
+	}
+	chain := FallbackChain{
+		Category:  "metadata",
+		Providers: []provider.ProviderName{"musicbrainz"},
+	}
+	priority := []provider.ProviderName{"theaudiodb", "fanart"}
+
+	gotField, gotChain := effectiveFieldOrdering(field, chain, priority, true)
+
+	if gotField.Primary != "theaudiodb" {
+		t.Errorf("expected Primary %q, got %q", "theaudiodb", gotField.Primary)
+	}
+	// Expected order: theaudiodb (priority[0]), fanart (priority[1] == field.Primary),
+	// musicbrainz (chain.Providers[0], not yet seen).
+	want := []provider.ProviderName{"theaudiodb", "fanart", "musicbrainz"}
+	if len(gotChain.Providers) != len(want) {
+		t.Fatalf("expected %d providers, got %d: %v", len(want), len(gotChain.Providers), gotChain.Providers)
+	}
+	for i, p := range want {
+		if gotChain.Providers[i] != p {
+			t.Errorf("Providers[%d]: want %q, got %q", i, p, gotChain.Providers[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a defensive length guard in the scraper executor's effective-field-ordering path so an empty provider-ordering slice can never index `ordered[0]` out of range. Belt-and-suspenders: the empty case is already prevented upstream, but the guard makes the helper safe in isolation and is covered by tests.

## Changes

- `internal/scraper/executor.go`: return early (`field, chain` unchanged) when the ordered slice is empty, before the `ordered[0]` access.
- `internal/scraper/executor_test.go`: two table cases - `TestEffectiveFieldOrdering_EmptyProviders_NoPanic` (empty slice does not panic, returns inputs unchanged) and `_NonEmpty_Unchanged` (non-empty behavior is preserved).

## Verification

- `go build ./...` clean; `go vet` clean.
- `go test ./internal/scraper/... -count=1` PASS.
- Rebased onto current main (behind=0); diff is scraper-only (executor.go + executor_test.go).

Defensive, behavior-neutral for the non-empty path -> `norabbit`.

Closes #1963
