### PR TITLE
fix(merge): gate loser DB-row deletion on actual dir removal (#2010)

### DIFF
--- a/internal/artist/merge_artists.go
+++ b/internal/artist/merge_artists.go
@@ -820,11 +820,25 @@ func (s *Service) commitMergeDB(ctx context.Context, survivor *NearDuplicateArti
 		}
 	}
 
+	// Only delete DB rows for losers whose directory was actually removed
+	// from disk (i.e. those recorded in result.Removed). A loser left on
+	// disk (removed=false, e.g. blocked by a non-regular survivor child)
+	// must keep its row so the scanner reconciles to the existing entry
+	// rather than resurrecting it as a new artist (#2010, follow-up to #1779).
+	// Metadata-forward (MBID fill above) still runs for all losers.
+	removedSet := make(map[string]bool, len(result.Removed))
+	for _, id := range result.Removed {
+		removedSet[id] = true
+	}
+
 	// Collect deleted IDs locally; only assign to result.LosersDeleted on
 	// successful commit so a failed commit does not falsely advertise
 	// loser-row deletions that never persisted.
 	var deletedIDs []string
 	for _, l := range losers {
+		if !removedSet[l.ID] {
+			continue
+		}
 		if _, err := tx.ExecContext(ctx, `DELETE FROM artists WHERE id = ?`, l.ID); err != nil {
 			return fmt.Errorf("deleting loser %s: %w", l.ID, err)
 		}

--- a/internal/artist/merge_artists_test.go
+++ b/internal/artist/merge_artists_test.go
@@ -1260,6 +1260,117 @@ func TestValidateMergeRequest_WhitespaceNormalized(t *testing.T) {
 	}
 }
 
+// TestMergeArtists_LoserRowSurvivesWhenNotRemoved is the regression test for
+// #2010 (follow-up to #1779). When executeLoserMerge returns removed=false
+// (the loser directory was left on disk due to a collision -- e.g. the
+// survivor has a same-named directory where the loser has a loose file),
+// commitMergeDB must NOT delete the loser's DB row. A deleted row with a
+// surviving directory causes the scanner to resurrect the loser as a new
+// artist on the next pass.
+//
+// The test uses two losers in the same merge call:
+//   - loserBlocked: has a loose "folder.jpg" that cannot be moved because the
+//     survivor already has a directory named "folder.jpg". Its dir is left on
+//     disk; its DB row must survive.
+//   - loserClean: has a non-colliding album subdir. Its dir is fully removed;
+//     its DB row must be deleted.
+func TestMergeArtists_LoserRowSurvivesWhenNotRemoved(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+	root := t.TempDir()
+
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO libraries (id, name, path, type, source, created_at, updated_at)
+		 VALUES ('lib-row-survive', 'lib-row-survive', ?, 'regular', 'manual', datetime('now'), datetime('now'))`,
+		root); err != nil {
+		t.Fatalf("seeding library: %v", err)
+	}
+
+	survivorPath := filepath.Join(root, "The Cure")
+	loserBlockedPath := filepath.Join(root, "Cure, The")
+	loserCleanPath := filepath.Join(root, "Cure")
+	for _, p := range []string{survivorPath, loserBlockedPath, loserCleanPath} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+
+	// Survivor has an album subdir and a DIRECTORY named "folder.jpg" --
+	// the same name as a loose file on loserBlocked. This makes the survivor
+	// child non-regular, so executeLoserMerge cannot move loserBlocked's
+	// "folder.jpg" and must leave the loser dir on disk.
+	if err := os.Mkdir(filepath.Join(survivorPath, "Disintegration"), 0o755); err != nil {
+		t.Fatalf("mkdir survivor album: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(survivorPath, "folder.jpg"), 0o755); err != nil {
+		t.Fatalf("mkdir survivor folder.jpg dir: %v", err)
+	}
+
+	// loserBlocked: only a loose file that collides with the survivor dir.
+	if err := os.WriteFile(filepath.Join(loserBlockedPath, "folder.jpg"), []byte("blocked-jpg"), 0o600); err != nil {
+		t.Fatalf("write loserBlocked folder.jpg: %v", err)
+	}
+
+	// loserClean: a non-colliding album subdir; it will be fully removed.
+	if err := os.Mkdir(filepath.Join(loserCleanPath, "Wish"), 0o755); err != nil {
+		t.Fatalf("mkdir loserClean album: %v", err)
+	}
+
+	survivor := &Artist{Name: "The Cure", SortName: "Cure, The", Path: survivorPath, LibraryID: "lib-row-survive"}
+	loserBlocked := &Artist{Name: "The Cure", SortName: "Cure, The", Path: loserBlockedPath, LibraryID: "lib-row-survive"}
+	loserClean := &Artist{Name: "The Cure", SortName: "Cure, The", Path: loserCleanPath, LibraryID: "lib-row-survive"}
+	for _, a := range []*Artist{survivor, loserBlocked, loserClean} {
+		if err := svc.Create(ctx, a); err != nil {
+			t.Fatalf("Create %s (%s): %v", a.Name, a.Path, err)
+		}
+	}
+
+	res, err := svc.MergeArtists(ctx, MergeRequest{
+		SurvivorID:  survivor.ID,
+		LoserIDs:    []string{loserBlocked.ID, loserClean.ID},
+		ArticleMode: "prefix",
+	})
+	if err != nil {
+		t.Fatalf("MergeArtists: %v", err)
+	}
+
+	// (a) loserBlocked's dir must still exist and its DB row must survive.
+	if _, statErr := os.Stat(loserBlockedPath); statErr != nil {
+		t.Errorf("loserBlocked dir should remain on disk; stat err = %v", statErr)
+	}
+	if _, getErr := svc.GetByID(ctx, loserBlocked.ID); getErr != nil {
+		t.Errorf("loserBlocked DB row must survive (not deleted); GetByID err = %v", getErr)
+	}
+	if len(res.Removed) != 1 || res.Removed[0] != loserClean.ID {
+		t.Errorf("Removed = %v, want [%s] (only loserClean)", res.Removed, loserClean.ID)
+	}
+	if len(res.LosersDeleted) != 1 || res.LosersDeleted[0] != loserClean.ID {
+		t.Errorf("LosersDeleted = %v, want [%s] (only loserClean)", res.LosersDeleted, loserClean.ID)
+	}
+
+	// (b) Warning must be emitted for the non-empty loserBlocked dir.
+	foundNonEmptyWarning := false
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "still contains") && strings.Contains(w, loserBlockedPath) {
+			foundNonEmptyWarning = true
+			break
+		}
+	}
+	if !foundNonEmptyWarning {
+		t.Errorf("Warnings = %v, want warning about non-empty loserBlocked dir", res.Warnings)
+	}
+
+	// (c) loserClean was fully removed; its DB row must be deleted.
+	if _, statErr := os.Stat(loserCleanPath); !os.IsNotExist(statErr) {
+		t.Errorf("loserClean dir should be removed; stat err = %v", statErr)
+	}
+	if _, getErr := svc.GetByID(ctx, loserClean.ID); !errors.Is(getErr, ErrNotFound) {
+		t.Errorf("loserClean DB row should be deleted; GetByID err = %v", getErr)
+	}
+}
+
 // --- small helpers ----------------------------------------------------------
 
 func dirNames(entries []os.DirEntry) []string {


### PR DESCRIPTION
## Summary

Follow-up to #1779 / PR #2007. A CodeRabbit **outside-diff Major** finding on #2007 was not addressed before merge: `commitMergeDB` deleted **every** loser's DB row regardless of whether `executeLoserMerge` actually removed the loser directory from disk. For the `removed=false` edge cases the loser directory survived on disk while its DB row was wiped, so the next library scan re-imported the directory as a brand-new artist - the exact duplicate-resurrection bug #1779 set out to fix.

## The bug (was present in main @ `7bee64c6`)

- The commit loop recorded a loser in `result.Removed` only when `executeLoserMerge` returned `removed=true`, but then passed **all** losers to `commitMergeDB`.
- `commitMergeDB`'s delete loop (`for _, l := range losers`) deleted every loser row (FK cascade: provider_ids, images, libraries, platform IDs, aliases, history).
- `executeLoserMerge` returns `removed=false` (dir left on disk + a warning) in real cases: a destination-appeared-race collision leaves a subdir in the loser dir, or a same-named entry in the survivor is not a regular file (dir/symlink) so the loser file is deliberately left in place.
- Result: loser dir remained on disk but its DB row was wiped -> next scan re-imports it as a new artist.

## Fix

Gate the DB delete on actual removal. `commitMergeDB` now builds a set from `result.Removed` and skips the `DELETE` for any loser whose directory was left on disk; that loser retains its DB row + associations so the scanner reconciles to the existing row instead of creating a new one. The MBID fill-forward loop is unchanged and still runs for **all** losers. `result.LosersDeleted` now reflects only the losers actually removed from disk.

## Test

`TestMergeArtists_LoserRowSurvivesWhenNotRemoved` - a two-loser merge where one loser is blocked by a survivor-side `folder.jpg` directory (`removed=false`) and one is cleanly removed (`removed=true`). It asserts the blocked loser's dir survives, its DB row survives (`GetByID` succeeds) and it is absent from `LosersDeleted`, the "still contains ... not removed" warning is emitted, and the clean loser's dir + row are both gone. The test fails if the gate is reverted (genuine regression guard).

## Verification

- `go build ./...`, `go vet ./...` clean; `internal/artist` + `internal/api` tests pass.
- `make check-openapi` PASS; generated files OK.
- Independent hostile review attempted to break the fix (revert-the-fix mental test, real-collision trace, FK-cascade + transaction audit) and found no defects.

Closes #2010
