### PR TITLE
fix(artist): skip no-op field writes; signal write-occurred for accurate platform-pull/revert (#1846)

### DIFF
--- a/internal/api/handlers_field.go
+++ b/internal/api/handlers_field.go
@@ -208,7 +208,7 @@ func (r *Router) handleFieldUpdate(w http.ResponseWriter, req *http.Request) {
 			writeError(w, req, http.StatusInternalServerError, "failed to update field")
 			return
 		}
-	} else if err := r.artistService.UpdateField(req.Context(), artistID, field, value); err != nil {
+	} else if _, err := r.artistService.UpdateField(req.Context(), artistID, field, value); err != nil {
 		writeError(w, req, http.StatusInternalServerError, "failed to update field")
 		return
 	}
@@ -287,7 +287,7 @@ func (r *Router) handleFieldClear(w http.ResponseWriter, req *http.Request) {
 			writeError(w, req, http.StatusInternalServerError, "failed to clear field")
 			return
 		}
-	} else if err := r.artistService.ClearField(req.Context(), artistID, field); err != nil {
+	} else if _, err := r.artistService.ClearField(req.Context(), artistID, field); err != nil {
 		writeError(w, req, http.StatusInternalServerError, "failed to clear field")
 		return
 	}

--- a/internal/api/handlers_history.go
+++ b/internal/api/handlers_history.go
@@ -505,14 +505,19 @@ func (r *Router) handleRevertHistory(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Emit activity.recent so the next/ dashboard live activity rail
-	// (M55 #1334) shows the revert without polling.
-	r.publishActivityRecent("reverted", change.Field+" reverted", change.ArtistID)
+	// (M55 #1334) shows the revert without polling. Gate on revertChanged
+	// so a no-op revert (field already at OldValue) does not inject a
+	// spurious "reverted" entry into the activity rail.
+	if revertChanged {
+		r.publishActivityRecent("reverted", change.Field+" reverted", change.ArtistID)
+	}
 
 	// For HTMX requests (undo button click), return an HTML fragment showing
 	// the new history entry. For plain API callers, return JSON.
 	if !isHTMXRequest(req) {
 		writeJSON(w, http.StatusOK, map[string]any{
-			"reverted":  true,
+			"reverted":  revertChanged,
+			"noop":      !revertChanged,
 			"change_id": changeID,
 		})
 		return

--- a/internal/api/handlers_history.go
+++ b/internal/api/handlers_history.go
@@ -343,20 +343,24 @@ func validateRevertable(change *artist.MetadataChange) error {
 // ID pre-assigned to the new history row; callers should fetch it with
 // GetByID after this call returns.
 //
+// changed is true when a real write (and history record) occurred, false when
+// the revert was a no-op because the field already equalled OldValue. Callers
+// can use changed to select an appropriate user-facing message.
+//
 // ClearField/UpdateField currently succeed silently when the artist ID does
 // not exist (UPDATE affects zero rows). The ErrNotFound guards are defensive:
 // they activate if the repo layer is updated to check RowsAffected.
-func (r *Router) performRevert(ctx context.Context, change *artist.MetadataChange) (revertChangeID string, err error) {
+func (r *Router) performRevert(ctx context.Context, change *artist.MetadataChange) (revertChangeID string, changed bool, err error) {
 	revertChangeID = uuid.New().String()
 	ctx = artist.ContextWithSource(ctx, "revert")
 	ctx = artist.ContextWithHistoryID(ctx, revertChangeID)
 
 	if change.OldValue == "" {
-		err = r.artistService.ClearField(ctx, change.ArtistID, change.Field)
+		changed, err = r.artistService.ClearField(ctx, change.ArtistID, change.Field)
 	} else {
-		err = r.artistService.UpdateField(ctx, change.ArtistID, change.Field, change.OldValue)
+		changed, err = r.artistService.UpdateField(ctx, change.ArtistID, change.Field, change.OldValue)
 	}
-	return revertChangeID, err
+	return revertChangeID, changed, err
 }
 
 // renderActivityRevertFragment renders the HTMX fragment for a revert that was
@@ -489,7 +493,7 @@ func (r *Router) handleRevertHistory(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	revertChangeID, err := r.performRevert(req.Context(), change)
+	revertChangeID, revertChanged, err := r.performRevert(req.Context(), change)
 	if err != nil {
 		if errors.Is(err, artist.ErrNotFound) {
 			writeError(w, req, http.StatusNotFound, "artist not found")
@@ -550,20 +554,30 @@ func (r *Router) handleRevertHistory(w http.ResponseWriter, req *http.Request) {
 
 	// Fallback: the revert succeeded but we could not render the rich
 	// confirmation fragment. Causes: (a) new row is outside the active feed
-	// filter, (b) a lookup failed (already logged above), or (c) the row is
-	// genuinely missing. Log level distinguishes the cases.
-	if revertChange != nil {
+	// filter, (b) a lookup failed (already logged above), (c) the row is
+	// genuinely missing, or (d) the revert was a no-op (field already matched
+	// OldValue so no write occurred). Log level distinguishes the cases.
+	var fallbackMsg string
+	if !revertChanged {
+		// No-op revert: field already equalled OldValue; nothing was written.
+		r.logger.Info("revert was a no-op; field already at old value",
+			"change_id", changeID, "revert_change_id", revertChangeID,
+			"field", change.Field, "artist_id", change.ArtistID)
+		fallbackMsg = "This field was already at the reverted value, nothing to change."
+	} else if revertChange != nil {
 		r.logger.Info("revert succeeded; fragment suppressed by active filter",
 			"change_id", changeID, "revert_change_id", revertChangeID,
 			"field", change.Field, "artist_id", change.ArtistID)
+		fallbackMsg = "Change reverted. Refresh the page to see the updated entry."
 	} else {
 		r.logger.Warn("revert record not located after mutation, using fallback confirmation",
 			"change_id", changeID, "revert_change_id", revertChangeID,
 			"field", change.Field, "artist_id", change.ArtistID)
+		fallbackMsg = "Change reverted. Refresh the page to see the updated entry."
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`<div class="border-l-2 border-amber-400 dark:border-amber-500 pl-4 py-2"><p class="text-sm text-amber-600 dark:text-amber-400">Change reverted. Refresh the page to see the updated entry.</p></div>`))
+	_, _ = w.Write([]byte(`<div class="border-l-2 border-amber-400 dark:border-amber-500 pl-4 py-2"><p class="text-sm text-amber-600 dark:text-amber-400">` + fallbackMsg + `</p></div>`))
 }
 
 // handleListGlobalHistory returns paginated metadata changes across all artists.

--- a/internal/api/handlers_history_test.go
+++ b/internal/api/handlers_history_test.go
@@ -381,7 +381,7 @@ func TestHandleRevertHistory(t *testing.T) {
 
 	// Update a field to create a history entry.
 	ctx := artist.ContextWithSource(context.Background(), "manual")
-	if err := artistSvc.UpdateField(ctx, a.ID, "biography", "original bio"); err != nil {
+	if _, err := artistSvc.UpdateField(ctx, a.ID, "biography", "original bio"); err != nil {
 		t.Fatalf("UpdateField: %v", err)
 	}
 
@@ -474,7 +474,7 @@ func TestHandleRevertHistory_HTMXActivityFragment(t *testing.T) {
 
 	a := addTestArtist(t, artistSvc, "HTMX Activity Artist")
 	ctx := artist.ContextWithSource(context.Background(), "manual")
-	if err := artistSvc.UpdateField(ctx, a.ID, "biography", "some bio"); err != nil {
+	if _, err := artistSvc.UpdateField(ctx, a.ID, "biography", "some bio"); err != nil {
 		t.Fatalf("UpdateField: %v", err)
 	}
 	changes, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
@@ -509,7 +509,7 @@ func TestHandleRevertHistory_HTMXArtistTabFragment(t *testing.T) {
 
 	a := addTestArtist(t, artistSvc, "HTMX Tab Artist")
 	ctx := artist.ContextWithSource(context.Background(), "manual")
-	if err := artistSvc.UpdateField(ctx, a.ID, "biography", "tab bio"); err != nil {
+	if _, err := artistSvc.UpdateField(ctx, a.ID, "biography", "tab bio"); err != nil {
 		t.Fatalf("UpdateField: %v", err)
 	}
 	changes, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
@@ -1006,7 +1006,7 @@ func TestPerformRevert_ClearBranch(t *testing.T) {
 
 	// Set biography to non-empty so ClearField has something to clear.
 	ctx := artist.ContextWithSource(context.Background(), "manual")
-	if err := artistSvc.UpdateField(ctx, a.ID, "biography", "some bio"); err != nil {
+	if _, err := artistSvc.UpdateField(ctx, a.ID, "biography", "some bio"); err != nil {
 		t.Fatalf("UpdateField: %v", err)
 	}
 
@@ -1018,7 +1018,7 @@ func TestPerformRevert_ClearBranch(t *testing.T) {
 		Source:   "manual",
 	}
 
-	revertChangeID, err := r.performRevert(context.Background(), change)
+	revertChangeID, _, err := r.performRevert(context.Background(), change)
 	if err != nil {
 		t.Fatalf("performRevert: %v", err)
 	}
@@ -1065,7 +1065,7 @@ func TestPerformRevert_UpdateBranch(t *testing.T) {
 		Source:   "manual",
 	}
 
-	revertChangeID, err := r.performRevert(context.Background(), change)
+	revertChangeID, _, err := r.performRevert(context.Background(), change)
 	if err != nil {
 		t.Fatalf("performRevert: %v", err)
 	}
@@ -1442,7 +1442,7 @@ func TestHandleRevertHistory_ActivitySourceFilter(t *testing.T) {
 
 	a := addTestArtist(t, artistSvc, "Source Filter Artist")
 	ctx := artist.ContextWithSource(context.Background(), "manual")
-	if err := artistSvc.UpdateField(ctx, a.ID, "biography", "filter bio"); err != nil {
+	if _, err := artistSvc.UpdateField(ctx, a.ID, "biography", "filter bio"); err != nil {
 		t.Fatalf("UpdateField: %v", err)
 	}
 	changes, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
@@ -1482,7 +1482,7 @@ func TestHandleRevertHistory_ActivityDateRangeFilter(t *testing.T) {
 
 	a := addTestArtist(t, artistSvc, "Date Range Artist")
 	ctx := artist.ContextWithSource(context.Background(), "manual")
-	if err := artistSvc.UpdateField(ctx, a.ID, "biography", "range bio"); err != nil {
+	if _, err := artistSvc.UpdateField(ctx, a.ID, "biography", "range bio"); err != nil {
 		t.Fatalf("UpdateField: %v", err)
 	}
 	changes, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
@@ -1551,5 +1551,102 @@ func TestHandleRevertHistory_NoopRevertFallback(t *testing.T) {
 	}
 	if !strings.Contains(body, "border-amber") {
 		t.Errorf("expected fallback amber div in body: %s", body)
+	}
+}
+
+// TestHandleRevertHistory_NoopRendersHonestMessage verifies that when a revert
+// is a no-op (the field already equals OldValue), the HTMX fallback fragment
+// contains the honest "already at the reverted value" message rather than the
+// generic "Change reverted. Refresh..." message.
+func TestHandleRevertHistory_NoopRendersHonestMessage(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, historySvc := testRouterWithHistory(t)
+	artistSvc.SetHistoryService(historySvc)
+
+	a := addTestArtist(t, artistSvc, "Noop Revert Artist")
+
+	// Record a history entry directly (source="manual", field changes from ""
+	// to "some bio"). OldValue="" means a revert would call ClearField.
+	changeID := "test-noop-change-" + a.ID
+	ctx := context.Background()
+	err := historySvc.Repo().Record(ctx, &artist.MetadataChange{
+		ID:       changeID,
+		ArtistID: a.ID,
+		Field:    "biography",
+		OldValue: "",
+		NewValue: "some bio",
+		Source:   "manual",
+	})
+	if err != nil {
+		t.Fatalf("inserting history entry: %v", err)
+	}
+
+	// The artist's biography is already "" (empty, same as OldValue), so the
+	// revert is a no-op: ClearField will see oldValue="" and skip the write.
+	// The HTMX response should carry the honest no-op message.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/history/"+changeID+"/revert", nil)
+	req.SetPathValue("id", changeID)
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set("HX-Current-URL", "http://localhost:1973/artists/"+a.ID)
+	w := httptest.NewRecorder()
+	r.handleRevertHistory(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "already at the reverted value") {
+		t.Errorf("expected honest no-op message in body; got: %s", body)
+	}
+	if strings.Contains(body, "Refresh the page") {
+		t.Errorf("got generic 'Refresh the page' message for a no-op revert; want honest message; body: %s", body)
+	}
+}
+
+// TestPlatformPullNoopFieldNotInUpdated verifies the service-level contract
+// underlying the platform-pull handler: UpdateField returns changed=false when
+// the field already matches the incoming platform value, so callers must gate
+// the append to `updated` on changed==true (not nil error).
+//
+// Note: end-to-end testing of handlePullMetadata requires a real Emby/Jellyfin
+// server. This test covers the service contract that the handler relies on.
+func TestPlatformPullNoopFieldNotInUpdated(t *testing.T) {
+	t.Parallel()
+	_, artistSvc, historySvc := testRouterWithHistory(t)
+	artistSvc.SetHistoryService(historySvc)
+
+	a := addTestArtist(t, artistSvc, "Platform Pull Noop Artist")
+	ctx := context.Background()
+
+	// Set a biography on the artist.
+	if _, err := artistSvc.UpdateField(ctx, a.ID, "biography", "existing bio"); err != nil {
+		t.Fatalf("setting initial biography: %v", err)
+	}
+
+	// Simulate what handlePullMetadata does: try to apply the same value the
+	// platform returned. Should be a no-op (changed=false).
+	var updated []string
+	changed, err := artistSvc.UpdateField(ctx, a.ID, "biography", "existing bio")
+	if err != nil {
+		t.Fatalf("UpdateField same value: %v", err)
+	}
+	if changed {
+		updated = append(updated, "biography")
+	}
+
+	if len(updated) != 0 {
+		t.Errorf("updated = %v, want [] (matching field must not appear in updated)", updated)
+	}
+
+	// Now apply a different value; it must be in updated.
+	changed, err = artistSvc.UpdateField(ctx, a.ID, "biography", "new bio")
+	if err != nil {
+		t.Fatalf("UpdateField new value: %v", err)
+	}
+	if changed {
+		updated = append(updated, "biography")
+	}
+	if len(updated) != 1 || updated[0] != "biography" {
+		t.Errorf("updated = %v, want [biography] after a real change", updated)
 	}
 }

--- a/internal/api/handlers_history_test.go
+++ b/internal/api/handlers_history_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +21,7 @@ import (
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/connection"
 	"github.com/sydlexius/stillwater/internal/encryption"
+	"github.com/sydlexius/stillwater/internal/event"
 	"github.com/sydlexius/stillwater/internal/i18n"
 	"github.com/sydlexius/stillwater/internal/nfo"
 	"github.com/sydlexius/stillwater/internal/provider"
@@ -461,6 +464,199 @@ func TestHandleRevertHistory(t *testing.T) {
 
 		if w.Code != http.StatusServiceUnavailable {
 			t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+		}
+	})
+}
+
+// TestHandleRevertHistory_JSONNoopPath verifies that when a revert is a no-op
+// (the field already equals OldValue), the JSON response signals that clearly
+// with reverted:false and noop:true rather than claiming a write occurred.
+func TestHandleRevertHistory_JSONNoopPath(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, historySvc := testRouterWithHistory(t)
+	artistSvc.SetHistoryService(historySvc)
+
+	a := addTestArtist(t, artistSvc, "NoOp JSON Revert Artist")
+
+	// Create a history record: biography "" -> "some-bio".
+	ctx := artist.ContextWithSource(context.Background(), "manual")
+	if _, err := artistSvc.UpdateField(ctx, a.ID, "biography", "some-bio"); err != nil {
+		t.Fatalf("UpdateField: %v", err)
+	}
+
+	// Get the most-recent change ID (the "" -> "some-bio" record).
+	changes, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
+	if err != nil || len(changes) == 0 {
+		t.Fatalf("List: err=%v len=%d", err, len(changes))
+	}
+	changeID := changes[0].ID
+
+	// Reset biography back to "" so the revert becomes a no-op:
+	// performRevert will call ClearField which finds the field already empty.
+	clearCtx := artist.ContextWithSource(context.Background(), "manual")
+	if _, err := artistSvc.ClearField(clearCtx, a.ID, "biography"); err != nil {
+		t.Fatalf("ClearField reset: %v", err)
+	}
+
+	// Issue the revert as a plain JSON (non-HTMX) request.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/history/"+changeID+"/revert", nil)
+	req.SetPathValue("id", changeID)
+	w := httptest.NewRecorder()
+
+	r.handleRevertHistory(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if resp["reverted"] != false {
+		t.Errorf("reverted = %v, want false for no-op revert", resp["reverted"])
+	}
+	if resp["noop"] != true {
+		t.Errorf("noop = %v, want true for no-op revert", resp["noop"])
+	}
+	if _, ok := resp["change_id"]; !ok {
+		t.Error("change_id missing from no-op revert response")
+	}
+
+	// Verify JSON path for a real revert still reports reverted:true, noop:false.
+	// First create a new change that will actually write something.
+	if _, err := artistSvc.UpdateField(ctx, a.ID, "biography", "real-bio"); err != nil {
+		t.Fatalf("UpdateField for real revert seed: %v", err)
+	}
+	changes2, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
+	if err != nil || len(changes2) == 0 {
+		t.Fatalf("List after seed: err=%v len=%d", err, len(changes2))
+	}
+	realChangeID := changes2[0].ID
+
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/history/"+realChangeID+"/revert", nil)
+	req2.SetPathValue("id", realChangeID)
+	w2 := httptest.NewRecorder()
+
+	r.handleRevertHistory(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("real revert: status = %d, want %d; body: %s", w2.Code, http.StatusOK, w2.Body.String())
+	}
+
+	var resp2 map[string]any
+	if err := json.NewDecoder(w2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("real revert: decoding response: %v", err)
+	}
+	if resp2["reverted"] != true {
+		t.Errorf("real revert: reverted = %v, want true", resp2["reverted"])
+	}
+	if resp2["noop"] != false {
+		t.Errorf("real revert: noop = %v, want false", resp2["noop"])
+	}
+}
+
+// TestHandleRevertHistory_ActivityPublishGatedOnChanged verifies that the
+// activity.recent event is published only for real reverts, not for no-ops.
+// A no-op revert (field already at OldValue) must not inject a spurious
+// "reverted" entry into the live activity rail.
+func TestHandleRevertHistory_ActivityPublishGatedOnChanged(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, historySvc := testRouterWithHistory(t)
+	artistSvc.SetHistoryService(historySvc)
+
+	busLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	a := addTestArtist(t, artistSvc, "Activity Gate Artist")
+	ctx := artist.ContextWithSource(context.Background(), "manual")
+
+	// Seed a "no-op" scenario: create a history record, then reset the field
+	// so that performRevert finds it already at OldValue and skips the write.
+	if _, err := artistSvc.UpdateField(ctx, a.ID, "biography", "temp-bio"); err != nil {
+		t.Fatalf("UpdateField seed: %v", err)
+	}
+	changes, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
+	if err != nil || len(changes) == 0 {
+		t.Fatalf("List after seed: err=%v len=%d", err, len(changes))
+	}
+	noopChangeID := changes[0].ID
+
+	clearCtx := artist.ContextWithSource(context.Background(), "manual")
+	if _, err := artistSvc.ClearField(clearCtx, a.ID, "biography"); err != nil {
+		t.Fatalf("ClearField reset: %v", err)
+	}
+
+	t.Run("no-op revert does not publish activity event", func(t *testing.T) {
+		bus := event.NewBus(busLogger, 16)
+		var mu sync.Mutex
+		var captured []event.Event
+		bus.Subscribe(event.ActivityRecent, func(e event.Event) {
+			mu.Lock()
+			captured = append(captured, e)
+			mu.Unlock()
+		})
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			bus.Start()
+		}()
+		r.eventBus = bus
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/history/"+noopChangeID+"/revert", nil)
+		req.SetPathValue("id", noopChangeID)
+		r.handleRevertHistory(httptest.NewRecorder(), req)
+
+		bus.Stop()
+		wg.Wait()
+
+		mu.Lock()
+		n := len(captured)
+		mu.Unlock()
+		if n != 0 {
+			t.Errorf("no-op revert: activity events = %d, want 0", n)
+		}
+	})
+
+	t.Run("real revert publishes one activity event", func(t *testing.T) {
+		// biography is currently "" after the ClearField above.
+		// UpdateField("real-bio") creates a change that can be reverted.
+		if _, err := artistSvc.UpdateField(ctx, a.ID, "biography", "real-bio"); err != nil {
+			t.Fatalf("UpdateField for real revert: %v", err)
+		}
+		changes2, _, err := historySvc.List(context.Background(), a.ID, 1, 0)
+		if err != nil || len(changes2) == 0 {
+			t.Fatalf("List after update: err=%v len=%d", err, len(changes2))
+		}
+		realChangeID := changes2[0].ID
+
+		bus := event.NewBus(busLogger, 16)
+		var mu sync.Mutex
+		var captured []event.Event
+		bus.Subscribe(event.ActivityRecent, func(e event.Event) {
+			mu.Lock()
+			captured = append(captured, e)
+			mu.Unlock()
+		})
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			bus.Start()
+		}()
+		r.eventBus = bus
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/history/"+realChangeID+"/revert", nil)
+		req.SetPathValue("id", realChangeID)
+		r.handleRevertHistory(httptest.NewRecorder(), req)
+
+		bus.Stop()
+		wg.Wait()
+
+		mu.Lock()
+		n := len(captured)
+		mu.Unlock()
+		if n != 1 {
+			t.Errorf("real revert: activity events = %d, want 1", n)
 		}
 	})
 }

--- a/internal/api/handlers_platform_state.go
+++ b/internal/api/handlers_platform_state.go
@@ -139,17 +139,19 @@ func (r *Router) handlePullMetadata(w http.ResponseWriter, req *http.Request) {
 	var updated []string
 
 	if state.Biography != "" {
-		if err := r.artistService.UpdateField(req.Context(), artistID, "biography", state.Biography); err != nil {
+		changed, err := r.artistService.UpdateField(req.Context(), artistID, "biography", state.Biography)
+		if err != nil {
 			r.logger.Warn("updating biography from platform", "error", err)
-		} else {
+		} else if changed {
 			updated = append(updated, "biography")
 		}
 	}
 
 	if len(state.Genres) > 0 {
-		if err := r.artistService.UpdateField(req.Context(), artistID, "genres", strings.Join(state.Genres, ", ")); err != nil {
+		changed, err := r.artistService.UpdateField(req.Context(), artistID, "genres", strings.Join(state.Genres, ", "))
+		if err != nil {
 			r.logger.Warn("updating genres from platform", "error", err)
-		} else {
+		} else if changed {
 			updated = append(updated, "genres")
 		}
 	}
@@ -161,17 +163,19 @@ func (r *Router) handlePullMetadata(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if state.PremiereDate != "" {
-		if err := r.artistService.UpdateField(req.Context(), artistID, premiereField, dateOnly(state.PremiereDate)); err != nil {
+		changed, err := r.artistService.UpdateField(req.Context(), artistID, premiereField, dateOnly(state.PremiereDate))
+		if err != nil {
 			r.logger.Warn("updating date from platform", "field", premiereField, "error", err)
-		} else {
+		} else if changed {
 			updated = append(updated, premiereField)
 		}
 	}
 
 	if state.EndDate != "" {
-		if err := r.artistService.UpdateField(req.Context(), artistID, endField, dateOnly(state.EndDate)); err != nil {
+		changed, err := r.artistService.UpdateField(req.Context(), artistID, endField, dateOnly(state.EndDate))
+		if err != nil {
 			r.logger.Warn("updating date from platform", "field", endField, "error", err)
-		} else {
+		} else if changed {
 			updated = append(updated, endField)
 		}
 	}

--- a/internal/api/handlers_platform_state_test.go
+++ b/internal/api/handlers_platform_state_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/connection"
+)
+
+// TestHandlePullMetadata_MatchingFieldNotInUpdated verifies that when the
+// platform value already matches the stored value, that field is NOT included
+// in the "updated" list (the changed bool is false, so the append is skipped).
+//
+// The test stands up a minimal httptest.Server that mimics just enough of the
+// Emby API for GetArtistDetail to succeed, then calls handlePullMetadata and
+// checks the JSON response.
+func TestHandlePullMetadata_MatchingFieldNotInUpdated(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, _ := testRouterWithHistory(t)
+	ctx := context.Background()
+
+	// Create an artist with a known biography.
+	a := addTestArtist(t, artistSvc, "Pull Noop Artist")
+	if _, err := artistSvc.UpdateField(ctx, a.ID, "biography", "existing bio"); err != nil {
+		t.Fatalf("setting initial biography: %v", err)
+	}
+
+	// Stand up a stub Emby server that returns the SAME biography the artist
+	// already has. The handler should not include "biography" in updated.
+	embyResp := `{"Name":"Pull Noop Artist","SortName":"Pull Noop Artist","Overview":"existing bio","Genres":[],"Tags":[],"ProviderIds":{},"ImageTags":{},"BackdropImageTags":[],"LockData":false,"LockedFields":[]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, embyResp)
+	}))
+	defer srv.Close()
+
+	// Create a connection pointing to the test server.
+	conn := &connection.Connection{
+		Name:           "Test Emby",
+		Type:           connection.TypeEmby,
+		URL:            srv.URL,
+		APIKey:         "test-api-key",
+		PlatformUserID: "user-001",
+		Enabled:        true,
+	}
+	if err := r.connectionService.Create(ctx, conn); err != nil {
+		t.Fatalf("creating connection: %v", err)
+	}
+
+	// Associate a platform artist ID with this artist on this connection.
+	platformID := "emby-artist-001"
+	if err := artistSvc.SetPlatformID(ctx, a.ID, conn.ID, platformID); err != nil {
+		t.Fatalf("setting platform artist ID: %v", err)
+	}
+
+	// Call handlePullMetadata.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/pull?connection_id="+conn.ID, nil)
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+	r.handlePullMetadata(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	// When updated is nil (no fields changed), the JSON will encode as null.
+	// Either null or an empty slice satisfies "biography not in updated".
+	if updatedRaw := resp["updated"]; updatedRaw != nil {
+		updated, ok := updatedRaw.([]any)
+		if !ok {
+			t.Fatalf("updated is not an array: %T %v", updatedRaw, updatedRaw)
+		}
+		for _, v := range updated {
+			if v == "biography" {
+				t.Errorf("biography appears in updated=%v but the value already matched the platform; want it absent", updated)
+			}
+		}
+	}
+}
+
+// TestHandlePullMetadata_ChangedFieldInUpdated verifies that when the platform
+// returns a value that differs from the stored value, that field IS included in
+// the "updated" list (changed==true).
+func TestHandlePullMetadata_ChangedFieldInUpdated(t *testing.T) {
+	t.Parallel()
+	r, artistSvc, _ := testRouterWithHistory(t)
+	ctx := context.Background()
+
+	a := addTestArtist(t, artistSvc, "Pull Changed Artist")
+	// Artist starts with no biography / no genres; platform returns new values for
+	// both plus dates so all 4 UpdateField branches are exercised.
+	embyResp := `{"Name":"Pull Changed Artist","SortName":"Pull Changed Artist","Overview":"new platform bio","Genres":["Rock","Grunge"],"Tags":[],"ProviderIds":{},"ImageTags":{},"BackdropImageTags":[],"LockData":false,"LockedFields":[],"PremiereDate":"1990-01-01T00:00:00.0000000Z","EndDate":"2000-06-01T00:00:00.0000000Z"}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, embyResp)
+	}))
+	defer srv.Close()
+
+	conn := &connection.Connection{
+		Name:           "Test Emby Changed",
+		Type:           connection.TypeEmby,
+		URL:            srv.URL,
+		APIKey:         "test-api-key",
+		PlatformUserID: "user-001",
+		Enabled:        true,
+	}
+	if err := r.connectionService.Create(ctx, conn); err != nil {
+		t.Fatalf("creating connection: %v", err)
+	}
+	if err := artistSvc.SetPlatformID(ctx, a.ID, conn.ID, "emby-artist-002"); err != nil {
+		t.Fatalf("setting platform artist ID: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/artists/"+a.ID+"/pull?connection_id="+conn.ID, nil)
+	req.SetPathValue("id", a.ID)
+	w := httptest.NewRecorder()
+	r.handlePullMetadata(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	updatedRaw := resp["updated"]
+	updated, ok := updatedRaw.([]any)
+	if !ok || len(updated) == 0 {
+		t.Fatalf("updated = %v, want [biography] (new platform value differs from stored value)", updatedRaw)
+	}
+	found := false
+	for _, v := range updated {
+		if v == "biography" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("biography not in updated=%v, want it present (field actually changed)", updated)
+	}
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -3982,11 +3982,20 @@ paths:
                 properties:
                   reverted:
                     type: boolean
-                    description: Whether the change was successfully reverted.
+                    description: >
+                      True when a write occurred (the field differed from OldValue
+                      and was updated). False when the revert was a no-op because
+                      the field already equalled OldValue.
+                  noop:
+                    type: boolean
+                    description: >
+                      True when the revert was a no-op (field already at OldValue,
+                      no write or history record created). Always the inverse of
+                      reverted.
                   change_id:
                     type: string
-                    description: ID of the reverted change record.
-                required: [reverted, change_id]
+                    description: ID of the original change that was targeted for revert.
+                required: [reverted, noop, change_id]
             text/html:
               schema:
                 type: string

--- a/internal/api/testdata/openapi-coverage-baseline.json
+++ b/internal/api/testdata/openapi-coverage-baseline.json
@@ -48,7 +48,6 @@
   "oidcLogin",
   "providerFetch",
   "providerSearch",
-  "pullMetadata",
   "pushMetadata",
   "refreshArtist",
   "refreshLink",

--- a/internal/api/testdata/openapi-coverage.json
+++ b/internal/api/testdata/openapi-coverage.json
@@ -1215,7 +1215,7 @@
     "method": "POST",
     "path": "/artists/{id}/pull",
     "handler": "handlePullMetadata",
-    "covered": false
+    "covered": true
   },
   {
     "operationId": "pushImages",

--- a/internal/artist/field_test.go
+++ b/internal/artist/field_test.go
@@ -258,13 +258,13 @@ func TestUpdateField_NameAndSortName(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	if err := svc.UpdateField(ctx, a.ID, "name", "New Name"); err != nil {
+	if _, err := svc.UpdateField(ctx, a.ID, "name", "New Name"); err != nil {
 		t.Fatalf("UpdateField(name): %v", err)
 	}
-	if err := svc.UpdateField(ctx, a.ID, "sort_name", "Name, New"); err != nil {
+	if _, err := svc.UpdateField(ctx, a.ID, "sort_name", "Name, New"); err != nil {
 		t.Fatalf("UpdateField(sort_name): %v", err)
 	}
-	if err := svc.UpdateField(ctx, a.ID, "disambiguation", "the famous one"); err != nil {
+	if _, err := svc.UpdateField(ctx, a.ID, "disambiguation", "the famous one"); err != nil {
 		t.Fatalf("UpdateField(disambiguation): %v", err)
 	}
 

--- a/internal/artist/history.go
+++ b/internal/artist/history.go
@@ -98,6 +98,9 @@ func (h *HistoryService) Record(ctx context.Context, artistID, field, oldValue, 
 	if source == "" {
 		return fmt.Errorf("source is required")
 	}
+	if oldValue == newValue {
+		return nil
+	}
 	validSource := source == "manual" || source == "scan" || source == "import" ||
 		source == "revert" ||
 		strings.HasPrefix(source, "provider:") || strings.HasPrefix(source, "rule:")

--- a/internal/artist/history.go
+++ b/internal/artist/history.go
@@ -98,7 +98,11 @@ func (h *HistoryService) Record(ctx context.Context, artistID, field, oldValue, 
 	if source == "" {
 		return fmt.Errorf("source is required")
 	}
-	if oldValue == newValue {
+	// Only skip when BOTH values are non-empty and identical. If oldValue is ""
+	// (as in rule_fix records, which always pass oldValue==""), the guard must
+	// not fire even when newValue is also "" - an accidental empty Message on a
+	// fix result would otherwise be silently dropped and leave no audit trail.
+	if oldValue != "" && oldValue == newValue {
 		return nil
 	}
 	validSource := source == "manual" || source == "scan" || source == "import" ||

--- a/internal/artist/noop_field_writes_test.go
+++ b/internal/artist/noop_field_writes_test.go
@@ -1,0 +1,159 @@
+package artist
+
+import (
+	"context"
+	"testing"
+)
+
+// TestUpdateFieldNoopSkipsWriteAndHistory verifies that calling UpdateField with
+// the same value that is already stored does not touch the DB or produce a
+// history entry.
+func TestUpdateFieldNoopSkipsWriteAndHistory(t *testing.T) {
+	t.Parallel()
+	svc, hsvc := setupServiceWithHistory(t)
+	ctx := context.Background()
+
+	a := testArtist("Pearl Jam", "/music/Pearl Jam")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Re-writing the same biography should be a no-op.
+	if err := svc.UpdateField(ctx, a.ID, "biography", "A test artist."); err != nil {
+		t.Fatalf("UpdateField (same value): %v", err)
+	}
+
+	_, total, err := hsvc.List(ctx, a.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("List history: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("expected 0 history entries for no-op UpdateField, got %d", total)
+	}
+
+	// Also verify the underlying DB value was not touched (updatedAt should
+	// be identical to what was set on Create -- we can't easily check that
+	// directly, but confirming the value is still the same is sufficient).
+	got, err := svc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Biography != "A test artist." {
+		t.Errorf("Biography = %q, want %q", got.Biography, "A test artist.")
+	}
+}
+
+// TestUpdateFieldRealChangeWritesAndRecords verifies that a genuine value
+// change still writes to the DB and produces a history entry.
+func TestUpdateFieldRealChangeWritesAndRecords(t *testing.T) {
+	t.Parallel()
+	svc, hsvc := setupServiceWithHistory(t)
+	ctx := context.Background()
+
+	a := testArtist("Mudhoney", "/music/Mudhoney")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := svc.UpdateField(ctx, a.ID, "biography", "Updated biography."); err != nil {
+		t.Fatalf("UpdateField (new value): %v", err)
+	}
+
+	got, err := svc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Biography != "Updated biography." {
+		t.Errorf("Biography = %q, want %q", got.Biography, "Updated biography.")
+	}
+
+	_, total, err := hsvc.List(ctx, a.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("List history: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("expected 1 history entry for real change, got %d", total)
+	}
+}
+
+// TestClearFieldAlreadyEmptyIsNoop verifies that ClearField on a field that is
+// already empty produces no DB write and no history entry.
+func TestClearFieldAlreadyEmptyIsNoop(t *testing.T) {
+	t.Parallel()
+	svc, hsvc := setupServiceWithHistory(t)
+	ctx := context.Background()
+
+	a := testArtist("Screaming Trees", "/music/Screaming Trees")
+	// biography starts non-empty; clear it first so the field is empty.
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := svc.ClearField(ctx, a.ID, "biography"); err != nil {
+		t.Fatalf("ClearField (first): %v", err)
+	}
+
+	// Second clear should be a no-op.
+	if err := svc.ClearField(ctx, a.ID, "biography"); err != nil {
+		t.Fatalf("ClearField (second, already empty): %v", err)
+	}
+
+	_, total, err := hsvc.List(ctx, a.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("List history: %v", err)
+	}
+	// Only the first clear should have generated an entry.
+	if total != 1 {
+		t.Errorf("expected 1 history entry (first clear only), got %d", total)
+	}
+}
+
+// TestHistoryServiceRecordNoopGuard verifies that HistoryService.Record returns
+// nil without writing when oldValue == newValue.
+func TestHistoryServiceRecordNoopGuard(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	hsvc := NewHistoryService(db)
+	ctx := context.Background()
+
+	// Supply a valid source and identical old/new values.
+	if err := hsvc.Record(ctx, "artist-id-1", "biography", "same", "same", "manual"); err != nil {
+		t.Fatalf("Record with identical values: %v", err)
+	}
+
+	// Nothing should have been persisted.
+	changes, total, err := hsvc.List(ctx, "artist-id-1", 50, 0)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	_ = changes
+	if total != 0 {
+		t.Errorf("expected 0 history entries for no-op Record, got %d", total)
+	}
+}
+
+// TestUpdateFieldNoopSliceField verifies the no-op check works for slice fields
+// (genres, styles, moods) with varying spacing/comma formatting.
+func TestUpdateFieldNoopSliceField(t *testing.T) {
+	t.Parallel()
+	svc, hsvc := setupServiceWithHistory(t)
+	ctx := context.Background()
+
+	a := testArtist("Soundgarden", "/music/Soundgarden")
+	// testArtist sets Genres: ["Rock", "Alternative"]
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Write the same genres with different comma spacing -- should be a no-op.
+	if err := svc.UpdateField(ctx, a.ID, "genres", "Rock,Alternative"); err != nil {
+		t.Fatalf("UpdateField (same genres, diff spacing): %v", err)
+	}
+
+	_, total, err := hsvc.List(ctx, a.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("List history: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("expected 0 history entries for same-genre no-op, got %d", total)
+	}
+}

--- a/internal/artist/noop_field_writes_test.go
+++ b/internal/artist/noop_field_writes_test.go
@@ -19,7 +19,7 @@ func TestUpdateFieldNoopSkipsWriteAndHistory(t *testing.T) {
 	}
 
 	// Re-writing the same biography should be a no-op.
-	if err := svc.UpdateField(ctx, a.ID, "biography", "A test artist."); err != nil {
+	if _, err := svc.UpdateField(ctx, a.ID, "biography", "A test artist."); err != nil {
 		t.Fatalf("UpdateField (same value): %v", err)
 	}
 
@@ -55,7 +55,7 @@ func TestUpdateFieldRealChangeWritesAndRecords(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	if err := svc.UpdateField(ctx, a.ID, "biography", "Updated biography."); err != nil {
+	if _, err := svc.UpdateField(ctx, a.ID, "biography", "Updated biography."); err != nil {
 		t.Fatalf("UpdateField (new value): %v", err)
 	}
 
@@ -88,12 +88,12 @@ func TestClearFieldAlreadyEmptyIsNoop(t *testing.T) {
 	if err := svc.Create(ctx, a); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if err := svc.ClearField(ctx, a.ID, "biography"); err != nil {
+	if _, err := svc.ClearField(ctx, a.ID, "biography"); err != nil {
 		t.Fatalf("ClearField (first): %v", err)
 	}
 
 	// Second clear should be a no-op.
-	if err := svc.ClearField(ctx, a.ID, "biography"); err != nil {
+	if _, err := svc.ClearField(ctx, a.ID, "biography"); err != nil {
 		t.Fatalf("ClearField (second, already empty): %v", err)
 	}
 
@@ -161,7 +161,7 @@ func TestUpdateFieldScalarPaddedValueIsNotNoop(t *testing.T) {
 	}
 
 	// A corrective write with the trimmed value must NOT be treated as a no-op.
-	if err := svc.UpdateField(ctx, a.ID, "biography", "A test artist."); err != nil {
+	if _, err := svc.UpdateField(ctx, a.ID, "biography", "A test artist."); err != nil {
 		t.Fatalf("UpdateField (corrective trim): %v", err)
 	}
 
@@ -196,7 +196,7 @@ func TestUpdateFieldNoopSliceField(t *testing.T) {
 	}
 
 	// Write the same genres with different comma spacing -- should be a no-op.
-	if err := svc.UpdateField(ctx, a.ID, "genres", "Rock,Alternative"); err != nil {
+	if _, err := svc.UpdateField(ctx, a.ID, "genres", "Rock,Alternative"); err != nil {
 		t.Fatalf("UpdateField (same genres, diff spacing): %v", err)
 	}
 
@@ -206,5 +206,192 @@ func TestUpdateFieldNoopSliceField(t *testing.T) {
 	}
 	if total != 0 {
 		t.Errorf("expected 0 history entries for same-genre no-op, got %d", total)
+	}
+}
+
+// TestUpdateFieldChangedBoolTrue verifies that UpdateField returns changed=true
+// when a real write occurs (new value differs from current).
+func TestUpdateFieldChangedBoolTrue(t *testing.T) {
+	t.Parallel()
+	svc, _ := setupServiceWithHistory(t)
+	ctx := context.Background()
+
+	a := testArtist("Foo Fighters", "/music/Foo Fighters")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	changed, err := svc.UpdateField(ctx, a.ID, "biography", "New bio.")
+	if err != nil {
+		t.Fatalf("UpdateField: %v", err)
+	}
+	if !changed {
+		t.Error("changed = false, want true for a real write")
+	}
+}
+
+// TestUpdateFieldChangedBoolFalse verifies that UpdateField returns changed=false
+// when the new value equals the current value (no-op).
+func TestUpdateFieldChangedBoolFalse(t *testing.T) {
+	t.Parallel()
+	svc, _ := setupServiceWithHistory(t)
+	ctx := context.Background()
+
+	a := testArtist("Audioslave", "/music/Audioslave")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// biography was set on Create; writing the same value must be a no-op.
+	changed, err := svc.UpdateField(ctx, a.ID, "biography", "A test artist.")
+	if err != nil {
+		t.Fatalf("UpdateField: %v", err)
+	}
+	if changed {
+		t.Error("changed = true, want false for no-op write")
+	}
+}
+
+// TestClearFieldChangedBoolTrue verifies that ClearField returns changed=true
+// when a real write occurs (field was non-empty).
+func TestClearFieldChangedBoolTrue(t *testing.T) {
+	t.Parallel()
+	svc, _ := setupServiceWithHistory(t)
+	ctx := context.Background()
+
+	a := testArtist("Alice in Chains", "/music/Alice in Chains")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	changed, err := svc.ClearField(ctx, a.ID, "biography")
+	if err != nil {
+		t.Fatalf("ClearField: %v", err)
+	}
+	if !changed {
+		t.Error("changed = false, want true when clearing a non-empty field")
+	}
+}
+
+// TestClearFieldChangedBoolFalse verifies that ClearField returns changed=false
+// when the field is already empty (no-op).
+func TestClearFieldChangedBoolFalse(t *testing.T) {
+	t.Parallel()
+	svc, _ := setupServiceWithHistory(t)
+	ctx := context.Background()
+
+	a := testArtist("Blind Melon", "/music/Blind Melon")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Clear once to make the field empty.
+	if _, err := svc.ClearField(ctx, a.ID, "biography"); err != nil {
+		t.Fatalf("ClearField (first): %v", err)
+	}
+
+	// Second clear must be a no-op.
+	changed, err := svc.ClearField(ctx, a.ID, "biography")
+	if err != nil {
+		t.Fatalf("ClearField (second): %v", err)
+	}
+	if changed {
+		t.Error("changed = true, want false when field is already empty")
+	}
+}
+
+// TestUpdateFieldPrefetchErrorStillWrites verifies that when GetByID fails
+// during the no-op pre-fetch, UpdateField proceeds with the write rather than
+// silently dropping it (oldKnown stays false, so the no-op guard never fires).
+func TestUpdateFieldPrefetchErrorStillWrites(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	// No history service attached - this test focuses on the write path.
+	ctx := context.Background()
+
+	a := testArtist("Mazzy Star", "/music/Mazzy Star")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// We cannot easily inject a fetch error without swapping the repo, so instead
+	// we verify the symmetric guarantee: when a real artist ID is used, the write
+	// always proceeds (changed=true). The pre-fetch error path is covered by the
+	// fact that the no-op guard is gated on oldKnown (only set when fetch succeeds);
+	// if fetch fails, oldKnown=false and the guard never fires even if values happen
+	// to be equal. This test confirms the write still returns changed=true.
+	changed, err := svc.UpdateField(ctx, a.ID, "biography", "Different bio.")
+	if err != nil {
+		t.Fatalf("UpdateField: %v", err)
+	}
+	if !changed {
+		t.Error("changed = false, want true for a write with a valid artist")
+	}
+}
+
+// TestClearFieldNoHistoryService verifies that ClearField works correctly
+// when no HistoryService is attached (history-disabled deployment).
+func TestClearFieldNoHistoryService(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db) // no history service
+	ctx := context.Background()
+
+	a := testArtist("Slowdive", "/music/Slowdive")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// First clear on a non-empty field must succeed and report changed=true.
+	changed, err := svc.ClearField(ctx, a.ID, "biography")
+	if err != nil {
+		t.Fatalf("ClearField: %v", err)
+	}
+	if !changed {
+		t.Error("changed = false, want true when clearing non-empty field (no history service)")
+	}
+
+	// Second clear on an already-empty field must be a no-op (changed=false).
+	changed, err = svc.ClearField(ctx, a.ID, "biography")
+	if err != nil {
+		t.Fatalf("ClearField (second): %v", err)
+	}
+	if changed {
+		t.Error("changed = true, want false when field already empty (no history service)")
+	}
+}
+
+// TestHistoryRecordRuleFxEmptyMessageNotDropped verifies that HistoryService.Record
+// does NOT silently discard a record where oldValue=="" and newValue=="" (the
+// rule_fix edge case where fr.Message is accidentally empty). The no-op guard
+// must only fire when BOTH values are non-empty and identical.
+func TestHistoryRecordRuleFxEmptyMessageNotDropped(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	hsvc := NewHistoryService(db)
+	ctx := context.Background()
+
+	// Create a real artist so the FK constraint on artist_id is satisfied.
+	a := testArtist("Rule Fix Subject", "/music/Rule Fix Subject")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Record a rule_fix-style entry with both oldValue and newValue empty.
+	// This must NOT be silently discarded (it represents an accidental empty
+	// message that callers should be warned about via the persisted record).
+	err := hsvc.Record(ctx, a.ID, "rule_fix", "", "", "rule:some-rule")
+	if err != nil {
+		t.Fatalf("Record(old='', new=''): unexpected error: %v", err)
+	}
+
+	changes, total, err := hsvc.List(ctx, a.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	_ = changes
+	if total != 1 {
+		t.Errorf("expected 1 history entry for (old='', new='') record, got %d (no-op guard must not fire when oldValue is empty)", total)
 	}
 }

--- a/internal/artist/noop_field_writes_test.go
+++ b/internal/artist/noop_field_writes_test.go
@@ -395,3 +395,51 @@ func TestHistoryRecordRuleFxEmptyMessageNotDropped(t *testing.T) {
 		t.Errorf("expected 1 history entry for (old='', new='') record, got %d (no-op guard must not fire when oldValue is empty)", total)
 	}
 }
+
+// TestUpdateFieldDBClosedCoversWarnPath exercises the slog.Warn path that fires
+// when the pre-fetch GetByID call fails. Closing the underlying *sql.DB forces
+// that failure so the no-op guard never has a chance to fire (oldKnown stays
+// false), and the subsequent UpdateField call also fails, covering both the
+// fetch-error branch and the write-error return.
+func TestUpdateFieldDBClosedCoversWarnPath(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db) // no history service; we are testing error paths only
+	ctx := context.Background()
+
+	a := testArtist("DB Close UpdateField", "/music/DBCloseUpdateField")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Close the DB so that the no-op pre-fetch (GetByID) returns an error.
+	// UpdateField must NOT silently drop the write on fetch failure -- instead
+	// it proceeds and also returns the write error.
+	_ = db.Close()
+
+	_, err := svc.UpdateField(ctx, a.ID, "biography", "Any value.")
+	if err == nil {
+		t.Error("expected error from UpdateField on a closed DB, got nil")
+	}
+}
+
+// TestClearFieldDBClosedCoversWarnPath exercises the slog.Warn path for the
+// ClearField pre-fetch failure, mirroring TestUpdateFieldDBClosedCoversWarnPath.
+func TestClearFieldDBClosedCoversWarnPath(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	a := testArtist("DB Close ClearField", "/music/DBCloseClearField")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	_ = db.Close()
+
+	_, err := svc.ClearField(ctx, a.ID, "biography")
+	if err == nil {
+		t.Error("expected error from ClearField on a closed DB, got nil")
+	}
+}

--- a/internal/artist/noop_field_writes_test.go
+++ b/internal/artist/noop_field_writes_test.go
@@ -131,6 +131,57 @@ func TestHistoryServiceRecordNoopGuard(t *testing.T) {
 	}
 }
 
+// TestUpdateFieldScalarPaddedValueIsNotNoop verifies that a corrective write
+// for a scalar field whose stored value has leading/trailing whitespace is
+// never silently dropped. The repository stores scalar values verbatim, so
+// comparing "  rock  " vs "rock" must be treated as a real change.
+func TestUpdateFieldScalarPaddedValueIsNotNoop(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc, hsvc := func() (*Service, *HistoryService) {
+		s := NewService(db)
+		h := NewHistoryService(db)
+		s.SetHistoryService(h)
+		return s, h
+	}()
+	ctx := context.Background()
+
+	a := testArtist("Temple of the Dog", "/music/TempleDog")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Write a padded biography directly to the DB, bypassing the service layer,
+	// to simulate data that arrived with surrounding whitespace.
+	if _, err := db.ExecContext(ctx,
+		"UPDATE artists SET biography = ? WHERE id = ?",
+		"  A test artist.  ", a.ID,
+	); err != nil {
+		t.Fatalf("direct DB write of padded value: %v", err)
+	}
+
+	// A corrective write with the trimmed value must NOT be treated as a no-op.
+	if err := svc.UpdateField(ctx, a.ID, "biography", "A test artist."); err != nil {
+		t.Fatalf("UpdateField (corrective trim): %v", err)
+	}
+
+	got, err := svc.GetByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if got.Biography != "A test artist." {
+		t.Errorf("Biography = %q, want %q after corrective write", got.Biography, "A test artist.")
+	}
+
+	_, total, err := hsvc.List(ctx, a.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("List history: %v", err)
+	}
+	if total != 1 {
+		t.Errorf("expected 1 history entry for corrective write, got %d (must not be silent no-op)", total)
+	}
+}
+
 // TestUpdateFieldNoopSliceField verifies the no-op check works for slice fields
 // (genres, styles, moods) with varying spacing/comma formatting.
 func TestUpdateFieldNoopSliceField(t *testing.T) {

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -1065,28 +1065,42 @@ func IsProviderIDField(field string) bool {
 	return ok
 }
 
+// normalizeFieldValue normalizes a field value for equality comparison to detect
+// no-op writes before touching the DB. For slice fields it trims and re-joins
+// entries with ", "; for string fields it trims surrounding whitespace. This
+// mirrors the round-trip through the repository layer so comparisons are accurate.
+func normalizeFieldValue(field, value string) string {
+	if sliceFields[field] {
+		return strings.Join(splitTags(value), ", ")
+	}
+	return strings.TrimSpace(value)
+}
+
 // UpdateField updates a single metadata field on an artist record.
 // For slice fields (genres, styles, moods), the value is a comma-separated
 // string that gets marshaled to a JSON array for storage.
 //
-// When a HistoryService is attached, the old value is read before the update
-// and a MetadataChange is recorded if the value changed. History recording is
-// best-effort and will not cause the update to fail.
+// If the normalized new value equals the current value the write is skipped
+// entirely (no DB mutation, no history entry). When a HistoryService is
+// attached, a MetadataChange is recorded for genuine changes. History
+// recording is best-effort and will not cause the update to fail.
 func (s *Service) UpdateField(ctx context.Context, id, field, value string) error {
-	// Capture old value before the mutation so we can record the diff.
-	// Track whether the read succeeded so we don't fabricate history from
-	// an unknown old state if GetByID fails transiently.
+	// Fetch current value unconditionally so the no-op check runs regardless
+	// of whether history is enabled.
 	var oldValue string
 	oldKnown := false
-	if s.history != nil {
-		a, err := s.artists.GetByID(ctx, id)
-		if err != nil {
-			slog.Warn("history: could not fetch artist for UpdateField diff",
-				"artist_id", id, "field", field, "error", err)
-		} else {
-			oldValue = FieldValueFromArtist(a, field)
-			oldKnown = true
-		}
+	a, fetchErr := s.artists.GetByID(ctx, id)
+	if fetchErr != nil {
+		slog.Warn("no-op check: could not fetch artist for UpdateField diff",
+			"artist_id", id, "field", field, "error", fetchErr)
+	} else {
+		oldValue = FieldValueFromArtist(a, field)
+		oldKnown = true
+	}
+
+	// Skip the write if the normalized value is unchanged.
+	if oldKnown && normalizeFieldValue(field, value) == normalizeFieldValue(field, oldValue) {
+		return nil
 	}
 
 	if err := s.artists.UpdateField(ctx, id, field, value); err != nil {
@@ -1120,20 +1134,27 @@ func (s *Service) UpdateField(ctx context.Context, id, field, value string) erro
 
 // ClearField sets a single metadata field to its zero value.
 //
-// When a HistoryService is attached, the old value is read before clearing
-// and a MetadataChange is recorded if the field was non-empty. History
-// recording is best-effort and will not cause the clear to fail.
+// If the field is already empty the write is skipped entirely (no DB mutation,
+// no history entry). When a HistoryService is attached, a MetadataChange is
+// recorded for genuine clears. History recording is best-effort and will not
+// cause the clear to fail.
 func (s *Service) ClearField(ctx context.Context, id, field string) error {
-	// Capture old value before clearing so we can record the diff.
+	// Fetch current value unconditionally so the no-op check runs regardless
+	// of whether history is enabled.
 	var oldValue string
-	if s.history != nil {
-		a, err := s.artists.GetByID(ctx, id)
-		if err != nil {
-			slog.Warn("history: could not fetch artist for ClearField diff",
-				"artist_id", id, "field", field, "error", err)
-		} else {
-			oldValue = FieldValueFromArtist(a, field)
-		}
+	oldKnown := false
+	a, fetchErr := s.artists.GetByID(ctx, id)
+	if fetchErr != nil {
+		slog.Warn("no-op check: could not fetch artist for ClearField diff",
+			"artist_id", id, "field", field, "error", fetchErr)
+	} else {
+		oldValue = FieldValueFromArtist(a, field)
+		oldKnown = true
+	}
+
+	// Skip the write if the field is already empty.
+	if oldKnown && oldValue == "" {
+		return nil
 	}
 
 	if err := s.artists.ClearField(ctx, id, field); err != nil {
@@ -1144,7 +1165,7 @@ func (s *Service) ClearField(ctx context.Context, id, field string) error {
 
 	// Record the change only if the field was non-empty before clearing.
 	// Use FieldValueFromArtist on the post-clear state for consistent representation.
-	if s.history != nil && oldValue != "" {
+	if s.history != nil && oldKnown && oldValue != "" {
 		newA, err := s.artists.GetByID(ctx, id)
 		if err != nil {
 			slog.Warn("history: could not fetch artist after ClearField",

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -1066,14 +1066,16 @@ func IsProviderIDField(field string) bool {
 }
 
 // normalizeFieldValue normalizes a field value for equality comparison to detect
-// no-op writes before touching the DB. For slice fields it trims and re-joins
-// entries with ", "; for string fields it trims surrounding whitespace. This
-// mirrors the round-trip through the repository layer so comparisons are accurate.
+// no-op writes before touching the DB. For slice fields it mirrors the
+// repository's splitTags+join round-trip (trim+split on comma, rejoin with ", ").
+// For scalar fields the repository stores values verbatim, so exact comparison
+// is used -- trimming would silently drop corrective writes that remove
+// leading/trailing whitespace stored in the DB.
 func normalizeFieldValue(field, value string) string {
 	if sliceFields[field] {
 		return strings.Join(splitTags(value), ", ")
 	}
-	return strings.TrimSpace(value)
+	return value
 }
 
 // UpdateField updates a single metadata field on an artist record.

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -1086,7 +1086,11 @@ func normalizeFieldValue(field, value string) string {
 // entirely (no DB mutation, no history entry). When a HistoryService is
 // attached, a MetadataChange is recorded for genuine changes. History
 // recording is best-effort and will not cause the update to fail.
-func (s *Service) UpdateField(ctx context.Context, id, field, value string) error {
+//
+// The returned bool is true when a real write (and history record) occurred,
+// false when the no-op skip fired (old == new). Callers that previously
+// treated a nil error as "write happened" must check the bool instead.
+func (s *Service) UpdateField(ctx context.Context, id, field, value string) (bool, error) {
 	// Fetch current value unconditionally so the no-op check runs regardless
 	// of whether history is enabled.
 	var oldValue string
@@ -1102,11 +1106,11 @@ func (s *Service) UpdateField(ctx context.Context, id, field, value string) erro
 
 	// Skip the write if the normalized value is unchanged.
 	if oldKnown && normalizeFieldValue(field, value) == normalizeFieldValue(field, oldValue) {
-		return nil
+		return false, nil
 	}
 
 	if err := s.artists.UpdateField(ctx, id, field, value); err != nil {
-		return err
+		return false, err
 	}
 
 	s.markDirtyBestEffort(ctx, id)
@@ -1131,7 +1135,7 @@ func (s *Service) UpdateField(ctx context.Context, id, field, value string) erro
 		}
 	}
 
-	return nil
+	return true, nil
 }
 
 // ClearField sets a single metadata field to its zero value.
@@ -1140,7 +1144,11 @@ func (s *Service) UpdateField(ctx context.Context, id, field, value string) erro
 // no history entry). When a HistoryService is attached, a MetadataChange is
 // recorded for genuine clears. History recording is best-effort and will not
 // cause the clear to fail.
-func (s *Service) ClearField(ctx context.Context, id, field string) error {
+//
+// The returned bool is true when a real write (and history record) occurred,
+// false when the no-op skip fired (field already empty). Callers that
+// previously treated a nil error as "write happened" must check the bool.
+func (s *Service) ClearField(ctx context.Context, id, field string) (bool, error) {
 	// Fetch current value unconditionally so the no-op check runs regardless
 	// of whether history is enabled.
 	var oldValue string
@@ -1156,11 +1164,11 @@ func (s *Service) ClearField(ctx context.Context, id, field string) error {
 
 	// Skip the write if the field is already empty.
 	if oldKnown && oldValue == "" {
-		return nil
+		return false, nil
 	}
 
 	if err := s.artists.ClearField(ctx, id, field); err != nil {
-		return err
+		return false, err
 	}
 
 	s.markDirtyBestEffort(ctx, id)
@@ -1184,7 +1192,7 @@ func (s *Service) ClearField(ctx context.Context, id, field string) error {
 		}
 	}
 
-	return nil
+	return true, nil
 }
 
 // UpdateProviderField sets a single provider ID field (musicbrainz_id,

--- a/internal/artist/service_test.go
+++ b/internal/artist/service_test.go
@@ -1405,7 +1405,7 @@ func TestUpdateFieldRecordsHistory(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	if err := svc.UpdateField(ctx, a.ID, "biography", "New biography text"); err != nil {
+	if _, err := svc.UpdateField(ctx, a.ID, "biography", "New biography text"); err != nil {
 		t.Fatalf("UpdateField: %v", err)
 	}
 
@@ -1440,7 +1440,7 @@ func TestClearFieldRecordsHistory(t *testing.T) {
 	}
 
 	// Clear biography (non-empty) -- should produce a history entry.
-	if err := svc.ClearField(ctx, a.ID, "biography"); err != nil {
+	if _, err := svc.ClearField(ctx, a.ID, "biography"); err != nil {
 		t.Fatalf("ClearField: %v", err)
 	}
 
@@ -1463,7 +1463,7 @@ func TestClearFieldRecordsHistory(t *testing.T) {
 	}
 
 	// Clear biography again (already empty) -- should NOT produce a new entry.
-	if err := svc.ClearField(ctx, a.ID, "biography"); err != nil {
+	if _, err := svc.ClearField(ctx, a.ID, "biography"); err != nil {
 		t.Fatalf("ClearField (second): %v", err)
 	}
 	_, total2, err := hsvc.List(ctx, a.ID, 50, 0)


### PR DESCRIPTION
## Summary

Skip no-op field writes (`old == new`) so they no longer persist to the DB or write a history row, which was inflating undo churn and littering the History tab.

Closes #1846

## What changed

- **No-op skip** (`internal/artist/service.go`): `UpdateField` / `ClearField` now pre-fetch the current value and skip the write + history record when the normalized old value equals the new value. Scalars are compared exactly (`normalizeFieldValue`), so a corrective whitespace/format write is NOT mistaken for a no-op.
- **Write-occurred signal**: `Service.UpdateField` / `ClearField` now return `(changed bool, err error)`. This was required because two callers relied on the old "nil error implies a write happened" contract, which the no-op skip broke:
  - `handlers_platform_state.go` (platform pull): only adds a field to the `"updated": [...]` response when `changed` is true, so an already-matching field is no longer falsely reported as updated.
  - `handlers_history.go` (revert): the HTMX fallback shows an honest "this field was already at the reverted value" message; the JSON response returns `{"reverted": changed, "noop": !changed, "change_id": ...}`; and the activity-rail publish is gated on `changed` so a no-op revert produces no phantom "reverted" entry. (`openapi.yaml` updated with the `noop` field.)
- **History guard** (`internal/artist/history.go`): the no-op guard now fires only when `oldValue != "" && oldValue == newValue`, so `rule_fix` history records (which always pass `oldValue == ""`) are never silently dropped.

## Tests & coverage

New tests cover the `changed` bool (true on write / false on no-op), the platform-pull updated-list gating, the revert honest-message + JSON no-op shape + activity-publish gating, the `rule_fix` empty-message path, and the service-layer fetch-error/write-error branches. Patch coverage **84.62%** (threshold 75%); `go build ./... && go vet ./...`, race tests, and `check-generated` all green.

## Review notes

Hostile review (2 rounds) cleared all findings; the two original BLOCKs (platform-pull false-`updated`, misleading revert message) and three follow-up findings are all resolved in-PR (no deferrals). The remaining uncovered lines are handler error-bodies that require a mock repository to exercise; total coverage clears the threshold.
