### PR TITLE
feat(docs): add preferences reference generator and unified registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ tailwind:
 ## generate: Run all code generation (templ + tailwind)
 generate: templ tailwind
 
-## generate-docs: Regenerate docs site content from code (provider matrix, env-var reference, rules catalogue, settings reference, doc anchors, envelope-versions, make-command reference, platform-profiles)
+## generate-docs: Regenerate docs site content from code (provider matrix, env-var reference, rules catalogue, settings reference, doc anchors, envelope-versions, make-command reference, platform-profiles, preferences reference)
 generate-docs:
 	go run ./cmd/gen-provider-matrix
 	go run ./cmd/gen-env-reference
@@ -153,6 +153,7 @@ generate-docs:
 	go run ./cmd/gen-envelope-changelog
 	go run ./cmd/gen-make-reference
 	go run ./cmd/gen-platform-profiles
+	go run ./cmd/gen-prefs-reference
 
 ## tailwind-watch: Watch and rebuild Tailwind CSS
 tailwind-watch:

--- a/cmd/gen-prefs-reference/main.go
+++ b/cmd/gen-prefs-reference/main.go
@@ -1,0 +1,280 @@
+// Command gen-prefs-reference renders the preferences reference table in
+// docs/site/src/reference/preferences.md from the canonical preference
+// registry (internal/api.PreferenceRegistry). Each rendered row includes the
+// preference key, its default value, allowed values or range, and a
+// description resolved from the i18n locale file.
+//
+// Usage:
+//
+//	go run ./cmd/gen-prefs-reference              # rewrite the file in place
+//	go run ./cmd/gen-prefs-reference -check       # exit non-zero if regen needed
+//	go run ./cmd/gen-prefs-reference -output FILE # write to a different file
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sydlexius/stillwater/internal/api"
+	"github.com/sydlexius/stillwater/internal/filesystem"
+)
+
+const (
+	beginMarker = "<!-- BEGIN GENERATED: prefs-reference -->"
+	endMarker   = "<!-- END GENERATED: prefs-reference -->"
+
+	defaultOutputPath = "docs/site/src/reference/preferences.md"
+	defaultI18nPath   = "internal/i18n/locales/en.json"
+)
+
+func main() {
+	var (
+		checkOnly bool
+		outPath   string
+		i18nPath  string
+	)
+	flag.BoolVar(&checkOnly, "check", false, "exit non-zero if the preferences reference needs to be regenerated")
+	flag.StringVar(&outPath, "output", defaultOutputPath, "path to the docs file to update")
+	flag.StringVar(&i18nPath, "i18n", defaultI18nPath, "path to the i18n locale file (en.json)")
+	flag.Parse()
+
+	if err := run(outPath, i18nPath, checkOnly); err != nil {
+		fmt.Fprintln(os.Stderr, "gen-prefs-reference:", err)
+		os.Exit(1)
+	}
+}
+
+func run(outPath, i18nPath string, checkOnly bool) error {
+	// Load i18n locale strings for label/description resolution.
+	i18n, err := loadI18n(i18nPath)
+	if err != nil {
+		return fmt.Errorf("load i18n: %w", err)
+	}
+
+	// Read the registry; it is already sorted alphabetically.
+	entries := api.PreferenceRegistry()
+
+	rendered := renderTable(entries, i18n)
+
+	// outPath comes from the -output flag; this is a developer-only build-time
+	// tool, so a configurable path is intended.
+	existing, err := os.ReadFile(outPath) //nolint:gosec // G304: developer CLI, path is intentionally configurable
+	if err != nil {
+		return fmt.Errorf("read %s: %w", outPath, err)
+	}
+
+	updated, err := replaceBetweenMarkers(existing, beginMarker, endMarker, rendered)
+	if err != nil {
+		return fmt.Errorf("update %s: %w", outPath, err)
+	}
+
+	if checkOnly {
+		if !bytes.Equal(existing, updated) {
+			return fmt.Errorf("%s is stale; run `make generate-docs` to regenerate", filepath.ToSlash(outPath))
+		}
+		return nil
+	}
+
+	if bytes.Equal(existing, updated) {
+		return nil
+	}
+	if err := filesystem.WriteFileAtomic(outPath, updated, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", outPath, err)
+	}
+	return nil
+}
+
+// loadI18n reads the locale JSON file and returns a flat key-to-string map.
+// The en.json file is a flat object: { "prefs.theme.label": "Theme", ... }.
+func loadI18n(path string) (map[string]string, error) {
+	// path comes from the -i18n flag; this is a developer-only build-time tool.
+	data, err := os.ReadFile(path) //nolint:gosec // G304: developer CLI, path is intentionally configurable
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return m, nil
+}
+
+// prefRow is a single row in the rendered Markdown table.
+type prefRow struct {
+	Key         string
+	Label       string
+	Default     string
+	AllowedStr  string // formatted allowed values or range
+	Description string
+}
+
+// buildRows converts registry entries into table rows with i18n labels resolved.
+func buildRows(entries []api.PreferenceDef, i18n map[string]string) []prefRow {
+	rows := make([]prefRow, 0, len(entries))
+	for _, e := range entries {
+		rows = append(rows, prefRow{
+			Key:         e.Key,
+			Label:       resolveLabel(e.Key, i18n),
+			Default:     e.Default,
+			AllowedStr:  formatAllowed(e),
+			Description: resolveDescription(e.Key, i18n),
+		})
+	}
+	// Entries from PreferenceRegistry are already sorted; sort here defensively
+	// so the output is deterministic even if the registry order changes.
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].Key < rows[j].Key
+	})
+	return rows
+}
+
+// keyI18nNamespace maps preference keys whose i18n entries live under a
+// namespace that does not follow the default prefs.{key}.* convention. Each
+// value is the full namespace prefix (without trailing dot) to use in place of
+// the conventional lookup. Keys absent from this map use the two-step fallback
+// chain: prefs.{key} then settings.appearance.{key}.
+//
+// Cases requiring an override:
+//   - auto_fetch_images: i18n authors named the entries prefs.auto_fetch.*
+//     (the UI label is "Prefetch Images", not "Auto Fetch Images").
+//   - sidebar_state: the settings namespace uses sidebar_default_state as the
+//     disambiguating suffix, so the i18n key is
+//     settings.appearance.sidebar_default_state.label.
+var keyI18nNamespace = map[string]string{
+	"auto_fetch_images": "prefs.auto_fetch",
+	"sidebar_state":     "settings.appearance.sidebar_default_state",
+}
+
+// i18nNamespaces returns the ordered list of i18n namespace prefixes to
+// search for a given preference key. Overridden keys get a single canonical
+// namespace; all others get the two-step fallback chain.
+func i18nNamespaces(key string) []string {
+	if ns, ok := keyI18nNamespace[key]; ok {
+		return []string{ns}
+	}
+	return []string{"prefs." + key, "settings.appearance." + key}
+}
+
+// resolveLabel looks up the human-readable label for a preference key using
+// the i18n namespace chain for that key (see i18nNamespaces). If no i18n
+// label is found it converts the snake_case key to Title Case as a last resort
+// (e.g. "metadata_name_romanization_fallback" -> "Metadata Name Romanization Fallback").
+func resolveLabel(key string, i18n map[string]string) string {
+	for _, ns := range i18nNamespaces(key) {
+		if v, ok := i18n[ns+".label"]; ok {
+			return v
+		}
+	}
+	return snakeToTitle(key)
+}
+
+// snakeToTitle converts a snake_case identifier to Title Case words
+// (e.g. "auto_fetch_images" -> "Auto Fetch Images"). Used as a fallback
+// label when no i18n entry is found for a preference key.
+func snakeToTitle(s string) string {
+	parts := strings.Split(s, "_")
+	for i, p := range parts {
+		if p != "" {
+			parts[i] = strings.ToUpper(p[:1]) + p[1:]
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// resolveDescription looks up a description for a preference key. For each
+// namespace in i18nNamespaces(key) it tries the .description suffix and then
+// the .help suffix, returning the first match found.
+func resolveDescription(key string, i18n map[string]string) string {
+	for _, ns := range i18nNamespaces(key) {
+		for _, suffix := range []string{".description", ".help"} {
+			if v, ok := i18n[ns+suffix]; ok {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+// formatAllowed returns the "Allowed Values" cell text for a preference entry.
+// Enum prefs list values comma-separated in backticks. Range prefs show the
+// numeric range and step.
+func formatAllowed(e api.PreferenceDef) string {
+	if len(e.AllowedValues) > 0 {
+		parts := make([]string, len(e.AllowedValues))
+		for i, v := range e.AllowedValues {
+			parts[i] = "`" + v + "`"
+		}
+		return strings.Join(parts, ", ")
+	}
+	if e.RangeMax > 0 {
+		if e.RangeStep > 1 {
+			return fmt.Sprintf("%d..%d (step %d)", e.RangeMin, e.RangeMax, e.RangeStep)
+		}
+		return fmt.Sprintf("%d..%d", e.RangeMin, e.RangeMax)
+	}
+	return ""
+}
+
+// renderTable returns the Markdown table body (without surrounding markers).
+func renderTable(entries []api.PreferenceDef, i18n map[string]string) string {
+	rows := buildRows(entries, i18n)
+	var b strings.Builder
+	b.WriteString("| Key | Label | Default | Allowed Values | Description |\n")
+	b.WriteString("|---|---|---|---|---|\n")
+	for _, r := range rows {
+		// Each key cell includes an HTML anchor for deep linking: #pref-{key}
+		anchor := `<a id="pref-` + r.Key + `"></a>`
+		fmt.Fprintf(&b, "| %s`%s` | %s | `%s` | %s | %s |\n",
+			anchor,
+			escapeMarkdownCell(r.Key),
+			escapeMarkdownCell(r.Label),
+			escapeMarkdownCell(r.Default),
+			escapeMarkdownCell(r.AllowedStr),
+			escapeMarkdownCell(r.Description),
+		)
+	}
+	return b.String()
+}
+
+// escapeMarkdownCell sanitizes a string for use inside a Markdown table cell.
+// Pipes break the column boundary; newlines break the row boundary.
+func escapeMarkdownCell(s string) string {
+	s = strings.ReplaceAll(s, "|", `\|`)
+	s = strings.ReplaceAll(s, "\n", "<br>")
+	return s
+}
+
+// replaceBetweenMarkers returns src with the region between begin and end
+// replaced by body. The markers themselves are preserved. body is sandwiched
+// in newlines so the rendered table has clean blank-line separation from the
+// markers; trailing newlines on body are normalized.
+//
+// begin and end are parameters (not constants) so the helper can be exercised
+// with bespoke markers in tests.
+func replaceBetweenMarkers(src []byte, begin, end, body string) ([]byte, error) { //nolint:unparam // begin/end are exposed as parameters for testability
+	beginIdx := bytes.Index(src, []byte(begin))
+	if beginIdx < 0 {
+		return nil, fmt.Errorf("begin marker %q not found", begin)
+	}
+	relEndIdx := bytes.Index(src[beginIdx:], []byte(end))
+	if relEndIdx < 0 {
+		return nil, fmt.Errorf("end marker %q not found after begin marker", end)
+	}
+	endIdx := beginIdx + relEndIdx
+
+	body = strings.TrimRight(body, "\n")
+	var out bytes.Buffer
+	out.Write(src[:beginIdx])
+	out.WriteString(begin)
+	out.WriteString("\n")
+	out.WriteString(body)
+	out.WriteString("\n")
+	out.Write(src[endIdx:])
+	return out.Bytes(), nil
+}

--- a/cmd/gen-prefs-reference/main.go
+++ b/cmd/gen-prefs-reference/main.go
@@ -204,6 +204,13 @@ func resolveDescription(key string, i18n map[string]string) string {
 // formatAllowed returns the "Allowed Values" cell text for a preference entry.
 // Enum prefs list values comma-separated in backticks. Range prefs show the
 // numeric range and step.
+//
+// The sentinel contract (from PreferenceDef): BOTH RangeMin == 0 AND
+// RangeMax == 0 means enum (no numeric range). A range whose min or max is
+// non-zero -- including ranges with a zero max, e.g. -10..0 -- must be
+// formatted as a range. The old guard `e.RangeMax > 0` incorrectly skipped
+// any range with RangeMax <= 0; this guard checks the correct both-zero
+// condition.
 func formatAllowed(e api.PreferenceDef) string {
 	if len(e.AllowedValues) > 0 {
 		parts := make([]string, len(e.AllowedValues))
@@ -212,7 +219,9 @@ func formatAllowed(e api.PreferenceDef) string {
 		}
 		return strings.Join(parts, ", ")
 	}
-	if e.RangeMax > 0 {
+	// A preference is a numeric range when at least one bound is non-zero.
+	// Both RangeMin == 0 AND RangeMax == 0 is the enum sentinel (no range).
+	if e.RangeMin != 0 || e.RangeMax != 0 {
 		if e.RangeStep > 1 {
 			return fmt.Sprintf("%d..%d (step %d)", e.RangeMin, e.RangeMax, e.RangeStep)
 		}

--- a/cmd/gen-prefs-reference/main_test.go
+++ b/cmd/gen-prefs-reference/main_test.go
@@ -120,6 +120,29 @@ func TestFormatAllowed_Empty(t *testing.T) {
 	}
 }
 
+// TestFormatAllowed_RangeNegativeMin covers a range whose max is zero (e.g.
+// -10..0). The old guard `RangeMax > 0` would misclassify this as an empty
+// enum entry; the corrected both-zero sentinel must format it as a range.
+func TestFormatAllowed_RangeNegativeMin(t *testing.T) {
+	e := api.PreferenceDef{Key: "neg_range", Default: "0", RangeMin: -10, RangeMax: 0, RangeStep: 1}
+	got := formatAllowed(e)
+	want := "-10..0"
+	if got != want {
+		t.Errorf("formatAllowed range with zero max = %q, want %q", got, want)
+	}
+}
+
+// TestFormatAllowed_EnumBothZero confirms that a PreferenceDef with RangeMin
+// and RangeMax both zero (the enum sentinel contract) falls through to the
+// AllowedValues path and returns "" when AllowedValues is nil.
+func TestFormatAllowed_EnumBothZero(t *testing.T) {
+	e := api.PreferenceDef{Key: "enum_entry", Default: "a", RangeMin: 0, RangeMax: 0}
+	got := formatAllowed(e)
+	if got != "" {
+		t.Errorf("enum sentinel (both-zero range, no AllowedValues) should return empty string; got %q", got)
+	}
+}
+
 // ---- resolveLabel -----------------------------------------------------------
 
 func TestResolveLabel_PrefsNamespace(t *testing.T) {

--- a/cmd/gen-prefs-reference/main_test.go
+++ b/cmd/gen-prefs-reference/main_test.go
@@ -1,0 +1,440 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/api"
+)
+
+// ---- helpers ----------------------------------------------------------------
+
+// writeFixtureDoc creates a minimal Markdown file with begin/end markers
+// wrapping the given stale body text and returns its path. The file lives in a
+// temp dir so tests never touch the real docs tree.
+func writeFixtureDoc(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prefs.md")
+	content := "intro\n" + beginMarker + "\n" + body + "\n" + endMarker + "\nfooter\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("seed fixture: %v", err)
+	}
+	return path
+}
+
+// writeI18nFixture writes a minimal en.json file and returns its path.
+func writeI18nFixture(t *testing.T, entries map[string]string) string {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("{\n")
+	i := 0
+	for k, v := range entries {
+		comma := ","
+		if i == len(entries)-1 {
+			comma = ""
+		}
+		b.WriteString(`  "` + k + `": "` + v + `"` + comma + "\n")
+		i++
+	}
+	b.WriteString("}\n")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "en.json")
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatalf("seed i18n fixture: %v", err)
+	}
+	return path
+}
+
+// syntheticEntry returns a minimal enum-type PreferenceDef for use in tests
+// that need a registry entry without calling the real PreferenceRegistry.
+func syntheticEntry(key, def string, allowed ...string) api.PreferenceDef {
+	return api.PreferenceDef{Key: key, Default: def, AllowedValues: allowed}
+}
+
+// ---- escapeMarkdownCell -----------------------------------------------------
+
+func TestEscapeMarkdownCell_Pipe(t *testing.T) {
+	got := escapeMarkdownCell("a|b")
+	if got != `a\|b` {
+		t.Errorf("pipe not escaped: got %q", got)
+	}
+}
+
+func TestEscapeMarkdownCell_Newline(t *testing.T) {
+	got := escapeMarkdownCell("line1\nline2")
+	if got != "line1<br>line2" {
+		t.Errorf("newline not replaced with <br>: got %q", got)
+	}
+}
+
+func TestEscapeMarkdownCell_MultiplePipes(t *testing.T) {
+	got := escapeMarkdownCell("a|b|c")
+	if got != `a\|b\|c` {
+		t.Errorf("multiple pipes not escaped: got %q", got)
+	}
+}
+
+func TestEscapeMarkdownCell_Clean(t *testing.T) {
+	got := escapeMarkdownCell("no special chars")
+	if got != "no special chars" {
+		t.Errorf("clean string should pass through unchanged: got %q", got)
+	}
+}
+
+// ---- formatAllowed ----------------------------------------------------------
+
+func TestFormatAllowed_Enum(t *testing.T) {
+	e := syntheticEntry("theme", "dark", "light", "dark", "system")
+	got := formatAllowed(e)
+	if !strings.Contains(got, "`light`") || !strings.Contains(got, "`dark`") || !strings.Contains(got, "`system`") {
+		t.Errorf("enum values not all backtick-formatted: got %q", got)
+	}
+}
+
+func TestFormatAllowed_RangeWithStep(t *testing.T) {
+	e := api.PreferenceDef{Key: "bg_opacity", Default: "85", RangeMin: 20, RangeMax: 100, RangeStep: 5}
+	got := formatAllowed(e)
+	want := "20..100 (step 5)"
+	if got != want {
+		t.Errorf("formatAllowed range+step = %q, want %q", got, want)
+	}
+}
+
+func TestFormatAllowed_RangeNoStep(t *testing.T) {
+	e := api.PreferenceDef{Key: "page_size", Default: "50", RangeMin: 10, RangeMax: 500, RangeStep: 1}
+	got := formatAllowed(e)
+	want := "10..500"
+	if got != want {
+		t.Errorf("formatAllowed range (step 1) = %q, want %q", got, want)
+	}
+}
+
+func TestFormatAllowed_Empty(t *testing.T) {
+	e := api.PreferenceDef{Key: "orphan", Default: "x"}
+	got := formatAllowed(e)
+	if got != "" {
+		t.Errorf("entry with no AllowedValues and no range should return empty string; got %q", got)
+	}
+}
+
+// ---- resolveLabel -----------------------------------------------------------
+
+func TestResolveLabel_PrefsNamespace(t *testing.T) {
+	i18n := map[string]string{"prefs.theme.label": "Theme"}
+	got := resolveLabel("theme", i18n)
+	if got != "Theme" {
+		t.Errorf("resolveLabel(theme) = %q, want %q", got, "Theme")
+	}
+}
+
+func TestResolveLabel_SettingsAppearanceFallback(t *testing.T) {
+	// No prefs.density.label; falls back to settings.appearance.density.label.
+	i18n := map[string]string{"settings.appearance.density.label": "Layout Density"}
+	got := resolveLabel("density", i18n)
+	if got != "Layout Density" {
+		t.Errorf("resolveLabel(density) fallback = %q, want %q", got, "Layout Density")
+	}
+}
+
+func TestResolveLabel_SnakeTitleFallback(t *testing.T) {
+	// Neither i18n namespace has an entry; snakeToTitle kicks in.
+	got := resolveLabel("my_pref_key", map[string]string{})
+	if got != "My Pref Key" {
+		t.Errorf("resolveLabel fallback = %q, want %q", got, "My Pref Key")
+	}
+}
+
+func TestResolveLabel_Override_AutoFetch(t *testing.T) {
+	// auto_fetch_images is overridden to prefs.auto_fetch.* namespace.
+	i18n := map[string]string{
+		"prefs.auto_fetch.label":        "Prefetch Images",
+		"prefs.auto_fetch_images.label": "WRONG - should not be used",
+	}
+	got := resolveLabel("auto_fetch_images", i18n)
+	if got != "Prefetch Images" {
+		t.Errorf("resolveLabel(auto_fetch_images) = %q, want %q (override not applied)", got, "Prefetch Images")
+	}
+}
+
+func TestResolveLabel_Override_SidebarState(t *testing.T) {
+	// sidebar_state is overridden to settings.appearance.sidebar_default_state.* namespace.
+	i18n := map[string]string{
+		"settings.appearance.sidebar_default_state.label": "Sidebar Default State",
+		"settings.appearance.sidebar_state.label":         "WRONG - should not be used",
+	}
+	got := resolveLabel("sidebar_state", i18n)
+	if got != "Sidebar Default State" {
+		t.Errorf("resolveLabel(sidebar_state) = %q, want %q (override not applied)", got, "Sidebar Default State")
+	}
+}
+
+// ---- resolveDescription -----------------------------------------------------
+
+func TestResolveDescription_PrefsDescription(t *testing.T) {
+	i18n := map[string]string{"prefs.theme.description": "Choose color scheme."}
+	got := resolveDescription("theme", i18n)
+	if got != "Choose color scheme." {
+		t.Errorf("resolveDescription(theme) = %q, want description", got)
+	}
+}
+
+func TestResolveDescription_PrefsHelpFallback(t *testing.T) {
+	// No description; falls back to prefs.{key}.help.
+	i18n := map[string]string{"prefs.theme.help": "Tip: system follows your OS."}
+	got := resolveDescription("theme", i18n)
+	if got != "Tip: system follows your OS." {
+		t.Errorf("resolveDescription help fallback = %q, want help text", got)
+	}
+}
+
+func TestResolveDescription_Override_AutoFetch(t *testing.T) {
+	// auto_fetch_images override resolves description from prefs.auto_fetch.* namespace.
+	i18n := map[string]string{
+		"prefs.auto_fetch.description":        "Automatically search providers for images.",
+		"prefs.auto_fetch_images.description": "WRONG - should not be used",
+	}
+	got := resolveDescription("auto_fetch_images", i18n)
+	if got != "Automatically search providers for images." {
+		t.Errorf("resolveDescription(auto_fetch_images) = %q, override not applied", got)
+	}
+}
+
+func TestResolveDescription_MissingReturnsEmpty(t *testing.T) {
+	got := resolveDescription("unknown_key", map[string]string{})
+	if got != "" {
+		t.Errorf("missing description should return empty string; got %q", got)
+	}
+}
+
+// ---- buildRows --------------------------------------------------------------
+
+func TestBuildRows_Sorted(t *testing.T) {
+	entries := []api.PreferenceDef{
+		syntheticEntry("z_key", "z", "z1", "z2"),
+		syntheticEntry("a_key", "a", "a1"),
+	}
+	i18n := map[string]string{
+		"prefs.z_key.label": "Z Key",
+		"prefs.a_key.label": "A Key",
+	}
+	rows := buildRows(entries, i18n)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if rows[0].Key != "a_key" || rows[1].Key != "z_key" {
+		t.Errorf("rows not sorted alphabetically: got %v, %v", rows[0].Key, rows[1].Key)
+	}
+}
+
+func TestBuildRows_LabelAndDescription(t *testing.T) {
+	entries := []api.PreferenceDef{syntheticEntry("theme", "dark", "light", "dark", "system")}
+	i18n := map[string]string{
+		"prefs.theme.label":       "Theme",
+		"prefs.theme.description": "Pick a color scheme.",
+	}
+	rows := buildRows(entries, i18n)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.Label != "Theme" {
+		t.Errorf("Label = %q, want %q", r.Label, "Theme")
+	}
+	if r.Description != "Pick a color scheme." {
+		t.Errorf("Description = %q, want description text", r.Description)
+	}
+	if !strings.Contains(r.AllowedStr, "`dark`") {
+		t.Errorf("AllowedStr should contain backtick-formatted value; got %q", r.AllowedStr)
+	}
+}
+
+func TestBuildRows_PipeInDescription(t *testing.T) {
+	entries := []api.PreferenceDef{syntheticEntry("theme", "dark", "light", "dark")}
+	i18n := map[string]string{
+		"prefs.theme.label":       "Theme",
+		"prefs.theme.description": "Light | dark mode toggle.",
+	}
+	rows := buildRows(entries, i18n)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	// The description is stored raw in prefRow; escaping happens in renderTable.
+	// Verify the raw value so the pipeline is clear.
+	if rows[0].Description != "Light | dark mode toggle." {
+		t.Errorf("description stored with unescaped pipe: got %q", rows[0].Description)
+	}
+}
+
+// ---- replaceBetweenMarkers --------------------------------------------------
+
+func TestReplaceBetweenMarkers_Basic(t *testing.T) {
+	src := []byte("prefix\n" + beginMarker + "\nstale body\n" + endMarker + "\nsuffix\n")
+	out, err := replaceBetweenMarkers(src, beginMarker, endMarker, "fresh body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "prefix\n" + beginMarker + "\nfresh body\n" + endMarker + "\nsuffix\n"
+	if string(out) != want {
+		t.Fatalf("unexpected output\nwant:\n%s\n\ngot:\n%s", want, string(out))
+	}
+}
+
+func TestReplaceBetweenMarkers_MissingBegin(t *testing.T) {
+	_, err := replaceBetweenMarkers([]byte("no markers here"), beginMarker, endMarker, "body")
+	if err == nil {
+		t.Fatal("expected error when begin marker is missing")
+	}
+	if !strings.Contains(err.Error(), "begin marker") {
+		t.Errorf("error should mention begin marker; got: %v", err)
+	}
+}
+
+func TestReplaceBetweenMarkers_MissingEnd(t *testing.T) {
+	src := []byte("prefix " + beginMarker + " no end")
+	_, err := replaceBetweenMarkers(src, beginMarker, endMarker, "body")
+	if err == nil {
+		t.Fatal("expected error when end marker is missing")
+	}
+	if !strings.Contains(err.Error(), "end marker") {
+		t.Errorf("error should mention end marker; got: %v", err)
+	}
+}
+
+func TestReplaceBetweenMarkers_TrailingNewlinesNormalized(t *testing.T) {
+	// Body with excess trailing newlines should produce exactly one trailing
+	// newline before the end marker.
+	src := []byte("a\n" + beginMarker + "\nold\n" + endMarker + "\nb\n")
+	out, err := replaceBetweenMarkers(src, beginMarker, endMarker, "new\n\n\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "a\n" + beginMarker + "\nnew\n" + endMarker + "\nb\n"
+	if string(out) != want {
+		t.Fatalf("trailing newlines not normalized\nwant:\n%s\ngot:\n%s", want, string(out))
+	}
+}
+
+// ---- run() ------------------------------------------------------------------
+
+func TestRun_RewritesStaleContent(t *testing.T) {
+	docPath := writeFixtureDoc(t, "STALE TABLE")
+	i18nPath := writeI18nFixture(t, map[string]string{})
+	if err := run(docPath, i18nPath, false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "STALE TABLE") {
+		t.Errorf("stale body should be replaced; got:\n%s", got)
+	}
+	if !strings.Contains(string(got), "| Key | Label | Default | Allowed Values | Description |") {
+		t.Errorf("regenerated table header missing; got:\n%s", got)
+	}
+	if !strings.Contains(string(got), "intro\n") || !strings.Contains(string(got), "footer\n") {
+		t.Errorf("manual prose around markers should be preserved; got:\n%s", got)
+	}
+}
+
+func TestRun_NoChangeIsNoop(t *testing.T) {
+	docPath := writeFixtureDoc(t, "STALE")
+	i18nPath := writeI18nFixture(t, map[string]string{})
+	if err := run(docPath, i18nPath, false); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	before, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := run(docPath, i18nPath, false); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	after, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("second run should be a no-op (content unchanged)")
+	}
+}
+
+func TestRun_CheckMode_StaleErrors(t *testing.T) {
+	docPath := writeFixtureDoc(t, "STALE")
+	i18nPath := writeI18nFixture(t, map[string]string{})
+	err := run(docPath, i18nPath, true)
+	if err == nil {
+		t.Fatal("expected error in -check mode against stale file")
+	}
+	if !strings.Contains(err.Error(), "stale") {
+		t.Errorf("error should mention staleness; got: %v", err)
+	}
+}
+
+func TestRun_CheckMode_FreshSucceeds(t *testing.T) {
+	docPath := writeFixtureDoc(t, "STALE")
+	i18nPath := writeI18nFixture(t, map[string]string{})
+	if err := run(docPath, i18nPath, false); err != nil {
+		t.Fatalf("seed regen: %v", err)
+	}
+	if err := run(docPath, i18nPath, true); err != nil {
+		t.Errorf("check mode should pass on fresh file; got: %v", err)
+	}
+}
+
+func TestRun_MissingOutputFile(t *testing.T) {
+	i18nPath := writeI18nFixture(t, map[string]string{})
+	err := run(filepath.Join(t.TempDir(), "does-not-exist.md"), i18nPath, false)
+	if err == nil {
+		t.Fatal("expected error when output path does not exist")
+	}
+	if !strings.Contains(err.Error(), "read") {
+		t.Errorf("error should mention read failure; got: %v", err)
+	}
+}
+
+func TestRun_MissingI18nFile(t *testing.T) {
+	docPath := writeFixtureDoc(t, "STALE")
+	err := run(docPath, filepath.Join(t.TempDir(), "does-not-exist.json"), false)
+	if err == nil {
+		t.Fatal("expected error when i18n path does not exist")
+	}
+	if !strings.Contains(err.Error(), "i18n") {
+		t.Errorf("error should mention i18n load failure; got: %v", err)
+	}
+}
+
+func TestRun_MalformedI18nFile(t *testing.T) {
+	docPath := writeFixtureDoc(t, "STALE")
+	dir := t.TempDir()
+	badJSON := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(badJSON, []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := run(docPath, badJSON, false)
+	if err == nil {
+		t.Fatal("expected error for malformed i18n JSON")
+	}
+	if !strings.Contains(err.Error(), "i18n") {
+		t.Errorf("error should mention i18n load failure; got: %v", err)
+	}
+}
+
+func TestRun_MissingMarkers(t *testing.T) {
+	dir := t.TempDir()
+	docPath := filepath.Join(dir, "prefs.md")
+	if err := os.WriteFile(docPath, []byte("no markers here\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	i18nPath := writeI18nFixture(t, map[string]string{})
+	err := run(docPath, i18nPath, false)
+	if err == nil {
+		t.Fatal("expected error when markers are absent")
+	}
+	if !strings.Contains(err.Error(), "marker") {
+		t.Errorf("error should mention missing marker; got: %v", err)
+	}
+}

--- a/docs/_generated/make-commands.md
+++ b/docs/_generated/make-commands.md
@@ -18,7 +18,7 @@
 | `make templ` | Generate Go code from Templ templates |
 | `make tailwind` | Build Tailwind CSS |
 | `make generate` | Run all code generation (templ + tailwind) |
-| `make generate-docs` | Regenerate docs site content from code (provider matrix, env-var reference, rules catalogue, settings reference, doc anchors, envelope-versions, make-command reference, platform-profiles) |
+| `make generate-docs` | Regenerate docs site content from code (provider matrix, env-var reference, rules catalogue, settings reference, doc anchors, envelope-versions, make-command reference, platform-profiles, preferences reference) |
 | `make tailwind-watch` | Watch and rebuild Tailwind CSS |
 | `make migrate` | Run database migrations |
 | `make favicon` | Regenerate PNG favicons from logo design |

--- a/docs/site/src/how-to/customize-preferences.md
+++ b/docs/site/src/how-to/customize-preferences.md
@@ -213,5 +213,6 @@ The **Reset to defaults** button in the drawer footer restores every preference 
 
 ## See also
 
+- [Preferences reference](../reference/preferences.md) for a quick-lookup table of every preference key, its default, and its allowed values.
 - [Find a setting](find-a-setting.md) for application-level configuration that requires admin access.
 - [Edit an artist](edit-artist.md) for the per-field clock (prior value revert) workflow.

--- a/docs/site/src/reference/index.md
+++ b/docs/site/src/reference/index.md
@@ -40,6 +40,14 @@ The map for "where do I find the exact list of X?" Each page is a deep enumerati
 
     [Read more](environment-variables.md)
 
+- __Preferences reference__
+
+    ---
+
+    Every user preference key, its default value, and its allowed values or numeric range. Generated from the Go preference registry.
+
+    [Read more](preferences.md)
+
 - __UI label glossary__
 
     ---

--- a/docs/site/src/reference/preferences.md
+++ b/docs/site/src/reference/preferences.md
@@ -1,0 +1,44 @@
+---
+description: Complete reference for all Stillwater user preference keys, their defaults, and valid values.
+---
+
+# Preferences reference
+
+Every user preference key that Stillwater accepts via `PUT /api/v1/preferences/{key}` or `PATCH /api/v1/preferences` is listed below. Preferences are per-user and persisted in the database; they can also be read with `GET /api/v1/preferences`.
+
+The table is generated from the Go preference registry (`internal/api.PreferenceRegistry`). Run `make generate-docs` to regenerate it after editing the registry.
+
+**Keys not in this table** (complex types documented by prose only):
+
+- `metadata_languages` - JSON array of BCP 47 language tags; see the Language section in Settings.
+- `artist_detail_section_order`, `artist_detail_hidden_sections` - JSON arrays of section identifiers; managed by the drag-reorder UI.
+- `suppress_confirm_{action}` - dynamic per-action confirm-dialog suppression keys; `"true"` or `"false"`.
+
+<!-- BEGIN GENERATED: prefs-reference -->
+| Key | Label | Default | Allowed Values | Description |
+|---|---|---|---|---|
+| <a id="pref-auto_fetch_images"></a>`auto_fetch_images` | Prefetch Images | `false` | `true`, `false` | Automatically search providers for images when opening an artist's image page. |
+| <a id="pref-bg_opacity"></a>`bg_opacity` | Background Opacity | `85` | 20..100 (step 5) | How opaque cards and the top bar are over the backdrop. The 85% floor keeps text AA-legible over the artwork; raise it toward 100% for fully solid surfaces. Lite mode forces opaque. |
+| <a id="pref-content_width"></a>`content_width` | Content Width | `narrow` | `narrow`, `wide` | Narrow caps line length for comfortable reading. Wide fills the screen to fit more per row. |
+| <a id="pref-density"></a>`density` | Layout Density | `comfortable` | `compact`, `comfortable`, `spacious` | Controls vertical spacing in lists and grids. Compact fits more content; Spacious adds breathing room. |
+| <a id="pref-font_family"></a>`font_family` | Font Family | `inter` | `system`, `inter`, `atkinson` | Inter is the default. System uses your operating system's native font. Atkinson Hyperlegible boosts legibility for low-vision readers. |
+| <a id="pref-font_size"></a>`font_size` | Font Size | `medium` | `small`, `medium`, `large`, `x-large`, `xx-large` | Scales text across the entire app. |
+| <a id="pref-kbd_hints"></a>`kbd_hints` | Keyboard Hints | `show` | `show`, `hide` | Show or hide keyboard shortcut badges throughout the UI. |
+| <a id="pref-language"></a>`language` | Language | `en` | `en` | Sets the interface language. Biography language fallbacks are configured separately in Settings. |
+| <a id="pref-letter_spacing"></a>`letter_spacing` | Letter Spacing | `normal` | `normal`, `wide`, `extra-wide` | Tracks the whole UI. Extra Wide (0.05em) is a dyslexia-readability aid; Wide is 0.025em. |
+| <a id="pref-lite_mode"></a>`lite_mode` | Lite Mode | `off` | `off`, `on`, `auto` | Lite mode is a single switch that turns off every visually expensive feature at once: frosted-glass blur, transitions, BlurHash placeholders that render before images load, and full-resolution image fetching. Use it if pages feel sluggish or if you would rather see thumbnails immediately than wait for full-size art. |
+| <a id="pref-metadata_name_romanization_fallback"></a>`metadata_name_romanization_fallback` | Metadata Name Romanization Fallback | `true` | `true`, `false` |  |
+| <a id="pref-mono_font"></a>`mono_font` | Monospace Font | `jetbrains` | `system`, `jetbrains`, `cascadia` | Used for keyboard badges, IDs, and timestamps. |
+| <a id="pref-notification_enabled"></a>`notification_enabled` | Notifications | `true` | `true`, `false` | Show in-app toast notifications for rule violations. |
+| <a id="pref-page_size"></a>`page_size` | Page Size | `50` | 10..500 | Rows per page on list screens (Artists, Reports). Server-side, so there is no live preview here; the value normalizes on blur. |
+| <a id="pref-reduced_motion"></a>`reduced_motion` | Reduced Motion | `system` | `system`, `on`, `off` | Some users find page transitions and animated state changes distracting or motion-sensitivity inducing. Turning this on suppresses or removes those animations across the app, so panels swap and toasts appear instantly instead of fading. |
+| <a id="pref-sidebar_state"></a>`sidebar_state` | Sidebar Default State | `full` | `full`, `icon-only`, `hidden` | The sidebar holds the primary navigation and can be collapsed to icons-only or expanded to show labels. This setting picks which state you land on every time you load Stillwater; you can still toggle it during a session. |
+| <a id="pref-theme"></a>`theme` | Theme | `dark` | `dark`, `light`, `system` | The theme is the overall color scheme: background, panel, and accent colors all derive from it. Light, Dark, and System (follow the operating system) are the available choices. |
+| <a id="pref-thumbnail_size"></a>`thumbnail_size` | Thumbnail Size | `medium` | `small`, `medium`, `large` | Size of artist artwork in lists and the action queue. Shown here at the actual pixel sizes. |
+<!-- END GENERATED: prefs-reference -->
+
+## See also
+
+- [Customize preferences](../how-to/customize-preferences.md) - step-by-step how-to for every preference group in the drawer UI.
+- [Settings reference](settings-by-tab.md) - application-level settings that require admin access.
+- [API reference](../api/index.md) - full REST API specification for the `/api/v1/preferences` endpoints.

--- a/internal/api/handlers_preferences_jssync_test.go
+++ b/internal/api/handlers_preferences_jssync_test.go
@@ -1,0 +1,124 @@
+package api
+
+// TestJSDefaultsMatchGoRegistry validates that the DEFAULTS object in
+// web/static/js/preferences.js is in sync with the Go preference registry
+// (PreferenceRegistry). This catches drift between the two sources that
+// previously had no automated link, preventing silent mismatches where the
+// client applies a different default than the server stores.
+//
+// The test is intentionally NOT in a _test package so it can reach the same
+// package-level constants (BgOpacityDefault, PageSizeDefault, etc.) and the
+// internal preferenceDefaults map through PreferenceRegistry without needing
+// an additional exported surface.
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// jsPrefsPath is the path to preferences.js relative to this test file's
+// package directory (internal/api/). Go tests run with the working directory
+// set to the package being tested, so two directory levels up reaches the repo
+// root, from which the web/ tree is accessible.
+const jsPrefsPath = "../../web/static/js/preferences.js"
+
+// serverOnlyKeys is the set of preference keys that exist in the Go registry
+// but are intentionally absent from the JS DEFAULTS object. These keys are
+// either server-side-only (page_size is applied server-side and never needed
+// by client-side default logic) or structurally complex (the romanization flag
+// is stored as a string but managed server-side only).
+//
+// Note: metadata_languages, artist_detail_section_order, and
+// artist_detail_hidden_sections are excluded from PreferenceRegistry() entirely
+// (they cannot be represented as a flat key/default table) and therefore never
+// appear in the registry loop below -- no guard is needed for them here.
+var serverOnlyKeys = map[string]bool{
+	PrefPageSize:                 true,
+	PrefMetadataNameRomanization: true,
+}
+
+// parseJSDefaults reads preferences.js and returns the contents of the
+// var DEFAULTS = { ... }; object as a map[string]string. It uses a simple
+// regex approach that is intentionally tied to the literal object syntax in
+// the file -- if the file format changes substantially, this test should be
+// updated alongside it.
+func parseJSDefaults(t *testing.T) map[string]string {
+	t.Helper()
+
+	data, err := os.ReadFile(jsPrefsPath)
+	if err != nil {
+		t.Fatalf("parseJSDefaults: read %s: %v", jsPrefsPath, err)
+	}
+
+	// Extract the var DEFAULTS = { ... }; block. The (?s) flag makes "."
+	// match newlines so the entire multi-line block is captured in one pass.
+	blockRE := regexp.MustCompile(`(?s)var DEFAULTS = \{(.*?)\};`)
+	matches := blockRE.FindSubmatch(data)
+	if matches == nil {
+		t.Fatalf("parseJSDefaults: could not find 'var DEFAULTS = { ... };' block in %s", jsPrefsPath)
+	}
+
+	// Parse key: 'value' pairs within the captured block. Comment lines
+	// (starting with //) are skipped implicitly because they do not match
+	// the (\w+): pattern. Trailing commas are ignored by the regex.
+	// NOTE: pairRE assumes all DEFAULTS values are single-quoted strings. If
+	// preferences.js is ever updated to use double quotes or numeric literals,
+	// this regex (and the test) must be updated to match.
+	pairRE := regexp.MustCompile(`\s*(\w+):\s*'([^']*)'`)
+	pairMatches := pairRE.FindAllStringSubmatch(string(matches[1]), -1)
+
+	if len(pairMatches) == 0 {
+		t.Fatalf("parseJSDefaults: parsed zero key-value pairs from DEFAULTS block in %s; check the regex", jsPrefsPath)
+	}
+
+	result := make(map[string]string, len(pairMatches))
+	for _, m := range pairMatches {
+		result[m[1]] = m[2]
+	}
+	return result
+}
+
+func TestJSDefaultsMatchGoRegistry(t *testing.T) {
+	jsDefaults := parseJSDefaults(t)
+	goRegistry := PreferenceRegistry()
+
+	// Build a quick-lookup map from the registry slice.
+	goByKey := make(map[string]PreferenceDef, len(goRegistry))
+	for _, def := range goRegistry {
+		goByKey[def.Key] = def
+	}
+
+	// Every key in JS DEFAULTS must exist in the Go registry with a matching
+	// default value. A JS key that has no Go counterpart indicates either a
+	// dead JS key or a Go key that was removed without updating preferences.js.
+	for jsKey, jsVal := range jsDefaults {
+		goDef, ok := goByKey[jsKey]
+		if !ok {
+			t.Errorf("JS DEFAULTS key %q not found in Go PreferenceRegistry()", jsKey)
+			continue
+		}
+		// Compare string values; bg_opacity stores "85" in both sources.
+		if jsVal != goDef.Default {
+			t.Errorf("JS DEFAULTS[%q] = %q, but Go registry default = %q; update preferences.js to match", jsKey, jsVal, goDef.Default)
+		}
+	}
+
+	// Every Go registry key that is not server-only must appear in JS DEFAULTS.
+	// A Go key that is missing from JS DEFAULTS means the client falls back to
+	// an undefined default, which may differ from the server's stored default.
+	for _, def := range goRegistry {
+		if serverOnlyKeys[def.Key] {
+			continue
+		}
+		// Also skip keys with the suppress_confirm_ prefix: they are
+		// dynamically created by the UI and have no static DEFAULTS entry.
+		if strings.HasPrefix(def.Key, PrefSuppressConfirmPrefix) {
+			continue
+		}
+		if _, ok := jsDefaults[def.Key]; !ok {
+			t.Errorf("Go registry key %q (default %q) not found in JS DEFAULTS in %s; add it or add to serverOnlyKeys", def.Key, def.Default, jsPrefsPath)
+		}
+	}
+}

--- a/internal/api/preference_registry.go
+++ b/internal/api/preference_registry.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"sort"
+	"strconv"
+)
+
+// PreferenceDef is the exported representation of a single user preference
+// entry. It is the element type returned by PreferenceRegistry and is used by
+// cmd/gen-prefs-reference (doc generator) and the JS-sync test
+// (TestJSDefaultsMatchGoRegistry).
+//
+// Enum-type entries have AllowedValues set and RangeMin/RangeMax/RangeStep
+// zero. Range-type entries (bg_opacity, page_size) have RangeMin/RangeMax
+// non-zero and AllowedValues nil.
+type PreferenceDef struct {
+	// Key is the preference key string (e.g. "theme", "bg_opacity").
+	Key string
+	// Default is the canonical default value as a string (e.g. "dark" or "85").
+	Default string
+	// AllowedValues lists the valid string values for enum-type preferences.
+	// Nil for range-type preferences.
+	AllowedValues []string
+	// RangeMin and RangeMax define the inclusive integer bounds for range-type
+	// preferences. Both are zero for enum-type preferences.
+	RangeMin int
+	RangeMax int
+	// RangeStep is the UI slider step for range-type preferences (informational;
+	// the API itself accepts any integer in [RangeMin, RangeMax]).
+	RangeStep int
+}
+
+// PreferenceRegistry returns a snapshot of all documented user preference
+// definitions sorted alphabetically by key. It is the single source of truth
+// consulted by doc generators and cross-validation tests.
+//
+// Enum-type preferences come from the internal preferenceDefaults map.
+// Range-type preferences (bg_opacity, page_size) are not in preferenceDefaults
+// -- they are validated as integers via dedicated normalizer functions rather
+// than a fixed enum set -- and are added here from the package-level range
+// constants so the registry presents a unified view to consumers.
+//
+// Intentionally omitted (complex keys that cannot be represented as a flat
+// key/default/allowed-values table):
+//   - metadata_languages: JSON-array of BCP 47 tags, structural validation
+//   - artist_detail_section_order, artist_detail_hidden_sections: free-form JSON arrays
+//   - suppress_confirm_*: dynamically created per-action keys
+func PreferenceRegistry() []PreferenceDef {
+	result := make([]PreferenceDef, 0, len(preferenceDefaults)+2)
+	for key, def := range preferenceDefaults {
+		pd := PreferenceDef{
+			Key:     key,
+			Default: def.defaultValue,
+		}
+		if len(def.allowedValues) > 0 {
+			pd.AllowedValues = make([]string, len(def.allowedValues))
+			copy(pd.AllowedValues, def.allowedValues)
+		}
+		result = append(result, pd)
+	}
+	// Range-type preferences are validated as integers rather than fixed enum
+	// strings and are therefore excluded from preferenceDefaults. They are added
+	// here explicitly so the registry is the single place a consumer looks.
+	result = append(result,
+		PreferenceDef{
+			Key:       PrefBgOpacity,
+			Default:   strconv.Itoa(BgOpacityDefault),
+			RangeMin:  BgOpacityMin,
+			RangeMax:  BgOpacityMax,
+			RangeStep: 5, // slider increments by 5% in the preferences UI
+		},
+		PreferenceDef{
+			Key:       PrefPageSize,
+			Default:   strconv.Itoa(PageSizeDefault),
+			RangeMin:  PageSizeMin,
+			RangeMax:  PageSizeMax,
+			RangeStep: 1,
+		},
+	)
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Key < result[j].Key
+	})
+	return result
+}

--- a/scripts/check-generated.sh
+++ b/scripts/check-generated.sh
@@ -122,4 +122,14 @@ if [ -f docs/_generated/platform-profiles.md ]; then
   fi
 fi
 
+# Verify the preferences reference is in sync with the Go preference registry.
+# The generator runs in -check mode and exits non-zero if regeneration is needed.
+# Skip silently if the docs file is absent (e.g., a docs-stripped checkout).
+if [ -f docs/site/src/reference/preferences.md ]; then
+  if ! go run ./cmd/gen-prefs-reference -check; then
+    echo "ERROR: docs/site/src/reference/preferences.md is stale. Run: make generate-docs"
+    exit 1
+  fi
+fi
+
 echo "Generated files: OK"


### PR DESCRIPTION
## Summary

Adds a preferences reference doc generator backed by a unified registry, so the user-facing preferences are documented from a single source of truth.

- `internal/api/preference_registry.go`: `PreferenceRegistry()` is the single source of truth for the 18 preferences (defaults, allowed values). No change to the preferences API behavior (bg_opacity/page_size are synthetic registry entries, so the runtime normalizers are untouched).
- `cmd/gen-prefs-reference`: generates `docs/site/src/reference/preferences.md`, resolving labels/descriptions from i18n with a key->namespace override map for keys whose i18n lives outside the default namespace (e.g. `auto_fetch_images` -> "Prefetch Images"). Includes `main_test.go` (90.5% coverage).
- Wired into `make generate-docs` with a `check-generated.sh` drift check so CI catches staleness.
- `handlers_preferences_jssync_test.go`: asserts the JS client defaults stay in sync with the Go registry.
- Cross-links from the reference index and the customize-preferences how-to.

## Test plan

- `scripts/pre-push-gate.sh`: all hard checks pass (build, vet, full test suite, lint, OpenAPI, generated-file drift incl. `gen-prefs-reference -check`, coverage floor). Patch coverage 90.27%.
- `cmd/gen-prefs-reference` unit tests cover label/description resolution (default + override + snakeToTitle fallback), allowed-value formatting, marker injection, and check-mode stale/fresh.

## Known minor follow-ups (non-blocking)

- `metadata_name_romanization_fallback` shows a blank Description in the generated table (its i18n lives outside both default namespaces; server-side-only key, not exposed in the preferences drawer).

Closes #2006


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a new Preferences Reference page documenting all available preference keys, their default values, and allowed options for quick lookup.

* **Tests**
  * Added comprehensive test coverage for preferences documentation generation and synchronization between client and server defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->