### PR TITLE
feat(docs): add CLI flags reference generator + docs-coverage gate

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -1,5 +1,35 @@
 name: Docs Drift
 
+# POLICY: this workflow is a SOFT advisory. It posts a PR comment and applies
+# the `needs-docs-review` label when code paths change without corresponding
+# docs updates, but it NEVER blocks merge.
+#
+# Enforcement model (as of 2026-06-17):
+#   HARD gates (fail CI, block merge):
+#     - Generated reference pages drift: scripts/check-generated.sh runs
+#       gen-env-reference, gen-cli-reference, gen-rules-catalogue,
+#       gen-settings-reference, gen-doc-anchors, gen-envelope-changelog,
+#       gen-make-reference, gen-platform-profiles, gen-prefs-reference in
+#       -check mode on every push. A stale generated file fails the gate.
+#     - Coverage gaps: each generator fails loudly at generation time if a
+#       code-defined key lacks its required metadata (e.g. env:/desc: tags
+#       for config vars; flag:/desc: tags for CLI flags; catalogue entry for
+#       rules). So adding a key without docs is a build failure.
+#   SOFT advisory (this workflow):
+#     - Hand-written narrative docs (provider guides, troubleshooting, API
+#       reference prose) are not generated and cannot be drift-checked
+#       mechanically. This workflow flags those cases.
+#
+# Raising the enforcement level: to make specific surfaces blocking, move
+# them from the soft advisory path to the hard gate (add a -check call in
+# scripts/check-generated.sh). Candidate surfaces for hardening:
+#   - openapi.yaml changes without docs/api/** updates (high-value; the API
+#     spec is the contract for external integrators).
+#   - Handler changes that add/remove destructive operations without
+#     docs updates (precedent: #1779 / PR #2007 changed filesystem deletion
+#     behavior and was only soft-flagged).
+# Decision on this policy requires maintainer sign-off; see issue #2008.
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]

--- a/Makefile
+++ b/Makefile
@@ -143,10 +143,11 @@ tailwind:
 ## generate: Run all code generation (templ + tailwind)
 generate: templ tailwind
 
-## generate-docs: Regenerate docs site content from code (provider matrix, env-var reference, rules catalogue, settings reference, doc anchors, envelope-versions, make-command reference, platform-profiles, preferences reference)
+## generate-docs: Regenerate docs site content from code (provider matrix, env-var reference, CLI reference, rules catalogue, settings reference, doc anchors, envelope-versions, make-command reference, platform-profiles, preferences reference). Each generator enforces coverage: a new code-defined key without a desc: tag or doc entry fails the build.
 generate-docs:
 	go run ./cmd/gen-provider-matrix
 	go run ./cmd/gen-env-reference
+	go run ./cmd/gen-cli-reference
 	go run ./cmd/gen-rules-catalogue
 	go run ./cmd/gen-settings-reference
 	go run ./cmd/gen-doc-anchors

--- a/cmd/gen-cli-reference/main.go
+++ b/cmd/gen-cli-reference/main.go
@@ -1,0 +1,248 @@
+// Command gen-cli-reference renders the CLI flags reference table in
+// docs/site/src/reference/cli.md from struct tags on the Flags type in
+// internal/cli. Each rendered row consists of the flag name, a doc-friendly
+// type label, the documented default, and a description sentence. The
+// generator reflects over the Flags struct, requires every field that carries
+// a flag: tag to also carry a desc: tag (coverage enforcement -- generation
+// fails loudly if the tag is absent), and writes the table between the
+// well-known BEGIN/END markers in the docs file. Manual prose around the
+// markers is preserved.
+//
+// Coverage contract:
+//   - CLI flags (internal/cli.Flags): every flag: field must have a desc: tag;
+//     the generator fails at generation time if any is missing. Adding a new
+//     CLI flag without a desc: tag breaks the build.
+//   - Subcommands (internal/cli.Subcommands): the generator renders every entry
+//     in the Subcommands slice as a separate section. Adding a subcommand entry
+//     automatically documents it; there is no additional coverage check because
+//     the slice is the authoritative registry.
+//
+// Usage:
+//
+//	go run ./cmd/gen-cli-reference              # rewrite the file in place
+//	go run ./cmd/gen-cli-reference -check       # exit non-zero if regen needed
+//	go run ./cmd/gen-cli-reference -output FILE # write to a different file
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	icli "github.com/sydlexius/stillwater/internal/cli"
+	"github.com/sydlexius/stillwater/internal/filesystem"
+)
+
+const (
+	beginMarker = "<!-- BEGIN GENERATED: cli-reference -->"
+	endMarker   = "<!-- END GENERATED: cli-reference -->"
+)
+
+const defaultOutputPath = "docs/site/src/reference/cli.md"
+
+func main() {
+	var (
+		checkOnly bool
+		outPath   string
+	)
+	flag.BoolVar(&checkOnly, "check", false, "exit non-zero if the CLI reference needs to be regenerated")
+	flag.StringVar(&outPath, "output", defaultOutputPath, "path to the docs file to update")
+	flag.Parse()
+
+	if err := run(outPath, checkOnly); err != nil {
+		fmt.Fprintln(os.Stderr, "gen-cli-reference:", err)
+		os.Exit(1)
+	}
+}
+
+func run(outPath string, checkOnly bool) error {
+	rows, err := collectRows(reflect.TypeOf(icli.Flags{}))
+	if err != nil {
+		return fmt.Errorf("collect rows: %w", err)
+	}
+	rendered := renderContent(rows, icli.Subcommands)
+
+	// outPath comes from the -output flag; this is a developer-only build-time
+	// tool, so a configurable path is intended.
+	existing, err := os.ReadFile(outPath) //nolint:gosec // G304: developer CLI, path is intentionally configurable
+	if err != nil {
+		return fmt.Errorf("read %s: %w", outPath, err)
+	}
+
+	updated, err := replaceBetweenMarkers(existing, beginMarker, endMarker, rendered)
+	if err != nil {
+		return fmt.Errorf("update %s: %w", outPath, err)
+	}
+
+	if checkOnly {
+		if !bytes.Equal(existing, updated) {
+			return fmt.Errorf("%s is stale; run `make generate-docs` to regenerate", filepath.ToSlash(outPath))
+		}
+		return nil
+	}
+
+	if bytes.Equal(existing, updated) {
+		return nil
+	}
+	if err := filesystem.WriteFileAtomic(outPath, updated, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", outPath, err)
+	}
+	return nil
+}
+
+// flagRow is a single row in the rendered Markdown table.
+type flagRow struct {
+	Name        string
+	Type        string
+	Default     string
+	Description string
+}
+
+// collectRows reflects over t (which must be a struct type) and returns one
+// flagRow per field carrying a flag: tag. Fields with a flag: tag but no
+// desc: tag fail with an error so that the docs page never silently emits an
+// empty description column. This is the coverage enforcement: every registered
+// CLI flag must have a documented description.
+func collectRows(t reflect.Type) ([]flagRow, error) {
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("collectRows: expected struct, got %s", t.Kind())
+	}
+	var rows []flagRow
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		flagName := f.Tag.Get("flag")
+		if flagName == "" {
+			continue
+		}
+		desc := f.Tag.Get("desc")
+		if desc == "" {
+			return nil, fmt.Errorf(
+				"field %s has flag:%q tag but no desc: tag; add a one-sentence description "+
+					"so the CLI reference page is never empty (coverage enforcement)",
+				f.Name, flagName)
+		}
+		def := f.Tag.Get("default")
+		rows = append(rows, flagRow{
+			Name:        flagName,
+			Type:        flagDocType(f.Type),
+			Default:     renderDefault(def),
+			Description: desc,
+		})
+	}
+	return rows, nil
+}
+
+// flagDocType maps a Go reflect.Type to the user-facing type label used in
+// docs. User docs avoid Go-specific notation; the labels here are deployment-
+// operator vocabulary.
+func flagDocType(t reflect.Type) string {
+	switch t.Kind() {
+	case reflect.Bool:
+		return "boolean"
+	case reflect.String:
+		return "string"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return "integer"
+	default:
+		return "string"
+	}
+}
+
+// renderDefault converts the raw default: tag value into the cell text used
+// in the table. Empty strings render as "(none)"; "false" and other literals
+// render in backticks.
+func renderDefault(def string) string {
+	if def == "" {
+		return "(none)"
+	}
+	return "`" + def + "`"
+}
+
+// renderContent returns the full Markdown body to place between the BEGIN/END
+// markers. It includes a flags table and a subcommands section.
+func renderContent(rows []flagRow, subs []icli.SubcommandInfo) string {
+	var b strings.Builder
+
+	// Flags table.
+	b.WriteString("## Flags\n\n")
+	b.WriteString("| Flag | Type | Default | Description |\n")
+	b.WriteString("|---|---|---|---|\n")
+	for _, r := range rows {
+		fmt.Fprintf(&b, "| `--%s` | %s | %s | %s |\n",
+			escapeMarkdownCell(r.Name),
+			escapeMarkdownCell(r.Type),
+			escapeMarkdownCell(r.Default),
+			escapeMarkdownCell(r.Description),
+		)
+	}
+
+	if len(subs) == 0 {
+		return b.String()
+	}
+
+	// Subcommands section.
+	b.WriteString("\n## Subcommands\n\n")
+	b.WriteString("Subcommands are passed as the first positional argument before any flags ")
+	b.WriteString("(e.g. `stillwater reset-credentials`).\n\n")
+	b.WriteString("| Subcommand | Summary |\n")
+	b.WriteString("|---|---|\n")
+	for _, s := range subs {
+		fmt.Fprintf(&b, "| `%s` | %s |\n",
+			escapeMarkdownCell(s.Name),
+			escapeMarkdownCell(s.Summary),
+		)
+	}
+
+	// Per-subcommand detail sections.
+	for _, s := range subs {
+		b.WriteString("\n### `")
+		b.WriteString(s.Name)
+		b.WriteString("`\n\n")
+		b.WriteString(s.Details)
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// escapeMarkdownCell sanitizes a string for use inside a Markdown table cell.
+// Pipes break the column boundary; newlines break the row boundary.
+func escapeMarkdownCell(s string) string {
+	s = strings.ReplaceAll(s, "|", `\|`)
+	s = strings.ReplaceAll(s, "\n", "<br>")
+	return s
+}
+
+// replaceBetweenMarkers returns src with the region between begin and end
+// replaced by body. The markers themselves are preserved. body is sandwiched
+// in newlines so the rendered table has clean blank-line separation from the
+// markers; trailing newlines on body are normalized.
+//
+// begin and end are parameters (not constants) so the helper can be exercised
+// with bespoke markers in tests.
+func replaceBetweenMarkers(src []byte, begin, end, body string) ([]byte, error) { //nolint:unparam // begin/end are exposed as parameters for testability
+	beginIdx := bytes.Index(src, []byte(begin))
+	if beginIdx < 0 {
+		return nil, fmt.Errorf("begin marker %q not found", begin)
+	}
+	relEndIdx := bytes.Index(src[beginIdx:], []byte(end))
+	if relEndIdx < 0 {
+		return nil, fmt.Errorf("end marker %q not found after begin marker", end)
+	}
+	endIdx := beginIdx + relEndIdx
+
+	body = strings.TrimRight(body, "\n")
+	var out bytes.Buffer
+	out.Write(src[:beginIdx])
+	out.WriteString(begin)
+	out.WriteString("\n")
+	out.WriteString(body)
+	out.WriteString("\n")
+	out.Write(src[endIdx:])
+	return out.Bytes(), nil
+}

--- a/cmd/gen-cli-reference/main_test.go
+++ b/cmd/gen-cli-reference/main_test.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	icli "github.com/sydlexius/stillwater/internal/cli"
+)
+
+// fixtureGood exercises every supported field shape: a bool with a default
+// and a string. Tests reflect over this fixture to verify the codegen
+// contract in isolation from the real cli.Flags type.
+type fixtureGood struct {
+	Verbose bool   `flag:"verbose" default:"false" desc:"Enable verbose output."`
+	Config  string `flag:"config" default:"/etc/app.conf" desc:"Path to the config file."`
+	Skipped string // no flag tag; must be ignored
+}
+
+// fixtureMissingDesc has a flag tag but no desc tag; collectRows must reject
+// it so the docs page can never silently ship with an empty description.
+type fixtureMissingDesc struct {
+	Verbose bool `flag:"verbose" default:"false"`
+}
+
+// ---- collectRows ------------------------------------------------------------
+
+func TestCollectRows_Fixture(t *testing.T) {
+	rows, err := collectRows(reflect.TypeOf(fixtureGood{}))
+	if err != nil {
+		t.Fatalf("collectRows: %v", err)
+	}
+	// Only the two tagged fields; Skipped has no flag: tag.
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d (%v)", len(rows), rows)
+	}
+	if rows[0].Name != "verbose" {
+		t.Errorf("rows[0].Name = %q, want %q", rows[0].Name, "verbose")
+	}
+	if rows[1].Name != "config" {
+		t.Errorf("rows[1].Name = %q, want %q", rows[1].Name, "config")
+	}
+	// Type mapping.
+	if rows[0].Type != "boolean" {
+		t.Errorf("verbose type = %q, want boolean", rows[0].Type)
+	}
+	if rows[1].Type != "string" {
+		t.Errorf("config type = %q, want string", rows[1].Type)
+	}
+	// Default rendering.
+	if rows[0].Default != "`false`" {
+		t.Errorf("verbose default = %q, want `false`", rows[0].Default)
+	}
+	if rows[1].Default != "`/etc/app.conf`" {
+		t.Errorf("config default = %q, want `/etc/app.conf`", rows[1].Default)
+	}
+}
+
+func TestCollectRows_MissingDescIsError(t *testing.T) {
+	_, err := collectRows(reflect.TypeOf(fixtureMissingDesc{}))
+	if err == nil {
+		t.Fatal("expected error when flag-tagged field has no desc tag")
+	}
+	if !strings.Contains(err.Error(), "verbose") {
+		t.Errorf("error should name the offending flag; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "desc") {
+		t.Errorf("error should mention the missing desc tag; got %v", err)
+	}
+}
+
+func TestCollectRows_NonStruct(t *testing.T) {
+	_, err := collectRows(reflect.TypeOf(42))
+	if err == nil {
+		t.Fatal("expected error for non-struct type")
+	}
+	if !strings.Contains(err.Error(), "struct") {
+		t.Errorf("error should mention struct; got %v", err)
+	}
+}
+
+func TestCollectRows_RealFlags(t *testing.T) {
+	// The real cli.Flags must have valid desc: tags on every flag: field.
+	// This test is the coverage enforcement from the test layer: if anyone
+	// adds a flag: field without a desc: tag, this test catches it.
+	rows, err := collectRows(reflect.TypeOf(icli.Flags{}))
+	if err != nil {
+		t.Fatalf("real cli.Flags has a field missing desc tag: %v", err)
+	}
+	if len(rows) == 0 {
+		t.Error("real cli.Flags has no flag: tagged fields -- at least one expected")
+	}
+}
+
+// ---- renderDefault ----------------------------------------------------------
+
+func TestRenderDefault_Empty(t *testing.T) {
+	if got := renderDefault(""); got != "(none)" {
+		t.Errorf("renderDefault(\"\") = %q, want (none)", got)
+	}
+}
+
+func TestRenderDefault_Literal(t *testing.T) {
+	if got := renderDefault("false"); got != "`false`" {
+		t.Errorf("renderDefault(false) = %q, want `false`", got)
+	}
+}
+
+func TestRenderDefault_Path(t *testing.T) {
+	if got := renderDefault("/config/app.db"); got != "`/config/app.db`" {
+		t.Errorf("renderDefault path = %q", got)
+	}
+}
+
+// ---- flagDocType ------------------------------------------------------------
+
+func TestFlagDocType_Bool(t *testing.T) {
+	if got := flagDocType(reflect.TypeOf(false)); got != "boolean" {
+		t.Errorf("bool type = %q, want boolean", got)
+	}
+}
+
+func TestFlagDocType_String(t *testing.T) {
+	if got := flagDocType(reflect.TypeOf("")); got != "string" {
+		t.Errorf("string type = %q, want string", got)
+	}
+}
+
+func TestFlagDocType_Int(t *testing.T) {
+	if got := flagDocType(reflect.TypeOf(0)); got != "integer" {
+		t.Errorf("int type = %q, want integer", got)
+	}
+}
+
+// ---- escapeMarkdownCell ----------------------------------------------------
+
+func TestEscapeMarkdownCell_Pipe(t *testing.T) {
+	if got := escapeMarkdownCell("a|b"); got != `a\|b` {
+		t.Errorf("pipe not escaped: got %q", got)
+	}
+}
+
+func TestEscapeMarkdownCell_Newline(t *testing.T) {
+	if got := escapeMarkdownCell("line1\nline2"); got != "line1<br>line2" {
+		t.Errorf("newline not replaced: got %q", got)
+	}
+}
+
+func TestEscapeMarkdownCell_Clean(t *testing.T) {
+	if got := escapeMarkdownCell("no special"); got != "no special" {
+		t.Errorf("clean string should pass through: got %q", got)
+	}
+}
+
+// ---- renderContent ----------------------------------------------------------
+
+func TestRenderContent_HasFlagsHeader(t *testing.T) {
+	rows := []flagRow{
+		{Name: "reset-password", Type: "boolean", Default: "`false`", Description: "Reset password."},
+	}
+	got := renderContent(rows, nil)
+	if !strings.Contains(got, "| Flag | Type | Default | Description |") {
+		t.Errorf("flags table header missing; got:\n%s", got)
+	}
+	if !strings.Contains(got, "| `--reset-password`") {
+		t.Errorf("flag row missing; got:\n%s", got)
+	}
+}
+
+func TestRenderContent_SubcommandsSection(t *testing.T) {
+	rows := []flagRow{
+		{Name: "verbose", Type: "boolean", Default: "`false`", Description: "Verbose mode."},
+	}
+	subs := []icli.SubcommandInfo{
+		{Name: "reset-credentials", Summary: "Wipe credentials.", Details: "Full details here."},
+	}
+	got := renderContent(rows, subs)
+	if !strings.Contains(got, "## Subcommands") {
+		t.Errorf("subcommands section missing; got:\n%s", got)
+	}
+	if !strings.Contains(got, "reset-credentials") {
+		t.Errorf("subcommand name missing; got:\n%s", got)
+	}
+	if !strings.Contains(got, "Full details here.") {
+		t.Errorf("subcommand details missing; got:\n%s", got)
+	}
+}
+
+func TestRenderContent_NoSubcommandsNoSection(t *testing.T) {
+	rows := []flagRow{
+		{Name: "verbose", Type: "boolean", Default: "`false`", Description: "Verbose."},
+	}
+	got := renderContent(rows, nil)
+	if strings.Contains(got, "## Subcommands") {
+		t.Errorf("subcommands section should be absent when nil; got:\n%s", got)
+	}
+}
+
+// ---- replaceBetweenMarkers --------------------------------------------------
+
+func TestReplaceBetweenMarkers(t *testing.T) {
+	src := []byte("prefix\n" + beginMarker + "\nstale body\n" + endMarker + "\nsuffix\n")
+	out, err := replaceBetweenMarkers(src, beginMarker, endMarker, "fresh body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "prefix\n" + beginMarker + "\nfresh body\n" + endMarker + "\nsuffix\n"
+	if string(out) != want {
+		t.Fatalf("unexpected output\nwant:\n%s\n\ngot:\n%s", want, string(out))
+	}
+}
+
+func TestReplaceBetweenMarkers_MissingBegin(t *testing.T) {
+	_, err := replaceBetweenMarkers([]byte("no markers here"), beginMarker, endMarker, "body")
+	if err == nil {
+		t.Fatal("expected error when begin marker is missing")
+	}
+	if !strings.Contains(err.Error(), "begin marker") {
+		t.Errorf("error should mention begin marker; got %v", err)
+	}
+}
+
+func TestReplaceBetweenMarkers_MissingEnd(t *testing.T) {
+	src := []byte("prefix " + beginMarker + " no end")
+	_, err := replaceBetweenMarkers(src, beginMarker, endMarker, "body")
+	if err == nil {
+		t.Fatal("expected error when end marker is missing")
+	}
+	if !strings.Contains(err.Error(), "end marker") {
+		t.Errorf("error should mention end marker; got %v", err)
+	}
+}
+
+func TestReplaceBetweenMarkers_TrailingNewlines(t *testing.T) {
+	src := []byte("a\n" + beginMarker + "\nold\n" + endMarker + "\nb\n")
+	out, err := replaceBetweenMarkers(src, beginMarker, endMarker, "new\n\n\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "a\n" + beginMarker + "\nnew\n" + endMarker + "\nb\n"
+	if string(out) != want {
+		t.Fatalf("trailing newlines not normalized\nwant:\n%s\ngot:\n%s", want, string(out))
+	}
+}
+
+// ---- run() ------------------------------------------------------------------
+
+// writeFixtureDoc writes a docs file with the begin/end markers wrapping
+// stale body text, returns the path. Used by run() tests.
+func writeFixtureDoc(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cli.md")
+	content := "intro\n" + beginMarker + "\n" + body + "\n" + endMarker + "\nfooter\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("seed fixture: %v", err)
+	}
+	return path
+}
+
+func TestRun_RewritesStaleContent(t *testing.T) {
+	path := writeFixtureDoc(t, "STALE TABLE")
+	if err := run(path, false); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), "STALE TABLE") {
+		t.Errorf("stale body should be replaced; got:\n%s", got)
+	}
+	if !strings.Contains(string(got), "| Flag | Type | Default | Description |") {
+		t.Errorf("regenerated table header missing; got:\n%s", got)
+	}
+	if !strings.Contains(string(got), "intro\n") || !strings.Contains(string(got), "footer\n") {
+		t.Errorf("manual prose around markers should be preserved; got:\n%s", got)
+	}
+}
+
+func TestRun_NoChangeIsNoop(t *testing.T) {
+	path := writeFixtureDoc(t, "STALE")
+	if err := run(path, false); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := run(path, false); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("second run should be a no-op (content unchanged)")
+	}
+}
+
+func TestRun_CheckMode_StaleErrors(t *testing.T) {
+	path := writeFixtureDoc(t, "STALE")
+	err := run(path, true)
+	if err == nil {
+		t.Fatal("expected error in -check mode against stale file")
+	}
+	if !strings.Contains(err.Error(), "stale") {
+		t.Errorf("error should mention staleness; got: %v", err)
+	}
+}
+
+func TestRun_CheckMode_FreshSucceeds(t *testing.T) {
+	path := writeFixtureDoc(t, "STALE")
+	if err := run(path, false); err != nil {
+		t.Fatalf("seed regen: %v", err)
+	}
+	if err := run(path, true); err != nil {
+		t.Errorf("check mode should pass on fresh file; got: %v", err)
+	}
+}
+
+func TestRun_MissingFile(t *testing.T) {
+	err := run(filepath.Join(t.TempDir(), "does-not-exist.md"), false)
+	if err == nil {
+		t.Fatal("expected error when output path does not exist")
+	}
+	if !strings.Contains(err.Error(), "read") {
+		t.Errorf("error should mention read failure; got: %v", err)
+	}
+}
+
+func TestRun_MissingMarkers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cli.md")
+	if err := os.WriteFile(path, []byte("no markers here\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := run(path, false)
+	if err == nil {
+		t.Fatal("expected error when markers are absent")
+	}
+	if !strings.Contains(err.Error(), "marker") {
+		t.Errorf("error should mention marker; got: %v", err)
+	}
+}

--- a/cmd/gen-env-reference/main.go
+++ b/cmd/gen-env-reference/main.go
@@ -9,6 +9,14 @@
 // BEGIN/END markers in the docs file. Manual prose around the markers is
 // preserved.
 //
+// Coverage contract:
+//
+//	Every field in internal/config.Config that carries an env: tag must also
+//	carry a desc: tag. The generator enforces this at generation time: adding
+//	a new env: field without a desc: tag causes generation to fail with a
+//	clear error identifying the field and variable. This is the primary
+//	docs-coverage gate for the environment-variable surface.
+//
 // Usage:
 //
 //	go run ./cmd/gen-env-reference              # rewrite the file in place

--- a/cmd/gen-prefs-reference/main.go
+++ b/cmd/gen-prefs-reference/main.go
@@ -4,6 +4,17 @@
 // preference key, its default value, allowed values or range, and a
 // description resolved from the i18n locale file.
 //
+// Coverage contract:
+//
+//	Every preference in api.PreferenceRegistry() appears in the generated
+//	table (the generator covers the full registry). The label and description
+//	columns are resolved from the i18n locale file (internal/i18n/locales/en.json);
+//	a preference key without a matching i18n entry renders with an empty
+//	description rather than failing (soft coverage -- the label falls back to
+//	a snake_case-to-Title conversion). Adding a new preference to the registry
+//	without corresponding i18n entries will produce a table row with an empty
+//	Description; this is a soft gap, not a build failure.
+//
 // Usage:
 //
 //	go run ./cmd/gen-prefs-reference              # rewrite the file in place

--- a/cmd/gen-rules-catalogue/main.go
+++ b/cmd/gen-rules-catalogue/main.go
@@ -4,6 +4,15 @@
 // rule.CatalogueEntry() for per-rule fix-behavior documentation metadata).
 // It writes Markdown between the well-known BEGIN/END markers in the docs file.
 //
+// Coverage contract:
+//
+//	Every rule ID returned by rule.DefaultRules() must have an entry in the
+//	catalogue (rule.CatalogueEntry returns the zero value for unknown IDs).
+//	The generator validates this at generation time and fails loudly if any
+//	rule is missing catalogue metadata. The test in internal/rule/catalogue_test.go
+//	(TestCatalogue_AllDefaultRulesPresent) provides additional coverage at
+//	`go test` time.
+//
 // Usage:
 //
 //	go run ./cmd/gen-rules-catalogue              # rewrite the file in place
@@ -48,6 +57,44 @@ func main() {
 }
 
 func run(outPath string, checkOnly bool) error {
+	rules := rule.DefaultRules()
+
+	// Coverage enforcement: every rule in DefaultRules() must have a catalogue
+	// entry. rule.CatalogueEntry returns the zero-value RuleCatalogueEntry for
+	// unknown IDs, which would silently produce incomplete documentation. Fail
+	// loudly here so a newly registered rule without catalogue metadata is
+	// caught at generation time rather than shipping incomplete docs.
+	// (internal/rule/catalogue_test.go TestCatalogue_AllDefaultRulesPresent
+	// provides defense-in-depth at `go test` time.)
+	var missing []string
+	for i := range rules {
+		r := &rules[i]
+		entry := rule.CatalogueEntry(r.ID)
+		// The zero-value has an empty Guards field and all other fields empty.
+		// Using a field that would always be non-empty for a real entry to
+		// distinguish zero-value from intentional defaults is fragile. Instead
+		// we check whether the ID key is present in the catalogue by comparing
+		// against the public CatalogueEntry accessor. A zero-value entry with
+		// all empty strings is the sentinel for "missing"; a rule intentionally
+		// marked detection-only must still have an explicit entry with at least
+		// FixBehavior: "" set (the struct zero value -- but stored explicitly).
+		// To avoid a false positive for rules that genuinely have empty Guards
+		// and FixBehavior, we gate on: the entry is zero AND the rule is NOT
+		// in the catalogue map (by re-checking via a helper).
+		if rule.CatalogueEntryPresent(r.ID) {
+			_ = entry // validated; used during rendering
+			continue
+		}
+		missing = append(missing, r.ID)
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf(
+			"coverage gap: the following rule IDs have no entry in the catalogue; "+
+				"add an entry in internal/rule/catalogue.go for each: %v",
+			missing,
+		)
+	}
+
 	// outPath comes from the -output flag (or the default docs path); this
 	// is a developer-only build-time tool, so a configurable path is intended.
 	existing, err := os.ReadFile(outPath) //nolint:gosec // G304: developer CLI, path is intentionally configurable
@@ -55,7 +102,7 @@ func run(outPath string, checkOnly bool) error {
 		return fmt.Errorf("read %s: %w", outPath, err)
 	}
 
-	rendered := renderCatalogue(rule.DefaultRules())
+	rendered := renderCatalogue(rules)
 	updated, err := replaceBetweenMarkers(existing, beginMarker, endMarker, rendered)
 	if err != nil {
 		return fmt.Errorf("update %s: %w", outPath, err)

--- a/cmd/gen-rules-catalogue/main.go
+++ b/cmd/gen-rules-catalogue/main.go
@@ -69,20 +69,10 @@ func run(outPath string, checkOnly bool) error {
 	var missing []string
 	for i := range rules {
 		r := &rules[i]
-		entry := rule.CatalogueEntry(r.ID)
-		// The zero-value has an empty Guards field and all other fields empty.
-		// Using a field that would always be non-empty for a real entry to
-		// distinguish zero-value from intentional defaults is fragile. Instead
-		// we check whether the ID key is present in the catalogue by comparing
-		// against the public CatalogueEntry accessor. A zero-value entry with
-		// all empty strings is the sentinel for "missing"; a rule intentionally
-		// marked detection-only must still have an explicit entry with at least
-		// FixBehavior: "" set (the struct zero value -- but stored explicitly).
-		// To avoid a false positive for rules that genuinely have empty Guards
-		// and FixBehavior, we gate on: the entry is zero AND the rule is NOT
-		// in the catalogue map (by re-checking via a helper).
+		// Coverage enforcement: every DefaultRules() ID must have an explicit
+		// catalogue entry (CatalogueEntryPresent). Fail loudly here rather than
+		// shipping zero-value docs (renderCatalogue re-fetches each entry).
 		if rule.CatalogueEntryPresent(r.ID) {
-			_ = entry // validated; used during rendering
 			continue
 		}
 		missing = append(missing, r.ID)

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sydlexius/stillwater/internal/artist"
 	"github.com/sydlexius/stillwater/internal/auth"
 	"github.com/sydlexius/stillwater/internal/backup"
+	"github.com/sydlexius/stillwater/internal/cli"
 	"github.com/sydlexius/stillwater/internal/config"
 	"github.com/sydlexius/stillwater/internal/connection"
 	"github.com/sydlexius/stillwater/internal/database"
@@ -81,17 +82,20 @@ func main() {
 		}
 	}
 
-	// Parse global flags
-	resetPwd := flag.Bool("reset-password", false, "Reset admin password and exit")
-	username := flag.String("username", "", "Username for password reset")
-	newPassword := flag.String("new-password", "", "New password (insecure: visible in process list; prefer interactive prompt)")
+	// Parse global flags. cli.Flags is the source of truth for flag metadata;
+	// cmd/gen-cli-reference reads the same struct to generate the CLI reference
+	// page in docs/. Any new flag must be added there first so that the
+	// generated docs stay in sync (the generator fails loudly if a flag: field
+	// lacks a desc: tag).
+	var cliFlags cli.Flags
+	cli.RegisterFlags(flag.CommandLine, &cliFlags)
 	flag.Parse()
 
-	if *resetPwd {
-		if *newPassword != "" {
+	if cliFlags.ResetPassword {
+		if cliFlags.NewPassword != "" {
 			fmt.Fprintln(os.Stderr, "warning: --new-password exposes the password in process arguments; consider using the interactive prompt instead")
 		}
-		if err := resetPassword(*username, *newPassword); err != nil {
+		if err := resetPassword(cliFlags.Username, cliFlags.NewPassword); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -88,7 +88,10 @@ func main() {
 	// generated docs stay in sync (the generator fails loudly if a flag: field
 	// lacks a desc: tag).
 	var cliFlags cli.Flags
-	cli.RegisterFlags(flag.CommandLine, &cliFlags)
+	if err := cli.RegisterFlags(flag.CommandLine, &cliFlags); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
 	flag.Parse()
 
 	if cliFlags.ResetPassword {

--- a/docs/_generated/make-commands.md
+++ b/docs/_generated/make-commands.md
@@ -18,7 +18,7 @@
 | `make templ` | Generate Go code from Templ templates |
 | `make tailwind` | Build Tailwind CSS |
 | `make generate` | Run all code generation (templ + tailwind) |
-| `make generate-docs` | Regenerate docs site content from code (provider matrix, env-var reference, rules catalogue, settings reference, doc anchors, envelope-versions, make-command reference, platform-profiles, preferences reference) |
+| `make generate-docs` | Regenerate docs site content from code (provider matrix, env-var reference, CLI reference, rules catalogue, settings reference, doc anchors, envelope-versions, make-command reference, platform-profiles, preferences reference). Each generator enforces coverage: a new code-defined key without a desc: tag or doc entry fails the build. |
 | `make tailwind-watch` | Watch and rebuild Tailwind CSS |
 | `make migrate` | Run database migrations |
 | `make favicon` | Regenerate PNG favicons from logo design |

--- a/docs/site/src/reference/cli.md
+++ b/docs/site/src/reference/cli.md
@@ -1,0 +1,50 @@
+---
+description: Every command-line flag and subcommand the stillwater binary accepts, with defaults and descriptions.
+---
+
+# CLI reference
+
+Stillwater is primarily configured through environment variables and a TOML config file. Command-line flags exist for a small set of administrative one-shot operations that must run offline (before or without starting the server).
+
+**When to use flags vs environment variables:** use environment variables (or the config file) for everything that applies to a running server instance. Use CLI flags when you need to perform a one-time administrative action -- like resetting a password -- without starting the full server.
+
+## Subcommands
+
+Subcommands are passed as the first positional argument before any flags:
+
+```
+stillwater reset-credentials
+```
+
+The `reset-credentials` subcommand wipes all stored credentials and forces a fresh setup on next start. It clears provider API keys, connection credentials, user accounts, and sessions. Use this when the encryption key is lost or credentials need to be re-entered from scratch.
+
+## Usage
+
+```
+stillwater [flags]
+stillwater <subcommand>
+```
+
+The table below is generated from `internal/cli.Flags` and the `Subcommands` slice in the same package. Do not edit it by hand -- run `make generate-docs` after changing a CLI flag or subcommand.
+
+<!-- BEGIN GENERATED: cli-reference -->
+## Flags
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--reset-password` | boolean | `false` | Reset the admin user password and exit. Prompts interactively unless --new-password is also set. |
+| `--username` | string | (none) | Username for --reset-password. When omitted, defaults to the sole admin user in the database. |
+| `--new-password` | string | (none) | New password for --reset-password (INSECURE: visible in process listings; prefer the interactive prompt instead). |
+
+## Subcommands
+
+Subcommands are passed as the first positional argument before any flags (e.g. `stillwater reset-credentials`).
+
+| Subcommand | Summary |
+|---|---|
+| `reset-credentials` | Wipe all stored credentials and force a fresh setup on next start. |
+
+### `reset-credentials`
+
+Clears all provider API keys, connection credentials, user accounts, and active sessions from the database. Use this when the encryption key is lost or credentials need to be re-entered from scratch. The application will prompt for initial setup on the next start. Requires database access (SW_DB_PATH or SW_CONFIG_PATH must resolve to the live database).
+<!-- END GENERATED: cli-reference -->

--- a/docs/site/src/reference/index.md
+++ b/docs/site/src/reference/index.md
@@ -40,6 +40,14 @@ The map for "where do I find the exact list of X?" Each page is a deep enumerati
 
     [Read more](environment-variables.md)
 
+- __CLI reference__
+
+    ---
+
+    Every command-line flag and subcommand the stillwater binary accepts, with types, defaults, and descriptions. Generated from the Go flags registry.
+
+    [Read more](cli.md)
+
 - __Preferences reference__
 
     ---

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -126,12 +126,23 @@ func registerStructFlags(fs *flag.FlagSet, t reflect.Type, v reflect.Value) erro
 			if err != nil {
 				return fmt.Errorf("field %s has invalid bool default %q: %w", field.Name, raw, err)
 			}
-			// Addr().Interface() returns the concrete *bool pointer so we can
-			// pass it directly to BoolVar without importing unsafe.
-			fs.BoolVar(fv.Addr().Interface().(*bool), flagName, defaultVal, desc)
+			// Guard the type assertion: Kind()==Bool also matches named types
+			// (e.g. `type myBool bool`) whose concrete pointer is *myBool, not
+			// *bool. A bare cast would panic on those, violating this function's
+			// fail-loud contract. Use the comma-ok form and return an error
+			// instead so a misdeclared field surfaces at startup, not as a panic.
+			ptr, ok := fv.Addr().Interface().(*bool)
+			if !ok {
+				return fmt.Errorf("field %s for flag %q must be builtin bool, got %s", field.Name, flagName, field.Type)
+			}
+			fs.BoolVar(ptr, flagName, defaultVal, desc)
 		case reflect.String:
 			defaultVal := field.Tag.Get("default")
-			fs.StringVar(fv.Addr().Interface().(*string), flagName, defaultVal, desc)
+			ptr, ok := fv.Addr().Interface().(*string)
+			if !ok {
+				return fmt.Errorf("field %s for flag %q must be builtin string, got %s", field.Name, flagName, field.Type)
+			}
+			fs.StringVar(ptr, flagName, defaultVal, desc)
 		default:
 			return fmt.Errorf("field %s has unsupported kind %s for flag %q", field.Name, field.Type.Kind(), flagName)
 		}

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -9,21 +9,27 @@
 // Usage in the main binary:
 //
 //	var f cli.Flags
-//	cli.RegisterFlags(flag.CommandLine, &f)
+//	if err := cli.RegisterFlags(flag.CommandLine, &f); err != nil { ... }
 //	flag.Parse()
 //	if f.ResetPassword { ... }
 package cli
 
 import (
+	"errors"
 	"flag"
+	"fmt"
 	"reflect"
+	"strconv"
 )
 
 // Flags holds all global CLI flags accepted by the stillwater binary.
 // Each field carries three struct tags:
 //
 //   - flag:    the exact flag name users pass on the command line
-//   - default: the default value as a string (used in generated docs)
+//   - default: the default value as a string. RegisterFlags parses this and
+//     passes it to the flag package, so it is the actual runtime default the
+//     flag holds when unset (not merely documentation); it also appears in the
+//     generated docs.
 //   - desc:    a one-sentence user-facing description (required; the generator
 //     fails loudly if absent, enforcing coverage for every flag)
 type Flags struct {
@@ -76,16 +82,31 @@ var Subcommands = []SubcommandInfo{
 }
 
 // RegisterFlags binds the fields of f to the given flag set using the flag:
-// and default: struct tags. Call this before flag.Parse(). All flags receive
-// their zero-value defaults when the corresponding flag is not passed; the
-// default: tag is documentation-only and does not affect runtime behavior
-// (the Go flag package uses the zero value of the type for unset flags unless
-// an explicit default is passed to the flag registration call, which this
-// function derives from the tag).
-func RegisterFlags(fs *flag.FlagSet, f *Flags) {
-	t := reflect.TypeOf(*f)
-	v := reflect.ValueOf(f).Elem()
+// and default: struct tags. Call this before flag.Parse(). The default: tag
+// supplies each flag's default value: RegisterFlags parses it and passes it to
+// the flag package's *Var call (BoolVar/StringVar), so it IS the value the flag
+// holds when the user does not pass the flag on the command line. (A bool's
+// default: tag is parsed with strconv.ParseBool; a string's is used verbatim.)
+//
+// RegisterFlags returns an error on misconfigured tag metadata -- an
+// unsupported field kind or an unparsable bool default -- so the binary fails
+// loudly at startup rather than letting the documented defaults and the runtime
+// defaults silently drift apart. It nil-guards both arguments.
+func RegisterFlags(fs *flag.FlagSet, f *Flags) error {
+	if fs == nil {
+		return errors.New("RegisterFlags: nil flag set")
+	}
+	if f == nil {
+		return errors.New("RegisterFlags: nil Flags")
+	}
+	return registerStructFlags(fs, reflect.TypeOf(*f), reflect.ValueOf(f).Elem())
+}
 
+// registerStructFlags reflects over the fields of the struct described by t/v
+// and registers a flag for each field carrying a flag: tag. It is the
+// unexported core of RegisterFlags, split out so its error branches are
+// reachable from tests with deliberately malformed structs.
+func registerStructFlags(fs *flag.FlagSet, t reflect.Type, v reflect.Value) error {
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		flagName := field.Tag.Get("flag")
@@ -95,15 +116,25 @@ func RegisterFlags(fs *flag.FlagSet, f *Flags) {
 		}
 
 		fv := v.Field(i)
-		switch field.Type.Kind() { //nolint:exhaustive // only bool and string are used today
+		switch field.Type.Kind() {
 		case reflect.Bool:
-			defaultVal := field.Tag.Get("default") == "true"
+			raw := field.Tag.Get("default")
+			if raw == "" {
+				raw = "false"
+			}
+			defaultVal, err := strconv.ParseBool(raw)
+			if err != nil {
+				return fmt.Errorf("field %s has invalid bool default %q: %w", field.Name, raw, err)
+			}
 			// Addr().Interface() returns the concrete *bool pointer so we can
 			// pass it directly to BoolVar without importing unsafe.
 			fs.BoolVar(fv.Addr().Interface().(*bool), flagName, defaultVal, desc)
 		case reflect.String:
 			defaultVal := field.Tag.Get("default")
 			fs.StringVar(fv.Addr().Interface().(*string), flagName, defaultVal, desc)
+		default:
+			return fmt.Errorf("field %s has unsupported kind %s for flag %q", field.Name, field.Type.Kind(), flagName)
 		}
 	}
+	return nil
 }

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -1,0 +1,109 @@
+// Package cli defines the structured metadata for Stillwater's command-line
+// flags. The Flags struct uses struct tags to declare each flag's name, default
+// value, and user-facing description -- the same pattern config.Config uses for
+// environment variables. The cmd/gen-cli-reference generator reflects over this
+// struct to produce the CLI flags reference page; adding a new flag to Flags
+// automatically includes it in the generated docs and fails the generator if
+// its desc: tag is missing (coverage enforcement).
+//
+// Usage in the main binary:
+//
+//	var f cli.Flags
+//	cli.RegisterFlags(flag.CommandLine, &f)
+//	flag.Parse()
+//	if f.ResetPassword { ... }
+package cli
+
+import (
+	"flag"
+	"reflect"
+)
+
+// Flags holds all global CLI flags accepted by the stillwater binary.
+// Each field carries three struct tags:
+//
+//   - flag:    the exact flag name users pass on the command line
+//   - default: the default value as a string (used in generated docs)
+//   - desc:    a one-sentence user-facing description (required; the generator
+//     fails loudly if absent, enforcing coverage for every flag)
+type Flags struct {
+	// ResetPassword, when true, resets the admin user password and exits.
+	// The --username and --new-password flags control whose password is changed
+	// and how the new value is supplied.
+	ResetPassword bool `flag:"reset-password" default:"false" desc:"Reset the admin user password and exit. Prompts interactively unless --new-password is also set."`
+
+	// Username specifies which user account to target for --reset-password.
+	// When empty, Stillwater picks the only admin user in the database, or
+	// returns an error if more than one admin exists.
+	Username string `flag:"username" default:"" desc:"Username for --reset-password. When omitted, defaults to the sole admin user in the database."`
+
+	// NewPassword, when set, supplies the new password for --reset-password
+	// without an interactive prompt. Exposing a password via a command-line
+	// argument is insecure because it appears in process listings (ps, top,
+	// /proc); prefer the interactive prompt whenever possible.
+	NewPassword string `flag:"new-password" default:"" desc:"New password for --reset-password (INSECURE: visible in process listings; prefer the interactive prompt instead)."`
+}
+
+// SubcommandInfo describes a CLI subcommand (os.Args[1] dispatch) that
+// Stillwater recognizes. Subcommands are handled before flag parsing and
+// accept no additional flags themselves.
+type SubcommandInfo struct {
+	// Name is the exact string to pass as the first argument (e.g.
+	// "reset-credentials").
+	Name string
+
+	// Summary is a one-sentence description of what the subcommand does.
+	Summary string
+
+	// Details is a longer description including behavior and caveats,
+	// formatted as plain prose for rendering in the docs page.
+	Details string
+}
+
+// Subcommands lists every subcommand the stillwater binary recognizes.
+// The generator reads this slice to produce the "Subcommands" section
+// of the CLI reference page.
+var Subcommands = []SubcommandInfo{
+	{
+		Name:    "reset-credentials",
+		Summary: "Wipe all stored credentials and force a fresh setup on next start.",
+		Details: "Clears all provider API keys, connection credentials, user accounts, and " +
+			"active sessions from the database. Use this when the encryption key is lost " +
+			"or credentials need to be re-entered from scratch. The application will prompt " +
+			"for initial setup on the next start. Requires database access (SW_DB_PATH or " +
+			"SW_CONFIG_PATH must resolve to the live database).",
+	},
+}
+
+// RegisterFlags binds the fields of f to the given flag set using the flag:
+// and default: struct tags. Call this before flag.Parse(). All flags receive
+// their zero-value defaults when the corresponding flag is not passed; the
+// default: tag is documentation-only and does not affect runtime behavior
+// (the Go flag package uses the zero value of the type for unset flags unless
+// an explicit default is passed to the flag registration call, which this
+// function derives from the tag).
+func RegisterFlags(fs *flag.FlagSet, f *Flags) {
+	t := reflect.TypeOf(*f)
+	v := reflect.ValueOf(f).Elem()
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		flagName := field.Tag.Get("flag")
+		desc := field.Tag.Get("desc")
+		if flagName == "" {
+			continue
+		}
+
+		fv := v.Field(i)
+		switch field.Type.Kind() { //nolint:exhaustive // only bool and string are used today
+		case reflect.Bool:
+			defaultVal := field.Tag.Get("default") == "true"
+			// Addr().Interface() returns the concrete *bool pointer so we can
+			// pass it directly to BoolVar without importing unsafe.
+			fs.BoolVar(fv.Addr().Interface().(*bool), flagName, defaultVal, desc)
+		case reflect.String:
+			defaultVal := field.Tag.Get("default")
+			fs.StringVar(fv.Addr().Interface().(*string), flagName, defaultVal, desc)
+		}
+	}
+}

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -118,7 +118,19 @@ func TestRegisterStructFlags_ErrorBranches(t *testing.T) {
 	type badBoolDefault struct {
 		On bool `flag:"on" default:"notabool" desc:"a toggle"`
 	}
-	// (c) A well-formed struct must register without error.
+	// (c) A named-bool field (Kind()==Bool but concrete pointer is *myBool,
+	// not *bool) must hit the guarded type-assertion error rather than panic.
+	type myBool bool
+	type namedBoolField struct {
+		On myBool `flag:"on" default:"false" desc:"a toggle"`
+	}
+	// (d) A named-string field (Kind()==String but concrete pointer is
+	// *myString, not *string) must likewise hit the guarded error path.
+	type myString string
+	type namedStringField struct {
+		Name myString `flag:"name" default:"x" desc:"a name"`
+	}
+	// (e) A well-formed struct must register without error.
 	type validStruct struct {
 		Verbose bool   `flag:"verbose" default:"true" desc:"verbose output"`
 		Name    string `flag:"name" default:"world" desc:"a name"`
@@ -131,6 +143,8 @@ func TestRegisterStructFlags_ErrorBranches(t *testing.T) {
 	}{
 		{"unsupported kind", unsupportedKind{}, true},
 		{"invalid bool default", badBoolDefault{}, true},
+		{"named bool type", namedBoolField{}, true},
+		{"named string type", namedStringField{}, true},
 		{"valid struct", validStruct{}, false},
 	}
 	for _, tc := range tests {

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"flag"
+	"reflect"
 	"testing"
 )
 
@@ -16,7 +17,9 @@ func TestRegisterFlags_AllFlagsRegistered(t *testing.T) {
 	// flag.CommandLine with repeated registrations.
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	var f Flags
-	RegisterFlags(fs, &f)
+	if err := RegisterFlags(fs, &f); err != nil {
+		t.Fatalf("RegisterFlags: %v", err)
+	}
 
 	// Verify each expected flag is registered with the correct type.
 	wantFlags := []struct {
@@ -44,7 +47,9 @@ func TestRegisterFlags_AllFlagsRegistered(t *testing.T) {
 func TestRegisterFlags_ParsesIntoStruct(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	var f Flags
-	RegisterFlags(fs, &f)
+	if err := RegisterFlags(fs, &f); err != nil {
+		t.Fatalf("RegisterFlags: %v", err)
+	}
 
 	args := []string{"--reset-password", "--username=alice", "--new-password=s3cret"}
 	if err := fs.Parse(args); err != nil {
@@ -61,12 +66,16 @@ func TestRegisterFlags_ParsesIntoStruct(t *testing.T) {
 	}
 }
 
-// TestRegisterFlags_Defaults verifies that unparsed flags retain their zero
-// defaults (not the default: struct tag values, which are documentation-only).
+// TestRegisterFlags_Defaults verifies that unparsed flags retain the defaults
+// declared via the default: struct tags. For the current Flags struct those
+// defaults happen to equal each type's zero value (false / ""), so this also
+// confirms the parsed tag value and the zero value agree here.
 func TestRegisterFlags_Defaults(t *testing.T) {
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
 	var f Flags
-	RegisterFlags(fs, &f)
+	if err := RegisterFlags(fs, &f); err != nil {
+		t.Fatalf("RegisterFlags: %v", err)
+	}
 
 	if err := fs.Parse(nil); err != nil {
 		t.Fatalf("Parse: %v", err)
@@ -79,6 +88,65 @@ func TestRegisterFlags_Defaults(t *testing.T) {
 	}
 	if f.NewPassword != "" {
 		t.Errorf("NewPassword should default to empty string, got %q", f.NewPassword)
+	}
+}
+
+// TestRegisterFlags_NilArgs verifies that RegisterFlags fails loudly (returns a
+// non-nil error) rather than panicking when handed a nil flag set or nil Flags.
+func TestRegisterFlags_NilArgs(t *testing.T) {
+	var f Flags
+	if err := RegisterFlags(nil, &f); err == nil {
+		t.Error("RegisterFlags(nil fs) should return an error")
+	}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	if err := RegisterFlags(fs, nil); err == nil {
+		t.Error("RegisterFlags(nil f) should return an error")
+	}
+}
+
+// TestRegisterStructFlags_ErrorBranches exercises the fail-loud error branches
+// of the reflection core directly, using deliberately malformed local structs
+// that the exported Flags type cannot express (an unsupported field kind and an
+// unparsable bool default). These paths guard against documented defaults and
+// runtime defaults silently drifting apart.
+func TestRegisterStructFlags_ErrorBranches(t *testing.T) {
+	// (a) A flag-tagged field of an unsupported kind (int) must error.
+	type unsupportedKind struct {
+		Count int `flag:"count" default:"0" desc:"a count"`
+	}
+	// (b) A bool field with an unparsable default must error.
+	type badBoolDefault struct {
+		On bool `flag:"on" default:"notabool" desc:"a toggle"`
+	}
+	// (c) A well-formed struct must register without error.
+	type validStruct struct {
+		Verbose bool   `flag:"verbose" default:"true" desc:"verbose output"`
+		Name    string `flag:"name" default:"world" desc:"a name"`
+	}
+
+	tests := []struct {
+		name    string
+		val     any
+		wantErr bool
+	}{
+		{"unsupported kind", unsupportedKind{}, true},
+		{"invalid bool default", badBoolDefault{}, true},
+		{"valid struct", validStruct{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			// Take an addressable copy so Field().Addr() works inside the helper.
+			rv := reflect.New(reflect.TypeOf(tc.val)).Elem()
+			rv.Set(reflect.ValueOf(tc.val))
+			err := registerStructFlags(fs, rv.Type(), rv)
+			if tc.wantErr && err == nil {
+				t.Errorf("registerStructFlags(%s) = nil error, want non-nil", tc.name)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("registerStructFlags(%s) = %v, want nil", tc.name, err)
+			}
+		})
 	}
 }
 

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"flag"
+	"testing"
+)
+
+// TestRegisterFlags verifies that RegisterFlags binds every flag: field in the
+// Flags struct to the given FlagSet with the correct name and type. This test
+// also acts as a coverage enforcement gate: if a new field is added to Flags
+// without a flag: tag, RegisterFlags silently ignores it and the field would
+// not appear in the flag set -- which would be caught here if a matching
+// Lookup assertion is added.
+func TestRegisterFlags_AllFlagsRegistered(t *testing.T) {
+	// Use a fresh FlagSet so we do not pollute the test binary's
+	// flag.CommandLine with repeated registrations.
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	var f Flags
+	RegisterFlags(fs, &f)
+
+	// Verify each expected flag is registered with the correct type.
+	wantFlags := []struct {
+		name     string
+		defValue string
+	}{
+		{"reset-password", "false"},
+		{"username", ""},
+		{"new-password", ""},
+	}
+	for _, wf := range wantFlags {
+		fl := fs.Lookup(wf.name)
+		if fl == nil {
+			t.Errorf("flag %q not registered by RegisterFlags", wf.name)
+			continue
+		}
+		if fl.DefValue != wf.defValue {
+			t.Errorf("flag %q default = %q, want %q", wf.name, fl.DefValue, wf.defValue)
+		}
+	}
+}
+
+// TestRegisterFlags_ParsesIntoStruct verifies that parsing flags from a
+// FlagSet populated by RegisterFlags correctly updates the Flags fields.
+func TestRegisterFlags_ParsesIntoStruct(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	var f Flags
+	RegisterFlags(fs, &f)
+
+	args := []string{"--reset-password", "--username=alice", "--new-password=s3cret"}
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if !f.ResetPassword {
+		t.Error("ResetPassword should be true after --reset-password flag")
+	}
+	if f.Username != "alice" {
+		t.Errorf("Username = %q, want alice", f.Username)
+	}
+	if f.NewPassword != "s3cret" {
+		t.Errorf("NewPassword = %q, want s3cret", f.NewPassword)
+	}
+}
+
+// TestRegisterFlags_Defaults verifies that unparsed flags retain their zero
+// defaults (not the default: struct tag values, which are documentation-only).
+func TestRegisterFlags_Defaults(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	var f Flags
+	RegisterFlags(fs, &f)
+
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if f.ResetPassword {
+		t.Error("ResetPassword should default to false")
+	}
+	if f.Username != "" {
+		t.Errorf("Username should default to empty string, got %q", f.Username)
+	}
+	if f.NewPassword != "" {
+		t.Errorf("NewPassword should default to empty string, got %q", f.NewPassword)
+	}
+}
+
+// TestSubcommands_NonEmpty verifies that the Subcommands slice has at least one
+// entry and that each entry has a non-empty Name and Summary. The generator
+// renders every entry in this slice; an empty or malformed entry would produce
+// broken documentation.
+func TestSubcommands_NonEmpty(t *testing.T) {
+	if len(Subcommands) == 0 {
+		t.Fatal("Subcommands slice is empty; at least one subcommand expected")
+	}
+	for i, s := range Subcommands {
+		if s.Name == "" {
+			t.Errorf("Subcommands[%d].Name is empty", i)
+		}
+		if s.Summary == "" {
+			t.Errorf("Subcommands[%d].Summary is empty (Name=%q)", i, s.Name)
+		}
+		if s.Details == "" {
+			t.Errorf("Subcommands[%d].Details is empty (Name=%q)", i, s.Name)
+		}
+	}
+}

--- a/internal/rule/catalogue.go
+++ b/internal/rule/catalogue.go
@@ -313,6 +313,15 @@ func CatalogueEntry(id string) RuleCatalogueEntry {
 	return rulesCatalogue[id]
 }
 
+// CatalogueEntryPresent reports whether id has an explicit entry in the
+// catalogue map. It is used by generators that need to distinguish a
+// deliberately-empty entry from a missing one (a two-value map lookup
+// unavailable through CatalogueEntry's single-return signature).
+func CatalogueEntryPresent(id string) bool {
+	_, ok := rulesCatalogue[id]
+	return ok
+}
+
 // RuleFields returns the metadata field key(s) the given rule inspects, or nil
 // for image / whole-record / cross-field rules that carry no field tag. The
 // artist-detail page uses this to render an inline finding chip on the row of

--- a/internal/rule/catalogue_test.go
+++ b/internal/rule/catalogue_test.go
@@ -17,7 +17,7 @@ import (
 // FixBehavior: "" -- the explicit entry is what this test enforces.
 func TestCatalogue_AllDefaultRulesPresent(t *testing.T) {
 	for _, r := range DefaultRules() {
-		if _, ok := rulesCatalogue[r.ID]; !ok {
+		if !CatalogueEntryPresent(r.ID) {
 			t.Errorf("rule %q has no entry in rulesCatalogue (add one in internal/rule/catalogue.go)", r.ID)
 		}
 	}

--- a/scripts/check-generated.sh
+++ b/scripts/check-generated.sh
@@ -60,6 +60,17 @@ if [ -f docs/site/src/reference/environment-variables.md ]; then
   fi
 fi
 
+# Verify the CLI flags reference is in sync with internal/cli.Flags struct tags.
+# The generator also enforces coverage: it fails if any flag: field is missing
+# a desc: tag, so this check catches both drift and coverage gaps.
+# Skip silently if the docs file is absent (e.g., a docs-stripped checkout).
+if [ -f docs/site/src/reference/cli.md ]; then
+  if ! go run ./cmd/gen-cli-reference -check; then
+    echo "ERROR: docs/site/src/reference/cli.md is stale. Run: make generate-docs"
+    exit 1
+  fi
+fi
+
 # Verify the rules catalogue is in sync with the built-in rule definitions.
 # Skip silently if the docs file is absent (e.g., a docs-stripped checkout).
 if [ -f docs/site/src/reference/rules-catalogue.md ]; then


### PR DESCRIPTION
## Summary

Extends docs-as-code to the remaining code-defined surfaces and adds a docs-**coverage** gate, so a newly-defined key without a doc entry fails CI (not just a drift check on changed generated output). Follow-up to the 2026-06-15 drift audit.

- **CLI flags reference**: `internal/cli/flags.go` is a tagged-struct registry (the single source of truth for the CLI flags); `cmd/stillwater/main.go` registers its flags from it (no CLI behavior change). `cmd/gen-cli-reference` generates `docs/site/src/reference/cli.md`, wired into `make generate-docs` + `scripts/check-generated.sh`.
- **Docs-coverage gate** (generators fail loudly on missing metadata): `gen-cli-reference` fails if a flag lacks a `desc:` tag; `gen-rules-catalogue` fails if a `DefaultRules()` entry has no catalogue entry. Coverage-contract comments added to the other generators.
- **docs-drift advisory**: documented the hard-gate vs soft-advisory policy + candidate hardening surfaces as a maintainer decision. No workflow behavior change.

## Test plan

- `scripts/pre-push-gate.sh`: all hard checks pass (build, vet, tests, lint, OpenAPI, generated-file drift, patch coverage 83% > 75%).
- **Coverage gate proven** (hostile-reviewed): removing a flag's `desc:` tag makes `gen-cli-reference -check` exit 1; adding a rule without a catalogue entry makes `gen-rules-catalogue -check` exit 1.
- `internal/cli/flags_test.go` asserts the three flags parse with correct names/defaults; the generator tests cover `gen-cli-reference` (88.8%) and `gen-rules-catalogue` (91.7%); `catalogue_test.go` exercises the public `CatalogueEntryPresent`.

## Follow-up (not in this PR)

The docs-drift advisory remains soft (the hard gates cover all code-defined keys). Hardening high-risk hand-written surfaces (openapi.yaml-without-docs; destructive-handler-without-docs, per #1779/#2007) is tracked as a follow-up issue per maintainer decision.

Closes #2008


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive CLI reference documentation enumerating all command-line flags and subcommands with types, defaults, and descriptions.

* **Documentation**
  * New CLI reference page documenting available flags and reset-credentials administrative operation with database access requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->