### PR TITLE
fix(auth): redirect logged-out browsers to login on wrapAuth page routes (#1941)

### DIFF
--- a/internal/api/handlers_artist_duplicates_view_test.go
+++ b/internal/api/handlers_artist_duplicates_view_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/artist"
 )
 
@@ -116,6 +117,44 @@ func TestHandleArtistDuplicatesPage_UnauthRendersLoginPage(t *testing.T) {
 		t.Error("unauthenticated visitor must not see the duplicates table")
 	}
 	if !strings.Contains(body, "/api/v1/auth/login") {
-		t.Error("response should contain the login form action (/api/v1/auth/login)")
+		t.Error("login page must have the login form action (/api/v1/auth/login)")
+	}
+	// Structural proof: both a username field and a password field must be
+	// present - confirming this is the login form, not just any page that
+	// happens to mention the auth endpoint.
+	if !strings.Contains(body, `name="username"`) {
+		t.Error("login page must include a username input field (name=username)")
+	}
+	if !strings.Contains(body, `type="password"`) {
+		t.Error("login page must include a password input field (type=password)")
+	}
+}
+
+// TestHandleArtistDuplicatesPage_AuthenticatedRendersPage is the
+// authenticated-path regression test for handleArtistDuplicatesPage. An admin
+// request must reach the real duplicates page, not the login render. This
+// guards the wrapAuth change introduced in #1941: adding the auth gate must
+// not break the authed path.
+func TestHandleArtistDuplicatesPage_AuthenticatedRendersPage(t *testing.T) {
+	t.Parallel()
+	r := newTestRouterFull(t)
+
+	ctx := middleware.WithTestUserID(context.Background(), "test-admin")
+	ctx = middleware.WithTestRole(ctx, "administrator")
+	req := withI18nCtx(t, httptest.NewRequestWithContext(ctx, http.MethodGet, "/reports/duplicates", nil))
+	w := httptest.NewRecorder()
+	r.handleArtistDuplicatesPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("authenticated admin request should get 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	// The real page must render the duplicates table container, not the
+	// login form.
+	if !strings.Contains(body, "artist-duplicates-table") {
+		t.Error("authenticated admin must see the artist-duplicates-table in the response")
+	}
+	if strings.Contains(body, `type="password"`) {
+		t.Error("authenticated admin must not see a login password field")
 	}
 }

--- a/internal/api/handlers_artist_duplicates_view_test.go
+++ b/internal/api/handlers_artist_duplicates_view_test.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/sydlexius/stillwater/internal/artist"
@@ -91,5 +93,29 @@ func TestHandleDuplicates_Empty(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("len(groups) = %d, want 0 (empty DB)", len(got))
+	}
+}
+
+// TestHandleArtistDuplicatesPage_UnauthRendersLoginPage asserts that an
+// unauthenticated GET /reports/duplicates returns HTTP 200 with the login page
+// rather than a 401 JSON error. The route uses wrapOptionalAuth so
+// requireForeignAdmin -> renderLoginPage runs for cookieless visitors.
+func TestHandleArtistDuplicatesPage_UnauthRendersLoginPage(t *testing.T) {
+	t.Parallel()
+	r := newTestRouterFull(t)
+
+	req := withI18nCtx(t, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/reports/duplicates", nil))
+	w := httptest.NewRecorder()
+	r.handleArtistDuplicatesPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("unauthenticated request should get login page (200), got %d", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "artist-duplicates-table") {
+		t.Error("unauthenticated visitor must not see the duplicates table")
+	}
+	if !strings.Contains(body, "/api/v1/auth/login") {
+		t.Error("response should contain the login form action (/api/v1/auth/login)")
 	}
 }

--- a/internal/api/handlers_foreign_files_test.go
+++ b/internal/api/handlers_foreign_files_test.go
@@ -1188,3 +1188,49 @@ func TestHandleForeignFilesCount_NextChannelSidebarPill(t *testing.T) {
 		}
 	}
 }
+
+// TestHandleForeignFilesPage_UnauthRendersLoginPage asserts that an
+// unauthenticated GET /settings/foreign-files returns HTTP 200 with the login
+// page rather than a 401 JSON error. The route uses wrapOptionalAuth so
+// requireForeignAdmin -> renderLoginPage runs for cookieless visitors.
+func TestHandleForeignFilesPage_UnauthRendersLoginPage(t *testing.T) {
+	t.Parallel()
+	r := newTestRouterFull(t)
+
+	req := withI18nCtx(t, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/settings/foreign-files", nil))
+	w := httptest.NewRecorder()
+	r.handleForeignFilesPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("unauthenticated request should get login page (200), got %d", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "foreign-files-table") {
+		t.Error("unauthenticated visitor must not see the foreign-files table")
+	}
+	if !strings.Contains(body, "/api/v1/auth/login") {
+		t.Error("response should contain the login form action (/api/v1/auth/login)")
+	}
+}
+
+// TestHandleForeignAllowlistPage_UnauthRendersLoginPage is the same check for
+// the allowlist route.
+func TestHandleForeignAllowlistPage_UnauthRendersLoginPage(t *testing.T) {
+	t.Parallel()
+	r := newTestRouterFull(t)
+
+	req := withI18nCtx(t, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/settings/foreign-files/allowlist", nil))
+	w := httptest.NewRecorder()
+	r.handleForeignAllowlistPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("unauthenticated request should get login page (200), got %d", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "foreign-files-table") {
+		t.Error("unauthenticated visitor must not see the allowlist table")
+	}
+	if !strings.Contains(body, "/api/v1/auth/login") {
+		t.Error("response should contain the login form action (/api/v1/auth/login)")
+	}
+}

--- a/internal/api/handlers_foreign_files_test.go
+++ b/internal/api/handlers_foreign_files_test.go
@@ -1209,7 +1209,16 @@ func TestHandleForeignFilesPage_UnauthRendersLoginPage(t *testing.T) {
 		t.Error("unauthenticated visitor must not see the foreign-files table")
 	}
 	if !strings.Contains(body, "/api/v1/auth/login") {
-		t.Error("response should contain the login form action (/api/v1/auth/login)")
+		t.Error("login page must have the login form action (/api/v1/auth/login)")
+	}
+	// Structural proof: both a username field and a password field must be
+	// present - confirming this is the login form, not just any page that
+	// happens to mention the auth endpoint.
+	if !strings.Contains(body, `name="username"`) {
+		t.Error("login page must include a username input field (name=username)")
+	}
+	if !strings.Contains(body, `type="password"`) {
+		t.Error("login page must include a password input field (type=password)")
 	}
 }
 
@@ -1231,6 +1240,69 @@ func TestHandleForeignAllowlistPage_UnauthRendersLoginPage(t *testing.T) {
 		t.Error("unauthenticated visitor must not see the allowlist table")
 	}
 	if !strings.Contains(body, "/api/v1/auth/login") {
-		t.Error("response should contain the login form action (/api/v1/auth/login)")
+		t.Error("login page must have the login form action (/api/v1/auth/login)")
+	}
+	// Structural proof: both a username field and a password field must be
+	// present - confirming this is the login form, not just any page that
+	// happens to mention the auth endpoint.
+	if !strings.Contains(body, `name="username"`) {
+		t.Error("login page must include a username input field (name=username)")
+	}
+	if !strings.Contains(body, `type="password"`) {
+		t.Error("login page must include a password input field (type=password)")
+	}
+}
+
+// TestHandleForeignFilesPage_AuthenticatedRendersPage is the authenticated-path
+// regression test for handleForeignFilesPage. An admin request must reach the
+// real foreign-files page, not the login render. This guards the wrapAuth change
+// introduced in #1941: adding the auth gate must not break the authed path.
+func TestHandleForeignFilesPage_AuthenticatedRendersPage(t *testing.T) {
+	t.Parallel()
+	r := newTestRouterFull(t)
+
+	ctx := middleware.WithTestUserID(context.Background(), "test-admin")
+	ctx = middleware.WithTestRole(ctx, "administrator")
+	req := withI18nCtx(t, httptest.NewRequestWithContext(ctx, http.MethodGet, "/settings/foreign-files", nil))
+	w := httptest.NewRecorder()
+	r.handleForeignFilesPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("authenticated admin request should get 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	// The real page must render the foreign-files table container, not the
+	// login form.
+	if !strings.Contains(body, "foreign-files-table") {
+		t.Error("authenticated admin must see the foreign-files-table in the response")
+	}
+	if strings.Contains(body, `type="password"`) {
+		t.Error("authenticated admin must not see a login password field")
+	}
+}
+
+// TestHandleForeignAllowlistPage_AuthenticatedRendersPage is the
+// authenticated-path regression test for handleForeignAllowlistPage.
+func TestHandleForeignAllowlistPage_AuthenticatedRendersPage(t *testing.T) {
+	t.Parallel()
+	r := newTestRouterFull(t)
+
+	ctx := middleware.WithTestUserID(context.Background(), "test-admin")
+	ctx = middleware.WithTestRole(ctx, "administrator")
+	req := withI18nCtx(t, httptest.NewRequestWithContext(ctx, http.MethodGet, "/settings/foreign-files/allowlist", nil))
+	w := httptest.NewRecorder()
+	r.handleForeignAllowlistPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("authenticated admin request should get 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	// The real page must render the allowlist table container, not the login
+	// form.
+	if !strings.Contains(body, "foreign-allowlist-table") {
+		t.Error("authenticated admin must see the foreign-allowlist-table in the response")
+	}
+	if strings.Contains(body, `type="password"`) {
+		t.Error("authenticated admin must not see a login password field")
 	}
 }

--- a/internal/api/handlers_reidentify_wizard.go
+++ b/internal/api/handlers_reidentify_wizard.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/i18n"
 	"github.com/sydlexius/stillwater/internal/provider"
@@ -343,6 +344,13 @@ func (r *Router) buildWizardStartSteps(ctx context.Context, ids []string) (steps
 //
 // GET /artists/re-identify/wizard/{sid}/step/{idx}
 func (r *Router) handleReIdentifyWizardStep(w http.ResponseWriter, req *http.Request) {
+	// Render the login page for unauthenticated visitors. wrapOptionalAuth
+	// passes the request through; the handler is responsible for the check.
+	if middleware.UserIDFromContext(req.Context()) == "" {
+		r.renderLoginPage(w, req)
+		return
+	}
+
 	sid := req.PathValue("sid")
 	sess := r.reIdentifyWizardStore.get(sid)
 	if sess == nil {

--- a/internal/api/handlers_reidentify_wizard_test.go
+++ b/internal/api/handlers_reidentify_wizard_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/provider"
 	templates "github.com/sydlexius/stillwater/web/templates"
@@ -509,7 +510,8 @@ func TestHandleReIdentifyWizardStart_ReportsSkippedIDs(t *testing.T) {
 func TestHandleReIdentifyWizardStep_NotFound(t *testing.T) {
 	t.Parallel()
 	r, _, _ := testRouterWithIdentify(t)
-	req := httptest.NewRequest(http.MethodGet, "/artists/re-identify/wizard/unknown/step/0", nil)
+	ctx := middleware.WithTestUserID(context.Background(), "test-user")
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/artists/re-identify/wizard/unknown/step/0", nil)
 	req.SetPathValue("sid", "unknown")
 	req.SetPathValue("idx", "0")
 	w := httptest.NewRecorder()
@@ -526,7 +528,8 @@ func TestHandleReIdentifyWizardStep_InvalidIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	req := httptest.NewRequest(http.MethodGet, "/artists/re-identify/wizard/"+sess.ID+"/step/-1", nil)
+	ctx := middleware.WithTestUserID(context.Background(), "test-user")
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/artists/re-identify/wizard/"+sess.ID+"/step/-1", nil)
 	req.SetPathValue("sid", sess.ID)
 	req.SetPathValue("idx", "nope")
 	w := httptest.NewRecorder()
@@ -1142,4 +1145,31 @@ func TestHandleReIdentifyWizardRetry(t *testing.T) {
 			t.Errorf("status = %d, want 404", w.Code)
 		}
 	})
+}
+
+// TestHandleReIdentifyWizardStep_UnauthRendersLoginPage asserts that an
+// unauthenticated GET to the wizard step page returns HTTP 200 with the login
+// page rather than a 401 JSON error. The route uses wrapOptionalAuth; the
+// handler's auth gate calls renderLoginPage when no user is present in context.
+func TestHandleReIdentifyWizardStep_UnauthRendersLoginPage(t *testing.T) {
+	t.Parallel()
+	r := newTestRouterFull(t)
+
+	req := withI18nCtx(t, httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/artists/re-identify/wizard/some-sid/step/0", nil))
+	req.SetPathValue("sid", "some-sid")
+	req.SetPathValue("idx", "0")
+	w := httptest.NewRecorder()
+	r.handleReIdentifyWizardStep(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("unauthenticated request should get login page (200), got %d", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "wizard-body") {
+		t.Error("unauthenticated visitor must not see the wizard content")
+	}
+	if !strings.Contains(body, "/api/v1/auth/login") {
+		t.Error("response should contain the login form action (/api/v1/auth/login)")
+	}
 }

--- a/internal/api/handlers_reidentify_wizard_test.go
+++ b/internal/api/handlers_reidentify_wizard_test.go
@@ -1170,6 +1170,15 @@ func TestHandleReIdentifyWizardStep_UnauthRendersLoginPage(t *testing.T) {
 		t.Error("unauthenticated visitor must not see the wizard content")
 	}
 	if !strings.Contains(body, "/api/v1/auth/login") {
-		t.Error("response should contain the login form action (/api/v1/auth/login)")
+		t.Error("login page must have the login form action (/api/v1/auth/login)")
+	}
+	// Structural proof: both a username field and a password field must be
+	// present - confirming this is the login form, not just any page that
+	// happens to mention the auth endpoint.
+	if !strings.Contains(body, `name="username"`) {
+		t.Error("login page must include a username input field (name=username)")
+	}
+	if !strings.Contains(body, `type="password"`) {
+		t.Error("login page must include a password input field (type=password)")
 	}
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -656,7 +656,7 @@ func (r *Router) Handler(ctx context.Context) http.Handler {
 	// same artist IDs that /bulk-actions accepts; see
 	// handlers_reidentify_wizard.go for the session-store design.
 	mux.HandleFunc("POST "+bp+"/api/v1/artists/re-identify/wizard", wrapAuth(r.handleReIdentifyWizardStart, authMw))
-	mux.HandleFunc("GET "+bp+"/artists/re-identify/wizard/{sid}/step/{idx}", wrapAuth(r.handleReIdentifyWizardStep, authMw))
+	mux.HandleFunc("GET "+bp+"/artists/re-identify/wizard/{sid}/step/{idx}", wrapOptionalAuth(r.handleReIdentifyWizardStep, optAuthMw))
 	mux.HandleFunc("POST "+bp+"/api/v1/artists/re-identify/wizard/{sid}/step/{idx}/accept", wrapAuth(r.handleReIdentifyWizardAccept, authMw))
 	mux.HandleFunc("POST "+bp+"/api/v1/artists/re-identify/wizard/{sid}/step/{idx}/skip", wrapAuth(r.handleReIdentifyWizardSkip, authMw))
 	mux.HandleFunc("POST "+bp+"/api/v1/artists/re-identify/wizard/{sid}/step/{idx}/decline", wrapAuth(r.handleReIdentifyWizardDecline, authMw))
@@ -776,15 +776,15 @@ func (r *Router) Handler(ctx context.Context) http.Handler {
 	mux.HandleFunc("GET "+bp+"/settings", wrapOptionalAuth(r.handleSettingsPage, optAuthMw))
 	// Foreign-file management pages (#1185). Registered before the catch-all
 	// /settings/{section} redirect so the more-specific routes win.
-	mux.HandleFunc("GET "+bp+"/settings/foreign-files", wrapAuth(r.handleForeignFilesPage, authMw))
-	mux.HandleFunc("GET "+bp+"/settings/foreign-files/allowlist", wrapAuth(r.handleForeignAllowlistPage, authMw))
+	mux.HandleFunc("GET "+bp+"/settings/foreign-files", wrapOptionalAuth(r.handleForeignFilesPage, optAuthMw))
+	mux.HandleFunc("GET "+bp+"/settings/foreign-files/allowlist", wrapOptionalAuth(r.handleForeignAllowlistPage, optAuthMw))
 	// Near-duplicate artist detection page (#1614). Canonical path is
 	// /reports/duplicates so it sits alongside /reports/compliance under
 	// the Reports hub. The old /settings/artist-duplicates path 301s to
 	// the new one so bookmarks and external links still resolve (#1615 IA
 	// move). Registered before the catch-all so the specific paths win
 	// over the /settings/{section} section redirect.
-	mux.HandleFunc("GET "+bp+"/reports/duplicates", wrapAuth(r.handleArtistDuplicatesPage, authMw))
+	mux.HandleFunc("GET "+bp+"/reports/duplicates", wrapOptionalAuth(r.handleArtistDuplicatesPage, optAuthMw))
 	mux.HandleFunc("GET "+bp+"/settings/artist-duplicates", wrapOptionalAuth(func(w http.ResponseWriter, req *http.Request) {
 		target := r.basePath + "/reports/duplicates"
 		if raw := req.URL.RawQuery; raw != "" {


### PR DESCRIPTION
## What

Page routes guarded by `wrapAuth` returned **401 JSON** to logged-out *browsers* instead of rendering the login page. `wrapAuth` hard-rejects unauthenticated requests before the handler runs, which is correct for `/api/v1/` JSON endpoints but wrong for human-facing pages.

This switches the four affected **page** routes to `wrapOptionalAuth` so the handler runs and renders the login page for unauthenticated visitors, with the auth gate enforced **inside** each handler.

## Audit — all four affected page routes

| Route | Handler | Auth gate |
|---|---|---|
| `GET /artists/re-identify/wizard/{sid}/step/{idx}` | `handleReIdentifyWizardStep` | **Added** (`UserIDFromContext=="" → renderLoginPage`) |
| `GET /settings/foreign-files` | `handleForeignFilesPage` | already `requireForeignAdmin` |
| `GET /settings/foreign-files/allowlist` | `handleForeignAllowlistPage` | already `requireForeignAdmin` |
| `GET /reports/duplicates` | `handleArtistDuplicatesPage` | already `requireForeignAdmin` |

No other `wrapAuth` page routes exist; all remaining `wrapAuth` routes are `/api/v1/` JSON endpoints where 401 is correct (unchanged).

## Safety

Because `wrapOptionalAuth` lets the handler body run for unauthenticated requests, each handler's auth gate is the **first executable statement**, ahead of any param use, DB read, state change, or data render — no unauthenticated work occurs. Verified by a hostile auth-bypass review (gate-before-sensitive-work confirmed on all four; context is correctly empty for unauthed/inactive; only these four page routes changed).

## Tests

- New unauthenticated-request tests on the foreign-files, allowlist, duplicates, and wizard-step routes asserting the **login page renders** (not 200-with-data).
- Existing wizard-step `_NotFound`/`_InvalidIndex` tests updated to inject an authenticated context so they still reach the real error paths.
- `go test ./internal/api/...` green (race detector); `go build ./...` + `go vet ./...` clean.

Closes #1941
