### PR TITLE
test(bruno): add parity smoke requests for 6 masked routes (#2049)

### DIFF
--- a/api/bruno/artists/get-platform-state.bru
+++ b/api/bruno/artists/get-platform-state.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Platform State
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{apiBase}}/artists/{{artistId}}/platform-state?connection_id={{connectionId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("returns 404 for sentinel artistId", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope reports artist not found", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.equal("artist not found");
+  });
+}

--- a/api/bruno/conflicts/get-conflicts.bru
+++ b/api/bruno/conflicts/get-conflicts.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Get Conflicts
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{apiBase}}/conflicts
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is an object", function() {
+    expect(res.body).to.be.an("object");
+  });
+}

--- a/api/bruno/connections/discover-libraries.bru
+++ b/api/bruno/connections/discover-libraries.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Discover Libraries
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{apiBase}}/connections/{{connectionId}}/libraries
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("returns 404 for sentinel connectionId", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope reports connection not found", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.equal("connection not found");
+  });
+}

--- a/api/bruno/foreign-files/list-foreign-files.bru
+++ b/api/bruno/foreign-files/list-foreign-files.bru
@@ -19,9 +19,11 @@ tests {
     expect(res.status).to.equal(200);
   });
 
-  test("response has items array and count", function() {
+  test("response has items array (or null on empty DB) and count", function() {
     expect(res.body).to.be.an("object");
-    expect(res.body.items).to.be.an("array");
+    var items = res.body.items;
+    var ok = items === null || Array.isArray(items);
+    expect(ok).to.equal(true);
     expect(res.body.count).to.be.a("number");
   });
 }

--- a/api/bruno/foreign-files/list-foreign-files.bru
+++ b/api/bruno/foreign-files/list-foreign-files.bru
@@ -1,0 +1,26 @@
+meta {
+  name: List Foreign Files
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{apiBase}}/foreign-files
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response has items array and count", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.count).to.be.a("number");
+  });
+}

--- a/api/bruno/foreign-files/list-foreign-files.bru
+++ b/api/bruno/foreign-files/list-foreign-files.bru
@@ -21,6 +21,7 @@ tests {
 
   test("response has items array and count", function() {
     expect(res.body).to.be.an("object");
+    expect(res.body.items).to.be.an("array");
     expect(res.body.count).to.be.a("number");
   });
 }

--- a/api/bruno/foreign-files/list-foreign-files.bru
+++ b/api/bruno/foreign-files/list-foreign-files.bru
@@ -25,5 +25,6 @@ tests {
     var ok = items === null || Array.isArray(items);
     expect(ok).to.equal(true);
     expect(res.body.count).to.be.a("number");
+    expect(res.body.count).to.equal(items === null ? 0 : items.length);
   });
 }

--- a/api/bruno/history/list-history.bru
+++ b/api/bruno/history/list-history.bru
@@ -1,0 +1,29 @@
+meta {
+  name: List Global History
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{apiBase}}/history
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is a paginated envelope (changes, total, limit, offset)", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.changes).to.be.an("array");
+    expect(res.body.total).to.be.a("number");
+    expect(res.body.limit).to.be.a("number");
+    expect(res.body.offset).to.be.a("number");
+  });
+}

--- a/api/bruno/parity-ignore.json
+++ b/api/bruno/parity-ignore.json
@@ -152,10 +152,6 @@
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
-    "route": "GET /api/v1/artists/{}/platform-state",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "GET /api/v1/artists/{}/rule-results",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
@@ -172,10 +168,6 @@
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
-    "route": "GET /api/v1/conflicts",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "GET /api/v1/connections/clobber-check",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
@@ -185,10 +177,6 @@
   },
   {
     "route": "GET /api/v1/connections/{}/conflict-detail",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/connections/{}/libraries",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
@@ -220,15 +208,7 @@
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
-    "route": "GET /api/v1/foreign-files",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "GET /api/v1/foreign-files/count",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/history",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
@@ -265,10 +245,6 @@
   },
   {
     "route": "GET /api/v1/reports/compliance/export",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/reports/duplicates",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {

--- a/api/bruno/reports/duplicates.bru
+++ b/api/bruno/reports/duplicates.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Duplicates Report
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{apiBase}}/reports/duplicates
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return array", function() {
+    expect(res.body).to.be.an("array");
+  });
+}


### PR DESCRIPTION
## What

Chips down the Bruno route-parity ignore baseline (added by #1765) by adding smoke requests for 6 masked `/api/v1` routes and removing their `parity-ignore.json` entries. Ignored routes: **153 → 147**.

| Route | `.bru` | Assertion |
|---|---|---|
| `GET /api/v1/conflicts` | `conflicts/get-conflicts.bru` | 200 + Ledger object |
| `GET /api/v1/foreign-files` | `foreign-files/list-foreign-files.bru` | 200 + `{items, count}` |
| `GET /api/v1/history` | `history/list-history.bru` | 200 + `{changes, total, limit, offset}` |
| `GET /api/v1/reports/duplicates` | `reports/duplicates.bru` | 200 + array |
| `GET /api/v1/connections/{id}/libraries` | `connections/discover-libraries.bru` | 404 + `"connection not found"` (sentinel id) |
| `GET /api/v1/artists/{id}/platform-state` | `artists/get-platform-state.bru` | 404 + `"artist not found"` (sentinel id) |

Collection routes assert the 200 JSON-contract shape on the empty CI DB; path-param routes use a CI sentinel UUID to hit the deterministic 404 error envelope (no seeded data needed). Each assertion was verified against the actual Go handler (status, shape, error string).

## Why

`#2049` — the parity guard freezes current coverage but masks core JSON-contract GETs. The guard FAILs on an obsolete ignore entry once a route gains a request, so add-`.bru` + remove-ignore is the self-enforcing paired step.

## Test plan

- `bash scripts/check-bruno-parity.sh` → `OK: every API route is covered by a Bruno request or ignore-listed; no stale requests.` (261 routes, 116 requests, 147 ignored).
- The `bruno-ci` job runs these requests against an ephemeral server.

Refs #2049 (long-running tracker — 6 of 153, chip down opportunistically).
