### PR TITLE
test(updater): cover non-empty skipped_versions + GetConfig failure; mark skipped_versions required in OpenAPI (#1984)

### DIFF
--- a/internal/api/handlers_updater_test.go
+++ b/internal/api/handlers_updater_test.go
@@ -1440,3 +1440,95 @@ func TestBuildUpdatesTabData_LastAutoApplied(t *testing.T) {
 		t.Errorf("LastAutoApplied = %q, not RFC3339: %v", data.LastAutoApplied, err)
 	}
 }
+
+// TestHandleGetUpdateStatus_NonEmptySkippedVersions verifies that when
+// skipped_versions are persisted in config, the status response returns them
+// as an ordered JSON array with the exact values.
+func TestHandleGetUpdateStatus_NonEmptySkippedVersions(t *testing.T) {
+	t.Parallel()
+	r := testRouterWithUpdater(t)
+	ctx := context.Background()
+
+	// Persist two skipped versions so they round-trip through GetConfig.
+	for _, tag := range []string{"v1.2.3", "v1.3.0"} {
+		if err := r.updaterService.AddSkippedVersion(ctx, tag); err != nil {
+			t.Fatalf("AddSkippedVersion(%q): %v", tag, err)
+		}
+	}
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/v1/updates/status", nil)
+	w := httptest.NewRecorder()
+	r.handleGetUpdateStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	sv, ok := raw["skipped_versions"]
+	if !ok {
+		t.Fatal(`missing field "skipped_versions" in UpdateStatus`)
+	}
+	arr, ok := sv.([]any)
+	if !ok {
+		t.Fatalf(`skipped_versions type = %T, want []any`, sv)
+	}
+	if len(arr) != 2 {
+		t.Fatalf("skipped_versions len = %d, want 2; got: %v", len(arr), arr)
+	}
+	if arr[0] != "v1.2.3" || arr[1] != "v1.3.0" {
+		t.Errorf("skipped_versions = %v, want [v1.2.3, v1.3.0]", arr)
+	}
+}
+
+// TestHandleGetUpdateStatus_GetConfigError verifies graceful degradation when
+// GetConfig fails: the handler must still return 200 with the in-memory status
+// and an empty skipped_versions array rather than an error response.
+func TestHandleGetUpdateStatus_GetConfigError(t *testing.T) {
+	t.Parallel()
+	r := testRouterWithUpdater(t)
+
+	// Close the shared DB to force GetConfig to fail with sql.ErrConnDone.
+	if err := r.db.Close(); err != nil {
+		t.Fatalf("closing db: %v", err)
+	}
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/updates/status", nil)
+	w := httptest.NewRecorder()
+	r.handleGetUpdateStatus(w, req)
+
+	// Handler logs a warning and returns 200 (not 500) on config-read failure.
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 on GetConfig error; body: %s", w.Code, w.Body.String())
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// The in-memory state fields must still be present.
+	for _, key := range []string{"state", "progress", "is_docker", "update_available", "restart_required"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing required field %q in UpdateStatus on GetConfig error", key)
+		}
+	}
+
+	// skipped_versions must be an empty array (the handler initializes it to
+	// []string{} before attempting GetConfig, so the field is never absent).
+	sv, ok := raw["skipped_versions"]
+	if !ok {
+		t.Fatal(`missing field "skipped_versions" in UpdateStatus on GetConfig error`)
+	}
+	arr, ok := sv.([]any)
+	if !ok {
+		t.Fatalf(`skipped_versions type = %T, want []any on GetConfig error`, sv)
+	}
+	if len(arr) != 0 {
+		t.Errorf("skipped_versions = %v, want empty array on GetConfig error", arr)
+	}
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1697,7 +1697,7 @@ components:
             when the check found no matching release on the current channel.
     UpdateStatus:
       type: object
-      required: [state, progress, is_docker, update_available, restart_required]
+      required: [state, progress, is_docker, update_available, restart_required, skipped_versions]
       properties:
         state:
           type: string


### PR DESCRIPTION
## Summary

Mark `skipped_versions` as `required` in the `/api/v1/updates/status` OpenAPI schema and cover two previously-untested paths. Closes the follow-up tracked from #1327 / PR #1980.

Closes #1984

## What changed

- `internal/api/openapi.yaml`: added `skipped_versions` to the `UpdateStatus` schema's `required` list. The handler initializes `SkippedVersions: []string{}` before any fallible call, so the field is always present (serializes to `[]`, never `null`); the schema now reflects that contract.
- `internal/api/handlers_updater_test.go`: two new tests -
  - `TestHandleGetUpdateStatus_NonEmptySkippedVersions` - round-trips real skipped versions through the DB and asserts exact values + insertion order in the response.
  - `TestHandleGetUpdateStatus_GetConfigError` - closes the shared DB to force `GetConfig` to fail, asserting graceful degradation (HTTP 200 with `skipped_versions: []`, not 500), since `Status()` is purely in-memory.

## Notes

Test + schema-annotation only; no production logic change. Gates green (64 packages, OpenAPI consistency + no-breaking-changes, generated files OK, `internal/updater` 87.7% > floor). Adversarial hostile review: no blocking findings (both tests confirmed meaningful and exercising the real paths).
