### PR TITLE
fix(image): normalize http web-search thumbnail URLs to https for CSP (#1864)

### DIFF
--- a/internal/api/handlers_image.go
+++ b/internal/api/handlers_image.go
@@ -554,6 +554,14 @@ func (r *Router) handleWebImageSearch(w http.ResponseWriter, req *http.Request) 
 		allImages = append(allImages, images...)
 	}
 
+	// Normalize http:// URLs to https:// so they satisfy the img-src CSP
+	// directive ("img-src 'self' data: https:"). Known web-search providers
+	// already serve content over TLS; this is a defensive upgrade applied at
+	// the single accumulation point rather than per-provider.
+	for i := range allImages {
+		allImages[i].URL = ensureHTTPS(allImages[i].URL)
+	}
+
 	sortImageResults(allImages, sortBy)
 
 	if isHTMXRequest(req) {
@@ -1738,6 +1746,17 @@ func (r *Router) revertSideEffects(ctx context.Context, a *artist.Artist, imageT
 		return r.publisher.SyncAllFanartToPlatforms(syncCtx, a)
 	}
 	return r.publisher.SyncImageToPlatforms(syncCtx, a, imageType)
+}
+
+// ensureHTTPS rewrites an http:// URL to https:// for CSP compatibility.
+// URLs already using https://, data: URIs, and any other scheme are returned
+// unchanged. Only the scheme prefix is replaced; path, host, and query are
+// preserved exactly.
+func ensureHTTPS(u string) string {
+	if strings.HasPrefix(u, "http://") {
+		return "https://" + u[len("http://"):]
+	}
+	return u
 }
 
 // imageTypeLabel returns a human-readable label for an image type.

--- a/internal/api/handlers_image_test.go
+++ b/internal/api/handlers_image_test.go
@@ -2782,6 +2782,77 @@ func TestProcessAndSaveImage_BackupFailureAborts(t *testing.T) {
 	}
 }
 
+// stubWebImageProvider is a minimal WebImageProvider for testing handleWebImageSearch.
+// It returns a fixed set of ImageResult values regardless of the query parameters.
+type stubWebImageProvider struct {
+	name    provider.ProviderName
+	results []provider.ImageResult
+}
+
+func (s *stubWebImageProvider) Name() provider.ProviderName { return s.name }
+func (s *stubWebImageProvider) RequiresAuth() bool          { return false }
+func (s *stubWebImageProvider) SearchImages(_ context.Context, _ string, _ provider.ImageType) ([]provider.ImageResult, error) {
+	return s.results, nil
+}
+
+// TestHandleWebImageSearch_NormalizesHTTPToHTTPS verifies that http:// thumbnail
+// URLs returned by a web-search provider are rewritten to https:// before the
+// response is sent, so they satisfy the "img-src 'self' data: https:" CSP header.
+// An already-https:// URL must remain unchanged.
+func TestHandleWebImageSearch_NormalizesHTTPToHTTPS(t *testing.T) {
+	t.Parallel()
+	r, svc := newImageHandlerTestServer(t)
+
+	a := &artist.Artist{Name: "CSP Artist", SortName: "CSP Artist", Path: t.TempDir()}
+	if err := svc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// Stub provider returns one http:// URL and one https:// URL.
+	stub := &stubWebImageProvider{
+		name: provider.NameDuckDuckGo,
+		results: []provider.ImageResult{
+			{URL: "http://example.com/img.jpg", Type: provider.ImageThumb, Source: "duckduckgo"},
+			{URL: "https://example.com/img2.jpg", Type: provider.ImageThumb, Source: "duckduckgo"},
+		},
+	}
+	r.webSearchRegistry.Register(stub)
+
+	if err := r.providerSettings.SetWebSearchEnabled(context.Background(), provider.NameDuckDuckGo, true); err != nil {
+		t.Fatalf("enabling provider: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/artists/"+a.ID+"/images/websearch?type=thumb", nil)
+	req.SetPathValue("id", a.ID)
+
+	w := serveValidated(t, http.HandlerFunc(r.handleWebImageSearch), req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Images []provider.ImageResult `json:"images"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if len(resp.Images) != 2 {
+		t.Fatalf("images = %d, want 2", len(resp.Images))
+	}
+	for _, im := range resp.Images {
+		if strings.HasPrefix(im.URL, "http://") {
+			t.Errorf("URL %q still uses http://, want https://", im.URL)
+		}
+	}
+	// Verify the http:// URL was upgraded and the https:// URL was left alone.
+	if want := "https://example.com/img.jpg"; resp.Images[0].URL != want {
+		t.Errorf("images[0].URL = %q, want %q", resp.Images[0].URL, want)
+	}
+	if want := "https://example.com/img2.jpg"; resp.Images[1].URL != want {
+		t.Errorf("images[1].URL = %q, want %q", resp.Images[1].URL, want)
+	}
+}
+
 // TestHandleLogoTrim_BackupFailureAborts proves F3/T2: a backup-write failure
 // aborts the trim with 500 and leaves the original logo intact.
 func TestHandleLogoTrim_BackupFailureAborts(t *testing.T) {


### PR DESCRIPTION
## Summary

Normalize `http://` web-search thumbnail URLs to `https://` so the `img-src 'self' data: https:` CSP doesn't block them.

Closes #1864

## What changed

- `internal/api/handlers_image.go`: added an `ensureHTTPS()` helper (upgrades only a leading `http://` scheme; leaves `https://`, `data:`, and protocol-relative `//` URLs untouched) and applied it in a single post-accumulation pass over the web-search results in `handleWebImageSearch`, before sorting - one site covers all providers.
- `internal/api/handlers_image_test.go`: new test asserting an `http://` result comes back `https://` and an `https://` one is unchanged.

## Notes

Defensive normalization: the known providers (DuckDuckGo / Qwant) already serve images over TLS, and Stillwater is always served over TLS, so an upgraded URL with no HTTPS backing yields a visible broken image (observable) rather than a silently CSP-blocked one. No CSP relaxation, no new endpoint, no behavior change beyond the URL scheme. Adversarial review: no blocking findings.

**CSP/security-adjacent** - flagging for the maintainer's call on whether to take a CR pass before merge (same posture as the #1981 supply-chain-adjacent flag).
