### PR TITLE
fix(merge): delete loser artist's loose metadata files on merge so duplicates don't resurrect (#1779)

### DIFF
--- a/docs/site/src/how-to/run-scans.md
+++ b/docs/site/src/how-to/run-scans.md
@@ -127,3 +127,9 @@ Each group offers a **Merge** action. Click it to open a confirmation modal that
 3. Lowest artist ID as a deterministic fallback if neither rule applies.
 
 You can override the recommendation by selecting a different survivor in the modal; the orchestrator will flag the deviation in the response but the merge still runs. Confirming the merge consolidates the directories on disk and collapses the artist records into one.
+
+### Loser directory cleanup after a merge
+
+After the album subdirectories are moved, Stillwater removes any loose metadata files (NFO files, artwork) that remain in the loser's directory and have a matching regular file in the survivor's directory. This step is **destructive** -- the loser's copies are permanently deleted from disk so that the loser's directory is left empty and can be removed, preventing the duplicate artist from reappearing on the next scan.
+
+A loser file is only deleted when the survivor already has a regular file at the same relative path. Survivor entries that are directories or symlinks are left alone, so the cleanup never removes files that the survivor side cannot clearly cover.

--- a/docs/site/src/reference/_doc-anchors.txt
+++ b/docs/site/src/reference/_doc-anchors.txt
@@ -389,6 +389,7 @@ how-to/reverse-proxy#verifying-the-proxy-works
 how-to/reverse-proxy#what-stillwater-expects-from-a-reverse-proxy
 how-to/run-scans#concurrent-scan-safety
 how-to/run-scans#imported-libraries
+how-to/run-scans#loser-directory-cleanup-after-a-merge
 how-to/run-scans#manual-libraries
 how-to/run-scans#monitor-an-in-progress-scan
 how-to/run-scans#possible-duplicate-artists

--- a/internal/api/handlers_artist_duplicates.go
+++ b/internal/api/handlers_artist_duplicates.go
@@ -124,6 +124,15 @@ type mergeMovedPayload struct {
 	To   string `json:"to"`
 }
 
+// mergeDeletedPayload mirrors artist.DeletedItem in snake_case. Surfaced in
+// the API response so callers can preview (dry-run) or audit (commit) which
+// loose files were removed from the loser directory because the same filename
+// already existed under the survivor.
+type mergeDeletedPayload struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
 // mergeResultPayload mirrors artist.MergeResult in snake_case. Conflicts is
 // omitted when empty so success responses do not carry the field.
 type mergeResultPayload struct {
@@ -132,6 +141,7 @@ type mergeResultPayload struct {
 	SurvivorPath     string                 `json:"survivor_path"`
 	SurvivorOverride bool                   `json:"survivor_override"`
 	Moved            []mergeMovedPayload    `json:"moved,omitempty"`
+	Deleted          []mergeDeletedPayload  `json:"deleted,omitempty"`
 	Conflicts        []mergeConflictPayload `json:"conflicts,omitempty"`
 	Removed          []string               `json:"removed,omitempty"`
 	Warnings         []string               `json:"warnings,omitempty"`
@@ -290,6 +300,14 @@ func toMergeMovedPayloads(in []artist.MovedItem) []mergeMovedPayload {
 	return out
 }
 
+func toMergeDeletedPayloads(in []artist.DeletedItem) []mergeDeletedPayload {
+	out := make([]mergeDeletedPayload, 0, len(in))
+	for _, d := range in {
+		out = append(out, mergeDeletedPayload{Name: d.Name, Path: d.Path})
+	}
+	return out
+}
+
 func toMergeResultPayload(r *artist.MergeResult) mergeResultPayload {
 	if r == nil {
 		return mergeResultPayload{}
@@ -300,6 +318,7 @@ func toMergeResultPayload(r *artist.MergeResult) mergeResultPayload {
 		SurvivorPath:     r.SurvivorPath,
 		SurvivorOverride: r.SurvivorOverride,
 		Moved:            toMergeMovedPayloads(r.Moved),
+		Deleted:          toMergeDeletedPayloads(r.Deleted),
 		Conflicts:        toMergeConflictPayloads(r.Conflicts),
 		Removed:          r.Removed,
 		Warnings:         r.Warnings,

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -210,6 +210,20 @@ components:
           type: string
           description: Absolute destination path under the survivor.
       required: [name, from, to]
+    MergeDeletedItem:
+      type: object
+      description: >-
+        One loose file deleted from a loser directory because the same filename
+        already existed under the survivor. Present in dry-run responses as a
+        preview and in commit responses as a record of what was removed.
+      properties:
+        name:
+          type: string
+          description: File basename.
+        path:
+          type: string
+          description: Absolute path of the file that was (or would be) deleted from the loser directory.
+      required: [name, path]
     MergeConflict:
       type: object
       description: >-
@@ -252,9 +266,20 @@ components:
             $ref: "#/components/schemas/MergeMovedItem"
           description: >-
             Every filesystem rename performed (album subdirs first, then
-            loose files). Empty on dry-run. Collisions return HTTP 409
-            with the MergeCollisionsResponse shape and are not represented
-            in this payload.
+            non-colliding loose files). Empty on dry-run. Collisions
+            return HTTP 409 with the MergeCollisionsResponse shape and are
+            not represented in this payload.
+        deleted:
+          type: array
+          items:
+            $ref: "#/components/schemas/MergeDeletedItem"
+          description: >-
+            Loose files removed from loser directories because the same
+            filename already existed under the survivor. The survivor's
+            copy is authoritative; the loser's redundant copy is deleted so
+            the loser directory can be emptied and unlinked. On dry-run this
+            previews which files WOULD be deleted; on commit it lists what
+            WAS actually removed.
         conflicts:
           type: array
           items:
@@ -271,16 +296,15 @@ components:
           description: >-
             Loser artist IDs whose on-disk directories were actually
             unlinked by the merge. A loser whose directory was left in
-            place (loose-file survivor-wins collision or a
-            destination-appeared race) is NOT listed here; see warnings
-            for the reason.
+            place (destination-appeared race or unexpected filesystem
+            content) is NOT listed here; see warnings for the reason.
         warnings:
           type: array
           items:
             type: string
           description: >-
-            Non-fatal observations (loose-file collisions skipped per
-            "survivor wins", symlinks skipped, the standing reminder that
+            Non-fatal observations (symlinks skipped, destination-appeared
+            race left a subdirectory in place, the standing reminder that
             connected platforms still index the loser path until the
             operator triggers a refresh).
         losers_deleted:

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -266,9 +266,10 @@ components:
             $ref: "#/components/schemas/MergeMovedItem"
           description: >-
             Every filesystem rename performed (album subdirs first, then
-            non-colliding loose files). Empty on dry-run. Collisions
-            return HTTP 409 with the MergeCollisionsResponse shape and are
-            not represented in this payload.
+            non-colliding loose files). Empty on dry-run. Album-subdirectory
+            collisions return HTTP 409 with the MergeCollisionsResponse shape.
+            Loose-file same-name collisions that are safely superseded by a
+            survivor regular file are represented in `deleted`.
         deleted:
           type: array
           items:

--- a/internal/artist/merge_artists.go
+++ b/internal/artist/merge_artists.go
@@ -111,6 +111,20 @@ type MovedItem struct {
 	To string
 }
 
+// DeletedItem records one loose file deleted from the loser directory during
+// the merge. When a loose file's name already exists under the survivor the
+// survivor's copy is authoritative; the loser's redundant copy is removed so
+// the loser directory can be emptied and unlinked. In dry-run mode the slice
+// previews which files WOULD be deleted; in commit mode it lists the files
+// that WERE actually removed.
+type DeletedItem struct {
+	// Name is the file basename.
+	Name string
+	// Path is the absolute path of the file that was (or would be) deleted
+	// from the loser directory.
+	Path string
+}
+
 // ConflictItem records one would-be filesystem collision found by the
 // pre-flight walk. Populated when MergeResult.Conflicts is non-empty;
 // nothing has been moved in that case.
@@ -155,14 +169,22 @@ type MergeResult struct {
 	// unlinked from the filesystem during the merge. An ID appears here
 	// only when executeLoserMerge confirmed the loser dir was empty after
 	// the rename loop AND os.Remove succeeded. A loser whose dir was left
-	// in place (loose-file collision, destination-appeared-race) is
-	// recorded in Warnings instead and does NOT appear here.
+	// in place (destination-appeared-race, symlinks, or unexpected
+	// filesystem content) does NOT appear here.
 	Removed []string
 
-	// Warnings collects non-fatal observations the user should see (loose
-	// file collisions skipped per "survivor wins", symlinks skipped, and
-	// the standing reminder that connected platforms still index the
-	// loser path until the operator triggers a refresh).
+	// Deleted lists loose files removed from loser directories because the
+	// same filename already existed under the survivor. The survivor's copy
+	// is authoritative; the loser's copy is redundant and is deleted so the
+	// loser directory becomes empty and can be unlinked. In dry-run mode
+	// this previews which files WOULD be deleted; in commit mode it lists
+	// what WAS actually removed.
+	Deleted []DeletedItem
+
+	// Warnings collects non-fatal observations the user should see (symlinks
+	// skipped, destination-appeared-race left a subdirectory in place, and
+	// the standing reminder that connected platforms still index the loser
+	// path until the operator triggers a refresh).
 	Warnings []string
 
 	// LosersDeleted lists the loser artist IDs whose rows were deleted
@@ -237,10 +259,11 @@ func (s *Service) MergeArtists(ctx context.Context, req MergeRequest) (*MergeRes
 		SurvivorOverride: override,
 	}
 
-	// Pre-flight collision walk over every loser. Album-subdir
-	// collisions are halting; loose-file collisions are recorded as
-	// warnings (survivor wins, loose file stays where it is so the user
-	// can copy it manually if they want it).
+	// Pre-flight collision walk over every loser. Album-subdir collisions
+	// are halting (ErrMergeCollisions). Loose-file collisions are recorded
+	// in result.Deleted as a preview of which files will be removed from
+	// the loser during the commit phase (survivor wins; the loser's
+	// redundant copy is deleted so the loser directory can be emptied).
 	losers := lookupLosers(members, req.LoserIDs)
 	if err := preflightAllLosers(losers, survivor.Path, result); err != nil {
 		return result, err
@@ -250,14 +273,19 @@ func (s *Service) MergeArtists(ctx context.Context, req MergeRequest) (*MergeRes
 		return result, nil
 	}
 
-	// Commit phase: per-loser, move each album subdir, move each
-	// non-colliding loose file, then unlink the now-empty loser dir. A
-	// failure mid-loop returns whatever has already been moved in
-	// result.Moved so the caller can reason about partial state. We only
-	// record a loser ID in result.Removed when executeLoserMerge confirms
-	// the loser directory was actually unlinked (loose-file collision and
-	// destination-appeared-race leave the dir in place; those are
-	// surfaced via result.Warnings).
+	// Clear the deletion preview populated by the pre-flight walk; the
+	// commit loop (executeLoserMerge) will repopulate result.Deleted with
+	// entries for files that were actually removed.
+	result.Deleted = nil
+
+	// Commit phase: per-loser, move each album subdir, delete each
+	// colliding loose file, move each non-colliding loose file, then
+	// unlink the now-empty loser dir. A failure mid-loop returns whatever
+	// has already been moved in result.Moved so the caller can reason
+	// about partial state. We only record a loser ID in result.Removed
+	// when executeLoserMerge confirms the loser directory was actually
+	// unlinked (destination-appeared-race leaves a subdir in place and
+	// does NOT appear here).
 	for _, loser := range losers {
 		removed, err := executeLoserMerge(loser, survivor.Path, result)
 		if err != nil {
@@ -553,9 +581,9 @@ func enumerateChildren(path string) (subdirs, files []os.DirEntry, symlinks []st
 }
 
 // preflightAllLosers walks every loser and collects collisions before any FS
-// mutation. Subdir collisions are halting (ErrMergeCollisions); loose-file
-// collisions and symlinks are recorded in result.Warnings so the caller
-// sees them but the merge can proceed.
+// mutation. Album-subdir collisions are halting (ErrMergeCollisions).
+// Loose-file collisions are recorded in result.Deleted as a preview of what
+// the commit phase will remove; symlinks are recorded in result.Warnings.
 func preflightAllLosers(losers []NearDuplicateArtist, survivorPath string, result *MergeResult) error {
 	for _, loser := range losers {
 		if err := preflightOneLoser(loser, survivorPath, result); err != nil {
@@ -603,9 +631,14 @@ func preflightOneLoser(loser NearDuplicateArtist, survivorPath string, result *M
 	for _, f := range files {
 		survivorChild := filepath.Join(survivorPath, f.Name())
 		if _, statErr := os.Lstat(survivorChild); statErr == nil {
-			result.Warnings = append(result.Warnings,
-				fmt.Sprintf("loose file %q already exists under survivor; left in place at %s",
-					f.Name(), filepath.Join(loser.Path, f.Name())))
+			// Survivor already has this file; the loser's copy is
+			// redundant and will be deleted during the commit phase.
+			// Record a preview entry so the caller can show what will
+			// be removed before asking the user to confirm.
+			result.Deleted = append(result.Deleted, DeletedItem{
+				Name: f.Name(),
+				Path: filepath.Join(loser.Path, f.Name()),
+			})
 		} else if !os.IsNotExist(statErr) {
 			return fmt.Errorf("checking survivor loose file %s: %w", survivorChild, statErr)
 		}
@@ -614,18 +647,20 @@ func preflightOneLoser(loser NearDuplicateArtist, survivorPath string, result *M
 }
 
 // executeLoserMerge performs the commit-phase filesystem operations for one
-// loser: move every non-colliding album subdir, move every non-colliding
-// loose file, then remove the now-empty loser directory. Per-child failures
-// abort the loop and leave the partially-moved state on disk -- the next
-// merge attempt will pick up where this one stopped (the loser dir still
-// exists and DetectDuplicates still groups it with the survivor).
+// loser: move every non-colliding album subdir, delete every colliding loose
+// file (survivor's copy wins; the loser's redundant copy is removed), move
+// every non-colliding loose file, then remove the now-empty loser directory.
+// Per-child failures abort the loop and leave the partially-moved state on
+// disk -- the next merge attempt will pick up where this one stopped (the
+// loser dir still exists and DetectDuplicates still groups it with the
+// survivor).
 //
 // Returns removed=true ONLY when the loser directory was actually unlinked
-// (rename loop drained the directory AND os.Remove succeeded). The two
-// skip cases that leave the dir on disk (loose-file survivor-wins collision
-// and destination-appeared-race) return removed=false with a warning
-// recorded in result.Warnings; the caller MUST NOT report the loser as
-// "removed" in those cases.
+// (rename/delete loop drained the directory AND os.Remove succeeded). The
+// destination-appeared-race case (a subdir collision detected between
+// pre-flight and commit) returns removed=false with a warning recorded in
+// result.Warnings; the caller MUST NOT report the loser as "removed" in
+// that case.
 //
 // Returns removed=true with no work performed if the loser directory does
 // not exist at all (ENOENT). This is the crash-recovery path: a previous
@@ -676,9 +711,13 @@ func executeLoserMerge(loser NearDuplicateArtist, survivorPath string, result *M
 		src := filepath.Join(loser.Path, f.Name())
 		dst := filepath.Join(survivorPath, f.Name())
 		if _, statErr := os.Lstat(dst); statErr == nil {
-			// Survivor wins; loose file stays in the loser dir. The loser
-			// directory removal below will skip because the dir is
-			// non-empty; the caller will see Removed unappended.
+			// Survivor already has a file with this name; its copy is
+			// authoritative. Delete the loser's redundant copy so the
+			// loser directory becomes empty and can be unlinked below.
+			if err := filesystem.RemoveFileSafe(src); err != nil {
+				return false, fmt.Errorf("deleting colliding loose file %s: %w", src, err)
+			}
+			result.Deleted = append(result.Deleted, DeletedItem{Name: f.Name(), Path: src})
 			continue
 		}
 		// RenameFileAtomic mirrors RenameDirAtomic's EXDEV fallback so a

--- a/internal/artist/merge_artists.go
+++ b/internal/artist/merge_artists.go
@@ -630,7 +630,16 @@ func preflightOneLoser(loser NearDuplicateArtist, survivorPath string, result *M
 	}
 	for _, f := range files {
 		survivorChild := filepath.Join(survivorPath, f.Name())
-		if _, statErr := os.Lstat(survivorChild); statErr == nil {
+		if info, statErr := os.Lstat(survivorChild); statErr == nil {
+			if !info.Mode().IsRegular() {
+				// Survivor has a same-named entry that is NOT a regular
+				// file (e.g. a directory or a symlink). The loser's loose
+				// file has no genuine authoritative survivor copy, so do
+				// not treat it as colliding -- leave it in the loser dir.
+				// The non-empty loser dir will trigger the "still contains"
+				// warning path in executeLoserMerge rather than a delete.
+				continue
+			}
 			// Survivor already has this file; the loser's copy is
 			// redundant and will be deleted during the commit phase.
 			// Record a preview entry so the caller can show what will
@@ -710,7 +719,15 @@ func executeLoserMerge(loser NearDuplicateArtist, survivorPath string, result *M
 	for _, f := range files {
 		src := filepath.Join(loser.Path, f.Name())
 		dst := filepath.Join(survivorPath, f.Name())
-		if _, statErr := os.Lstat(dst); statErr == nil {
+		if info, statErr := os.Lstat(dst); statErr == nil {
+			if !info.Mode().IsRegular() {
+				// Survivor's same-named entry is not a regular file (e.g.
+				// a directory or a symlink). There is no genuine
+				// authoritative survivor copy, so do not delete the
+				// loser's file -- leave it in place. The non-empty loser
+				// dir will surface via the "still contains" warning below.
+				continue
+			}
 			// Survivor already has a file with this name; its copy is
 			// authoritative. Delete the loser's redundant copy so the
 			// loser directory becomes empty and can be unlinked below.

--- a/internal/artist/merge_artists_test.go
+++ b/internal/artist/merge_artists_test.go
@@ -970,8 +970,15 @@ func TestMergeArtists_LooseFileCollision_SurvivorDirectory(t *testing.T) {
 	}
 
 	// A warning must be emitted for the non-empty loser directory.
-	if len(res.Warnings) == 0 {
-		t.Errorf("Warnings = empty, want at least one warning about non-empty loser dir")
+	foundNonEmptyWarning := false
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "still contains") && strings.Contains(w, loser.Path) {
+			foundNonEmptyWarning = true
+			break
+		}
+	}
+	if !foundNonEmptyWarning {
+		t.Errorf("Warnings = %v, want warning about non-empty loser dir %s", res.Warnings, loser.Path)
 	}
 
 	// result.Deleted must not record folder.jpg -- it was NOT deleted.

--- a/internal/artist/merge_artists_test.go
+++ b/internal/artist/merge_artists_test.go
@@ -678,11 +678,13 @@ func TestMergeArtists_MultipleLosers(t *testing.T) {
 	}
 }
 
-// TestMergeArtists_LooseFileCollision exercises the survivor-wins
-// loose-file collision path. The pre-flight collision walk warns (but
-// does not halt) when a loose file with the same name exists on both
-// sides; the commit phase leaves the loser file in place and therefore
-// the loser directory is NOT removed (the post-rename dir is non-empty).
+// TestMergeArtists_LooseFileCollision exercises the survivor-wins loose-file
+// collision path. When a loose file with the same name exists on both sides
+// the survivor's copy is authoritative; the loser's redundant copy is deleted
+// so the loser directory becomes empty and can be unlinked. This is the fix
+// for the resurrection bug (#1779): previously the loser directory was left on
+// disk with its colliding files intact, causing the next scan to re-promote it
+// as a new artist row.
 //
 // TG3 in the PR #1654 triage doc.
 func TestMergeArtists_LooseFileCollision(t *testing.T) {
@@ -714,16 +716,18 @@ func TestMergeArtists_LooseFileCollision(t *testing.T) {
 	}
 
 	// The loose-file collision should NOT halt the merge; album subdirs
-	// should still move. But the loser dir must remain because folder.jpg
-	// stays inside it.
-	if len(res.Removed) != 0 {
-		t.Errorf("Removed = %v, want empty (loose-file collision blocked dir removal)", res.Removed)
+	// should still move. The colliding loser file is deleted, leaving the
+	// loser directory empty so it can be unlinked.
+	if len(res.Removed) != 1 || res.Removed[0] != loserID {
+		t.Errorf("Removed = %v, want [%s] (loser dir should be unlinked after collision delete)", res.Removed, loserID)
 	}
-	if _, err := os.Stat(loser.Path); err != nil {
-		t.Errorf("loser dir should still exist: %v", err)
+	if _, err := os.Stat(loser.Path); !os.IsNotExist(err) {
+		t.Errorf("loser dir should be removed after merge, stat err = %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(loser.Path, "folder.jpg")); err != nil {
-		t.Errorf("loser folder.jpg should still be in place: %v", err)
+	// The loser's folder.jpg was deleted (redundant copy); survivor's copy
+	// is untouched.
+	if _, err := os.Stat(filepath.Join(loser.Path, "folder.jpg")); !os.IsNotExist(err) {
+		t.Errorf("loser folder.jpg should have been deleted, stat err = %v", err)
 	}
 	// The survivor's original folder.jpg should be untouched (survivor wins).
 	got, err := os.ReadFile(filepath.Join(survivor.Path, "folder.jpg"))
@@ -732,24 +736,186 @@ func TestMergeArtists_LooseFileCollision(t *testing.T) {
 	} else if string(got) != "survivor-jpg" {
 		t.Errorf("survivor folder.jpg content = %q, want %q (overwritten by loser)", got, "survivor-jpg")
 	}
-	// A warning should mention the collided file by name so the operator
-	// can investigate.
-	foundWarning := false
-	for _, w := range res.Warnings {
-		if strings.Contains(w, "folder.jpg") {
-			foundWarning = true
+	// result.Deleted should record the deletion.
+	foundDeleted := false
+	for _, d := range res.Deleted {
+		if d.Name == "folder.jpg" {
+			foundDeleted = true
 			break
 		}
 	}
-	if !foundWarning {
-		t.Errorf("expected warning mentioning folder.jpg, got %v", res.Warnings)
+	if !foundDeleted {
+		t.Errorf("expected Deleted entry for folder.jpg, got %v", res.Deleted)
 	}
-	// LosersDeleted SHOULD still contain the loser ID -- the DB row is
-	// deleted even though the dir was not unlinked. That asymmetry is
-	// documented; the next scan will re-promote the leftover dir into a
-	// fresh row that the operator can clean up manually.
-	if len(res.LosersDeleted) != 1 {
+	// Both the DB row and the directory are gone; no resurrection is possible.
+	if len(res.LosersDeleted) != 1 || res.LosersDeleted[0] != loserID {
 		t.Errorf("LosersDeleted = %v, want [%s]", res.LosersDeleted, loserID)
+	}
+}
+
+// TestMergeArtists_LooseFileOnlyLoser tests the exact resurrection bug
+// scenario from #1779: the loser artist directory contains ONLY loose files
+// (no album subdirectories) and every one of those files already exists under
+// the survivor. Before the fix, the loser DB row was deleted but the directory
+// was left on disk, causing the next scan to re-promote it as a new artist.
+// After the fix, the colliding files are deleted, the directory becomes empty,
+// and the loser row + directory are both removed.
+func TestMergeArtists_LooseFileOnlyLoser(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	root := t.TempDir()
+
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)
+		 VALUES ('lib-loose-only', 'lib-loose-only', ?, 'regular', 'manual', datetime('now'), datetime('now'))`,
+		root); err != nil {
+		t.Fatalf("seeding library: %v", err)
+	}
+
+	// "The Cure" and "Cure, The" normalize to the same duplicate key, so they
+	// will be grouped by DetectDuplicates. The loser has NO album subdirs --
+	// only loose files that all collide with the survivor. This is the
+	// resurrection bug scenario: the directory-only-metadata case.
+	survivorPath := filepath.Join(root, "The Cure")
+	loserPath := filepath.Join(root, "Cure, The")
+	for _, p := range []string{survivorPath, loserPath} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+
+	// Survivor has an album subdir and the same loose files as the loser.
+	if err := os.Mkdir(filepath.Join(survivorPath, "Disintegration"), 0o755); err != nil {
+		t.Fatalf("mkdir survivor album: %v", err)
+	}
+	looseFiles := []string{"artist.nfo", "folder.jpg", "fanart.jpg"}
+	for _, f := range looseFiles {
+		if err := os.WriteFile(filepath.Join(survivorPath, f), []byte("survivor-"+f), 0o600); err != nil {
+			t.Fatalf("seed survivor %s: %v", f, err)
+		}
+		// Loser has identically named files -- all collide with survivor.
+		if err := os.WriteFile(filepath.Join(loserPath, f), []byte("loser-"+f), 0o600); err != nil {
+			t.Fatalf("seed loser %s: %v", f, err)
+		}
+	}
+
+	survivor := &Artist{Name: "The Cure", SortName: "Cure, The", Path: survivorPath, LibraryID: "lib-loose-only"}
+	loser := &Artist{Name: "The Cure", SortName: "Cure, The", Path: loserPath, LibraryID: "lib-loose-only"}
+	if err := svc.Create(ctx, survivor); err != nil {
+		t.Fatalf("Create survivor: %v", err)
+	}
+	if err := svc.Create(ctx, loser); err != nil {
+		t.Fatalf("Create loser: %v", err)
+	}
+
+	res, err := svc.MergeArtists(ctx, MergeRequest{
+		SurvivorID:  survivor.ID,
+		LoserIDs:    []string{loser.ID},
+		ArticleMode: "prefix",
+	})
+	if err != nil {
+		t.Fatalf("MergeArtists: %v", err)
+	}
+
+	// Loser directory must be gone -- no resurrection on next scan.
+	if _, statErr := os.Stat(loserPath); !os.IsNotExist(statErr) {
+		t.Errorf("loser dir should be removed (resurrection bug): stat err = %v", statErr)
+	}
+	// All colliding files must be deleted from the loser.
+	for _, f := range looseFiles {
+		if _, statErr := os.Stat(filepath.Join(loserPath, f)); !os.IsNotExist(statErr) {
+			t.Errorf("loser %s should be deleted: stat err = %v", f, statErr)
+		}
+	}
+	// Survivor's files must be untouched (survivor wins).
+	for _, f := range looseFiles {
+		got, err := os.ReadFile(filepath.Join(survivorPath, f))
+		if err != nil {
+			t.Errorf("survivor %s missing: %v", f, err)
+		} else if string(got) != "survivor-"+f {
+			t.Errorf("survivor %s = %q, want %q", f, got, "survivor-"+f)
+		}
+	}
+	// Both the DB row and directory are gone.
+	if len(res.Removed) != 1 || res.Removed[0] != loser.ID {
+		t.Errorf("Removed = %v, want [%s]", res.Removed, loser.ID)
+	}
+	if len(res.LosersDeleted) != 1 || res.LosersDeleted[0] != loser.ID {
+		t.Errorf("LosersDeleted = %v, want [%s]", res.LosersDeleted, loser.ID)
+	}
+	// result.Deleted should have an entry for each colliding file.
+	if len(res.Deleted) != len(looseFiles) {
+		t.Errorf("Deleted = %v (%d entries), want %d (one per colliding file)", res.Deleted, len(res.Deleted), len(looseFiles))
+	}
+	// The loser row is gone from the DB.
+	if _, err := svc.GetByID(ctx, loser.ID); !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected loser row deleted (ErrNotFound), got err = %v", err)
+	}
+}
+
+// TestMergeArtists_DryRunDeletesPreview verifies that a dry-run merge
+// previews colliding loose-file deletions in result.Deleted (not
+// result.Warnings) and makes no filesystem changes.
+func TestMergeArtists_DryRunDeletesPreview(t *testing.T) {
+	t.Parallel()
+	svc, _, survivorID, loserID := mergeSetup(t)
+	ctx := context.Background()
+
+	survivor, _ := svc.GetByID(ctx, survivorID)
+	loser, _ := svc.GetByID(ctx, loserID)
+
+	// Seed a loose file collision: same name on both sides.
+	if err := os.WriteFile(filepath.Join(survivor.Path, "folder.jpg"), []byte("survivor-jpg"), 0o600); err != nil {
+		t.Fatalf("seed survivor folder.jpg: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(loser.Path, "folder.jpg"), []byte("loser-jpg"), 0o600); err != nil {
+		t.Fatalf("seed loser folder.jpg: %v", err)
+	}
+
+	res, err := svc.MergeArtists(ctx, MergeRequest{
+		SurvivorID:  survivorID,
+		LoserIDs:    []string{loserID},
+		DryRun:      true,
+		ArticleMode: "prefix",
+	})
+	if err != nil {
+		t.Fatalf("DryRun MergeArtists: %v", err)
+	}
+	if !res.DryRun {
+		t.Errorf("DryRun flag not set in result")
+	}
+
+	// Dry-run should populate Deleted with preview entries for colliding files.
+	foundDeleted := false
+	for _, d := range res.Deleted {
+		if d.Name == "folder.jpg" {
+			foundDeleted = true
+			break
+		}
+	}
+	if !foundDeleted {
+		t.Errorf("DryRun Deleted = %v, want preview entry for folder.jpg", res.Deleted)
+	}
+
+	// Dry-run must not mutate the filesystem.
+	if _, err := os.Stat(filepath.Join(loser.Path, "folder.jpg")); err != nil {
+		t.Errorf("dry-run should not remove loser folder.jpg: %v", err)
+	}
+	if _, err := os.Stat(loser.Path); err != nil {
+		t.Errorf("dry-run should not remove loser dir: %v", err)
+	}
+
+	// Dry-run Moved, Removed, and LosersDeleted must be empty.
+	if len(res.Moved) != 0 {
+		t.Errorf("DryRun Moved = %v, want empty", res.Moved)
+	}
+	if len(res.Removed) != 0 {
+		t.Errorf("DryRun Removed = %v, want empty", res.Removed)
+	}
+	if len(res.LosersDeleted) != 0 {
+		t.Errorf("DryRun LosersDeleted = %v, want empty", res.LosersDeleted)
 	}
 }
 
@@ -847,9 +1013,9 @@ func TestMergeArtists_PerChildRenameFailure(t *testing.T) {
 	// instrumenting the orchestrator, this test instead pre-creates the
 	// collision and asserts the pre-flight HALT semantics (a stronger
 	// guarantee than per-child resume because nothing moves at all).
-	// CG1's resume guarantee is exercised by the loose-file collision
-	// test (TestMergeArtists_LooseFileCollision) which proves the
-	// partial-state path (some children move, dir stays, row deleted).
+	// CG1's resume guarantee is exercised by the ENOENT recovery test
+	// (TestMergeArtists_ENOENTRecovery) which proves the crash-recovery
+	// path (dir already gone, orphan row cleaned up on re-run).
 	//
 	// Specifically here we prove: a post-preflight halt leaves zero
 	// half-state on disk AND a re-run resumes the same group cleanly.

--- a/internal/artist/merge_artists_test.go
+++ b/internal/artist/merge_artists_test.go
@@ -919,6 +919,69 @@ func TestMergeArtists_DryRunDeletesPreview(t *testing.T) {
 	}
 }
 
+// TestMergeArtists_LooseFileCollision_SurvivorDirectory verifies the
+// regular-file hardening added in #1779: when the survivor's same-named
+// child is a DIRECTORY (not a regular file) the loser's loose file must
+// NOT be deleted -- there is no genuine authoritative survivor copy.
+// The loser directory therefore remains on disk (non-empty), a warning
+// is recorded, and result.Deleted has no entry for that file.
+func TestMergeArtists_LooseFileCollision_SurvivorDirectory(t *testing.T) {
+	t.Parallel()
+	svc, _, survivorID, loserID := mergeSetup(t)
+	ctx := context.Background()
+
+	survivor, _ := svc.GetByID(ctx, survivorID)
+	loser, _ := svc.GetByID(ctx, loserID)
+
+	// Place a DIRECTORY named "folder.jpg" under the survivor -- same name
+	// as a loose file we add to the loser. This is the edge case: the
+	// survivor has a same-named child that is not a regular file.
+	if err := os.Mkdir(filepath.Join(survivor.Path, "folder.jpg"), 0o755); err != nil {
+		t.Fatalf("mkdir survivor folder.jpg dir: %v", err)
+	}
+	// Loser has the genuine regular file. Without the fix this would be
+	// deleted (data loss); with the fix it must be preserved.
+	if err := os.WriteFile(filepath.Join(loser.Path, "folder.jpg"), []byte("loser-jpg"), 0o600); err != nil {
+		t.Fatalf("write loser folder.jpg: %v", err)
+	}
+
+	res, err := svc.MergeArtists(ctx, MergeRequest{
+		SurvivorID:  survivorID,
+		LoserIDs:    []string{loserID},
+		ArticleMode: "prefix",
+	})
+	if err != nil {
+		t.Fatalf("MergeArtists: %v", err)
+	}
+
+	// Loser's folder.jpg must still exist -- the fix skips the delete when
+	// the survivor child is not a regular file.
+	loserJPG := filepath.Join(loser.Path, "folder.jpg")
+	if _, statErr := os.Stat(loserJPG); statErr != nil {
+		t.Errorf("loser folder.jpg was incorrectly deleted (data-loss edge); stat err = %v", statErr)
+	}
+
+	// Because the loser dir still holds folder.jpg, it cannot be unlinked.
+	if _, statErr := os.Stat(loser.Path); statErr != nil {
+		t.Errorf("loser dir should remain on disk (folder.jpg blocks removal); stat err = %v", statErr)
+	}
+	if len(res.Removed) != 0 {
+		t.Errorf("Removed = %v, want empty (loser dir not removed due to leftover file)", res.Removed)
+	}
+
+	// A warning must be emitted for the non-empty loser directory.
+	if len(res.Warnings) == 0 {
+		t.Errorf("Warnings = empty, want at least one warning about non-empty loser dir")
+	}
+
+	// result.Deleted must not record folder.jpg -- it was NOT deleted.
+	for _, d := range res.Deleted {
+		if d.Name == "folder.jpg" {
+			t.Errorf("Deleted records folder.jpg but it should not have been deleted (survivor child is a dir, not a file)")
+		}
+	}
+}
+
 // TestMergeArtists_PerChildRenameFailure injects a rename failure between
 // the first and second album subdir. The contract (file header) promises
 // the first move stays, the second is not attempted, and the next merge

--- a/web/components/_doc-anchors.txt
+++ b/web/components/_doc-anchors.txt
@@ -389,6 +389,7 @@ how-to/reverse-proxy#verifying-the-proxy-works
 how-to/reverse-proxy#what-stillwater-expects-from-a-reverse-proxy
 how-to/run-scans#concurrent-scan-safety
 how-to/run-scans#imported-libraries
+how-to/run-scans#loser-directory-cleanup-after-a-merge
 how-to/run-scans#manual-libraries
 how-to/run-scans#monitor-an-in-progress-scan
 how-to/run-scans#possible-duplicate-artists


### PR DESCRIPTION
## Summary

When merging duplicate artists, if the loser artist's directory contained only loose metadata files (NFO, artwork) and no media tracks, those files were left on disk. The loser directory therefore survived the merge, and the duplicate artist re-appeared on the next library scan. This deletes the loser's colliding loose files during the merge so the loser directory is fully removed and the duplicate does not resurrect.

## Changes

- `internal/artist/merge_artists.go`: during a merge, delete the loser's loose files that collide with the survivor so the now-empty loser directory can be removed (`ae5c9d2a`).
- Safety hardening: a loser loose file is deleted ONLY when the survivor's copy at that same relative path is a REGULAR file (not a directory or symlink). This guards against deleting a loser file whose survivor-side counterpart is an unexpected path type. Applied at BOTH the preflight and execute sites (`7f6a17ae`).
- `internal/api/openapi.yaml`: add the `MergeDeletedItem` schema and update `MergeResult` so the merge response reports the files it removed (`1df34a5f`).
- Tests: `TestMergeArtists_LooseFileCollision_SurvivorDirectory` plus the existing merge suite cover the collision path and the regular-file guard.

## Safety note

This change deletes files on disk during a merge. The deletion is gated: a loser file is removed only when the survivor genuinely supersedes it with a regular file at the same relative path. Directory/symlink path types on the survivor side are skipped, not deleted. Build and race tests pass.

Closes #1779


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loose-file duplicates in loser directories are now detected and removed when the survivor already has matching files.
  * Merge API response now includes details of deleted files.

* **Documentation**
  * Added guidance on loser directory cleanup after artist merge.

* **Tests**
  * Enhanced test coverage for loose-file collision deletion during merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->