### PR TITLE
chore(js): consolidate third escapeHtml copy into shared window.escapeHTML (#1974)

### DIFF
--- a/web/static/js/help.js
+++ b/web/static/js/help.js
@@ -90,8 +90,8 @@
         for (var i = 0; i < results.length; i++) {
             var s = results[i];
             html += '<a href="' + bp + '/guide#' + encodeURIComponent(s.id) + '" class="block rounded-lg border border-gray-200 dark:border-gray-700 p-3 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">'
-                + '<h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100">' + escapeHtml(s.title) + '</h4>'
-                + '<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">' + escapeHtml(s.summary) + '</p>'
+                + '<h4 class="text-sm font-semibold text-gray-900 dark:text-gray-100">' + window.escapeHTML(s.title) + '</h4>'
+                + '<p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">' + window.escapeHTML(s.summary) + '</p>'
                 + '</a>';
         }
         container.innerHTML = html;
@@ -125,12 +125,6 @@
             }
         }
         return matched.concat(unmatched);
-    }
-
-    function escapeHtml(str) {
-        var div = document.createElement('div');
-        div.appendChild(document.createTextNode(str));
-        return div.innerHTML;
     }
 
     // Close on backdrop click


### PR DESCRIPTION
## Summary

Removes the third duplicate `escapeHtml` implementation (in `web/static/js/help.js`) and repoints its call sites to the shared `window.escapeHTML` from `utils.js`.

This is the dead-code/dedup follow-up to #1965, which already extracted `window.escapeHTML` into `utils.js` and wired `utils.js` to load globally via `LayoutGlobalChrome`. Only the help.js copy remained.

## Changes

- Delete the local `escapeHtml` function in `web/static/js/help.js`.
- Repoint its two call sites to `window.escapeHTML`.

## Notes

- No Go changes; the global `utils.js` wiring already shipped in #1965, so nothing in `AssetPaths`/handlers/layout needed touching. `go build ./...` clean.
- `grep` confirms no remaining local `escapeHtml` definition in help.js.

Closes #1974
