### PR TITLE
fix(rules): seed "Last evaluated" from the DB so it survives restart + no-schedule (#1796)

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -591,6 +591,17 @@ func resolveRuleSchedule(a *Application, db *sql.DB, logger *slog.Logger) {
 		a.ruleScheduler = rule.NewScheduler(a.pipeline, a.ruleService, a.artistService, logger)
 		langprefRepo := langpref.NewRepository(db)
 		a.ruleScheduler.SetLangPrefProvider(langprefRepo.EffectiveForBackground)
+		// Seed the scheduler's in-memory lastRunAt from the DB so the
+		// dashboard's "Last evaluated" stat reflects the most recent previous-
+		// session evaluation after a server restart (#1796). Without this, the
+		// stat always shows "Never" until the first tick fires because lastRunAt
+		// is zero-initialized and never persisted across restarts.
+		if ts, err := a.artistService.LatestRulesEvaluatedAt(ctx); err != nil {
+			logger.Warn("could not seed last-evaluated timestamp from DB", "error", err)
+		} else if ts != nil {
+			a.ruleScheduler.SeedLastEvaluated(*ts)
+			logger.Debug("seeded scheduler last-evaluated from DB", "ts", ts.String())
+		}
 	} else if a.ruleScheduleMinutes > 0 && a.ruleScheduleMinutes < 5 {
 		logger.Warn("rule scheduler interval too short (minimum 5 minutes); scheduler not started",
 			"minutes", a.ruleScheduleMinutes)

--- a/internal/api/handlers_rule.go
+++ b/internal/api/handlers_rule.go
@@ -726,8 +726,18 @@ func (r *Router) handleRunAllRulesStatus(w http.ResponseWriter, req *http.Reques
 // GET /api/v1/rules/status
 func (r *Router) handleRulesStatus(w http.ResponseWriter, req *http.Request) {
 	if r.ruleScheduler == nil {
+		// No schedule is configured (rule_schedule.interval_minutes=0). The
+		// dashboard stat must still reflect real evaluations triggered by
+		// manual runs, so read last_evaluation_at directly from the DB (#1796).
+		var lastEval any
+		ts, err := r.artistService.LatestRulesEvaluatedAt(req.Context())
+		if err != nil {
+			r.logger.Warn("querying latest rules_evaluated_at for status", "error", err)
+		} else if ts != nil {
+			lastEval = ts
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
-			"last_evaluation_at": nil,
+			"last_evaluation_at": lastEval,
 			"interval_minutes":   0,
 			"next_evaluation_at": nil,
 			"scheduler_enabled":  false,

--- a/internal/api/handlers_rule_test.go
+++ b/internal/api/handlers_rule_test.go
@@ -797,12 +797,20 @@ func TestHandleRulesStatus_NoScheduler_ReturnsDBValue(t *testing.T) {
 	}
 
 	// scheduler_enabled must be false (no schedule configured).
-	if v, _ := resp["scheduler_enabled"].(bool); v {
+	seEnabled, ok := resp["scheduler_enabled"].(bool)
+	if !ok {
+		t.Fatalf("scheduler_enabled missing or not bool: %v", resp["scheduler_enabled"])
+	}
+	if seEnabled {
 		t.Error("scheduler_enabled: got true, want false")
 	}
 	// interval_minutes must be 0.
-	if v, _ := resp["interval_minutes"].(float64); int(v) != 0 {
-		t.Errorf("interval_minutes: got %v, want 0", v)
+	intervalMins, ok := resp["interval_minutes"].(float64)
+	if !ok {
+		t.Fatalf("interval_minutes missing or not float64: %v", resp["interval_minutes"])
+	}
+	if int(intervalMins) != 0 {
+		t.Errorf("interval_minutes: got %v, want 0", intervalMins)
 	}
 	// next_evaluation_at must be nil.
 	if resp["next_evaluation_at"] != nil {
@@ -863,7 +871,11 @@ func TestHandleRulesStatus_NoScheduler_DBError(t *testing.T) {
 	if resp["last_evaluation_at"] != nil {
 		t.Errorf("last_evaluation_at: got %v, want nil on DB parse error", resp["last_evaluation_at"])
 	}
-	if v, _ := resp["scheduler_enabled"].(bool); v {
+	seEnabled, ok := resp["scheduler_enabled"].(bool)
+	if !ok {
+		t.Fatalf("scheduler_enabled missing or not bool: %v", resp["scheduler_enabled"])
+	}
+	if seEnabled {
 		t.Error("scheduler_enabled: got true, want false")
 	}
 }
@@ -887,7 +899,11 @@ func TestHandleRulesStatus_NoScheduler_NoEvaluations(t *testing.T) {
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decoding response: %v", err)
 	}
-	if v, _ := resp["scheduler_enabled"].(bool); v {
+	seEnabled, ok := resp["scheduler_enabled"].(bool)
+	if !ok {
+		t.Fatalf("scheduler_enabled missing or not bool: %v", resp["scheduler_enabled"])
+	}
+	if seEnabled {
 		t.Error("scheduler_enabled: got true, want false")
 	}
 	if resp["last_evaluation_at"] != nil {

--- a/internal/api/handlers_rule_test.go
+++ b/internal/api/handlers_rule_test.go
@@ -822,6 +822,52 @@ func TestHandleRulesStatus_NoScheduler_ReturnsDBValue(t *testing.T) {
 	}
 }
 
+// TestHandleRulesStatus_NoScheduler_DBError verifies that when the scheduler is
+// nil and LatestRulesEvaluatedAt returns an error (e.g. a malformed
+// rules_evaluated_at value in the DB), handleRulesStatus still returns HTTP 200
+// with last_evaluation_at: null and scheduler_enabled: false instead of
+// propagating the error (#1796 error-path coverage).
+func TestHandleRulesStatus_NoScheduler_DBError(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouter(t)
+	r.ruleScheduler = nil
+
+	ctx := context.Background()
+
+	// Seed an artist so the DB has a non-excluded row for the MAX() query.
+	a := &artist.Artist{Name: "DBError Artist", Path: "/music/dberror"}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Write a non-RFC3339 value directly so time.Parse fails inside
+	// LatestRulesEvaluatedAt, exercising the error branch in handleRulesStatus.
+	if _, err := r.db.ExecContext(ctx,
+		`UPDATE artists SET rules_evaluated_at = 'INVALID-TIMESTAMP' WHERE id = ?`, a.ID); err != nil {
+		t.Fatalf("ExecContext: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rules/status", nil)
+	w := httptest.NewRecorder()
+	r.handleRulesStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	// Error must be swallowed; last_evaluation_at falls back to nil.
+	if resp["last_evaluation_at"] != nil {
+		t.Errorf("last_evaluation_at: got %v, want nil on DB parse error", resp["last_evaluation_at"])
+	}
+	if v, _ := resp["scheduler_enabled"].(bool); v {
+		t.Error("scheduler_enabled: got true, want false")
+	}
+}
+
 // TestHandleRulesStatus_NoScheduler_NoEvaluations verifies that the nil case
 // is preserved when the scheduler is nil AND no artist has been evaluated yet.
 func TestHandleRulesStatus_NoScheduler_NoEvaluations(t *testing.T) {

--- a/internal/api/handlers_rule_test.go
+++ b/internal/api/handlers_rule_test.go
@@ -757,3 +757,94 @@ func TestHandleRuleResults_QueryParamOverridesPref(t *testing.T) {
 		t.Errorf("expected at most 12 rows with query param override, got %d", len(rows))
 	}
 }
+
+// TestHandleRulesStatus_NoScheduler_ReturnsDBValue verifies that when no rule
+// scheduler is configured (ruleScheduler == nil, i.e. interval_minutes = 0),
+// the GET /api/v1/rules/status endpoint still returns the real last_evaluation_at
+// from the DB rather than a hard-coded nil (#1796). This is the path taken by
+// every default installation where rule_schedule.interval_minutes is not set.
+func TestHandleRulesStatus_NoScheduler_ReturnsDBValue(t *testing.T) {
+	t.Parallel()
+	r, artistSvc := testRouter(t)
+	r.ruleScheduler = nil // simulate default no-schedule configuration
+
+	ctx := context.Background()
+
+	// Seed one evaluated artist so the DB has a non-nil MAX(rules_evaluated_at).
+	a := &artist.Artist{
+		Name: "Status Artist",
+		Path: "/music/status",
+	}
+	if err := artistSvc.Create(ctx, a); err != nil {
+		t.Fatalf("Create artist: %v", err)
+	}
+	evalAt := time.Date(2025, 5, 20, 12, 0, 0, 0, time.UTC)
+	if err := artistSvc.MarkRulesEvaluated(ctx, a.ID, evalAt); err != nil {
+		t.Fatalf("MarkRulesEvaluated: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rules/status", nil)
+	w := httptest.NewRecorder()
+	r.handleRulesStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+
+	// scheduler_enabled must be false (no schedule configured).
+	if v, _ := resp["scheduler_enabled"].(bool); v {
+		t.Error("scheduler_enabled: got true, want false")
+	}
+	// interval_minutes must be 0.
+	if v, _ := resp["interval_minutes"].(float64); int(v) != 0 {
+		t.Errorf("interval_minutes: got %v, want 0", v)
+	}
+	// next_evaluation_at must be nil.
+	if resp["next_evaluation_at"] != nil {
+		t.Errorf("next_evaluation_at: got %v, want nil", resp["next_evaluation_at"])
+	}
+	// last_evaluation_at must be the DB value, not nil.
+	rawTS, ok := resp["last_evaluation_at"].(string)
+	if !ok || rawTS == "" {
+		t.Fatalf("last_evaluation_at: got %v (%T), want RFC3339 string", resp["last_evaluation_at"], resp["last_evaluation_at"])
+	}
+	got, err := time.Parse(time.RFC3339, rawTS)
+	if err != nil {
+		t.Fatalf("parsing last_evaluation_at %q: %v", rawTS, err)
+	}
+	if !got.Equal(evalAt) {
+		t.Errorf("last_evaluation_at: got %v, want %v", got, evalAt)
+	}
+}
+
+// TestHandleRulesStatus_NoScheduler_NoEvaluations verifies that the nil case
+// is preserved when the scheduler is nil AND no artist has been evaluated yet.
+func TestHandleRulesStatus_NoScheduler_NoEvaluations(t *testing.T) {
+	t.Parallel()
+	r, _ := testRouter(t)
+	r.ruleScheduler = nil
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rules/status", nil)
+	w := httptest.NewRecorder()
+	r.handleRulesStatus(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if v, _ := resp["scheduler_enabled"].(bool); v {
+		t.Error("scheduler_enabled: got true, want false")
+	}
+	if resp["last_evaluation_at"] != nil {
+		t.Errorf("last_evaluation_at: got %v, want nil (no evaluations in DB)", resp["last_evaluation_at"])
+	}
+}

--- a/internal/api/testdata/openapi-coverage-baseline.json
+++ b/internal/api/testdata/openapi-coverage-baseline.json
@@ -28,7 +28,6 @@
   "getOpenAPISpec",
   "getPlatform",
   "getPriorities",
-  "getRulesStatus",
   "getScannerStatus",
   "getScraperConfig",
   "getWebSearchProviders",

--- a/internal/api/testdata/openapi-coverage.json
+++ b/internal/api/testdata/openapi-coverage.json
@@ -816,7 +816,7 @@
     "method": "GET",
     "path": "/rules/status",
     "handler": "handleRulesStatus",
-    "covered": false
+    "covered": true
   },
   {
     "operationId": "getRunAllRulesStatus",

--- a/internal/artist/repository.go
+++ b/internal/artist/repository.go
@@ -104,6 +104,13 @@ type Repository interface {
 	// progress reporting.
 	CountEligibleArtists(ctx context.Context) (int, error)
 
+	// LatestRulesEvaluatedAt returns the most recent rules_evaluated_at
+	// timestamp across all non-excluded artists, or nil when no artist has
+	// ever been evaluated. Used to hydrate the scheduler's in-memory
+	// lastRunAt on startup so the dashboard's "Last evaluated" stat survives
+	// a server restart (#1796).
+	LatestRulesEvaluatedAt(ctx context.Context) (*time.Time, error)
+
 	// ListIDs returns the IDs of all artists matching the given filters,
 	// ordered by sort_name then id for a stable, deterministic sequence.
 	// Results are capped at MaxListIDs via a LIMIT clause. A separate

--- a/internal/artist/service.go
+++ b/internal/artist/service.go
@@ -387,6 +387,14 @@ func (s *Service) CountEligibleArtists(ctx context.Context) (int, error) {
 	return s.artists.CountEligibleArtists(ctx)
 }
 
+// LatestRulesEvaluatedAt returns the most recent rules_evaluated_at timestamp
+// across all non-excluded artists, or nil when no artist has ever been evaluated.
+// Used by the rule scheduler to hydrate its in-memory lastRunAt on startup so
+// the dashboard's "Last evaluated" stat reflects previous-session runs (#1796).
+func (s *Service) LatestRulesEvaluatedAt(ctx context.Context) (*time.Time, error) {
+	return s.artists.LatestRulesEvaluatedAt(ctx)
+}
+
 // GetByID retrieves an artist by primary key. Without opts every side-table
 // hydration runs (provider IDs, images, primary library) for API back-compat.
 // Pass a HydrateOpts value to opt into a leaner load that skips one or more

--- a/internal/artist/sqlite_dirty.go
+++ b/internal/artist/sqlite_dirty.go
@@ -126,3 +126,25 @@ func (r *sqliteArtistRepo) CountEligibleArtists(ctx context.Context) (int, error
 	}
 	return n, nil
 }
+
+// LatestRulesEvaluatedAt returns the most recent rules_evaluated_at timestamp
+// across all non-excluded artists, or nil when no artist has ever been evaluated.
+// Used to hydrate the scheduler's in-memory lastRunAt on startup so the
+// dashboard's "Last evaluated" stat survives a server restart (#1796).
+func (r *sqliteArtistRepo) LatestRulesEvaluatedAt(ctx context.Context) (*time.Time, error) {
+	var raw *string
+	err := r.db.QueryRowContext(ctx,
+		`SELECT MAX(rules_evaluated_at) FROM artists WHERE is_excluded = 0`).Scan(&raw)
+	if err != nil {
+		return nil, fmt.Errorf("querying latest rules_evaluated_at: %w", err)
+	}
+	if raw == nil || *raw == "" {
+		return nil, nil
+	}
+	ts, err := time.Parse(time.RFC3339, *raw)
+	if err != nil {
+		return nil, fmt.Errorf("parsing latest rules_evaluated_at %q: %w", *raw, err)
+	}
+	ts = ts.UTC()
+	return &ts, nil
+}

--- a/internal/artist/sqlite_dirty.go
+++ b/internal/artist/sqlite_dirty.go
@@ -130,7 +130,13 @@ func (r *sqliteArtistRepo) CountEligibleArtists(ctx context.Context) (int, error
 // LatestRulesEvaluatedAt returns the most recent rules_evaluated_at timestamp
 // across all non-excluded artists, or nil when no artist has ever been evaluated.
 // Used to hydrate the scheduler's in-memory lastRunAt on startup so the
-// dashboard's "Last evaluated" stat survives a server restart (#1796).
+// dashboard's "Last evaluated" stat survives a server restart (#1796), and to
+// populate the stat when no scheduler is configured (interval_minutes=0).
+//
+// Filter: is_excluded = 0 only (deliberately unlike ListDirtyIDs, which also
+// requires locked = 0). A locked artist's past evaluation still counts toward
+// "when were rules last evaluated" -- locking prevents future pipeline runs
+// but does not erase historical evaluation history.
 func (r *sqliteArtistRepo) LatestRulesEvaluatedAt(ctx context.Context) (*time.Time, error) {
 	var raw *string
 	err := r.db.QueryRowContext(ctx,

--- a/internal/artist/sqlite_dirty_test.go
+++ b/internal/artist/sqlite_dirty_test.go
@@ -2,6 +2,7 @@ package artist
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -331,6 +332,155 @@ func TestUpdateAfterRuleEvaluation_DoesNotStampDirty(t *testing.T) {
 	}
 	if len(ids) != 0 {
 		t.Fatalf("ListDirtyIDs = %v, want []; UpdateAfterRuleEvaluation must not re-dirty the artist", ids)
+	}
+}
+
+// TestLatestRulesEvaluatedAt_EmptyTable verifies that nil is returned when the
+// artists table is empty -- the no-data bootstrap path.
+func TestLatestRulesEvaluatedAt_EmptyTable(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	got, err := svc.LatestRulesEvaluatedAt(ctx)
+	if err != nil {
+		t.Fatalf("LatestRulesEvaluatedAt on empty table: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("want nil, got %v", got)
+	}
+}
+
+// TestLatestRulesEvaluatedAt_AllNullEvals verifies that nil is returned when
+// artists exist but none has been evaluated yet (rules_evaluated_at IS NULL).
+func TestLatestRulesEvaluatedAt_AllNullEvals(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	a := testArtist("Unevaluated", "/music/unevaluated")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.LatestRulesEvaluatedAt(ctx)
+	if err != nil {
+		t.Fatalf("LatestRulesEvaluatedAt: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("all rules_evaluated_at NULL: want nil, got %v", got)
+	}
+}
+
+// TestLatestRulesEvaluatedAt_ExcludedIgnored verifies that an excluded artist
+// (is_excluded=1) with a newer stamp does not influence the result. Only
+// non-excluded artists contribute to the MAX.
+func TestLatestRulesEvaluatedAt_ExcludedIgnored(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	earlier := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	later := earlier.Add(time.Hour)
+
+	normal := testArtist("Normal", "/music/normal")
+	if err := svc.Create(ctx, normal); err != nil {
+		t.Fatalf("Create normal: %v", err)
+	}
+	if err := svc.MarkRulesEvaluated(ctx, normal.ID, earlier); err != nil {
+		t.Fatalf("MarkRulesEvaluated normal: %v", err)
+	}
+
+	excluded := testArtist("Excluded", "/music/excluded")
+	excluded.IsExcluded = true
+	if err := svc.Create(ctx, excluded); err != nil {
+		t.Fatalf("Create excluded: %v", err)
+	}
+	if err := svc.MarkRulesEvaluated(ctx, excluded.ID, later); err != nil {
+		t.Fatalf("MarkRulesEvaluated excluded: %v", err)
+	}
+
+	got, err := svc.LatestRulesEvaluatedAt(ctx)
+	if err != nil {
+		t.Fatalf("LatestRulesEvaluatedAt: %v", err)
+	}
+	if got == nil {
+		t.Fatal("want non-nil, got nil")
+	}
+	if !got.Equal(earlier) {
+		t.Fatalf("excluded artist stamp leaked: got %v, want %v", got, earlier)
+	}
+}
+
+// TestLatestRulesEvaluatedAt_ReturnsMax verifies that the chronological
+// maximum is returned when multiple non-excluded artists have been evaluated.
+func TestLatestRulesEvaluatedAt_ReturnsMax(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	base := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	stamps := []time.Time{base, base.Add(time.Hour), base.Add(2 * time.Hour)}
+
+	for i, ts := range stamps {
+		a := testArtist(fmt.Sprintf("Artist%d", i), fmt.Sprintf("/music/%d", i))
+		if err := svc.Create(ctx, a); err != nil {
+			t.Fatalf("Create artist %d: %v", i, err)
+		}
+		if err := svc.MarkRulesEvaluated(ctx, a.ID, ts); err != nil {
+			t.Fatalf("MarkRulesEvaluated artist %d: %v", i, err)
+		}
+	}
+
+	got, err := svc.LatestRulesEvaluatedAt(ctx)
+	if err != nil {
+		t.Fatalf("LatestRulesEvaluatedAt: %v", err)
+	}
+	if got == nil {
+		t.Fatal("want non-nil, got nil")
+	}
+	want := stamps[len(stamps)-1]
+	if !got.Equal(want) {
+		t.Fatalf("got %v, want %v (chronological MAX)", got, want)
+	}
+}
+
+// TestLatestRulesEvaluatedAt_RoundTrip verifies that a value written by
+// MarkRulesEvaluated survives storage as RFC3339 UTC and is returned with
+// second-level precision intact by LatestRulesEvaluatedAt.
+func TestLatestRulesEvaluatedAt_RoundTrip(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	// Truncate to seconds: SQLite stores RFC3339 which has 1-second resolution.
+	stamp := time.Date(2025, 3, 15, 14, 30, 45, 0, time.UTC)
+
+	a := testArtist("RoundTrip", "/music/roundtrip")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := svc.MarkRulesEvaluated(ctx, a.ID, stamp); err != nil {
+		t.Fatalf("MarkRulesEvaluated: %v", err)
+	}
+
+	got, err := svc.LatestRulesEvaluatedAt(ctx)
+	if err != nil {
+		t.Fatalf("LatestRulesEvaluatedAt: %v", err)
+	}
+	if got == nil {
+		t.Fatal("want non-nil, got nil")
+	}
+	if !got.Equal(stamp) {
+		t.Fatalf("round-trip mismatch: got %v, want %v", got, stamp)
+	}
+	if got.Location() != time.UTC {
+		t.Fatalf("expected UTC location, got %v", got.Location())
 	}
 }
 

--- a/internal/artist/sqlite_dirty_test.go
+++ b/internal/artist/sqlite_dirty_test.go
@@ -3,6 +3,7 @@ package artist
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -517,5 +518,36 @@ func TestUpdate_DoesStampDirty(t *testing.T) {
 	}
 	if reread.DirtySince == nil {
 		t.Fatalf("dirty_since was not stamped by Update; external mutations must re-schedule evaluation")
+	}
+}
+
+// TestLatestRulesEvaluatedAt_MalformedTimestamp verifies that a non-RFC3339
+// rules_evaluated_at value stored in the DB (e.g. from a hand-edited row or a
+// future schema bug) causes LatestRulesEvaluatedAt to return a wrapped error
+// rather than silently returning a zero time or nil.
+func TestLatestRulesEvaluatedAt_MalformedTimestamp(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	// Create an artist so the table has a non-excluded row.
+	a := testArtist("MalformedTS", "/music/malformed-ts")
+	if err := svc.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Directly write a value that is not valid RFC3339 so time.Parse will fail.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE artists SET rules_evaluated_at = 'not-a-valid-rfc3339' WHERE id = ?`, a.ID); err != nil {
+		t.Fatalf("ExecContext: %v", err)
+	}
+
+	got, err := svc.LatestRulesEvaluatedAt(ctx)
+	if err == nil {
+		t.Fatalf("expected error for malformed timestamp, got %v", got)
+	}
+	if !strings.Contains(err.Error(), "parsing latest rules_evaluated_at") {
+		t.Errorf("error = %v, want message containing 'parsing latest rules_evaluated_at'", err)
 	}
 }

--- a/internal/artist/sqlite_dirty_test.go
+++ b/internal/artist/sqlite_dirty_test.go
@@ -521,6 +521,25 @@ func TestUpdate_DoesStampDirty(t *testing.T) {
 	}
 }
 
+// TestLatestRulesEvaluatedAt_ScanError verifies that a DB-level error during the
+// MAX() scan (e.g. closed connection) is surfaced as a wrapped error rather than
+// silently returning nil. This covers the `if err != nil` branch after Scan.
+func TestLatestRulesEvaluatedAt_ScanError(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+
+	// Close the DB before querying so the Scan call returns sql.ErrConnDone.
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	_, err := svc.LatestRulesEvaluatedAt(context.Background())
+	if err == nil {
+		t.Fatal("expected error on closed DB, got nil")
+	}
+}
+
 // TestLatestRulesEvaluatedAt_MalformedTimestamp verifies that a non-RFC3339
 // rules_evaluated_at value stored in the DB (e.g. from a hand-edited row or a
 // future schema bug) causes LatestRulesEvaluatedAt to return a wrapped error

--- a/internal/rule/scheduler.go
+++ b/internal/rule/scheduler.go
@@ -142,6 +142,23 @@ func (s *Scheduler) MarkEvaluated() {
 	s.mu.Unlock()
 }
 
+// SeedLastEvaluated hydrates the in-memory lastRunAt from a persisted value
+// (e.g. MAX(rules_evaluated_at) from the DB) so the dashboard's "Last
+// evaluated" stat survives a server restart (#1796). It is a no-op when
+// lastRunAt is already non-zero (i.e. the scheduler has already run a tick or
+// MarkEvaluated was called), so it is safe to call at any point after
+// construction without racing the running ticker.
+func (s *Scheduler) SeedLastEvaluated(t time.Time) {
+	if t.IsZero() {
+		return
+	}
+	s.mu.Lock()
+	if s.lastRunAt.IsZero() {
+		s.lastRunAt = t.UTC()
+	}
+	s.mu.Unlock()
+}
+
 // Status returns the current scheduler state for the status endpoint.
 func (s *Scheduler) Status() SchedulerStatus {
 	s.mu.RLock()

--- a/internal/rule/scheduler_test.go
+++ b/internal/rule/scheduler_test.go
@@ -122,6 +122,50 @@ func TestScheduler_MarkEvaluated(t *testing.T) {
 	}
 }
 
+// TestScheduler_SeedLastEvaluated verifies that SeedLastEvaluated hydrates the
+// scheduler's in-memory lastRunAt from a persisted timestamp (e.g. from the DB)
+// so the dashboard's "Last evaluated" stat survives a server restart (#1796).
+// Before this fix, lastRunAt was always zero after a restart, so Status()
+// returned nil for LastEvaluationAt and the JS always showed "Never" even when
+// artists had been evaluated in a previous session.
+func TestScheduler_SeedLastEvaluated(t *testing.T) {
+	logger := slog.Default()
+	pipeline := &Pipeline{logger: logger.With(slog.String("component", "fix-pipeline"))}
+	sched := NewScheduler(pipeline, nil, nil, logger)
+
+	if sched.Status().LastEvaluationAt != nil {
+		t.Fatal("precondition: LastEvaluationAt should be nil before seeding")
+	}
+
+	// Seed with a known past timestamp (simulating a DB-loaded value).
+	seed := time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC)
+	sched.SeedLastEvaluated(seed)
+
+	got := sched.Status().LastEvaluationAt
+	if got == nil {
+		t.Fatal("LastEvaluationAt should be non-nil after SeedLastEvaluated")
+	}
+	if !got.Equal(seed) {
+		t.Errorf("LastEvaluationAt = %v, want %v", got, seed)
+	}
+
+	// SeedLastEvaluated is a no-op when lastRunAt is already set (prevents
+	// overwriting a live tick that advanced beyond the seed value).
+	later := seed.Add(time.Hour)
+	sched.SeedLastEvaluated(later)
+	got2 := sched.Status().LastEvaluationAt
+	if !got2.Equal(seed) {
+		t.Errorf("SeedLastEvaluated should not overwrite existing value: got %v, want %v", got2, seed)
+	}
+
+	// Zero value is silently ignored.
+	sched2 := NewScheduler(pipeline, nil, nil, logger)
+	sched2.SeedLastEvaluated(time.Time{})
+	if sched2.Status().LastEvaluationAt != nil {
+		t.Error("SeedLastEvaluated with zero time should be a no-op")
+	}
+}
+
 func TestScheduler_Status_AfterRun(t *testing.T) {
 	db := setupTestDB(t)
 	artistSvc := artist.NewService(db)


### PR DESCRIPTION
## Summary

Fixes the NEXT/ dashboard "Last evaluated" stat always reading "Never". Two layers:

1. **Restart (scheduled config):** the rule scheduler's in-memory `lastRunAt` was zero-initialized on startup and never seeded from the DB, so the stat showed "Never" until the first tick. Now `Scheduler.SeedLastEvaluated` hydrates it from `MAX(rules_evaluated_at)` at startup (no-op if a tick/MarkEvaluated already ran).
2. **Default no-schedule config (the reporter's actual case):** with no rule schedule configured (`rule_schedule.interval_minutes=0`), `ruleScheduler` is nil and `handleRulesStatus` hard-coded `last_evaluation_at: nil` -> "Never" forever, even after manual rule runs. The nil-scheduler branch now reads `LatestRulesEvaluatedAt` from the DB (logs Warn + falls back to nil on error).

## What changed

- `internal/rule/scheduler.go`: `SeedLastEvaluated(t)` (mutex-guarded, zero-only).
- `internal/artist/{repository,service,sqlite_dirty}.go`: `LatestRulesEvaluatedAt` -> `MAX(rules_evaluated_at)` over non-excluded artists (locked artists intentionally still count).
- `cmd/stillwater/main.go`: seed the scheduler from the DB in `resolveRuleSchedule`.
- `internal/api/handlers_rule.go`: nil-scheduler status reads the DB value.

## Test plan

- `go build ./... && go vet ./...` clean; lint 0; patch coverage 77.6% (> 75% gate).
- Unit + integration tests: `SeedLastEvaluated` (seed/no-op/zero-ignored), `LatestRulesEvaluatedAt` (empty/all-null/excluded-ignored/max/round-trip/parse-error/scan-error), `handleRulesStatus` nil-scheduler (returns DB value / preserves nil when none).
- Lead UAT (live, no-schedule config): `/api/v1/rules/status` returns the real timestamp with `scheduler_enabled:false`; `/next/dashboard` bubble renders "Evaluated 56m ago" instead of "Never".

Closes #1796.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Dashboard's "Last evaluated" stat now displays actual evaluation time from the database, rather than showing "Never" until the first scheduled run after startup.
  * Rules status endpoint now returns accurate evaluation history even when the scheduler is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->