### PR TITLE
build: make uat (atomic appdata DB+key clone) + fail-loud encryption-key guard (#2036)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ data/
 *.db-shm
 *.db-wal
 
+# UAT staging dir (cloned DB + encryption key, see `make uat`). Kept out of git
+# so secrets never land in history and `git worktree remove` (no --force) can
+# delete the worktree even with a staged copy present.
+/.uat/
+
 # Coverage
 coverage.out
 coverage.html

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-shuffle test-race test-cover test-js test-a11y lint fmt clean docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks doctor worktree check-openapi sync-tool-versions hadolint vulncheck scan bruno-ci
+.PHONY: build run test test-shuffle test-race test-cover test-js test-a11y lint fmt clean clean-uat uat docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks doctor worktree check-openapi sync-tool-versions hadolint vulncheck scan bruno-ci
 
 # Binary name
 BINARY=stillwater
@@ -260,6 +260,47 @@ clean:
 	rm -f $(BINARY)
 	rm -f coverage.out coverage.html
 	rm -f $(TAILWIND_OUTPUT)
+
+# Source of the live data dir to clone for UAT. Override on the command line,
+# e.g. `make uat SW_APPDATA=/path/to/data`. The DB and its sibling
+# encryption.key both live here.
+SW_APPDATA ?= $(HOME)/appdata/stillwater/data
+# Port the printed run command binds to. Override with `make uat SW_PORT=1975`.
+SW_PORT    ?= 1975
+
+## uat: Stage a UAT copy of the live DB + encryption key into ./.uat/ (siblings) and print the run command
+# Clones the live SQLite DB via the online .backup API (consistent snapshot, no
+# locking of the source) and copies the encryption key as a LITERAL SIBLING so
+# the server resolves it automatically via the encryption.key-alongside-DB path.
+# The staged copy is fully disposable; `make clean-uat` removes it. The printed
+# command intentionally does NOT set SW_ENCRYPTION_KEY_FILE -- the sibling key
+# is resolved without it.
+uat:
+	@set -euo pipefail; \
+	src_db="$(SW_APPDATA)/stillwater.db"; \
+	src_key="$(SW_APPDATA)/encryption.key"; \
+	if [ ! -f "$$src_db" ]; then \
+		echo "uat: source DB not found: $$src_db (set SW_APPDATA=<dir>)" >&2; exit 1; \
+	fi; \
+	if [ ! -f "$$src_key" ]; then \
+		echo "uat: source encryption key not found: $$src_key (set SW_APPDATA=<dir>)" >&2; exit 1; \
+	fi; \
+	command -v sqlite3 >/dev/null 2>&1 || { echo "uat: sqlite3 not found on PATH" >&2; exit 1; }; \
+	rm -rf "$(CURDIR)/.uat"; \
+	mkdir -p "$(CURDIR)/.uat"; \
+	sqlite3 "$$src_db" ".backup '$(CURDIR)/.uat/sw.db'"; \
+	cp "$$src_key" "$(CURDIR)/.uat/encryption.key"; \
+	chmod 0600 "$(CURDIR)/.uat/encryption.key"; \
+	echo ""; \
+	echo "UAT copy staged in $(CURDIR)/.uat (sw.db + sibling encryption.key)."; \
+	echo "Run it with:"; \
+	echo ""; \
+	echo "  SW_PORT=$(SW_PORT) SW_UX=dual SW_DB_PATH=$(CURDIR)/.uat/sw.db SW_RUN_ROOT=$(CURDIR)/.uat/run ./stillwater"; \
+	echo ""
+
+## clean-uat: Remove the staged ./.uat/ UAT copy (DB + key + run root)
+clean-uat:
+	rm -rf $(CURDIR)/.uat
 
 ## bruno-ci: Build binary, run ephemeral server, execute Bruno API tests, clean up.
 # Required: npx / @usebruno/cli reachable. Admin credentials are ephemeral and

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: build run test test-shuffle test-race test-cover test-js test-a11y lint fmt clean clean-uat uat docker-build docker-run dev templ tailwind generate generate-docs migrate favicon hooks doctor worktree check-openapi sync-tool-versions hadolint vulncheck scan bruno-ci
 
+# Use bash for all recipes so bash-only constructs (set -o pipefail) work even
+# where /bin/sh is dash (Debian/Ubuntu); plain sh lacks pipefail.
+SHELL := /usr/bin/env bash
+
 # Binary name
 BINARY=stillwater
 BUILD_DIR=./build

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -1193,29 +1193,47 @@ func databaseHasEncryptedSecrets(dbPath string) (bool, error) {
 	}
 	defer func() { _ = db.Close() }()
 
-	if err := db.PingContext(context.Background()); err != nil {
+	// Bound every probe with a Go-side deadline so a locked or corrupted DB
+	// cannot hang startup indefinitely; the read-only DSN's busy_timeout only
+	// covers SQLite-level lock waits, not a wedged handle.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
 		return false, fmt.Errorf("pinging database read-only: %w", err)
 	}
 
-	// Each probe returns sql.ErrNoRows when the table exists but holds no
-	// secret, and a "no such table" error when the schema predates that table;
-	// both mean "no secret here", so only an unexpected error is fatal.
+	// Each probe carries the table it reads so we can check existence explicitly
+	// via sqlite_master rather than string-matching a "no such table" error
+	// (brittle, driver-dependent). An absent table means the schema predates it,
+	// so there is nothing to orphan; an empty table (sql.ErrNoRows) likewise has
+	// no secret. Only an unexpected error is fatal.
 	probes := []struct {
 		desc  string
+		table string
 		query string
 	}{
-		{"connection API keys", `SELECT 1 FROM connections WHERE TRIM(encrypted_api_key) != '' LIMIT 1`},
-		{"provider API keys", `SELECT 1 FROM settings WHERE key LIKE 'provider.%.api_key' AND TRIM(value) != '' LIMIT 1`},
+		{"connection API keys", "connections", `SELECT 1 FROM connections WHERE TRIM(encrypted_api_key) != '' LIMIT 1`},
+		{"provider API keys", "settings", `SELECT 1 FROM settings WHERE key LIKE 'provider.%.api_key' AND TRIM(value) != '' LIMIT 1`},
 	}
 	for _, p := range probes {
+		var name string
+		err := db.QueryRowContext(ctx,
+			`SELECT name FROM sqlite_master WHERE type='table' AND name=? LIMIT 1`,
+			p.table).Scan(&name)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			continue // table absent, nothing to orphan
+		case err != nil:
+			return false, fmt.Errorf("checking %s table existence: %w", p.table, err)
+		}
+
 		var found int
-		err := db.QueryRowContext(context.Background(), p.query).Scan(&found)
+		err = db.QueryRowContext(ctx, p.query).Scan(&found)
 		switch {
 		case err == nil:
 			return true, nil
 		case errors.Is(err, sql.ErrNoRows):
-			continue
-		case strings.Contains(err.Error(), "no such table"):
 			continue
 		default:
 			return false, fmt.Errorf("probing %s: %w", p.desc, err)

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -1070,10 +1070,39 @@ func applyPersistedBasePath(ctx context.Context, db *sql.DB, cfg *config.Config,
 }
 
 // resolveEncryptionKey determines the encryption key to use.
-// Priority: SW_ENCRYPTION_KEY env var > encryption.key alongside DB > generate new.
+//
+// Priority, highest first:
+//  1. SW_ENCRYPTION_KEY -- the raw key VALUE (cfg.Encryption.Key).
+//  2. SW_ENCRYPTION_KEY_FILE -- a path whose CONTENTS are the key value
+//     (cfg.Encryption.KeyFile). When set the file must exist and be non-empty;
+//     a missing/empty/unreadable file is fatal so an operator who explicitly
+//     pointed at a secret file is never silently fed a different key.
+//  3. encryption.key file alongside the database (the historical default).
+//  4. Generate a new key -- BUT only when the database is genuinely fresh.
+//     Generating a fresh key against a DB that already holds encrypted secrets
+//     would orphan every one of them ("cipher: message authentication failed"),
+//     so this path aborts loudly when secrets are present.
 func resolveEncryptionKey(cfg *config.Config, logger *slog.Logger) (string, error) {
 	if cfg.Encryption.Key != "" {
 		return cfg.Encryption.Key, nil
+	}
+
+	// SW_ENCRYPTION_KEY_FILE: read the key VALUE from the operator-supplied path.
+	// Any failure here is fatal -- the operator explicitly asked us to load the
+	// key from this file, so falling through to a different source (sibling file
+	// or a freshly generated key) would silently substitute the wrong key and
+	// orphan every encrypted secret.
+	if cfg.Encryption.KeyFile != "" {
+		data, err := os.ReadFile(cfg.Encryption.KeyFile)
+		if err != nil {
+			return "", fmt.Errorf("reading SW_ENCRYPTION_KEY_FILE %s: %w", cfg.Encryption.KeyFile, err)
+		}
+		key := strings.TrimSpace(string(data))
+		if key == "" {
+			return "", fmt.Errorf("SW_ENCRYPTION_KEY_FILE %s is empty", cfg.Encryption.KeyFile)
+		}
+		logger.Debug("loaded encryption key from SW_ENCRYPTION_KEY_FILE", slog.String("path", cfg.Encryption.KeyFile))
+		return key, nil
 	}
 
 	dataDir := filepath.Dir(cfg.Database.Path)
@@ -1093,6 +1122,22 @@ func resolveEncryptionKey(cfg *config.Config, logger *slog.Logger) (string, erro
 		}
 	case !errors.Is(err, os.ErrNotExist):
 		return "", fmt.Errorf("reading encryption key file %s: %w", keyFile, err)
+	}
+
+	// No key was supplied or found. Generating one is only safe on a genuinely
+	// fresh database; doing it against a DB that already holds encrypted secrets
+	// would orphan all of them. Refuse loudly in that case so the operator
+	// restores the real key (SW_ENCRYPTION_KEY, SW_ENCRYPTION_KEY_FILE, or the
+	// sibling encryption.key) rather than silently losing every secret.
+	hasSecrets, err := databaseHasEncryptedSecrets(cfg.Database.Path)
+	if err != nil {
+		return "", fmt.Errorf("checking %s for existing encrypted secrets before generating a key: %w", cfg.Database.Path, err)
+	}
+	if hasSecrets {
+		return "", fmt.Errorf(
+			"refusing to generate a new encryption key: DB %s exists with encrypted secrets but no key found "+
+				"(no SW_ENCRYPTION_KEY, no SW_ENCRYPTION_KEY_FILE, no sibling encryption.key) -- "+
+				"generating now would orphan all existing secrets", cfg.Database.Path)
 	}
 
 	// Generate a new key
@@ -1117,6 +1162,66 @@ func resolveEncryptionKey(cfg *config.Config, logger *slog.Logger) (string, erro
 		slog.String("path", keyFile))
 
 	return key, nil
+}
+
+// databaseHasEncryptedSecrets reports whether the SQLite database at dbPath
+// already holds at-rest encrypted secrets (connection API keys or provider API
+// keys). It is the guard that stops resolveEncryptionKey from generating a
+// fresh key against a populated database, which would orphan every secret.
+//
+// It opens the database read-only so the check never mutates the file or
+// creates WAL sidecars. An absent or empty file means a genuinely fresh
+// install (no secrets), so it returns false. A missing secrets table likewise
+// means there is nothing to orphan. Any other open/query error is returned so
+// the caller can fail loudly rather than guess.
+func databaseHasEncryptedSecrets(dbPath string) (bool, error) {
+	info, err := os.Stat(dbPath)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return false, nil // fresh install, nothing to orphan
+	case err != nil:
+		return false, fmt.Errorf("stat database %s: %w", dbPath, err)
+	case info.Size() == 0:
+		return false, nil // freshly created, no schema or rows yet
+	}
+
+	// Read-only DSN: mode=ro forbids any write and immutable avoids touching
+	// the WAL, so probing the DB cannot alter it.
+	db, err := sql.Open("sqlite", dbPath+"?mode=ro&_pragma=busy_timeout(2000)")
+	if err != nil {
+		return false, fmt.Errorf("opening database read-only: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.PingContext(context.Background()); err != nil {
+		return false, fmt.Errorf("pinging database read-only: %w", err)
+	}
+
+	// Each probe returns sql.ErrNoRows when the table exists but holds no
+	// secret, and a "no such table" error when the schema predates that table;
+	// both mean "no secret here", so only an unexpected error is fatal.
+	probes := []struct {
+		desc  string
+		query string
+	}{
+		{"connection API keys", `SELECT 1 FROM connections WHERE TRIM(encrypted_api_key) != '' LIMIT 1`},
+		{"provider API keys", `SELECT 1 FROM settings WHERE key LIKE 'provider.%.api_key' AND TRIM(value) != '' LIMIT 1`},
+	}
+	for _, p := range probes {
+		var found int
+		err := db.QueryRowContext(context.Background(), p.query).Scan(&found)
+		switch {
+		case err == nil:
+			return true, nil
+		case errors.Is(err, sql.ErrNoRows):
+			continue
+		case strings.Contains(err.Error(), "no such table"):
+			continue
+		default:
+			return false, fmt.Errorf("probing %s: %w", p.desc, err)
+		}
+	}
+	return false, nil
 }
 
 // resolveSessionSecret determines the CSRF signing secret to use.

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -1185,8 +1185,8 @@ func databaseHasEncryptedSecrets(dbPath string) (bool, error) {
 		return false, nil // freshly created, no schema or rows yet
 	}
 
-	// Read-only DSN: mode=ro forbids any write and immutable avoids touching
-	// the WAL, so probing the DB cannot alter it.
+	// Read-only DSN: mode=ro forbids any write, so probing the DB cannot alter
+	// it.
 	db, err := sql.Open("sqlite", dbPath+"?mode=ro&_pragma=busy_timeout(2000)")
 	if err != nil {
 		return false, fmt.Errorf("opening database read-only: %w", err)

--- a/cmd/stillwater/phases_test.go
+++ b/cmd/stillwater/phases_test.go
@@ -434,6 +434,30 @@ func TestResolveEncryptionKey_GeneratesOnMigratedButSecretlessDB(t *testing.T) {
 	}
 }
 
+// TestResolveEncryptionKey_AbortsOnProbeError covers the security-critical
+// fail-closed branch: when the existing DB file cannot be probed (here a
+// non-empty file that is not a valid SQLite database, so the read-only
+// PingContext/query errors), resolveEncryptionKey must surface that error
+// rather than silently generating a fresh key -- generating one could orphan
+// secrets that a transient/permission/corruption fault merely hid.
+func TestResolveEncryptionKey_AbortsOnProbeError(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "stillwater.db")
+	// Non-empty garbage: passes the size>0 gate, fails the sqlite probe.
+	if err := os.WriteFile(dbPath, []byte("this is not a sqlite database"), 0o600); err != nil {
+		t.Fatalf("writing garbage db: %v", err)
+	}
+	cfg := &config.Config{}
+	cfg.Database.Path = dbPath // no env key, no sibling encryption.key
+
+	if _, err := resolveEncryptionKey(cfg, slog.Default()); err == nil {
+		t.Fatal("expected abort on unprobeable DB, got nil error (would risk orphaning secrets)")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "encryption.key")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("must not generate a key file when the probe fails; stat err = %v", statErr)
+	}
+}
+
 // TestDatabaseHasEncryptedSecrets_AbsentAndEmpty verifies the probe treats a
 // missing or empty DB file as a fresh install (no secrets).
 func TestDatabaseHasEncryptedSecrets_AbsentAndEmpty(t *testing.T) {

--- a/cmd/stillwater/phases_test.go
+++ b/cmd/stillwater/phases_test.go
@@ -265,6 +265,201 @@ func TestResolveEncryptionKey_LoadsFromFile(t *testing.T) {
 	}
 }
 
+// TestResolveEncryptionKey_KeyFileLoadsValue verifies SW_ENCRYPTION_KEY_FILE
+// loads the key VALUE from the referenced path (priority 2: above the sibling
+// encryption.key, below SW_ENCRYPTION_KEY).
+func TestResolveEncryptionKey_KeyFileLoadsValue(t *testing.T) {
+	dir := t.TempDir()
+	keyFilePath := filepath.Join(dir, "secret", "enc.key")
+	if err := os.MkdirAll(filepath.Dir(keyFilePath), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	const want = "keyfilevalue"
+	if err := os.WriteFile(keyFilePath, []byte(want+"\n"), 0o600); err != nil {
+		t.Fatalf("writing key file: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Database.Path = filepath.Join(dir, "stillwater.db")
+	cfg.Encryption.KeyFile = keyFilePath
+	// A sibling encryption.key with a DIFFERENT value must lose to the key file.
+	if err := os.WriteFile(filepath.Join(dir, "encryption.key"), []byte("siblingvalue\n"), 0o600); err != nil {
+		t.Fatalf("writing sibling key: %v", err)
+	}
+
+	key, err := resolveEncryptionKey(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("resolveEncryptionKey: %v", err)
+	}
+	if key != want {
+		t.Errorf("key = %q; want %q (SW_ENCRYPTION_KEY_FILE must win over the sibling)", key, want)
+	}
+}
+
+// TestResolveEncryptionKey_ConfigKeyBeatsKeyFile verifies SW_ENCRYPTION_KEY (the
+// raw value) outranks SW_ENCRYPTION_KEY_FILE.
+func TestResolveEncryptionKey_ConfigKeyBeatsKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	keyFilePath := filepath.Join(dir, "enc.key")
+	if err := os.WriteFile(keyFilePath, []byte("fromfile\n"), 0o600); err != nil {
+		t.Fatalf("writing key file: %v", err)
+	}
+	cfg := &config.Config{}
+	cfg.Database.Path = filepath.Join(dir, "stillwater.db")
+	cfg.Encryption.Key = "fromenv"
+	cfg.Encryption.KeyFile = keyFilePath
+
+	key, err := resolveEncryptionKey(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("resolveEncryptionKey: %v", err)
+	}
+	if key != "fromenv" {
+		t.Errorf("key = %q; want %q", key, "fromenv")
+	}
+}
+
+// TestResolveEncryptionKey_KeyFileMissingIsFatal verifies that an explicitly
+// configured but missing SW_ENCRYPTION_KEY_FILE fails loudly rather than
+// silently falling through to a different source.
+func TestResolveEncryptionKey_KeyFileMissingIsFatal(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Database.Path = filepath.Join(dir, "stillwater.db")
+	cfg.Encryption.KeyFile = filepath.Join(dir, "does-not-exist.key")
+	// Even with a usable sibling present, the missing explicit file must abort.
+	if err := os.WriteFile(filepath.Join(dir, "encryption.key"), []byte("sibling\n"), 0o600); err != nil {
+		t.Fatalf("writing sibling key: %v", err)
+	}
+
+	if _, err := resolveEncryptionKey(cfg, slog.Default()); err == nil {
+		t.Fatal("expected error for missing SW_ENCRYPTION_KEY_FILE, got nil")
+	}
+}
+
+// TestResolveEncryptionKey_KeyFileEmptyIsFatal verifies that an
+// SW_ENCRYPTION_KEY_FILE pointing at an empty/whitespace file aborts.
+func TestResolveEncryptionKey_KeyFileEmptyIsFatal(t *testing.T) {
+	dir := t.TempDir()
+	keyFilePath := filepath.Join(dir, "empty.key")
+	if err := os.WriteFile(keyFilePath, []byte("   \n"), 0o600); err != nil {
+		t.Fatalf("writing key file: %v", err)
+	}
+	cfg := &config.Config{}
+	cfg.Database.Path = filepath.Join(dir, "stillwater.db")
+	cfg.Encryption.KeyFile = keyFilePath
+
+	if _, err := resolveEncryptionKey(cfg, slog.Default()); err == nil {
+		t.Fatal("expected error for empty SW_ENCRYPTION_KEY_FILE, got nil")
+	}
+}
+
+// populatedDBPath builds a migrated SQLite DB at dir/stillwater.db, runs the
+// supplied seed against it, and returns the path. The DB is closed so a later
+// read-only probe sees the persisted (checkpointed) rows.
+func populatedDBPath(t *testing.T, dir string, seed func(*sql.DB)) string {
+	t.Helper()
+	dbPath := filepath.Join(dir, "stillwater.db")
+	db, err := database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening seed db: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("migrating seed db: %v", err)
+	}
+	if seed != nil {
+		seed(db)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing seed db: %v", err)
+	}
+	return dbPath
+}
+
+// TestResolveEncryptionKey_AbortsOnPopulatedDBConnectionSecret verifies the
+// fail-loud guard: a DB holding an encrypted connection API key with no key
+// available must refuse to generate a new key (which would orphan the secret).
+func TestResolveEncryptionKey_AbortsOnPopulatedDBConnectionSecret(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := populatedDBPath(t, dir, func(db *sql.DB) {
+		if _, err := db.ExecContext(context.Background(),
+			`INSERT INTO connections (id, name, type, url, encrypted_api_key)
+			 VALUES ('c1', 'Emby', 'emby', 'http://x', 'ENCRYPTED-BLOB')`); err != nil {
+			t.Fatalf("inserting connection: %v", err)
+		}
+	})
+	cfg := &config.Config{}
+	cfg.Database.Path = dbPath // no sibling key, no env key
+
+	if _, err := resolveEncryptionKey(cfg, slog.Default()); err == nil {
+		t.Fatal("expected abort on populated DB with no key, got nil error (would orphan secrets)")
+	}
+}
+
+// TestResolveEncryptionKey_AbortsOnPopulatedDBProviderSecret covers the second
+// secret surface: provider API keys stored in the settings table.
+func TestResolveEncryptionKey_AbortsOnPopulatedDBProviderSecret(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := populatedDBPath(t, dir, func(db *sql.DB) {
+		if _, err := db.ExecContext(context.Background(),
+			`INSERT INTO settings (key, value) VALUES ('provider.fanarttv.api_key', 'ENCRYPTED-BLOB')`); err != nil {
+			t.Fatalf("inserting provider secret: %v", err)
+		}
+	})
+	cfg := &config.Config{}
+	cfg.Database.Path = dbPath
+
+	if _, err := resolveEncryptionKey(cfg, slog.Default()); err == nil {
+		t.Fatal("expected abort on populated DB with provider secret and no key, got nil")
+	}
+}
+
+// TestResolveEncryptionKey_GeneratesOnMigratedButSecretlessDB verifies the
+// guard does NOT over-trigger: a migrated DB that holds no encrypted secrets is
+// a legitimate fresh install, so key generation proceeds.
+func TestResolveEncryptionKey_GeneratesOnMigratedButSecretlessDB(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := populatedDBPath(t, dir, nil) // schema only, zero secrets
+	cfg := &config.Config{}
+	cfg.Database.Path = dbPath
+
+	key, err := resolveEncryptionKey(cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("resolveEncryptionKey on secretless DB: %v", err)
+	}
+	if key == "" {
+		t.Fatal("expected a generated key on a secretless DB")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "encryption.key")); statErr != nil {
+		t.Errorf("expected generated sibling key file: %v", statErr)
+	}
+}
+
+// TestDatabaseHasEncryptedSecrets_AbsentAndEmpty verifies the probe treats a
+// missing or empty DB file as a fresh install (no secrets).
+func TestDatabaseHasEncryptedSecrets_AbsentAndEmpty(t *testing.T) {
+	dir := t.TempDir()
+
+	has, err := databaseHasEncryptedSecrets(filepath.Join(dir, "absent.db"))
+	if err != nil {
+		t.Fatalf("absent DB: %v", err)
+	}
+	if has {
+		t.Error("absent DB must report no secrets")
+	}
+
+	emptyPath := filepath.Join(dir, "empty.db")
+	if err := os.WriteFile(emptyPath, nil, 0o600); err != nil {
+		t.Fatalf("writing empty db: %v", err)
+	}
+	has, err = databaseHasEncryptedSecrets(emptyPath)
+	if err != nil {
+		t.Fatalf("empty DB: %v", err)
+	}
+	if has {
+		t.Error("empty DB must report no secrets")
+	}
+}
+
 // --- applyPersistedBasePath tests ---
 
 func TestApplyPersistedBasePath_EnvWins(t *testing.T) {

--- a/cmd/stillwater/phases_test.go
+++ b/cmd/stillwater/phases_test.go
@@ -353,6 +353,34 @@ func TestResolveEncryptionKey_KeyFileEmptyIsFatal(t *testing.T) {
 	}
 }
 
+// TestResolveEncryptionKey_KeyFileUnreadableIsFatal verifies that an
+// SW_ENCRYPTION_KEY_FILE that exists but cannot be read (permission denied)
+// surfaces the read error rather than silently generating a fresh key, which
+// would orphan every at-rest secret.
+func TestResolveEncryptionKey_KeyFileUnreadableIsFatal(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("unreadable-file perms bypassed as root")
+	}
+	dir := t.TempDir()
+	keyFilePath := filepath.Join(dir, "unreadable.key")
+	if err := os.WriteFile(keyFilePath, []byte("secretkey\n"), 0o600); err != nil {
+		t.Fatalf("writing key file: %v", err)
+	}
+	if err := os.Chmod(keyFilePath, 0o000); err != nil {
+		t.Fatalf("chmod key file unreadable: %v", err)
+	}
+	// Restore read perms so t.TempDir cleanup can remove the file.
+	t.Cleanup(func() { _ = os.Chmod(keyFilePath, 0o600) })
+
+	cfg := &config.Config{}
+	cfg.Database.Path = filepath.Join(dir, "stillwater.db")
+	cfg.Encryption.KeyFile = keyFilePath
+
+	if _, err := resolveEncryptionKey(cfg, slog.Default()); err == nil {
+		t.Fatal("expected error for unreadable SW_ENCRYPTION_KEY_FILE, got nil")
+	}
+}
+
 // populatedDBPath builds a migrated SQLite DB at dir/stillwater.db, runs the
 // supplied seed against it, and returns the path. The DB is closed so a later
 // read-only probe sees the persisted (checkpointed) rows.

--- a/docs/_generated/make-commands.md
+++ b/docs/_generated/make-commands.md
@@ -33,5 +33,7 @@
 | `make worktree` | Create a sibling worktree with hooks wired and tracker row inserted into the Active table |
 | `make remove-worktree` | Remove a sibling worktree (via cleanup-worktree.sh) and delete its Active-table row |
 | `make clean` | Remove build artifacts |
+| `make uat` | Stage a UAT copy of the live DB + encryption key into ./.uat/ (siblings) and print the run command |
+| `make clean-uat` | Remove the staged ./.uat/ UAT copy (DB + key + run root) |
 | `make bruno-ci` | Build binary, run ephemeral server, execute Bruno API tests, clean up. |
 | `make help` | Show this help message |

--- a/docs/site/src/reference/environment-variables.md
+++ b/docs/site/src/reference/environment-variables.md
@@ -27,6 +27,7 @@ The table below is generated from the configuration definition; do not edit it b
 | `SW_BASE_PATH` | path | `/` | URL prefix for subfolder reverse-proxy deployments (for example /stillwater). When set from the environment the Settings UI marks the field read-only. |
 | `SW_DB_PATH` | path | `/config/stillwater.db` | Filesystem path to the SQLite database file. |
 | `SW_ENCRYPTION_KEY` | string | unset | Key used to encrypt provider API keys at rest. When unset Stillwater generates one on first run and persists it in the config directory. |
+| `SW_ENCRYPTION_KEY_FILE` | string | (none) | Path to a file whose contents are the encryption key. Read at startup and resolved after SW_ENCRYPTION_KEY but before the encryption.key file alongside the database. When set, the file must exist and be non-empty or startup fails. Use this to mount the key as a secret instead of baking it into SW_ENCRYPTION_KEY. |
 | `SW_HTTP3_ENABLED` | boolean | `false` | Set to true or 1 to enable an HTTP/3 (QUIC) listener over UDP. Requires direct TLS to be configured (SW_TLS_CERT_FILE and SW_TLS_KEY_FILE). The Alt-Svc header is added to HTTPS responses so HTTP/3-capable clients upgrade automatically; clients with UDP blocked fall back to HTTP/1.1+HTTP/2 over TCP. |
 | `SW_HTTP3_PORT` | integer | unset | Optional dedicated UDP port for HTTP/3. When unset HTTP/3 reuses the effective HTTPS port (SW_TLS_PORT or SW_PORT). Numeric values outside 1-65535 are rejected at startup. |
 | `SW_HTTP_REDIRECT_PORT` | integer | unset | Optional plain-HTTP listener port that 301-redirects to the HTTPS listener. Requires TLS to be configured (SW_TLS_CERT_FILE + SW_TLS_KEY_FILE). Typical value 80; must differ from SW_TLS_PORT (or SW_PORT in collapse mode). Numeric values outside 1-65535 are rejected at startup. |
@@ -104,6 +105,19 @@ Anything else disables backups -- `True`, `TRUE`, and `yes` all disable. Pin to 
 If you don't set `SW_SESSION_SECRET` and `SW_ENCRYPTION_KEY`, Stillwater writes generated values into the config directory on first run. **Back these files up.** Losing the encryption key means losing the ability to decrypt stored provider API keys (you'd have to re-enter them); losing the session secret signs everyone out.
 
 In container deployments, mount a Docker volume at `/config` so these files survive container recreation. The [install with Docker Compose](../getting-started/install-docker-compose.md) page covers this.
+
+### Encryption key resolution order
+
+At startup Stillwater resolves the encryption key from the first source that yields a value:
+
+1. `SW_ENCRYPTION_KEY` -- the key value, supplied directly.
+2. `SW_ENCRYPTION_KEY_FILE` -- a path whose **contents** are the key value. When set, the file must exist and be non-empty or startup fails (a missing or empty file is never silently skipped). Use this to mount the key as a secret.
+3. `encryption.key` alongside the database (the file Stillwater writes on first run).
+4. Generate a new key -- **only** when the database is genuinely fresh. If the database already holds encrypted secrets (connection or provider API keys) and none of the above sources supplied a key, startup aborts rather than generating a new key that would orphan every stored secret.
+
+### Local UAT against a copy of live data
+
+To exercise a real database without risking the live one, run `make uat`. It stages a consistent copy of your live DB plus its encryption key into a disposable `.uat/` directory **as siblings**, so the server resolves the key automatically (resolution step 3 above -- no `SW_ENCRYPTION_KEY_FILE` needed). The target prints the exact run command on completion; `make clean-uat` removes the staged copy. Override the source data directory with `SW_APPDATA=<dir>` and the port with `SW_PORT=<port>`.
 
 ### UI channel (`SW_UX`)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,7 +107,8 @@ type AuthConfig struct {
 
 // EncryptionConfig holds encryption key settings.
 type EncryptionConfig struct {
-	Key string `yaml:"key" toml:"key" env:"SW_ENCRYPTION_KEY" default:"unset" desc:"Key used to encrypt provider API keys at rest. When unset Stillwater generates one on first run and persists it in the config directory."`
+	Key     string `yaml:"key" toml:"key" env:"SW_ENCRYPTION_KEY" default:"unset" desc:"Key used to encrypt provider API keys at rest. When unset Stillwater generates one on first run and persists it in the config directory."`
+	KeyFile string `yaml:"key_file" toml:"key_file" env:"SW_ENCRYPTION_KEY_FILE" default:"" desc:"Path to a file whose contents are the encryption key. Read at startup and resolved after SW_ENCRYPTION_KEY but before the encryption.key file alongside the database. When set, the file must exist and be non-empty or startup fails. Use this to mount the key as a secret instead of baking it into SW_ENCRYPTION_KEY."`
 }
 
 // MusicConfig holds music library path settings.
@@ -520,6 +521,7 @@ func (c *Config) loadFromEnv() error {
 		// Auth / encryption
 		{Key: "SW_SESSION_SECRET", Apply: setString(&c.Auth.SessionSecret)},
 		{Key: "SW_ENCRYPTION_KEY", Apply: setString(&c.Encryption.Key)},
+		{Key: "SW_ENCRYPTION_KEY_FILE", Apply: setString(&c.Encryption.KeyFile)},
 		// Music
 		{Key: "SW_MUSIC_PATH", Apply: setString(&c.Music.LibraryPath)},
 		{Key: "SW_SCANNER_EXCLUSIONS", Apply: setCSV(&c.Scanner.Exclusions)},


### PR DESCRIPTION
## Summary

The durable fix for the recurring UAT encryption-key drift. **Root cause:** `SW_ENCRYPTION_KEY_FILE` was a *phantom* env var - never read by the binary. The key resolved as `SW_ENCRYPTION_KEY` (value) → `encryption.key` sibling of the DB → else **silently generate a new key**, which orphaned every existing encrypted secret whenever a populated DB was run without its matching key. That cost multiple UAT sessions to `cipher: message authentication failed`.

This PR:
- **Real `SW_ENCRYPTION_KEY_FILE` support** - new config field + env binding; resolution priority `SW_ENCRYPTION_KEY` value > `SW_ENCRYPTION_KEY_FILE` path > sibling `encryption.key` > guarded-generate.
- **Fail-loud guard** - before generating a new key, probe whether the DB already holds encrypted secrets (`connections.encrypted_api_key` / `settings provider.%.api_key`); if so, **ABORT** with a clear error instead of minting a key and orphaning them. The probe opens a read-only handle and fails **closed** on any read error.
- **`make uat` / `make clean-uat`** - atomically clone the appdata DB **and** its `encryption.key` as same-directory **siblings** into the worktree's `.uat/`, so the pair can never mismatch; `/.uat/` gitignored.
- Docs + generated env/settings reference updated.

closes #2036

## Test plan

- Unit tests (env-independent, `t.TempDir`): loads sibling key, `SW_ENCRYPTION_KEY` value wins, `SW_ENCRYPTION_KEY_FILE` path loads the value, **aborts on populated-DB-with-no-key**, generates cleanly on a fresh/secretless DB, and **fails-closed on a probe error** (`TestResolveEncryptionKey_AbortsOnProbeError`).
- **Hostile review PASS**: encryption-key core sound; the two make-or-break checks held - the probe fails-CLOSED on error, and there is no dev `:1973` regression (the live `.env` `SW_ENCRYPTION_KEY_FILE` resolves the same key value at priority 2, so the guard is never reached on the populated DB). False-positive (fresh / secretless / WAL-locked) and false-negative (missing secret surface) both refuted.
- **Live root-cause proof**: `make uat` staged the sibling-key copy; the server loaded the key from file with 0 cipher errors. Removing the sibling key → the server ABORTED with the refuse message and did **not** mint a new key.
- Patch coverage 84.48%; `go build/vet/test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
