### PR TITLE
ci(bruno): instrument CI Bruno binary with coverage, upload to Codecov

### DIFF
--- a/.github/workflows/bruno-ci.yml
+++ b/.github/workflows/bruno-ci.yml
@@ -25,13 +25,16 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
-  # Required for Codecov OIDC token exchange (use_oidc: true).
-  id-token: write
 
 jobs:
   bruno:
     name: Bruno API Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      # Required for Codecov OIDC token exchange (use_oidc: true).
+      id-token: write
     # Belt-and-braces against an inadvertently hanging Bruno request or stuck
     # ephemeral server. The full pipeline (build + 4 tools + Bruno + cleanup)
     # comfortably finishes inside 10 min; 15 leaves headroom for runner cold
@@ -99,6 +102,7 @@ jobs:
           PKG=github.com/sydlexius/stillwater/internal/version
           CGO_ENABLED=0 go build \
             -cover \
+            -coverpkg=./... \
             -trimpath \
             -ldflags="-s -w -X ${PKG}.Version=${VERSION} -X ${PKG}.Commit=${COMMIT} -X ${PKG}.Date=${DATE}" \
             -o stillwater ./cmd/stillwater

--- a/.github/workflows/bruno-ci.yml
+++ b/.github/workflows/bruno-ci.yml
@@ -96,6 +96,7 @@ jobs:
           DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           PKG=github.com/sydlexius/stillwater/internal/version
           CGO_ENABLED=0 go build \
+            -cover \
             -trimpath \
             -ldflags="-s -w -X ${PKG}.Version=${VERSION} -X ${PKG}.Commit=${COMMIT} -X ${PKG}.Date=${DATE}" \
             -o stillwater ./cmd/stillwater
@@ -119,6 +120,10 @@ jobs:
           PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); p=s.getsockname()[1]; s.close(); print(p)')
           echo "port=${PORT}" >> "$GITHUB_OUTPUT"
 
+      - name: Create coverage directory
+        if: steps.filter.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
+        run: mkdir -p "${{ runner.temp }}/bruno-coverage"
+
       - name: Start Stillwater
         if: steps.filter.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
         id: server
@@ -128,6 +133,7 @@ jobs:
           SW_LOG_FORMAT: text
           SW_LOG_LEVEL: warn
           SW_BACKUP_ENABLED: "false"
+          GOCOVERDIR: ${{ runner.temp }}/bruno-coverage
         run: |
           ./stillwater > "${{ runner.temp }}/stillwater-ci.log" 2>&1 &
           echo "pid=$!" >> "$GITHUB_OUTPUT"
@@ -308,6 +314,26 @@ jobs:
           if [ -n "${PID}" ]; then
             kill "${PID}" 2>/dev/null || true
           fi
+
+      - name: Convert Bruno coverage
+        if: always() && (steps.filter.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch')
+        run: |
+          COVERDIR="${{ runner.temp }}/bruno-coverage"
+          if [ -d "${COVERDIR}" ] && [ -n "$(ls -A "${COVERDIR}" 2>/dev/null)" ]; then
+            go tool covdata textfmt -i="${COVERDIR}" -o=bruno-coverage.out
+          else
+            echo "Coverage directory missing or empty; skipping conversion"
+          fi
+
+      - name: Upload Bruno coverage to Codecov
+        if: always() && (steps.filter.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch')
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: bruno-coverage.out
+          flags: bruno
+          token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
+          fail_ci_if_error: true
 
       - name: Upload test results on failure
         if: failure() && (steps.filter.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/bruno-ci.yml
+++ b/.github/workflows/bruno-ci.yml
@@ -25,6 +25,8 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  # Required for Codecov OIDC token exchange (use_oidc: true).
+  id-token: write
 
 jobs:
   bruno:
@@ -313,6 +315,7 @@ jobs:
         run: |
           if [ -n "${PID}" ]; then
             kill "${PID}" 2>/dev/null || true
+            wait "${PID}" 2>/dev/null || true
           fi
 
       - name: Convert Bruno coverage
@@ -331,9 +334,9 @@ jobs:
         with:
           files: bruno-coverage.out
           flags: bruno
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           disable_search: true
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       - name: Upload test results on failure
         if: failure() && (steps.filter.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch')

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,10 @@
+flag_management:
+  default_rules:
+    carryforward: false
+  individual_flags:
+    - name: bruno
+      carryforward: true
+
 coverage:
   status:
     patch:

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -176,6 +176,33 @@ Use Bruno collections in `api/bruno/` to test endpoints:
 3. Run requests against a local or running instance
 4. Bruno exports as plaintext files (no binary lock-in)
 
+#### Local Bruno Coverage Recipe
+
+To measure API coverage from the Bruno collection locally:
+
+```bash
+# 1. Build an instrumented binary
+GOCOVDIR=$(mktemp -d)
+go build -cover -o /tmp/stillwater-cover ./cmd/stillwater
+
+# 2. Start the server with coverage output enabled
+GOCOVERDIR="$GOCOVDIR" /tmp/stillwater-cover &
+SERVER_PID=$!
+
+# 3. Run the Bruno collection (from api/bruno/)
+cd api/bruno
+bru run --env ci --env-var "baseUrl=http://127.0.0.1:1973" -r .
+
+# 4. Stop server gracefully (flushes coverage counters)
+kill "$SERVER_PID"
+
+# 5. Convert binary coverage to a Go coverage profile
+go tool covdata textfmt -i="$GOCOVDIR" -o bruno-coverage.out
+
+# 6. View the report
+go tool cover -func=bruno-coverage.out | tail -1
+```
+
 ## Running Tests
 
 ```bash

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -182,22 +182,22 @@ To measure API coverage from the Bruno collection locally:
 
 ```bash
 # 1. Build an instrumented binary
-GOCOVDIR=$(mktemp -d)
+GOCOVERDIR=$(mktemp -d)
 go build -cover -o /tmp/stillwater-cover ./cmd/stillwater
 
 # 2. Start the server with coverage output enabled
-GOCOVERDIR="$GOCOVDIR" /tmp/stillwater-cover &
+GOCOVERDIR="$GOCOVERDIR" /tmp/stillwater-cover &
 SERVER_PID=$!
 
 # 3. Run the Bruno collection (from api/bruno/)
 cd api/bruno
-bru run --env ci --env-var "baseUrl=http://127.0.0.1:1973" -r .
+bru run --env ci --env-var "baseUrl=http://127.0.0.1:1973" --disable-cookies -r .
 
 # 4. Stop server gracefully (flushes coverage counters)
-kill "$SERVER_PID"
+kill "$SERVER_PID" && wait "$SERVER_PID" 2>/dev/null || true
 
 # 5. Convert binary coverage to a Go coverage profile
-go tool covdata textfmt -i="$GOCOVDIR" -o bruno-coverage.out
+go tool covdata textfmt -i="$GOCOVERDIR" -o bruno-coverage.out
 
 # 6. View the report
 go tool cover -func=bruno-coverage.out | tail -1


### PR DESCRIPTION
## What

Instruments the CI Bruno test binary with Go coverage and uploads it to Codecov under a dedicated `bruno` flag, so the API surface exercised by the Bruno collection counts toward coverage.

- `bruno-ci.yml`: build the server with `go build -cover`, set `GOCOVERDIR` on the **server-run** step, create the coverage dir, and after the suite convert the binary coverage to a Go profile (`go tool covdata textfmt`) and upload it.
- `codecov.yml`: add a `flag_management` block so the `bruno` flag carries forward between runs (the rest of the suite is unaffected).
- `docs/dev-setup.md`: a local "Bruno Coverage Recipe" so a developer can reproduce the measurement.

## Why

`#1766` - the Bruno collection drives a large slice of the HTTP API that unit tests don't reach; without instrumentation that exercise was invisible to coverage.

## Notes / design choices

- **Codecov auth matches the repo convention**: OIDC (`use_oidc: true` + job `id-token: write`), not a rotating `CODECOV_TOKEN` secret - same as `ci.yml`.
- **`fail_ci_if_error: false`**, matching `ci.yml`'s documented rationale: the job is non-required, transient Codecov outages shouldn't block the gate, and a no-counters run (which skips writing the profile) must not spuriously fail the upload.
- **Graceful shutdown waits for the server to exit** (`wait` after `kill`) so Go's `-cover` counters flush before conversion.
- The `codecov-action` is SHA-pinned to the same commit `ci.yml` uses (`fb8b3582` # v7.0.0).

## Test plan

- `actionlint .github/workflows/bruno-ci.yml` - clean.
- `codecov.yml` validates as YAML.
- The new steps reuse the existing `steps.filter.outputs.relevant || workflow_dispatch` gating, with `if: always()` on convert/upload so coverage is collected even when a test fails.
- No Go source changed.

Closes #1766
