### PR TITLE
feat(publish): route image-upload push failures through notifyPushFailure (#1687)

### DIFF
--- a/internal/publish/publisher.go
+++ b/internal/publish/publisher.go
@@ -34,6 +34,12 @@ const pushOpLockToggle = "lock_toggle"
 // to distinguish a metadata-write failure from a lock-toggle failure.
 const pushOpMetadataPush = "metadata_push"
 
+// pushOpImageUpload is the operation slug emitted on connection.push_failed
+// events from SyncImageToPlatforms and SyncAllFanartToPlatforms. Toast
+// subscribers can filter by this slug to distinguish an image-upload failure
+// from a metadata-write or lock-toggle failure.
+const pushOpImageUpload = "image_upload"
+
 const (
 	// pushTimeout is the per-connection timeout for async metadata pushes.
 	pushTimeout = 30 * time.Second
@@ -530,6 +536,7 @@ func (p *Publisher) SyncImageToPlatforms(ctx context.Context, a *artist.Artist, 
 		if connErr != nil {
 			p.logger.Error("getting connection for image sync", "connection_id", pid.ConnectionID, "error", connErr)
 			warnings = append(warnings, truncateWarning(fmt.Sprintf("connection %s: failed to load", pid.ConnectionID)))
+			p.notifyPushFailure(shortConnLabel(pid.ConnectionID), classifyPushErr(connErr), a.ID, artistDisplayName(a), pushOpImageUpload, connErr)
 			continue
 		}
 		if !conn.Enabled || conn.Status != "ok" {
@@ -547,6 +554,7 @@ func (p *Publisher) SyncImageToPlatforms(ctx context.Context, a *artist.Artist, 
 		if uploadErr := uploader.UploadImage(ctx, pid.PlatformArtistID, imageType, data, ct); uploadErr != nil {
 			p.logger.Error("syncing image to platform", "artist", a.Name, "connection", conn.Name, "type", imageType, "error", uploadErr)
 			warnings = append(warnings, truncateWarning(fmt.Sprintf("%s (%s): image upload failed", conn.Name, conn.Type)))
+			p.notifyPushFailure(conn.Name, classifyPushErr(uploadErr), a.ID, artistDisplayName(a), pushOpImageUpload, uploadErr)
 		}
 	}
 	return warnings
@@ -602,6 +610,7 @@ func (p *Publisher) SyncAllFanartToPlatforms(ctx context.Context, a *artist.Arti
 				slog.String("connection_id", pid.ConnectionID),
 				slog.String("error", connErr.Error()))
 			warnings = append(warnings, truncateWarning(fmt.Sprintf("connection %s: failed to load", pid.ConnectionID)))
+			p.notifyPushFailure(shortConnLabel(pid.ConnectionID), classifyPushErr(connErr), a.ID, artistDisplayName(a), pushOpImageUpload, connErr)
 			continue
 		}
 		if !conn.Enabled || conn.Status != "ok" {
@@ -641,6 +650,7 @@ func (p *Publisher) SyncAllFanartToPlatforms(ctx context.Context, a *artist.Arti
 					slog.Int("index", i),
 					slog.String("error", uploadErr.Error()))
 				warnings = append(warnings, truncateWarning(fmt.Sprintf("%s (%s): fanart %d upload failed", conn.Name, conn.Type, i)))
+				p.notifyPushFailure(conn.Name, classifyPushErr(uploadErr), a.ID, artistDisplayName(a), pushOpImageUpload, uploadErr)
 			}
 		}
 	}

--- a/internal/publish/publisher_test.go
+++ b/internal/publish/publisher_test.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -796,5 +798,69 @@ func TestPushMetadataAsync_NotifierNotCalledOnSuccess(t *testing.T) {
 	}
 	if got := notifier.snapshot(); len(got) != 0 {
 		t.Errorf("notifier calls on success = %d, want 0; calls=%+v", len(got), got)
+	}
+}
+
+// TestSyncImageToPlatforms_NotifierFiresOnUploadFailure mirrors
+// TestPushMetadataAsync_NotifierFiresOnPushFailure for the image-upload
+// surface (#1687). When the platform POST returns 401, SyncImageToPlatforms
+// must invoke the Notifier with the connection name, "auth_failed" class,
+// and the "image_upload" operation slug. Without this hook the operator
+// sees a blank warning string while the platform silently rejected the
+// image write.
+func TestSyncImageToPlatforms_NotifierFiresOnUploadFailure(t *testing.T) {
+	// Reject every image upload POST with 401.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	// SyncImageToPlatforms reads an image file from the artist's filesystem
+	// path. Place a minimal folder.jpg (the first "thumb" pattern) in a temp
+	// dir so the file-read step succeeds and the upload is actually attempted.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "folder.jpg"), []byte("JFIF"), 0o600); err != nil {
+		t.Fatalf("writing test image: %v", err)
+	}
+
+	notifier := &recordingNotifier{}
+	p := New(Deps{
+		ArtistService: &fakePlatformLister{ids: []artist.PlatformID{
+			{ArtistID: "a1", ConnectionID: "c-emby", PlatformArtistID: "p1"},
+		}},
+		ConnectionService: &fakeConnectionGetter{conns: map[string]*connection.Connection{
+			"c-emby": {ID: "c-emby", Name: "my-emby", Type: connection.TypeEmby, URL: srv.URL, Enabled: true, Status: "ok", PlatformUserID: "u1"},
+		}},
+		Logger:   silentLogger(),
+		Notifier: notifier,
+	})
+
+	a := &artist.Artist{ID: "a1", Name: "Test Artist", Path: dir}
+	// SyncImageToPlatforms is synchronous, so the notifier is called before
+	// the function returns -- no polling or channel signaling needed.
+	p.SyncImageToPlatforms(context.Background(), a, "thumb")
+
+	got := notifier.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("notifier calls = %d, want 1; calls=%+v", len(got), got)
+	}
+	if got[0].connection != "my-emby" {
+		t.Errorf("connection = %q, want %q", got[0].connection, "my-emby")
+	}
+	// classifyPushErr maps "image upload failed with status 401" -> "auth_failed".
+	if got[0].errorClass != "auth_failed" {
+		t.Errorf("errorClass = %q, want %q (401 should classify as auth_failed)", got[0].errorClass, "auth_failed")
+	}
+	if got[0].artistID != "a1" {
+		t.Errorf("artistID = %q, want %q", got[0].artistID, "a1")
+	}
+	if got[0].artistName != "Test Artist" {
+		t.Errorf("artistName = %q, want %q", got[0].artistName, "Test Artist")
+	}
+	if got[0].operation != pushOpImageUpload {
+		t.Errorf("operation = %q, want %q", got[0].operation, pushOpImageUpload)
+	}
+	if got[0].err == nil {
+		t.Error("err = nil, want a non-nil error so logs can correlate")
 	}
 }


### PR DESCRIPTION
## Summary

Route image/fanart upload push failures through the existing `notifyPushFailure` path so they surface to the user the same way metadata-push failures do (they're silent today).

Closes #1687

## What changed

- `internal/publish/publisher.go`: added a `pushOpImageUpload = "image_upload"` operation const; `SyncImageToPlatforms` and `SyncAllFanartToPlatforms` now call `notifyPushFailure` on their connection-load and upload failure sites, mirroring the reviewed metadata-push path.
- `internal/publish/publisher_test.go`: new test - a real `httptest` server returning 401 + a real Emby uploader; a recording notifier asserts the failure notification fires with the correct fields (connection, error class `auth_failed`, artist, operation `image_upload`).

## Notes

Purely additive - no signature or success-path change. Unnotified paths (`GetPlatformIDs` failure, local disk-read errors, unsupported-uploader-type) are intentional omissions matching the metadata-push precedent. Adversarial review confirmed all four real failure sites are covered, no double-notify / notify-on-success, and the `status 401 -> auth_failed` classification end-to-end. No CR (additive, reviewed pattern).
