### PR TITLE
ci(release): reuse setup-tailwind action in copilot-setup-steps for pinned integrity (#1950)

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -24,12 +24,7 @@ steps:
     run: go install golang.org/x/tools/cmd/goimports@v0.43.0
 
   - name: Install Tailwind CSS
-    run: |
-      curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/download/v4.2.0/tailwindcss-linux-x64
-      curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/download/v4.2.0/sha256sums.txt
-      grep ' tailwindcss-linux-x64$' sha256sums.txt | sha256sum -c -
-      chmod +x tailwindcss-linux-x64
-      sudo mv tailwindcss-linux-x64 /usr/local/bin/tailwindcss
+    uses: ./.github/actions/setup-tailwind
 
   - name: Install golangci-lint
     run: |


### PR DESCRIPTION
## Summary

Pin the Tailwind CLI download integrity in the Copilot setup workflow by reusing the existing hardened `setup-tailwind` composite action.

Closes #1950

## What changed

`.github/copilot-setup-steps.yml` previously fetched `sha256sums.txt` at runtime from the same GitHub release endpoint as the binary, then verified the binary against that fetched file. A compromised release page could serve a matching fake checksum file -- a Trust-On-First-Use (TOFU) gap, not a real integrity pin.

The fix replaces that inline 6-line step with a single `uses: ./.github/actions/setup-tailwind`. That composite action already hardcodes the SHA256 for `tailwindcss-linux-x64 v4.2.0` at author time and verifies against the pre-committed hash, so integrity is pinned in source rather than trusted from a runtime fetch. Net diff: -6/+1 lines.

## Scope

No other download paths need changing: `release.yml` does not download Tailwind (compiled `styles.css` is committed), and `build/docker/Dockerfile` uses musl variants with hardcoded per-arch SHAs already covered by `check-tool-versions.sh`.

## Notes

`norabbit`: mechanical reuse of the already-reviewed `setup-tailwind` action (no new verification logic introduced). actionlint reports only the 3 pre-existing `copilot_setup`-format warnings (inherent to the Copilot setup-steps file, not standard Actions syntax); YAML validated. Ships on CI + Codoki.
