### PR TITLE
fix(next): unify opt-out 404 across all next/ page handlers

### DIFF
--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -74,6 +74,8 @@ The `/next/*` URL namespace is hard-gated by `middleware.UX`: when `SW_UX=stable
 
 **Why middleware, not handler registration:** All `/next/*` routes are registered unconditionally in `router.go`. The gate lives in `middleware.UX` where `laneEnabled` is already computed, so no route-table churn is needed to toggle the feature.
 
-**Handler-level guards (defense in depth):** Each `handleNext*` handler also checks `UXChannelFromContext != UXNext` and returns 404. In stable mode this is dead code (the middleware gate fires first). In next/dual mode it guards the edge case where an explicit `X-Stillwater-UX: stable` header opts a sub-request back to the stable channel -- those requests reach the handler but must not render next/ content.
+**Handler-level guards (defense in depth):** Every `handleNext*` handler calls `checkNextChannel` as its first guard, which checks `UXChannelFromContext != UXNext` and returns 404 uniformly. In stable mode this is dead code (the middleware gate fires first). In next/dual mode it guards the edge case where an explicit `X-Stillwater-UX: stable` header opts a sub-request back to the stable channel -- those requests reach the handler but the explicit `/next/` path does not serve stable content, so 404 is the honest response.
+
+The policy is: an explicit `/next/` path with the stable opt-out header always returns 404 across all next/ handlers, regardless of whether a stable equivalent exists. Five handlers previously delegated to the stable equivalent instead (`handleNextDashboardPage`, `handleNextArtistsPage`, `handleNextArtistDetailPage`, `handleNextForeignFilesPage`, `handleNextForeignAllowlistPage`); that inconsistency was corrected in #1933 to match the documented policy.
 
 **Promotion path:** Set `SW_UX=next` to make the next/ lane the default (a `sw_ux=stable` cookie opts a user back). The `middleware.UX` gate is lifted automatically; no code change is required (#1757).

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1429,11 +1429,16 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 // nextFallback returns the handler for the /next/* UI-channel lane (M55 #1340).
 // Until a screen's next template lands, it re-dispatches the request to the
 // stable route by stripping the /next prefix and forwarding through the mux, so
-// navigation never breaks and no /next path 404s (decision 12). The UX
-// middleware has already set X-Stillwater-UX: next on the response. Each screen
-// issue replaces this generic fallback with a flag-aware handler as its next
-// template lands. No per-route auth wrapper is applied here because the
-// re-dispatched stable route applies its own auth.
+// navigation to unimplemented next/ paths never dead-ends. The UX middleware has
+// already set X-Stillwater-UX: next on the response. Each screen issue replaces
+// this generic fallback with a dedicated next/ handler as its template lands.
+// No per-route auth wrapper is applied here because the re-dispatched stable
+// route applies its own auth.
+//
+// Note: nextFallback only covers paths with NO dedicated next/ handler yet.
+// Implemented handlers use checkNextChannel (decision 12) and return 404 on the
+// per-request stable opt-out; that policy does not apply here because this
+// handler is the scaffolding for screens that are not yet implemented.
 func (r *Router) nextFallback(mux *http.ServeMux) http.HandlerFunc {
 	bp := r.basePath
 	return func(w http.ResponseWriter, req *http.Request) {

--- a/internal/api/handlers_next_artist_detail.go
+++ b/internal/api/handlers_next_artist_detail.go
@@ -19,15 +19,14 @@ import (
 // before this handler runs (decision 12 in architecture-decisions.md). The
 // in-handler channel guard below is therefore only reachable when the lane IS
 // enabled (next/dual mode) and the resolved channel is not "next" -- triggered
-// by an explicit X-Stillwater-UX: stable header. In that edge case it delegates
-// to handleArtistDetailPage so the path never dead-ends (mirroring
-// handleNextArtistsPage). Otherwise it assembles the shared ArtistDetailData,
-// resolves prev/next-artist neighbor ids (for the h/l shortcuts) from the
-// filter-aware ListIDs ordering, reads the section order/hidden prefs, and
-// renders next.ArtistDetailPage.
+// by an explicit X-Stillwater-UX: stable header. In that edge case it returns
+// 404 (decision 12: all handleNext* handlers return 404 on an explicit /next/
+// path with the stable opt-out; the path does not serve stable content).
+// Otherwise it assembles the shared ArtistDetailData, resolves prev/next-artist
+// neighbor ids (for the h/l shortcuts) from the filter-aware ListIDs ordering,
+// reads the section order/hidden prefs, and renders next.ArtistDetailPage.
 func (r *Router) handleNextArtistDetailPage(w http.ResponseWriter, req *http.Request) {
-	if middleware.UXChannelFromContext(req.Context()) != middleware.UXNext {
-		r.handleArtistDetailPage(w, req)
+	if !checkNextChannel(w, req) {
 		return
 	}
 
@@ -82,8 +81,7 @@ func artworkKindToType(kind string) string {
 // AutoCrop:false and SelectedIndex:-1 (the modal does not pre-select a slot).
 // The modal shell lazy-loads this fragment per active kind.
 func (r *Router) handleNextArtworkModal(w http.ResponseWriter, req *http.Request) {
-	if middleware.UXChannelFromContext(req.Context()) != middleware.UXNext {
-		http.NotFound(w, req)
+	if !checkNextChannel(w, req) {
 		return
 	}
 	userID := middleware.UserIDFromContext(req.Context())

--- a/internal/api/handlers_next_artist_detail_test.go
+++ b/internal/api/handlers_next_artist_detail_test.go
@@ -85,6 +85,30 @@ func TestHandleNextArtistDetailPage_StableMode404(t *testing.T) {
 	}
 }
 
+// TestHandleNextArtistDetailPage_OptOutHeader404 verifies the handler-level
+// decision-12 guard: when the lane IS enabled (next/dual mode) but the
+// per-request X-Stillwater-UX: stable header opts back to the stable channel,
+// the handler returns 404. The channel is injected directly via
+// WithTestUXChannel, simulating the header opt-out scenario without relying on
+// the middleware-level gate (which is tested by
+// TestHandleNextArtistDetailPage_StableMode404).
+func TestHandleNextArtistDetailPage_OptOutHeader404(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := detailTestRouter(t)
+	id := seedDetailArtist(t, artistSvc, "Opt-Out Artist")
+
+	ctx := middleware.WithTestUXChannel(context.Background(), middleware.UXStable)
+	ctx = middleware.WithTestUserID(ctx, "test-user")
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/next/artists/"+id, nil)
+	req.SetPathValue("id", id)
+	w := httptest.NewRecorder()
+	r.handleNextArtistDetailPage(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("opt-out header: status = %d, want 404 (decision 12)", w.Code)
+	}
+}
+
 // TestHandleNextArtistDetailPage_Neighbors verifies prev/next-artist neighbor
 // ids are resolved from the sort_name-ascending ListIDs order and linked in the
 // hero's h/l navigation.

--- a/internal/api/handlers_next_artists.go
+++ b/internal/api/handlers_next_artists.go
@@ -3,32 +3,27 @@ package api
 import (
 	"net/http"
 
-	"github.com/sydlexius/stillwater/internal/api/middleware"
 	"github.com/sydlexius/stillwater/web/templates/next"
 )
 
 // handleNextArtistsPage serves the next/ channel artists list (M55 #1335). When
 // the resolved UI channel is "next" it renders the next.ArtistsPage shell; for
 // an HTMX request it renders the next/ table/grid fragment. The toolbar's
-// hx-get and the shared sort/selection JS resolve to /next/artists (channel-aware),
-// so swaps render the next-specific table rather than the stable one (#1335).
+// hx-get and the shared sort/selection JS resolve to /next/artists
+// (channel-aware), so swaps render the next-specific table rather than the
+// stable one (#1335).
 //
 // In stable mode (SW_UX=stable) the UX middleware 404s any /next/* request
 // before this handler runs (decision 12 in architecture-decisions.md). The
 // in-handler channel guard below is therefore only reachable when the lane IS
 // enabled (next/dual mode) and the resolved channel is not "next" -- which
-// happens when a user sent an explicit X-Stillwater-UX: stable header. In that
-// case it delegates to the stable handleArtistsPage so the path never
-// dead-ends. The data assembly is shared via buildArtistListData, so both
-// channels render the identical data set.
-//
-// Unlike the generic /next/{path...} fallback, this screen has a dedicated
-// stable handler, so the stable branch calls it directly rather than going
-// through nextFallback (whose PathValue("path") lookup only resolves under the
-// wildcard route, not this literal /next/artists registration).
+// happens when a user sends an explicit X-Stillwater-UX: stable header. In that
+// case it returns 404 (decision 12: all handleNext* handlers return 404 on an
+// explicit /next/ path with the stable opt-out; the path does not serve stable
+// content). The data assembly is shared via buildArtistListData, so the next/
+// table/grid uses the same data set as the stable list.
 func (r *Router) handleNextArtistsPage(w http.ResponseWriter, req *http.Request) {
-	if middleware.UXChannelFromContext(req.Context()) != middleware.UXNext {
-		r.handleArtistsPage(w, req)
+	if !checkNextChannel(w, req) {
 		return
 	}
 	data, ok := r.buildArtistListData(w, req)

--- a/internal/api/handlers_next_artists_test.go
+++ b/internal/api/handlers_next_artists_test.go
@@ -66,6 +66,27 @@ func TestHandleNextArtistsPage_StableMode404(t *testing.T) {
 	}
 }
 
+// TestHandleNextArtistsPage_OptOutHeader404 verifies the handler-level
+// decision-12 guard: when the lane IS enabled (next/dual mode) but the
+// per-request X-Stillwater-UX: stable header opts back to the stable channel,
+// the handler returns 404. The channel is injected directly via
+// WithTestUXChannel, simulating the header opt-out scenario without relying on
+// the middleware-level gate (which is tested by TestHandleNextArtistsPage_StableMode404).
+func TestHandleNextArtistsPage_OptOutHeader404(t *testing.T) {
+	t.Parallel()
+	r, _, _ := testRouterWithLibrary(t)
+
+	ctx := middleware.WithTestUXChannel(context.Background(), middleware.UXStable)
+	ctx = middleware.WithTestUserID(ctx, "test-user")
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/next/artists", nil)
+	w := httptest.NewRecorder()
+	r.handleNextArtistsPage(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("opt-out header: status = %d, want 404 (decision 12)", w.Code)
+	}
+}
+
 // TestHandleNextArtistsPage_WiresNextBaseURL verifies the PR's core routing fix
 // end to end: when the channel is "next", buildArtistListData stamps the
 // /next/artists BaseURL, so the rendered toolbar/pagination hx-get targets

--- a/internal/api/handlers_next_channel.go
+++ b/internal/api/handlers_next_channel.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/sydlexius/stillwater/internal/api/middleware"
+)
+
+// checkNextChannel writes 404 and returns false when the resolved UX channel is
+// not "next". Callers must return immediately when this returns false.
+//
+// In stable mode (SW_UX=stable) the middleware.UX gate already 404s any /next/*
+// request before any handler runs, so this call is dead code in that mode. In
+// next/dual mode it guards the edge case where an explicit
+// X-Stillwater-UX: stable header opts a per-request sub-request back to the
+// stable channel -- those requests reach the handler but must not render next/
+// content (decision 12, docs/architecture-decisions.md).
+//
+// All handleNext* page handlers call this as their first guard so the policy is
+// enforced consistently regardless of which handler is reached.
+func checkNextChannel(w http.ResponseWriter, req *http.Request) bool {
+	if middleware.UXChannelFromContext(req.Context()) != middleware.UXNext {
+		http.NotFound(w, req)
+		return false
+	}
+	return true
+}

--- a/internal/api/handlers_next_dashboard.go
+++ b/internal/api/handlers_next_dashboard.go
@@ -16,9 +16,10 @@ import (
 // before this handler runs (decision 12 in architecture-decisions.md). The
 // in-handler channel guard below is therefore only reachable when the lane IS
 // enabled (next/dual mode) and the resolved channel is not "next" -- which
-// happens when the user sent an explicit X-Stillwater-UX: stable header to opt
-// back out. In that case it delegates to handleIndex so the path never
-// dead-ends (consistent with the guard in handleNextArtistsPage and others).
+// happens when a user sends an explicit X-Stillwater-UX: stable header to opt
+// back out. In that case it returns 404 (decision 12: all handleNext* handlers
+// return 404 on an explicit /next/ path with the stable opt-out; the path does
+// not serve stable content).
 //
 // When the channel is "next" it runs the same auth + onboarding checks as
 // handleIndex (checking auth from context, then the onboarding.completed
@@ -29,8 +30,7 @@ import (
 // template to show "---" placeholders rather than misleading zeros, matching
 // the defensive pattern used by DashboardActionHeader in the stable channel.
 func (r *Router) handleNextDashboardPage(w http.ResponseWriter, req *http.Request) {
-	if middleware.UXChannelFromContext(req.Context()) != middleware.UXNext {
-		r.handleIndex(w, req)
+	if !checkNextChannel(w, req) {
 		return
 	}
 

--- a/internal/api/handlers_next_dashboard_test.go
+++ b/internal/api/handlers_next_dashboard_test.go
@@ -317,6 +317,29 @@ func TestHandleNextDashboardPage_StableMode404(t *testing.T) {
 	}
 }
 
+// TestHandleNextDashboardPage_OptOutHeader404 verifies the handler-level
+// decision-12 guard: when the lane IS enabled (next/dual mode) but the per-request
+// X-Stillwater-UX: stable header opts back to the stable channel, the handler
+// returns 404. This is distinct from the middleware-level stable-mode 404
+// (TestHandleNextDashboardPage_StableMode404) which fires before the handler runs.
+// Here the channel is injected directly via WithTestUXChannel, simulating the
+// header opt-out scenario.
+func TestHandleNextDashboardPage_OptOutHeader404(t *testing.T) {
+	t.Parallel()
+	r := testDashboardRouter(t, false)
+	markOnboardingComplete(t, r)
+
+	ctx := middleware.WithTestUXChannel(context.Background(), middleware.UXStable)
+	ctx = middleware.WithTestUserID(ctx, "test-user")
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/next/", nil)
+	w := httptest.NewRecorder()
+	r.handleNextDashboardPage(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("opt-out header: status = %d, want 404 (decision 12)", w.Code)
+	}
+}
+
 // TestHandleNextDashboardPage_InitialQueryForwarded verifies that recognized
 // filter query params are forwarded into the initial HTMX load so a bookmarked
 // /next/?severity=warning opens with that filter applied. The forwarded query

--- a/internal/api/handlers_next_foreign_files.go
+++ b/internal/api/handlers_next_foreign_files.go
@@ -15,11 +15,11 @@ import (
 // before this handler runs (decision 12 in architecture-decisions.md). The
 // in-handler channel guard below is therefore only reachable when the lane IS
 // enabled (next/dual mode) and the resolved channel is not "next" -- triggered
-// by an explicit X-Stillwater-UX: stable header. In that edge case it delegates
-// to handleForeignFilesPage so the path never dead-ends.
+// by an explicit X-Stillwater-UX: stable header. In that edge case it returns
+// 404 (decision 12: all handleNext* handlers return 404 on an explicit /next/
+// path with the stable opt-out; the path does not serve stable content).
 func (r *Router) handleNextForeignFilesPage(w http.ResponseWriter, req *http.Request) {
-	if middleware.UXChannelFromContext(req.Context()) != middleware.UXNext {
-		r.handleForeignFilesPage(w, req)
+	if !checkNextChannel(w, req) {
 		return
 	}
 	if !r.requireForeignAdmin(w, req) {
@@ -41,8 +41,9 @@ func (r *Router) handleNextForeignFilesPage(w http.ResponseWriter, req *http.Req
 // before this handler runs (decision 12 in architecture-decisions.md). The
 // in-handler channel guard below is therefore only reachable when the lane IS
 // enabled (next/dual mode) and the resolved channel is not "next" -- triggered
-// by an explicit X-Stillwater-UX: stable header. In that edge case it delegates
-// to handleForeignAllowlistPage so the path never dead-ends.
+// by an explicit X-Stillwater-UX: stable header. In that edge case it returns
+// 404 (decision 12: all handleNext* handlers return 404 on an explicit /next/
+// path with the stable opt-out; the path does not serve stable content).
 //
 // Pagination: the handler reads "page" and "page_size" query parameters
 // (respecting the user's stored page-size preference via getUserPageSize) and
@@ -51,8 +52,7 @@ func (r *Router) handleNextForeignFilesPage(w http.ResponseWriter, req *http.Req
 // so the swap replaces just the table-plus-pager region without re-rendering
 // the surrounding next/ chrome.
 func (r *Router) handleNextForeignAllowlistPage(w http.ResponseWriter, req *http.Request) {
-	if middleware.UXChannelFromContext(req.Context()) != middleware.UXNext {
-		r.handleForeignAllowlistPage(w, req)
+	if !checkNextChannel(w, req) {
 		return
 	}
 	if !r.requireForeignAdmin(w, req) {

--- a/internal/api/handlers_next_foreign_files_test.go
+++ b/internal/api/handlers_next_foreign_files_test.go
@@ -114,6 +114,43 @@ func TestHandleNextForeignAllowlistPage_StableMode404(t *testing.T) {
 	}
 }
 
+// TestHandleNextForeignFilesPage_OptOutHeader404 verifies the handler-level
+// decision-12 guard: when the lane IS enabled (next/dual mode) but the
+// per-request X-Stillwater-UX: stable header opts back to the stable channel,
+// the handler returns 404. The channel is injected directly via
+// WithTestUXChannel, simulating the header opt-out scenario without relying on
+// the middleware-level gate (which is tested by
+// TestHandleNextForeignFilesPage_StableMode404).
+func TestHandleNextForeignFilesPage_OptOutHeader404(t *testing.T) {
+	t.Parallel()
+	r := newTestRouterFull(t)
+
+	ctx := middleware.WithTestUXChannel(adminContext(), middleware.UXStable)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/next/reports/foreign-files", nil)
+	w := httptest.NewRecorder()
+	r.handleNextForeignFilesPage(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("opt-out header: status = %d, want 404 (decision 12)", w.Code)
+	}
+}
+
+// TestHandleNextForeignAllowlistPage_OptOutHeader404 verifies the handler-level
+// decision-12 guard on the allowlist handler: opt-out header returns 404.
+func TestHandleNextForeignAllowlistPage_OptOutHeader404(t *testing.T) {
+	t.Parallel()
+	r := newTestRouterFull(t)
+
+	ctx := middleware.WithTestUXChannel(adminContext(), middleware.UXStable)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/next/reports/foreign-files/allowlist", nil)
+	w := httptest.NewRecorder()
+	r.handleNextForeignAllowlistPage(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("opt-out header: status = %d, want 404 (decision 12)", w.Code)
+	}
+}
+
 // TestHandleNextForeignFilesPage_NonAdminForbidden verifies the admin gate
 // on the next/ foreign-files page handler.
 func TestHandleNextForeignFilesPage_NonAdminForbidden(t *testing.T) {

--- a/internal/api/handlers_next_preferences.go
+++ b/internal/api/handlers_next_preferences.go
@@ -19,8 +19,7 @@ import (
 // GET /next/preferences
 // GET /next/preferences-drawer (drawer fragment; same handler, no chrome)
 func (r *Router) handleNextPreferencesPage(w http.ResponseWriter, req *http.Request) {
-	if middleware.UXChannelFromContext(req.Context()) != middleware.UXNext {
-		http.NotFound(w, req)
+	if !checkNextChannel(w, req) {
 		return
 	}
 	userID := middleware.UserIDFromContext(req.Context())
@@ -42,8 +41,7 @@ func (r *Router) handleNextPreferencesPage(w http.ResponseWriter, req *http.Requ
 //
 // GET /next/preferences-drawer
 func (r *Router) handleNextPreferencesDrawer(w http.ResponseWriter, req *http.Request) {
-	if middleware.UXChannelFromContext(req.Context()) != middleware.UXNext {
-		http.NotFound(w, req)
+	if !checkNextChannel(w, req) {
 		return
 	}
 	userID := middleware.UserIDFromContext(req.Context())


### PR DESCRIPTION
## Summary

Unifies the `/next/` opt-out behavior. All eight `next/` page handlers now return **404** on an explicit `/next/` path when the `X-Stillwater-UX: stable` opt-out header is present, instead of three (now five, including the foreign-files handlers) delegating to the stable equivalent. This implements Decision 12 / Option 3 (the maintainer-chosen policy) and removes the inconsistency where some handlers delegated to stable while the Phase-2 handlers already returned 404.

- New `internal/api/handlers_next_channel.go` with a shared `checkNextChannel` guard, called first in all 8 `handleNext*` page/drawer/modal handlers.
- `docs/architecture-decisions.md` Decision 12 updated to document the unified policy and name the five corrected handlers.

## Test plan

- Opt-out 404 unit tests for every handler (inject `middleware.UXStable` via `WithTestUXChannel`, assert HTTP 404), exercising the handler-level guard independently of the middleware gate. 100% patch coverage (14/14).
- `scripts/pre-push-gate.sh`: all hard checks pass (build, vet, tests, lint, OpenAPI consistency, generated files, coverage floor).

Closes #1933
