### PR TITLE
ci: single-saver Go cache primer + PR-close cache cleanup (#2035)

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,57 @@
+# Cache Cleanup
+#
+# Deletes all Actions cache entries scoped to a closed PR's merge ref
+# (refs/pull/<n>/merge).  Closed-PR caches accumulate forever unless
+# explicitly deleted; at the 10 GiB/repo cap they cause LRU thrash that
+# cold-rebuilds unrelated PRs.
+#
+# SCOPE: strictly limited to the PR's own merge ref.  The step uses the
+# caches?ref= filter parameter which matches the stored ref field exactly;
+# refs/heads/* and refs/tags/* are never touched.
+#
+# Permissions: job-level actions:write + contents:read.
+# No checkout step (no source needed, so persist-credentials is N/A).
+# No external actions used (pure gh-api shell); SHA-pinning is N/A.
+
+name: Cache Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+# Workflow-level: no permissions -- job-level permissions fully replace
+# workflow-level in GitHub Actions (omitted scopes become none).
+permissions: {}
+
+jobs:
+  cleanup:
+    name: Delete PR cache entries
+    runs-on: ubuntu-latest
+    permissions:
+      # write to delete cache entries
+      actions: write
+      # read required for checkout-less gh api calls against the repo
+      contents: read
+    steps:
+      - name: Delete caches for refs/pull/${{ github.event.pull_request.number }}/merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          # --paginate follows Link: next headers so all pages are collected.
+          # .actions_caches[].id extracts the numeric ID from each page.
+          # Each ID is then deleted individually via the REST API.
+          deleted=0
+          while IFS= read -r cache_id; do
+            [ -z "$cache_id" ] && continue
+            if gh api -X DELETE "repos/${REPO}/actions/caches/${cache_id}" > /dev/null; then
+              echo "Deleted cache ${cache_id} (${PR_REF})"
+              deleted=$(( deleted + 1 ))
+            else
+              echo "Warning: failed to delete cache ${cache_id}"
+            fi
+          done < <(gh api --paginate \
+            "repos/${REPO}/actions/caches?ref=${PR_REF}" \
+            --jq '.actions_caches[].id' 2>/dev/null || true)
+          echo "Cache cleanup complete: ${deleted} entr(ies) deleted for ${PR_REF}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,6 +712,7 @@ jobs:
       contents: read
     steps:
       - name: Check Actions cache usage
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,57 @@ jobs:
             echo 'build_matrix={"include":[{"goos":"linux","goarch":"amd64","skip":true}]}' >> "$GITHUB_OUTPUT"
           fi
 
+  # ---------------------------------------------------------------------------
+  # Go module + build cache primer (D3 -- shard cache consolidation)
+  #
+  # Runs a single go mod download before the 9 test shards so the module
+  # cache is warm and saved under one cache entry.  Shards restore that
+  # entry read-only (actions/cache/restore, no post-job save) to avoid
+  # 9 concurrent writes that race to save the same key.
+  #
+  # D2 (restore-keys): the explicit actions/cache step here carries a
+  # restore-keys fallback so a go.sum change warms from the last matching
+  # cache instead of cold-building.  Other Go jobs (lint, coverage, build)
+  # keep setup-go cache:true; they each have at most 1-2 concurrent
+  # instances so the multiplier effect is small compared to the 9-shard
+  # case, and fewer changes lower the diff risk.
+  # ---------------------------------------------------------------------------
+  go-cache-primer:
+    name: Go Cache Primer
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          # Disable the built-in cache so the explicit actions/cache step
+          # below owns the lifecycle (keyed on go.sum with restore-keys).
+          cache: false
+
+      - name: Restore Go module + build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          # Exact key: cache hit restores the most recent warm build.
+          # Restore-key: cache miss on a go.sum change warms from the last
+          # compatible entry instead of forcing a cold rebuild.
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      # Populate the module cache so shards avoid redundant downloads.
+      # go mod download is fast (~5-30s) and its output is the shared
+      # ~/go/pkg/mod tree that all 9 shards will restore read-only.
+      - name: Warm Go module cache
+        run: go mod download
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -172,9 +223,29 @@ jobs:
       - name: Install JS dependencies
         run: npm ci
 
-      - name: Install Playwright Chromium
-        # Install only Chromium (no Firefox/WebKit) to keep the binary footprint small.
-        run: npx playwright install chromium --with-deps
+      # Cache the Playwright browser binary on a key derived from
+      # package-lock.json (which pins the exact @playwright/* version).
+      # On a cache hit the binary download is skipped; system dependencies
+      # are installed separately below (they are OS packages, not cached).
+      - name: Cache Playwright browser binaries
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            playwright-chromium-
+
+      - name: Install Playwright Chromium browser binary
+        # Skip binary download on cache hit; the binary is already in
+        # ~/.cache/ms-playwright restored above.
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
+
+      - name: Install Playwright Chromium system dependencies
+        # Always install OS-level deps (libnss3, libgbm, etc.); they are
+        # not included in the cached browser archive.
+        run: npx playwright install-deps chromium
 
       - name: Generate templ
         run: go tool templ generate
@@ -266,7 +337,7 @@ jobs:
     # update at merge time.
     name: Test Shard
     runs-on: ubuntu-latest
-    needs: [changes]
+    needs: [changes, go-cache-primer]
     if: needs.changes.outputs.code == 'true'
     strategy:
       # One shard's failure should not cancel the others -- a flake in one
@@ -282,7 +353,23 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
-          cache: true
+          # Disable built-in cache; read-only restore from the primer's
+          # shared entry below.  Shards do not save (actions/cache/restore),
+          # so all 9 write to the SAME key without racing.
+          cache: false
+
+      # Restore Go cache from the shared primer entry (read-only).
+      # restore-keys ensures a go.sum change still warms from the last
+      # compatible entry rather than cold-building.
+      - name: Restore Go module + build cache (read-only)
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       # Resolve the package list (and optional -run bucket regex) for this
       # shard. Named shards (services / settingsio / providers / scan) come from the SHARDS
@@ -593,6 +680,34 @@ jobs:
             exit 1
           fi
           echo "Build matrix result: $result"
+
+  # ---------------------------------------------------------------------------
+  # D4 -- Cache usage guardrail
+  #
+  # Reads the repository's Actions cache usage via the REST API and emits a
+  # ::warning:: annotation when usage exceeds 8 GiB (cap = 10 GiB).
+  # This is a non-blocking informational job; it never fails CI.
+  # Run on every push + PR so the signal appears in the workflow summary.
+  # ---------------------------------------------------------------------------
+  cache-usage:
+    name: Cache Usage Check
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Check Actions cache usage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          usage_bytes=$(gh api "repos/${REPO}/actions/cache/usage" \
+            --jq '.active_caches_size_in_bytes')
+          usage_gib=$(awk "BEGIN{printf \"%.2f\", ${usage_bytes}/1073741824}")
+          echo "Actions cache usage: ${usage_gib} GiB / 10 GiB"
+          if awk "BEGIN{exit !(${usage_gib} > 8)}"; then
+            echo "::warning::Actions cache usage ${usage_gib} GiB exceeds 8 GiB warning threshold (cap = 10 GiB). Cache thrash risk -- consider pruning stale entries."
+          fi
 
   docker:
     name: Docker Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,17 @@ jobs:
   # ---------------------------------------------------------------------------
   # Go module + build cache primer (D3 -- shard cache consolidation)
   #
-  # Runs a single go mod download before the 9 test shards so the module
-  # cache is warm and saved under one cache entry.  Shards restore that
-  # entry read-only (actions/cache/restore, no post-job save) to avoid
-  # 9 concurrent writes that race to save the same key.
+  # Before the 9 test shards run, this job warms BOTH halves of the Go
+  # cache and saves them under one cache entry:
+  #   1. go mod download         -> populates the module cache (~/go/pkg/mod)
+  #   2. go test -race -run='^$'  -> compiles every test binary + dep WITH
+  #      race instrumentation (running zero tests) so the build cache
+  #      (~/.cache/go-build) holds the exact race-instrumented objects the
+  #      shards' `go test -v -race` needs.  Without this step the build
+  #      cache would be empty and all 9 read-only shards would cold-compile
+  #      -race on every run (a regression vs main's per-shard cache: true).
+  # Shards restore that entry read-only (actions/cache/restore, no post-job
+  # save) to avoid 9 concurrent writes that race to save the same key.
   #
   # D2 (restore-keys): the explicit actions/cache step here carries a
   # restore-keys fallback so a go.sum change warms from the last matching
@@ -129,6 +136,14 @@ jobs:
       # ~/go/pkg/mod tree that all 9 shards will restore read-only.
       - name: Warm Go module cache
         run: go mod download
+
+      # Warm the build cache (~/.cache/go-build) with race-instrumented
+      # objects.  -run='^$' matches no tests, so this compiles every test
+      # binary + dependency with -race but executes zero tests.  The
+      # post-job actions/cache save then captures these objects so the 9
+      # read-only shards restore them instead of cold-compiling -race.
+      - name: Warm Go build cache (race-instrumented)
+        run: go test -race -count=1 -run='^$' ./...
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,11 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
           # Exact key: cache hit restores the most recent warm build.
-          # Restore-key: cache miss on a go.sum change warms from the last
-          # compatible entry instead of forcing a cold rebuild.
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          # Restore-key: cache miss on a go.sum/go.mod change warms from the
+          # last compatible entry instead of forcing a cold rebuild.
+          # go.mod is hashed too so a toolchain-directive bump that leaves
+          # go.sum untouched still invalidates the stale build cache.
+          key: ${{ runner.os }}-go-${{ hashFiles('go.mod', '**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
 
@@ -382,7 +384,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('go.mod', '**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
 
@@ -712,13 +714,18 @@ jobs:
       contents: read
     steps:
       - name: Check Actions cache usage
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+        # Tolerate only the API being unavailable (transient gh failure or an
+        # empty response): those exit 0 so the guardrail stays non-blocking.
+        # Any real logic error past that point still fails the step rather
+        # than being silently swallowed by continue-on-error.
         run: |
           usage_bytes=$(gh api "repos/${REPO}/actions/cache/usage" \
-            --jq '.active_caches_size_in_bytes')
+            --jq '.active_caches_size_in_bytes' 2>/dev/null) || {
+            echo "Warning: cache usage API unavailable; skipping guardrail."; exit 0; }
+          [ -z "$usage_bytes" ] && { echo "Warning: empty cache-usage response; skipping guardrail."; exit 0; }
           usage_gib=$(awk "BEGIN{printf \"%.2f\", ${usage_bytes}/1073741824}")
           echo "Actions cache usage: ${usage_gib} GiB / 10 GiB"
           if awk "BEGIN{exit !(${usage_gib} > 8)}"; then


### PR DESCRIPTION
## Summary

Reduce GitHub Actions cache-cap thrash. The 9 race-test shards each saved their own `~/.cache/go-build` (`cache: true`), blowing the 10GB repo cache cap -> LRU evictions -> cold builds + churn. This moves to a **single-saver** design: a `go-cache-primer` job warms the module + `-race` build cache once and saves it; the 9 shards restore it **read-only** (no per-shard saves). Adds a PR-close cache-cleanup workflow, an >8GB usage guardrail warning, and a Playwright browser cache.

closes #2035

## Design note (single-saver primer)

Chosen over per-shard `restore-keys` because #2035's goal is cap-thrash reduction: one cache entry (primer) vs nine (per-shard) is what eliminates the cap pressure. The primer compiles with race instrumentation (`go test -race -count=1 -run='^$' ./...`) so the saved `go-build` cache is genuinely warm for the read-only shards.

## Acks (reviewer findings, non-blocking)

- The primer adds a serial gate (~30-90s) before shards start - accepted tradeoff: a one-time serial compile is cheaper than recurring cap thrash + eviction-driven cold builds.
- The module cache is stored under two key schemes (primer's manual `linux-go-*` vs setup-go `cache:true` on lint/coverage/build jobs) - minor extra footprint, mitigated by the cleanup workflow + cap guardrail; could unify in a follow-up.

## Security

All actions SHA-pinned (`# vX`). `cache-cleanup.yml`: workflow `permissions: {}` + job-level `actions: write` + `contents: read` (least-priv); delete scoped to the PR's own `refs/pull/<n>/merge` cache (cannot touch main/shared caches); `pull_request` trigger (fork tokens read-only). No untrusted input interpolated into a shell.

## Test plan

- actionlint clean on both workflows; all actions SHA-pinned.
- Adversarial prep gate GREEN (race suite clean, generated-file in sync, OpenAPI consistency, golangci-lint).
- Hostile review: an initial BLOCK (the primer warmed nothing - `go mod download` populates only the module cache) was RESOLVED by adding the `-race` build-cache warm step; the cache-cleanup delete-scope and the usage guardrail passed adversarial review.
- Real CI wall-clock + cache-cap effect to be confirmed on this PR's own runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI performance by warming and reusing Go build/module caches across test shards.
  * Reduced Playwright setup time by caching downloaded browser binaries and only installing them on cache misses.
  * Added automated cleanup of GitHub Actions cache entries when pull requests are closed, plus non-blocking monitoring/alerts for action cache usage growth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->