### PR TITLE
feat(provider): adaptive AIMD rate limiting with hysteresis

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -40,3 +40,7 @@ limite = "limite"
 # capped message ("{count} artistes sur {total} chargés"). typos flags it
 # as a misspelling of English "sure".
 sur = "sur"
+# AIMD (Additive Increase / Multiplicative Decrease) is a network-congestion
+# control algorithm; its abbreviation is not a misspelling of "aimed".
+AIMD = "AIMD"
+aimd = "aimd"

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -678,6 +678,24 @@ func (a *Application) wireProviders(ctx context.Context) error {
 	a.providerSettings = provider.NewSettingsService(db, a.encryptor)
 	a.providerRegistry = provider.NewRegistry()
 
+	// Build the AIMD controller and load any stored per-provider ceiling
+	// overrides from the settings database.
+	aimdCtrl := provider.NewAIMDController(a.rateLimiters, provider.SystemClock())
+	for _, name := range provider.AllProviderNames() {
+		ceiling, err := a.providerSettings.GetRateLimitCeiling(ctx, name)
+		if err != nil {
+			logger.Warn("failed to load AIMD rate-limit ceiling from database",
+				slog.String("provider", string(name)), "error", err)
+			continue
+		}
+		if ceiling > 0 {
+			aimdCtrl.SetCeiling(name, rate.Limit(ceiling))
+			logger.Info("loaded AIMD rate-limit ceiling",
+				slog.String("provider", string(name)),
+				slog.Float64("ceiling_req_per_sec", ceiling))
+		}
+	}
+
 	mb := musicbrainz.New(a.rateLimiters, logger)
 	if baseURL, err := a.providerSettings.GetBaseURL(ctx, provider.NameMusicBrainz); err != nil {
 		logger.Warn("failed to load MusicBrainz mirror URL from database", "error", err)
@@ -705,7 +723,7 @@ func (a *Application) wireProviders(ctx context.Context) error {
 	a.webSearchRegistry = provider.NewWebSearchRegistry()
 	a.webSearchRegistry.Register(duckduckgo.New(a.rateLimiters, logger))
 
-	a.orchestrator = provider.NewOrchestrator(a.providerRegistry, a.providerSettings, logger)
+	a.orchestrator = provider.NewOrchestrator(a.providerRegistry, a.providerSettings, logger, aimdCtrl)
 
 	// --- Scraper ---
 	a.scraperService = scraper.NewService(db, logger)

--- a/internal/api/handlers_deezer_test.go
+++ b/internal/api/handlers_deezer_test.go
@@ -35,7 +35,7 @@ func installDeezerOrchestrator(t *testing.T, r *Router,
 	registry.Register(stub)
 	r.providerRegistry = registry
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	r.orchestrator = provider.NewOrchestrator(registry, nil, logger)
+	r.orchestrator = provider.NewOrchestrator(registry, nil, logger, nil)
 }
 
 func TestIsAllDigits(t *testing.T) {

--- a/internal/api/handlers_discogs_test.go
+++ b/internal/api/handlers_discogs_test.go
@@ -36,7 +36,7 @@ func installDiscogsOrchestrator(t *testing.T, r *Router,
 	registry.Register(stub)
 	r.providerRegistry = registry
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	r.orchestrator = provider.NewOrchestrator(registry, nil, logger)
+	r.orchestrator = provider.NewOrchestrator(registry, nil, logger, nil)
 }
 
 func TestToDiscogsTemplateCandidates(t *testing.T) {

--- a/internal/api/handlers_field_providers_test.go
+++ b/internal/api/handlers_field_providers_test.go
@@ -68,7 +68,7 @@ func TestHandleFieldProviders_LanguageContextInjected(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	providerSettings := provider.NewSettingsService(r.db, nil)
-	orch := provider.NewOrchestrator(reg, providerSettings, logger)
+	orch := provider.NewOrchestrator(reg, providerSettings, logger, nil)
 	r.orchestrator = orch
 
 	a := addTestArtist(t, artistSvc, "Language Injection Test Artist")

--- a/internal/api/handlers_identify_tier2_test.go
+++ b/internal/api/handlers_identify_tier2_test.go
@@ -98,7 +98,7 @@ func newIdentifyTestServer(t *testing.T, search func(ctx context.Context, name s
 	// (which would otherwise dereference the nil settings service), we install
 	// a no-op ScraperExecutor that short-circuits the executor branch.
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := provider.NewOrchestrator(registry, nil, logger)
+	orch := provider.NewOrchestrator(registry, nil, logger, nil)
 	orch.SetExecutor(&stubScraperExecutor{result: &provider.FetchResult{Metadata: &provider.ArtistMetadata{}}})
 	r.orchestrator = orch
 
@@ -678,7 +678,7 @@ func TestRunBulkIdentify_PanicRecovered(t *testing.T) {
 	registry := provider.NewRegistry()
 	registry.Register(panicProv)
 	r.providerRegistry = registry
-	r.orchestrator = provider.NewOrchestrator(registry, nil, logger)
+	r.orchestrator = provider.NewOrchestrator(registry, nil, logger, nil)
 
 	// Seed one unidentified artist (no path, so tier 3 fires immediately).
 	a := &artist.Artist{Name: "Boom"}
@@ -746,7 +746,7 @@ func TestBulkIdentify_ResetsAfterPanic(t *testing.T) {
 	registry := provider.NewRegistry()
 	registry.Register(panicProv)
 	r.providerRegistry = registry
-	r.orchestrator = provider.NewOrchestrator(registry, nil, logger)
+	r.orchestrator = provider.NewOrchestrator(registry, nil, logger, nil)
 
 	a := &artist.Artist{Name: "Crashy"}
 	if err := artistSvc.Create(context.Background(), a); err != nil {

--- a/internal/api/handlers_image_coverage_test.go
+++ b/internal/api/handlers_image_coverage_test.go
@@ -54,7 +54,7 @@ func newImageHandlerTestServer(t *testing.T) (*Router, *artist.Service) {
 	// non-error path for the test.
 	emptyRegistry := provider.NewRegistry()
 	settings := provider.NewSettingsService(r.db, nil)
-	r.orchestrator = provider.NewOrchestrator(emptyRegistry, settings, r.logger)
+	r.orchestrator = provider.NewOrchestrator(emptyRegistry, settings, r.logger, nil)
 	r.providerSettings = settings
 
 	// handleWebImageSearch ranges r.webSearchRegistry.All(); a nil registry

--- a/internal/api/handlers_refresh_search_test.go
+++ b/internal/api/handlers_refresh_search_test.go
@@ -49,7 +49,7 @@ func installSearchOrchestrator(t *testing.T, r *Router, providers ...*minimalSea
 	}
 	r.providerRegistry = registry
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := provider.NewOrchestrator(registry, nil, logger)
+	orch := provider.NewOrchestrator(registry, nil, logger, nil)
 	r.orchestrator = orch
 }
 

--- a/internal/api/handlers_refresh_test.go
+++ b/internal/api/handlers_refresh_test.go
@@ -626,7 +626,7 @@ func TestExecuteRefreshAndPostHook_ResolvesBioViolation(t *testing.T) {
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := provider.NewOrchestrator(nil, nil, logger)
+	orch := provider.NewOrchestrator(nil, nil, logger, nil)
 	orch.SetExecutor(stub)
 	r.orchestrator = orch
 
@@ -738,7 +738,7 @@ func TestExecuteRefreshCtx_AppliesMemberRefresh(t *testing.T) {
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := provider.NewOrchestrator(nil, nil, logger)
+	orch := provider.NewOrchestrator(nil, nil, logger, nil)
 	orch.SetExecutor(stub)
 	r.orchestrator = orch
 
@@ -798,7 +798,7 @@ func TestExecuteRefreshCtx_PreservesTagsWhenProviderReturnsNoData(t *testing.T) 
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := provider.NewOrchestrator(nil, nil, logger)
+	orch := provider.NewOrchestrator(nil, nil, logger, nil)
 	orch.SetExecutor(stub)
 	r.orchestrator = orch
 
@@ -847,7 +847,7 @@ func TestExecuteRefreshCtx_OverwritesTagsWhenProviderReturnsData(t *testing.T) {
 		},
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := provider.NewOrchestrator(nil, nil, logger)
+	orch := provider.NewOrchestrator(nil, nil, logger, nil)
 	orch.SetExecutor(stub)
 	r.orchestrator = orch
 

--- a/internal/api/handlers_reidentify_wizard_search_test.go
+++ b/internal/api/handlers_reidentify_wizard_search_test.go
@@ -43,7 +43,7 @@ func TestEnsureWizardCandidates_ProviderFailureRoutesToStepFailed(t *testing.T) 
 	})
 	r.providerRegistry = registry
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	r.orchestrator = provider.NewOrchestrator(registry, nil, logger)
+	r.orchestrator = provider.NewOrchestrator(registry, nil, logger, nil)
 
 	sess, err := r.reIdentifyWizardStore.create([]*reIdentifyWizardStep{
 		{ArtistID: a.ID, ArtistName: a.Name, ArtistPath: a.Path},
@@ -100,7 +100,7 @@ func TestEnsureWizardCandidates_AllProvidersOKReadiesStep(t *testing.T) {
 	})
 	r.providerRegistry = registry
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	r.orchestrator = provider.NewOrchestrator(registry, nil, logger)
+	r.orchestrator = provider.NewOrchestrator(registry, nil, logger, nil)
 
 	sess, err := r.reIdentifyWizardStore.create([]*reIdentifyWizardStep{
 		{ArtistID: a.ID, ArtistName: a.Name, ArtistPath: a.Path},

--- a/internal/provider/aimd.go
+++ b/internal/provider/aimd.go
@@ -92,8 +92,14 @@ func (c *AIMDController) stateFor(name ProviderName) *aimdState {
 		// doesn't divide by zero or produce a nonsensical ceiling.
 		ceiling = aimdIncrement * aimdDefaultCeilingMultiplier
 	}
+	// currentLimit must start at least at aimdIncrement so that an unknown
+	// provider (floor == 0) cannot wedge itself at zero on the first failure.
+	currentLimit := floor
+	if currentLimit < aimdIncrement {
+		currentLimit = aimdIncrement
+	}
 	s := &aimdState{
-		currentLimit: floor,
+		currentLimit: currentLimit,
 		ceiling:      ceiling,
 	}
 	c.states[name] = s
@@ -156,9 +162,15 @@ func (c *AIMDController) RecordFailure(name ProviderName, retryAfter time.Durati
 	}
 
 	floor := defaultRateLimits[name]
+	// Ensure the floor is at least aimdIncrement so currentLimit can never
+	// reach zero or go negative, even for providers not in defaultRateLimits.
+	effectiveFloor := floor
+	if effectiveFloor < aimdIncrement {
+		effectiveFloor = aimdIncrement
+	}
 	newLimit := rate.Limit(float64(s.currentLimit) * aimdDecreaseFactor)
-	if newLimit < floor {
-		newLimit = floor
+	if newLimit < effectiveFloor {
+		newLimit = effectiveFloor
 	}
 	s.currentLimit = newLimit
 	s.successCount = 0
@@ -187,11 +199,20 @@ func (c *AIMDController) SetCeiling(name ProviderName, ceiling rate.Limit) {
 }
 
 // GetCeiling returns the current ceiling for a provider, initializing state
-// lazily if needed.
+// lazily if needed. The fast path uses an RLock; the first-touch init falls
+// back to a write lock with a double-checked re-read.
 func (c *AIMDController) GetCeiling(name ProviderName) rate.Limit {
+	c.mu.RLock()
+	if s, ok := c.states[name]; ok {
+		v := s.ceiling
+		c.mu.RUnlock()
+		return v
+	}
+	c.mu.RUnlock()
+
+	// State not yet initialized -- take the write lock, re-check, then init.
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
-	s := c.stateFor(name)
+	s := c.stateFor(name) // stateFor handles the already-initialized case
 	return s.ceiling
 }

--- a/internal/provider/aimd.go
+++ b/internal/provider/aimd.go
@@ -1,0 +1,197 @@
+package provider
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// AIMD tuning constants. These are locked values, not suggestions.
+const (
+	// aimdIncrement is the additive-increase step applied to the current rate
+	// limit (in requests per second) after aimdSuccessThreshold consecutive
+	// successful provider calls.
+	aimdIncrement = rate.Limit(0.5)
+
+	// aimdDecreaseFactor is the multiplicative-decrease factor applied to the
+	// current rate limit when a provider signals rate-limiting (429 / 503 with
+	// a RetryAfter). The limit is halved on each decrease, floored at the
+	// provider's configured default.
+	aimdDecreaseFactor = 0.5
+
+	// aimdSuccessThreshold is the number of consecutive successful provider
+	// calls required before one additive increase is applied.
+	aimdSuccessThreshold = 10
+
+	// aimdHysteresisCooldown is the minimum interval between two consecutive
+	// multiplicative decreases for the same provider. Decreases that arrive
+	// within this window are ignored to prevent thrashing on a burst of 429s.
+	aimdHysteresisCooldown = 30 * time.Second
+
+	// aimdDefaultCeilingMultiplier sets the default per-provider ceiling as a
+	// multiple of the provider's default rate limit. An explicit ceiling set via
+	// SetCeiling overrides this.
+	aimdDefaultCeilingMultiplier = 10
+)
+
+// aimdState tracks the adaptive rate-limit state for a single provider.
+type aimdState struct {
+	// currentLimit is the active rate limit (req/s) managed by this controller.
+	// It starts at the provider's default and is adjusted by AIMD logic.
+	currentLimit rate.Limit
+	// ceiling is the maximum rate limit this provider is allowed to reach.
+	// Additive increases are capped here.
+	ceiling rate.Limit
+	// lastDecrease records when the most recent multiplicative decrease was
+	// applied. It is used to enforce the hysteresis cooldown.
+	lastDecrease time.Time
+	// successCount is the number of consecutive successes since the last
+	// increase or decrease. When it reaches aimdSuccessThreshold, one additive
+	// increase is applied and successCount resets to zero.
+	successCount int
+}
+
+// AIMDController implements additive-increase / multiplicative-decrease
+// adaptive rate limiting for the provider layer. It wraps a RateLimiterMap and
+// adjusts each provider's rate limit in response to success and failure signals
+// from the orchestrator.
+//
+// All methods are safe for concurrent use.
+type AIMDController struct {
+	mu     sync.RWMutex
+	rlm    *RateLimiterMap
+	clock  Clock
+	states map[ProviderName]*aimdState
+	logger *slog.Logger
+}
+
+// NewAIMDController creates a new AIMDController backed by rlm. The clock
+// parameter is used for hysteresis checks; pass SystemClock() in production
+// and a controllable fake in tests.
+func NewAIMDController(rlm *RateLimiterMap, clock Clock) *AIMDController {
+	return &AIMDController{
+		rlm:    rlm,
+		clock:  clock,
+		states: make(map[ProviderName]*aimdState),
+		logger: slog.Default().With(slog.String("component", "aimd")),
+	}
+}
+
+// stateFor returns the aimdState for name, initializing it lazily on first
+// access. The caller must hold at least a write lock.
+func (c *AIMDController) stateFor(name ProviderName) *aimdState {
+	if s, ok := c.states[name]; ok {
+		return s
+	}
+	floor := defaultRateLimits[name]
+	ceiling := rate.Limit(float64(floor) * aimdDefaultCeilingMultiplier)
+	if ceiling <= 0 {
+		// Unknown provider or zero-floor: use a safe default so the controller
+		// doesn't divide by zero or produce a nonsensical ceiling.
+		ceiling = aimdIncrement * aimdDefaultCeilingMultiplier
+	}
+	s := &aimdState{
+		currentLimit: floor,
+		ceiling:      ceiling,
+	}
+	c.states[name] = s
+	return s
+}
+
+// RecordSuccess signals that a provider call succeeded. After
+// aimdSuccessThreshold consecutive successes, the current rate limit is
+// increased by aimdIncrement (capped at ceiling) and pushed into the
+// underlying RateLimiterMap.
+func (c *AIMDController) RecordSuccess(name ProviderName) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	s := c.stateFor(name)
+	s.successCount++
+	if s.successCount < aimdSuccessThreshold {
+		return
+	}
+
+	// Threshold reached: apply one additive increase.
+	s.successCount = 0
+	newLimit := s.currentLimit + aimdIncrement
+	if newLimit > s.ceiling {
+		newLimit = s.ceiling
+	}
+	if newLimit == s.currentLimit {
+		// Already at ceiling; nothing to do.
+		return
+	}
+	s.currentLimit = newLimit
+	c.rlm.SetLimit(name, newLimit)
+	c.logger.Info("aimd: rate limit increased",
+		slog.String("provider", string(name)),
+		slog.Float64("new_limit", float64(newLimit)),
+	)
+}
+
+// RecordFailure signals that a provider call failed with a rate-limit or
+// server-unavailable error. It applies a multiplicative decrease to the
+// current rate limit, floored at the provider's default, and resets the
+// success counter. A hysteresis guard prevents more than one decrease per
+// aimdHysteresisCooldown window to avoid thrashing on a burst of 429s.
+//
+// retryAfter is the server-advised backoff duration from the error (may be 0
+// if the server provided no hint); it is available for future observability
+// but the core decrease logic uses the multiplicative factor and floor only.
+func (c *AIMDController) RecordFailure(name ProviderName, retryAfter time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	s := c.stateFor(name)
+	now := c.clock.Now()
+
+	// Hysteresis: ignore a decrease if one was applied within the cooldown
+	// window. This prevents a burst of 429s from repeatedly halving the limit
+	// in quick succession.
+	if !s.lastDecrease.IsZero() && now.Sub(s.lastDecrease) < aimdHysteresisCooldown {
+		return
+	}
+
+	floor := defaultRateLimits[name]
+	newLimit := rate.Limit(float64(s.currentLimit) * aimdDecreaseFactor)
+	if newLimit < floor {
+		newLimit = floor
+	}
+	s.currentLimit = newLimit
+	s.successCount = 0
+	s.lastDecrease = now
+	c.rlm.SetLimit(name, newLimit)
+	c.logger.Info("aimd: rate limit decreased",
+		slog.String("provider", string(name)),
+		slog.Float64("new_limit", float64(newLimit)),
+		slog.Duration("retry_after", retryAfter),
+	)
+}
+
+// SetCeiling overrides the rate limit ceiling for a provider. The ceiling caps
+// how high additive increases can push the limit. A ceiling of zero or less
+// reverts to the default (aimdDefaultCeilingMultiplier * floor).
+func (c *AIMDController) SetCeiling(name ProviderName, ceiling rate.Limit) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	s := c.stateFor(name)
+	if ceiling <= 0 {
+		floor := defaultRateLimits[name]
+		ceiling = rate.Limit(float64(floor) * aimdDefaultCeilingMultiplier)
+	}
+	s.ceiling = ceiling
+}
+
+// GetCeiling returns the current ceiling for a provider, initializing state
+// lazily if needed.
+func (c *AIMDController) GetCeiling(name ProviderName) rate.Limit {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	s := c.stateFor(name)
+	return s.ceiling
+}

--- a/internal/provider/aimd_test.go
+++ b/internal/provider/aimd_test.go
@@ -265,6 +265,59 @@ func TestAIMDSetCeilingZeroReverts(t *testing.T) {
 	}
 }
 
+// TestAIMDConcurrencyTwoKeys is a race-detector test that initializes two
+// different provider keys concurrently. The single-key concurrency test misses
+// the case where stateFor's lazy-init is racing on two distinct map entries at
+// the same instant. This test covers that gap.
+func TestAIMDConcurrencyTwoKeys(t *testing.T) {
+	t.Parallel()
+	clk := newFakeClock(time.Now())
+	ctrl := newTestAIMD(clk)
+
+	// Use two providers with different floors to ensure distinct state slots.
+	nameA := NameMusicBrainz // floor = 1 req/s
+	nameB := NameFanartTV    // floor = 3 req/s
+
+	const goroutines = 20
+	const opsPerGoroutine = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			for j := range opsPerGoroutine {
+				// Split goroutines evenly across the two keys.
+				n := nameA
+				if idx%2 == 1 {
+					n = nameB
+				}
+				if (idx+j)%3 == 0 {
+					clk.advance(time.Millisecond)
+					ctrl.RecordFailure(n, time.Second)
+				} else {
+					ctrl.RecordSuccess(n)
+				}
+				_ = ctrl.GetCeiling(n)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Both limits must remain within their respective [floor, ceiling] ranges.
+	for _, n := range []ProviderName{nameA, nameB} {
+		got := aimdCurrentLimit(ctrl, n)
+		floor := defaultRateLimits[n]
+		ceiling := ctrl.GetCeiling(n)
+		if got < floor {
+			t.Errorf("provider %s: limit %v below floor %v", n, got, floor)
+		}
+		if got > ceiling {
+			t.Errorf("provider %s: limit %v above ceiling %v", n, got, ceiling)
+		}
+	}
+}
+
 // TestAIMDConcurrency is a race-detector test that hammers RecordSuccess and
 // RecordFailure from multiple goroutines concurrently. It does not assert
 // specific limit values; the race detector catches unsafe concurrent access.

--- a/internal/provider/aimd_test.go
+++ b/internal/provider/aimd_test.go
@@ -1,0 +1,311 @@
+package provider
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// fakeClock is a controllable Clock implementation for AIMD tests. It avoids
+// any real wall-clock dependency so tests are deterministic and instantaneous.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock(t time.Time) *fakeClock { return &fakeClock{now: t} }
+
+func (f *fakeClock) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.now
+}
+
+// Sleep does not actually sleep; it is a no-op in tests. AIMD tests do not
+// exercise the sleep path, so this keeps the interface satisfied.
+func (f *fakeClock) Sleep(_ context.Context, _ time.Duration) error { return nil }
+
+// advance moves the fake clock forward by d.
+func (f *fakeClock) advance(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.now = f.now.Add(d)
+}
+
+// --- helpers ------------------------------------------------------------------
+
+// newTestAIMD builds an AIMDController backed by a fresh RateLimiterMap and a
+// fakeClock. Tests inspect state via the controller itself using aimdCurrentLimit.
+func newTestAIMD(clk *fakeClock) *AIMDController {
+	rlm := NewRateLimiterMap()
+	return NewAIMDController(rlm, clk)
+}
+
+// currentLimit reads the current rate limit for name by forcing a lookup
+// through SetLimit (which replaces the limiter) and then measuring the rate.
+// We use the RateLimiterMap's internal state indirectly via the AIMD state.
+func aimdCurrentLimit(ctrl *AIMDController, name ProviderName) rate.Limit {
+	ctrl.mu.RLock()
+	s, ok := ctrl.states[name]
+	ctrl.mu.RUnlock()
+	if !ok {
+		return defaultRateLimits[name]
+	}
+	return s.currentLimit
+}
+
+// --- tests --------------------------------------------------------------------
+
+// TestAIMDSuccessRamp verifies that aimdSuccessThreshold consecutive successes
+// trigger exactly one additive increase and then the counter resets.
+func TestAIMDSuccessRamp(t *testing.T) {
+	t.Parallel()
+	clk := newFakeClock(time.Now())
+	ctrl := newTestAIMD(clk)
+	name := NameMusicBrainz // floor = 1 req/s
+
+	floor := defaultRateLimits[name]
+	expected := floor + aimdIncrement
+
+	// Record one fewer than the threshold -- no increase yet.
+	for i := range aimdSuccessThreshold - 1 {
+		ctrl.RecordSuccess(name)
+		got := aimdCurrentLimit(ctrl, name)
+		if got != floor {
+			t.Fatalf("iteration %d: expected limit %v before threshold, got %v", i, floor, got)
+		}
+	}
+
+	// One more success crosses the threshold.
+	ctrl.RecordSuccess(name)
+	got := aimdCurrentLimit(ctrl, name)
+	if got != expected {
+		t.Fatalf("expected limit %v after threshold, got %v", expected, got)
+	}
+
+	// Counter should have reset; the next (threshold-1) successes must not
+	// produce another increase.
+	for i := range aimdSuccessThreshold - 1 {
+		ctrl.RecordSuccess(name)
+		got = aimdCurrentLimit(ctrl, name)
+		if got != expected {
+			t.Fatalf("iteration %d: expected limit %v after reset, got %v", i, expected, got)
+		}
+	}
+}
+
+// TestAIMDSuccessCappedAtCeiling verifies that additive increases stop at the ceiling.
+func TestAIMDSuccessCappedAtCeiling(t *testing.T) {
+	t.Parallel()
+	clk := newFakeClock(time.Now())
+	ctrl := newTestAIMD(clk)
+	name := NameMusicBrainz
+	floor := defaultRateLimits[name]
+
+	// Set ceiling just above floor so one increase hits it and subsequent
+	// increases are clamped.
+	ceiling := floor + aimdIncrement
+	ctrl.SetCeiling(name, ceiling)
+
+	// Trigger the first increase.
+	for range aimdSuccessThreshold {
+		ctrl.RecordSuccess(name)
+	}
+	got := aimdCurrentLimit(ctrl, name)
+	if got != ceiling {
+		t.Fatalf("expected limit to equal ceiling %v, got %v", ceiling, got)
+	}
+
+	// Trigger a second batch of successes; limit must stay at ceiling.
+	for range aimdSuccessThreshold {
+		ctrl.RecordSuccess(name)
+	}
+	got = aimdCurrentLimit(ctrl, name)
+	if got != ceiling {
+		t.Fatalf("expected limit to remain at ceiling %v after second batch, got %v", ceiling, got)
+	}
+}
+
+// TestAIMDMultiplicativeDecrease verifies that RecordFailure halves the limit
+// and floors it at the provider default.
+func TestAIMDMultiplicativeDecrease(t *testing.T) {
+	t.Parallel()
+	clk := newFakeClock(time.Now())
+	ctrl := newTestAIMD(clk)
+	name := NameFanartTV // floor = 3 req/s
+
+	floor := defaultRateLimits[name]
+
+	// First, pump the limit up above floor by recording enough successes.
+	// ceiling defaults to floor * 10.
+	for range aimdSuccessThreshold {
+		ctrl.RecordSuccess(name)
+	}
+	before := aimdCurrentLimit(ctrl, name)
+	if before <= floor {
+		t.Fatalf("expected limit above floor %v after successes, got %v", floor, before)
+	}
+
+	// Record a failure. Limit should halve.
+	ctrl.RecordFailure(name, 0)
+	afterFirst := aimdCurrentLimit(ctrl, name)
+	expectedFirst := rate.Limit(float64(before) * aimdDecreaseFactor)
+	if expectedFirst < floor {
+		expectedFirst = floor
+	}
+	if afterFirst != expectedFirst {
+		t.Fatalf("expected limit %v after first failure, got %v", expectedFirst, afterFirst)
+	}
+}
+
+// TestAIMDDecreaseFloored verifies that repeated decreases never drop below the
+// provider's configured floor, even when starting at or near the floor.
+func TestAIMDDecreaseFloored(t *testing.T) {
+	t.Parallel()
+	clk := newFakeClock(time.Now())
+	ctrl := newTestAIMD(clk)
+	name := NameMusicBrainz // floor = 1 req/s
+
+	floor := defaultRateLimits[name]
+
+	// Force the clock well past the cooldown between decreases.
+	for range 5 {
+		clk.advance(aimdHysteresisCooldown + time.Second)
+		ctrl.RecordFailure(name, 0)
+		got := aimdCurrentLimit(ctrl, name)
+		if got < floor {
+			t.Fatalf("limit %v dropped below floor %v", got, floor)
+		}
+	}
+	// Limit must still be at or above floor.
+	got := aimdCurrentLimit(ctrl, name)
+	if got < floor {
+		t.Fatalf("final limit %v below floor %v", got, floor)
+	}
+}
+
+// TestAIMDHysteresisWithinCooldown verifies that a second failure within the
+// hysteresis cooldown window does NOT produce another decrease.
+func TestAIMDHysteresisWithinCooldown(t *testing.T) {
+	t.Parallel()
+	clk := newFakeClock(time.Now())
+	ctrl := newTestAIMD(clk)
+	name := NameFanartTV // floor = 3 req/s
+
+	// Drive the limit up first so there is room to decrease.
+	for range aimdSuccessThreshold {
+		ctrl.RecordSuccess(name)
+	}
+	before := aimdCurrentLimit(ctrl, name)
+
+	// First failure: should decrease.
+	ctrl.RecordFailure(name, 0)
+	afterFirst := aimdCurrentLimit(ctrl, name)
+	if afterFirst >= before {
+		t.Fatalf("expected limit to decrease from %v; got %v", before, afterFirst)
+	}
+
+	// Second failure immediately (no clock advance): should NOT decrease.
+	ctrl.RecordFailure(name, 0)
+	afterSecond := aimdCurrentLimit(ctrl, name)
+	if afterSecond != afterFirst {
+		t.Fatalf("hysteresis: expected limit to stay at %v within cooldown, got %v", afterFirst, afterSecond)
+	}
+
+	// Advance past the cooldown; now a failure should decrease again.
+	clk.advance(aimdHysteresisCooldown + time.Millisecond)
+	ctrl.RecordFailure(name, 0)
+	afterThird := aimdCurrentLimit(ctrl, name)
+	// afterFirst may already be at floor -- if so, another decrease is clamped.
+	floor := defaultRateLimits[name]
+	expectedThird := rate.Limit(float64(afterFirst) * aimdDecreaseFactor)
+	if expectedThird < floor {
+		expectedThird = floor
+	}
+	if afterThird != expectedThird {
+		t.Fatalf("expected limit %v after cooldown-expiry failure, got %v", expectedThird, afterThird)
+	}
+}
+
+// TestAIMDCeilingSetGet verifies SetCeiling and GetCeiling round-trip.
+func TestAIMDCeilingSetGet(t *testing.T) {
+	t.Parallel()
+	clk := newFakeClock(time.Now())
+	ctrl := newTestAIMD(clk)
+	name := NameLastFM
+
+	want := rate.Limit(20.0)
+	ctrl.SetCeiling(name, want)
+	got := ctrl.GetCeiling(name)
+	if got != want {
+		t.Fatalf("GetCeiling: expected %v, got %v", want, got)
+	}
+}
+
+// TestAIMDSetCeilingZeroReverts verifies that SetCeiling(name, 0) resets the
+// ceiling to the default (aimdDefaultCeilingMultiplier * floor) rather than
+// setting an unusable zero limit.
+func TestAIMDSetCeilingZeroReverts(t *testing.T) {
+	t.Parallel()
+	clk := newFakeClock(time.Now())
+	ctrl := newTestAIMD(clk)
+	name := NameMusicBrainz
+	floor := defaultRateLimits[name]
+	defaultCeiling := rate.Limit(float64(floor) * aimdDefaultCeilingMultiplier)
+
+	// Set a custom ceiling, then reset it to zero.
+	ctrl.SetCeiling(name, rate.Limit(50))
+	ctrl.SetCeiling(name, 0)
+	got := ctrl.GetCeiling(name)
+	if got != defaultCeiling {
+		t.Fatalf("SetCeiling(0): expected ceiling to revert to %v, got %v", defaultCeiling, got)
+	}
+}
+
+// TestAIMDConcurrency is a race-detector test that hammers RecordSuccess and
+// RecordFailure from multiple goroutines concurrently. It does not assert
+// specific limit values; the race detector catches unsafe concurrent access.
+func TestAIMDConcurrency(t *testing.T) {
+	t.Parallel()
+	clk := newFakeClock(time.Now())
+	ctrl := newTestAIMD(clk)
+	name := NameMusicBrainz
+
+	const goroutines = 20
+	const opsPerGoroutine = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			for j := range opsPerGoroutine {
+				if (idx+j)%3 == 0 {
+					// Advance the fake clock from multiple goroutines to exercise
+					// the hysteresis path under concurrent time reads.
+					clk.advance(time.Millisecond)
+					ctrl.RecordFailure(name, time.Second)
+				} else {
+					ctrl.RecordSuccess(name)
+				}
+				// GetCeiling exercises the RLock path alongside write-lock ops.
+				_ = ctrl.GetCeiling(name)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// The limit must still be within [floor, ceiling] after all the noise.
+	got := aimdCurrentLimit(ctrl, name)
+	floor := defaultRateLimits[name]
+	ceiling := ctrl.GetCeiling(name)
+	if got < floor {
+		t.Errorf("limit %v below floor %v after concurrency test", got, floor)
+	}
+	if got > ceiling {
+		t.Errorf("limit %v above ceiling %v after concurrency test", got, ceiling)
+	}
+}

--- a/internal/provider/integration_test.go
+++ b/internal/provider/integration_test.go
@@ -245,7 +245,7 @@ func TestIntegration_Orchestrator_AHa(t *testing.T) {
 		registry.Register(lastfm.New(limiter, settings, logger))
 	}
 
-	orch := provider.NewOrchestrator(registry, settings, logger)
+	orch := provider.NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(testCtx(t), aHaMBID, aHaName, nil)
 	if err != nil {

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -150,6 +150,10 @@ func (o *Orchestrator) SetExecutor(e ScraperExecutor) {
 //nolint:gocognit // Per-field provider iteration in priority order with provider-ID enrichment carry-forward between fields; this is the legacy non-scraper path retained for callers that have no scraper config, and its semantics must match ScrapeAll's outcome on a parallel diagram.
 func (o *Orchestrator) FetchMetadata(ctx context.Context, mbid, name string, providerIDs map[ProviderName]string) (*FetchResult, error) {
 	if o.executor != nil {
+		// NOTE: the ScraperExecutor (scraper.Executor.ScrapeAll) is the production
+		// refresh path and bypasses all AIMD instrumentation below. Wiring AIMD
+		// signals into the executor is tracked as a follow-up; do not instrument it
+		// in this PR.
 		return o.executor.ScrapeAll(ctx, mbid, name, "global", providerIDs)
 	}
 
@@ -340,7 +344,9 @@ func (o *Orchestrator) FetchImages(ctx context.Context, mbid string, providerIDs
 				slog.String("error", ScrubError(err)),
 				retryAfterAttr(err))
 			result.Errors = append(result.Errors, fmt.Sprintf("%s: image fetch failed", p.Name()))
-			if o.aimd != nil {
+			// Only signal AIMD on rate-limit / provider-unavailable errors.
+			// Ordinary errors (not-found, auth, JSON parse) are not AIMD signals.
+			if o.aimd != nil && isRateLimitError(err) {
 				o.aimd.RecordFailure(p.Name(), retryAfterDuration(err))
 			}
 			continue
@@ -370,7 +376,9 @@ func (o *Orchestrator) Search(ctx context.Context, name string) ([]ArtistSearchR
 				slog.String("provider", string(p.Name())),
 				slog.String("error", ScrubError(err)),
 				retryAfterAttr(err))
-			if o.aimd != nil {
+			// Only signal AIMD on rate-limit / provider-unavailable errors.
+			// Ordinary errors (not-found, auth, JSON parse) are not AIMD signals.
+			if o.aimd != nil && isRateLimitError(err) {
 				o.aimd.RecordFailure(p.Name(), retryAfterDuration(err))
 			}
 			continue
@@ -382,6 +390,16 @@ func (o *Orchestrator) Search(ctx context.Context, name string) ([]ArtistSearchR
 	}
 
 	return allResults, nil
+}
+
+// isRateLimitError reports whether err is a provider-rate-limit / transient-
+// unavailability signal that the AIMD controller should react to. Only
+// *ErrProviderUnavailable qualifies: it carries 429/503/Retry-After semantics.
+// Ordinary errors (ErrNotFound, auth/401, JSON parse, context cancellation)
+// must NOT drive an AIMD decrease.
+func isRateLimitError(err error) bool {
+	var unavailable *ErrProviderUnavailable
+	return errors.As(err, &unavailable)
 }
 
 // retryAfterAttr returns a slog attribute carrying the server-advised backoff
@@ -502,6 +520,17 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 
 	pr := &providerResult{}
 
+	// aimdRateLimitErr records the first rate-limit / provider-unavailable error
+	// encountered across both GetArtist and GetImages within this single provider
+	// call. It is used to emit exactly ONE AIMD signal at the end of the function:
+	// RecordFailure if a rate-limit error was seen, RecordSuccess if results were
+	// returned without a rate-limit error. Ordinary errors (ErrNotFound, auth/401,
+	// JSON parse, context cancellation) are not AIMD signals.
+	var aimdRateLimitErr error
+	// aimdGotResult is true when at least one of GetArtist or GetImages returned
+	// a useful (non-error) result. Used to decide whether RecordSuccess is warranted.
+	aimdGotResult := false
+
 	// Lookup precedence: provider-specific ID > MBID > artist name.
 	// Providers like AudioDB, Discogs, and Deezer have their own numeric IDs
 	// that are more reliable than passing an MBID they may not recognize.
@@ -551,15 +580,14 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 					slog.String("error", ScrubError(err)),
 					retryAfterAttr(err))
 				pr.err = err
-				if o.aimd != nil {
-					o.aimd.RecordFailure(name, retryAfterDuration(err))
+				// Record the first rate-limit error for the composite AIMD signal.
+				if isRateLimitError(err) && aimdRateLimitErr == nil {
+					aimdRateLimitErr = err
 				}
 			}
 		} else {
 			pr.meta = meta
-			if o.aimd != nil {
-				o.aimd.RecordSuccess(name)
-			}
+			aimdGotResult = true
 		}
 	}
 
@@ -593,15 +621,28 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 				// marked as attempted. This prevents clearing existing image data
 				// when the provider was merely unreachable.
 				pr.imageErr = err
-				if o.aimd != nil {
-					o.aimd.RecordFailure(name, retryAfterDuration(err))
+				// Record the first rate-limit error for the composite AIMD signal.
+				if isRateLimitError(err) && aimdRateLimitErr == nil {
+					aimdRateLimitErr = err
 				}
 			}
 		} else {
 			pr.images = images
-			if o.aimd != nil {
-				o.aimd.RecordSuccess(name)
-			}
+			aimdGotResult = true
+		}
+	}
+
+	// Emit exactly ONE AIMD signal per provider call:
+	//   - RecordFailure when a rate-limit / provider-unavailable error was seen.
+	//   - RecordSuccess when at least one sub-call (GetArtist or GetImages)
+	//     returned a useful result and no rate-limit error was recorded.
+	// Ordinary errors (ErrNotFound, auth, JSON parse, context cancel) are NOT
+	// AIMD signals and neither case fires for them.
+	if o.aimd != nil {
+		if aimdRateLimitErr != nil {
+			o.aimd.RecordFailure(name, retryAfterDuration(aimdRateLimitErr))
+		} else if aimdGotResult {
+			o.aimd.RecordSuccess(name)
 		}
 	}
 
@@ -1239,16 +1280,25 @@ func (o *Orchestrator) SearchForLinking(ctx context.Context, name string, provid
 			scrubbed := ScrubError(err)
 			o.logger.Warn("provider search failed",
 				slog.String("provider", string(provName)),
-				slog.String("error", scrubbed))
+				slog.String("error", scrubbed),
+				retryAfterAttr(err))
 			statuses = append(statuses, ProviderSearchStatus{
 				Provider:        provName,
 				Errored:         true,
 				ScrubbedMessage: scrubbed,
 			})
+			// Only signal AIMD on rate-limit / provider-unavailable errors.
+			// Ordinary errors (not-found, auth, JSON parse) are not AIMD signals.
+			if o.aimd != nil && isRateLimitError(err) {
+				o.aimd.RecordFailure(provName, retryAfterDuration(err))
+			}
 			continue
 		}
 		statuses = append(statuses, ProviderSearchStatus{Provider: provName})
 		allResults = append(allResults, results...)
+		if o.aimd != nil {
+			o.aimd.RecordSuccess(provName)
+		}
 	}
 
 	return allResults, statuses, nil

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/provider/tagdict"
 )
@@ -115,14 +116,18 @@ type Orchestrator struct {
 	registry *Registry
 	settings *SettingsService
 	executor ScraperExecutor
+	aimd     *AIMDController
 	logger   *slog.Logger
 }
 
-// NewOrchestrator creates a new Orchestrator.
-func NewOrchestrator(registry *Registry, settings *SettingsService, logger *slog.Logger) *Orchestrator {
+// NewOrchestrator creates a new Orchestrator. aimd may be nil; when nil, the
+// adaptive rate-limiting hook sites are skipped and the orchestrator behaves
+// exactly as before.
+func NewOrchestrator(registry *Registry, settings *SettingsService, logger *slog.Logger, aimd *AIMDController) *Orchestrator {
 	return &Orchestrator{
 		registry: registry,
 		settings: settings,
+		aimd:     aimd,
 		logger:   logger.With(slog.String("component", "orchestrator")),
 	}
 }
@@ -335,9 +340,15 @@ func (o *Orchestrator) FetchImages(ctx context.Context, mbid string, providerIDs
 				slog.String("error", ScrubError(err)),
 				retryAfterAttr(err))
 			result.Errors = append(result.Errors, fmt.Sprintf("%s: image fetch failed", p.Name()))
+			if o.aimd != nil {
+				o.aimd.RecordFailure(p.Name(), retryAfterDuration(err))
+			}
 			continue
 		}
 		result.Images = append(result.Images, images...)
+		if o.aimd != nil {
+			o.aimd.RecordSuccess(p.Name())
+		}
 	}
 
 	return result, nil
@@ -359,9 +370,15 @@ func (o *Orchestrator) Search(ctx context.Context, name string) ([]ArtistSearchR
 				slog.String("provider", string(p.Name())),
 				slog.String("error", ScrubError(err)),
 				retryAfterAttr(err))
+			if o.aimd != nil {
+				o.aimd.RecordFailure(p.Name(), retryAfterDuration(err))
+			}
 			continue
 		}
 		allResults = append(allResults, results...)
+		if o.aimd != nil {
+			o.aimd.RecordSuccess(p.Name())
+		}
 	}
 
 	return allResults, nil
@@ -379,6 +396,18 @@ func retryAfterAttr(err error) slog.Attr {
 		return slog.Duration("retry_after", unavailable.RetryAfter)
 	}
 	return slog.Attr{}
+}
+
+// retryAfterDuration extracts the RetryAfter duration from an
+// *ErrProviderUnavailable, returning 0 when the error is not of that type or
+// carries no hint. Used to pass the server-advised backoff to the AIMD
+// controller so it can log it alongside the multiplicative decrease.
+func retryAfterDuration(err error) time.Duration {
+	var unavailable *ErrProviderUnavailable
+	if errors.As(err, &unavailable) {
+		return unavailable.RetryAfter
+	}
+	return 0
 }
 
 // availableProviders returns only the registered providers whose API keys are
@@ -522,9 +551,15 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 					slog.String("error", ScrubError(err)),
 					retryAfterAttr(err))
 				pr.err = err
+				if o.aimd != nil {
+					o.aimd.RecordFailure(name, retryAfterDuration(err))
+				}
 			}
 		} else {
 			pr.meta = meta
+			if o.aimd != nil {
+				o.aimd.RecordSuccess(name)
+			}
 		}
 	}
 
@@ -558,9 +593,15 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 				// marked as attempted. This prevents clearing existing image data
 				// when the provider was merely unreachable.
 				pr.imageErr = err
+				if o.aimd != nil {
+					o.aimd.RecordFailure(name, retryAfterDuration(err))
+				}
 			}
 		} else {
 			pr.images = images
+			if o.aimd != nil {
+				o.aimd.RecordSuccess(name)
+			}
 		}
 	}
 

--- a/internal/provider/orchestrator_searchlinking_test.go
+++ b/internal/provider/orchestrator_searchlinking_test.go
@@ -30,7 +30,7 @@ func TestSearchForLinking_ReturnsPerProviderStatus(t *testing.T) {
 		for _, m := range mocks {
 			registry.Register(m)
 		}
-		return NewOrchestrator(registry, settings, logger)
+		return NewOrchestrator(registry, settings, logger, nil)
 	}
 
 	t.Run("all providers succeed", func(t *testing.T) {

--- a/internal/provider/orchestrator_test.go
+++ b/internal/provider/orchestrator_test.go
@@ -103,7 +103,7 @@ func TestOrchestratorFallback(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-123", "Radiohead", nil)
 	if err != nil {
@@ -179,7 +179,7 @@ func TestFetchMetadata_MBNameAuthoritative(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "test-mbid", "Canonical Name", nil)
 	if err != nil {
@@ -221,7 +221,7 @@ func TestFetchMetadata_MBNameAuthoritative_EmptyDoesNotClobber(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "test-mbid", "Whatever", nil)
 	if err != nil {
@@ -259,7 +259,7 @@ func TestFetchMetadata_MBNameAuthoritative_MBErrorDoesNotClobber(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "test-mbid", "Whatever", nil)
 	if err != nil {
@@ -305,7 +305,7 @@ func TestOrchestratorTagAggregation(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-agg", "TestArtist", nil)
 	if err != nil {
@@ -364,7 +364,7 @@ func TestOrchestratorProviderError(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-123", "Radiohead", nil)
 	if err != nil {
@@ -403,7 +403,7 @@ func TestOrchestratorSearch(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	results, err := orch.Search(context.Background(), "Radiohead")
 	if err != nil {
@@ -444,7 +444,7 @@ func TestOrchestratorCustomPriority(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-123", "Radiohead", nil)
 	if err != nil {
@@ -500,7 +500,7 @@ func TestOrchestratorMBIDFallbackToName(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-uuid-1234", "Radiohead", nil)
 	if err != nil {
@@ -540,7 +540,7 @@ func TestOrchestratorMBIDNoRetryWithoutNameLookup(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	_, _ = orch.FetchMetadata(context.Background(), "mbid-uuid-1234", "Radiohead", nil)
 
@@ -589,7 +589,7 @@ func TestFetchFieldFromProviders_ErrNotFoundSuppressed(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	results, err := orch.FetchFieldFromProviders(context.Background(), "mbid-1234", "Test Artist", "styles", nil)
 	if err != nil {
@@ -675,7 +675,7 @@ func TestOrchestratorGetImagesTimeoutDoesNotMarkImageFieldAttempted(t *testing.T
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-1234", "Test Artist", nil)
 	if err != nil {
@@ -725,7 +725,7 @@ func TestOrchestratorGetImagesErrNotFoundMarksImageFieldAttempted(t *testing.T) 
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-1234", "Test Artist", nil)
 	if err != nil {
@@ -768,7 +768,7 @@ func TestOrchestratorGetImagesDataMarksImageFieldAttempted(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-1234", "Test Artist", nil)
 	if err != nil {
@@ -821,7 +821,7 @@ func TestOrchestratorGetImagesNotCalledDoesNotMarkImageFieldAttempted(t *testing
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	// Pass empty MBID and providerIDs with an empty AudioDB entry.
 	// GetImages requires a numeric ID; without one it must not be called.
@@ -866,7 +866,7 @@ func TestOrchestratorProviderIDPrecedence(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	// Pass a wrong MBID but the correct AudioDB numeric ID in providerIDs.
 	// The orchestrator should prefer the provider-specific ID.
@@ -905,7 +905,7 @@ func TestOrchestratorNilProviderIDsPreservesBehavior(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	_, err := orch.FetchMetadata(context.Background(), "mbid-123", "Radiohead", nil)
 	if err != nil {
@@ -930,7 +930,7 @@ func TestOrchestratorEmptyProviderIDFallsBackToMBID(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	// Provider ID entry exists but is empty -- should fall back to MBID.
 	providerIDs := map[ProviderName]string{
@@ -1156,7 +1156,7 @@ func TestOrchestratorRejectsJunkBiography(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-noise", "Noise Ratchet", nil)
 	if err != nil {
@@ -1207,7 +1207,7 @@ func TestOrchestratorRejectsShortBiography(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-test", "Test Artist", nil)
 	if err != nil {
@@ -1255,7 +1255,7 @@ func TestOrchestratorAllJunkBiographiesLeaveFieldEmpty(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-obscure", "Obscure Band", nil)
 	if err != nil {
@@ -1335,7 +1335,7 @@ func TestOrchestratorCrossProviderIDEnrichment(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	// No stored provider IDs -- only the MBID.
 	_, err := orch.FetchMetadata(context.Background(), "cc2c9c3c-b7bc-4b8b-84d8-4fbd8779e493", "A-ha", nil)
@@ -1666,7 +1666,7 @@ func TestFetchMetadataAggregatesImagesFromMultipleProviders(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-aha", "a-ha", nil)
 	if err != nil {
@@ -1720,7 +1720,7 @@ func TestFetchMetadataTextFieldStopsAtFirstMatch(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-test", "Test", nil)
 	if err != nil {
@@ -1762,7 +1762,7 @@ func TestFetchImagesCollectsFromAllProviders(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchImages(context.Background(), "mbid-test", nil)
 	if err != nil {
@@ -1833,7 +1833,7 @@ func TestFetchImagesRespectsProviderPriority(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchImages(context.Background(), "mbid-test", nil)
 	if err != nil {
@@ -1910,7 +1910,7 @@ func TestFetchImages_CrossFieldPriorityConflict(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchImages(context.Background(), "mbid-test", nil)
 	if err != nil {
@@ -1983,7 +1983,7 @@ func TestFetchImagesDefaultOrderWithoutCustomPriority(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchImages(context.Background(), "mbid-test", nil)
 	if err != nil {
@@ -2050,7 +2050,7 @@ func TestApplyFieldImageDoesNotBlockOnWrongType(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-test", "Test", nil)
 	if err != nil {
@@ -2091,7 +2091,7 @@ func TestOrchestratorErrNotFoundMarksFieldAttempted(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-1234", "Test Artist", nil)
 	if err != nil {
@@ -2137,7 +2137,7 @@ func TestOrchestratorNetworkErrorDoesNotMarkFieldAttempted(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-1234", "Test Artist", nil)
 	if err != nil {
@@ -2167,7 +2167,7 @@ func TestOrchestratorErrNotFoundCountsAsAttemptedProvider(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-1234", "Test Artist", nil)
 	if err != nil {
@@ -2223,7 +2223,7 @@ func TestFetchImagesQueriesAllProviders(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchImages(context.Background(), "mbid-test", nil)
 	if err != nil {
@@ -2342,7 +2342,7 @@ func TestOrchestratorPopulatedFieldsTracking(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-1234", "Test Artist", nil)
 	if err != nil {
@@ -2412,7 +2412,7 @@ func TestOrchestratorPopulatedFields_DedupAcrossProviders(t *testing.T) {
 	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	orch := NewOrchestrator(registry, settings, logger)
+	orch := NewOrchestrator(registry, settings, logger, nil)
 
 	result, err := orch.FetchMetadata(context.Background(), "mbid-1234", "X", nil)
 	if err != nil {
@@ -3120,7 +3120,7 @@ func TestFetchMetadata_MembersAuthoritative(t *testing.T) {
 		}
 
 		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-		orch := NewOrchestrator(registry, settings, logger)
+		orch := NewOrchestrator(registry, settings, logger, nil)
 		result, err := orch.FetchMetadata(context.Background(), "mb-sparse", "Sparse Band", nil)
 		if err != nil {
 			t.Fatalf("FetchMetadata: %v", err)
@@ -3158,7 +3158,7 @@ func TestFetchMetadata_MembersAuthoritative(t *testing.T) {
 		}
 
 		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-		orch := NewOrchestrator(registry, settings, logger)
+		orch := NewOrchestrator(registry, settings, logger, nil)
 		result, err := orch.FetchMetadata(context.Background(), "mb-solo", "Solo Artist", nil)
 		if err != nil {
 			t.Fatalf("FetchMetadata: %v", err)
@@ -3197,7 +3197,7 @@ func TestFetchMetadata_MembersAuthoritative(t *testing.T) {
 		}
 
 		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-		orch := NewOrchestrator(registry, settings, logger)
+		orch := NewOrchestrator(registry, settings, logger, nil)
 		result, err := orch.FetchMetadata(context.Background(), "mb-band", "Real Band", nil)
 		if err != nil {
 			t.Fatalf("FetchMetadata: %v", err)
@@ -3237,7 +3237,7 @@ func TestFetchMetadata_MembersAuthoritative(t *testing.T) {
 		}
 
 		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-		orch := NewOrchestrator(registry, settings, logger)
+		orch := NewOrchestrator(registry, settings, logger, nil)
 		result, err := orch.FetchMetadata(context.Background(), "mb-error", "Error Artist", nil)
 		if err != nil {
 			t.Fatalf("FetchMetadata: %v", err)

--- a/internal/provider/orchestrator_test.go
+++ b/internal/provider/orchestrator_test.go
@@ -3396,6 +3396,145 @@ func TestAIMDSingleSignalPerProviderCall(t *testing.T) {
 	}
 }
 
+// TestAIMDFetchImagesRateLimitSignal verifies that FetchImages sends
+// RecordFailure on *ErrProviderUnavailable and RecordSuccess on a normal result.
+func TestAIMDFetchImagesRateLimitSignal(t *testing.T) {
+	t.Parallel()
+	orch, ctrl, registry, settings := newTestOrchWithAIMD(t)
+
+	// FanartTV requires an API key; store a dummy so it passes availability check.
+	const prov = NameFanartTV
+	if err := settings.SetAPIKey(context.Background(), prov, "test-key"); err != nil {
+		t.Fatalf("SetAPIKey: %v", err)
+	}
+
+	registry.Register(&mockProvider{
+		name: prov,
+		getImgFn: func(_ context.Context, _ string) ([]ImageResult, error) {
+			return nil, &ErrProviderUnavailable{
+				Provider:   prov,
+				Cause:      fmt.Errorf("429"),
+				RetryAfter: time.Second,
+			}
+		},
+	})
+
+	_, _ = orch.FetchImages(context.Background(), "mbid-test", nil)
+
+	if aimdLastDecrease(ctrl, prov).IsZero() {
+		t.Fatalf("FetchImages: rate-limit error did not trigger RecordFailure")
+	}
+}
+
+// TestAIMDFetchImagesOrdinaryErrorNoSignal verifies that FetchImages does NOT
+// send RecordFailure for a non-rate-limit error.
+func TestAIMDFetchImagesOrdinaryErrorNoSignal(t *testing.T) {
+	t.Parallel()
+	orch, ctrl, registry, settings := newTestOrchWithAIMD(t)
+
+	// FanartTV requires an API key; store a dummy so it passes availability check.
+	const prov = NameFanartTV
+	if err := settings.SetAPIKey(context.Background(), prov, "test-key"); err != nil {
+		t.Fatalf("SetAPIKey: %v", err)
+	}
+
+	registry.Register(&mockProvider{
+		name: prov,
+		getImgFn: func(_ context.Context, _ string) ([]ImageResult, error) {
+			return nil, fmt.Errorf("generic error")
+		},
+	})
+
+	_, _ = orch.FetchImages(context.Background(), "mbid-test", nil)
+
+	if !aimdLastDecrease(ctrl, prov).IsZero() {
+		t.Fatalf("FetchImages: ordinary error incorrectly triggered RecordFailure")
+	}
+	if aimdSuccessCount(ctrl, prov) != 0 {
+		t.Fatalf("FetchImages: ordinary error incorrectly triggered RecordSuccess")
+	}
+}
+
+// TestAIMDSearchRateLimitSignal verifies that Search sends RecordFailure on
+// *ErrProviderUnavailable and no signal on an ordinary error.
+func TestAIMDSearchRateLimitSignal(t *testing.T) {
+	t.Parallel()
+	orch, ctrl, registry, settings := newTestOrchWithAIMD(t)
+
+	const prov = NameMusicBrainz
+	registry.Register(&mockProvider{
+		name: prov,
+		searchFn: func(_ context.Context, _ string) ([]ArtistSearchResult, error) {
+			return nil, &ErrProviderUnavailable{
+				Provider:   prov,
+				Cause:      fmt.Errorf("503"),
+				RetryAfter: time.Second,
+			}
+		},
+	})
+	// MusicBrainz does not require auth so no API key needed; mark available.
+	if err := settings.SetAPIKey(context.Background(), prov, ""); err != nil {
+		t.Fatalf("SetAPIKey: %v", err)
+	}
+
+	_, _ = orch.Search(context.Background(), "Radiohead")
+
+	if aimdLastDecrease(ctrl, prov).IsZero() {
+		t.Fatalf("Search: rate-limit error did not trigger RecordFailure")
+	}
+}
+
+// TestAIMDSearchForLinkingRateLimitSignal verifies that SearchForLinking sends
+// RecordFailure on *ErrProviderUnavailable and RecordSuccess on success.
+func TestAIMDSearchForLinkingRateLimitSignal(t *testing.T) {
+	t.Parallel()
+	orch, ctrl, registry, _ := newTestOrchWithAIMD(t)
+
+	const prov = NameMusicBrainz
+
+	t.Run("rate-limit fires RecordFailure", func(t *testing.T) {
+		registry.Register(&mockProvider{
+			name: prov,
+			searchFn: func(_ context.Context, _ string) ([]ArtistSearchResult, error) {
+				return nil, &ErrProviderUnavailable{
+					Provider:   prov,
+					Cause:      fmt.Errorf("429"),
+					RetryAfter: time.Second,
+				}
+			},
+		})
+
+		_, _, _ = orch.SearchForLinking(context.Background(), "Artist", []ProviderName{prov})
+
+		if aimdLastDecrease(ctrl, prov).IsZero() {
+			t.Fatalf("SearchForLinking: rate-limit error did not trigger RecordFailure")
+		}
+	})
+
+	t.Run("success fires RecordSuccess", func(t *testing.T) {
+		clk := newFakeClock(time.Now())
+		rlm := NewRateLimiterMap()
+		ctrl2 := NewAIMDController(rlm, clk)
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		reg2 := NewRegistry()
+		_, settings2 := setupOrchestratorTest(t)
+		orch2 := NewOrchestrator(reg2, settings2, logger, ctrl2)
+
+		reg2.Register(&mockProvider{
+			name: prov,
+			searchFn: func(_ context.Context, _ string) ([]ArtistSearchResult, error) {
+				return []ArtistSearchResult{{Name: "Artist"}}, nil
+			},
+		})
+
+		_, _, _ = orch2.SearchForLinking(context.Background(), "Artist", []ProviderName{prov})
+
+		if aimdSuccessCount(ctrl2, prov) != 1 {
+			t.Fatalf("SearchForLinking: expected 1 RecordSuccess signal, got %d", aimdSuccessCount(ctrl2, prov))
+		}
+	})
+}
+
 // TestApplyTagSliceField_VocabFilter verifies the orchestrator tag-merge path
 // applies the user's vocab exclude filter and count cap (issue #1130). This is
 // the orchestrator half of the dual-path integration: a refresh runs through

--- a/internal/provider/orchestrator_test.go
+++ b/internal/provider/orchestrator_test.go
@@ -7,7 +7,9 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/provider/tagdict"
@@ -3255,6 +3257,143 @@ func TestFetchMetadata_MembersAuthoritative(t *testing.T) {
 			t.Error("MembersAuthoritative must be false when provider returned an error")
 		}
 	})
+}
+
+// --- AIMD signal tests --------------------------------------------------------
+
+// newTestOrchWithAIMD builds a minimal test Orchestrator with a real
+// AIMDController so we can observe signal counts. Returns the orchestrator,
+// its AIMD controller, the registry, and the settings service.
+func newTestOrchWithAIMD(t *testing.T) (*Orchestrator, *AIMDController, *Registry, *SettingsService) {
+	t.Helper()
+	registry, settings := setupOrchestratorTest(t)
+	clk := newFakeClock(time.Now())
+	rlm := NewRateLimiterMap()
+	ctrl := NewAIMDController(rlm, clk)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	orch := NewOrchestrator(registry, settings, logger, ctrl)
+	return orch, ctrl, registry, settings
+}
+
+// aimdLastDecrease reads the lastDecrease timestamp for a provider from AIMD
+// state. Returns zero if the provider state has not been initialized yet.
+func aimdLastDecrease(ctrl *AIMDController, name ProviderName) time.Time {
+	ctrl.mu.RLock()
+	defer ctrl.mu.RUnlock()
+	if s, ok := ctrl.states[name]; ok {
+		return s.lastDecrease
+	}
+	return time.Time{}
+}
+
+// aimdSuccessCount reads the current successCount for a provider.
+func aimdSuccessCount(ctrl *AIMDController, name ProviderName) int {
+	ctrl.mu.RLock()
+	defer ctrl.mu.RUnlock()
+	if s, ok := ctrl.states[name]; ok {
+		return s.successCount
+	}
+	return 0
+}
+
+// TestAIMDOrdinaryErrorDoesNotTriggerRecordFailure verifies that a non-rate-limit
+// error (e.g. a plain fmt.Errorf, simulating a JSON parse or auth failure) from
+// GetArtist does NOT drive a RecordFailure signal. Only *ErrProviderUnavailable
+// must trigger the AIMD decrease path.
+func TestAIMDOrdinaryErrorDoesNotTriggerRecordFailure(t *testing.T) {
+	t.Parallel()
+	orch, ctrl, registry, settings := newTestOrchWithAIMD(t)
+
+	const prov = NameMusicBrainz
+	registry.Register(&mockProvider{
+		name: prov,
+		// Return an ordinary error (not *ErrProviderUnavailable).
+		getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+			return nil, fmt.Errorf("simulated JSON parse error")
+		},
+		getImgFn: func(_ context.Context, _ string) ([]ImageResult, error) {
+			return nil, fmt.Errorf("simulated auth error")
+		},
+	})
+
+	if err := settings.SetAPIKey(context.Background(), prov, ""); err != nil {
+		t.Fatalf("SetAPIKey: %v", err)
+	}
+
+	cache := make(map[ProviderName]*providerResult)
+	var mu sync.Mutex
+	_ = orch.getProviderResult(context.Background(), prov, "mbid-test", "Artist Name", nil, cache, &mu)
+
+	// lastDecrease must remain zero -- RecordFailure must NOT have been called.
+	if !aimdLastDecrease(ctrl, prov).IsZero() {
+		t.Fatalf("ordinary error incorrectly triggered RecordFailure; lastDecrease is non-zero")
+	}
+	// successCount must also be zero -- RecordSuccess must NOT have been called.
+	if aimdSuccessCount(ctrl, prov) != 0 {
+		t.Fatalf("ordinary error incorrectly triggered RecordSuccess; successCount=%d", aimdSuccessCount(ctrl, prov))
+	}
+}
+
+// TestAIMDRateLimitErrorTriggerRecordFailure verifies that an
+// *ErrProviderUnavailable from GetArtist DOES drive RecordFailure.
+func TestAIMDRateLimitErrorTriggerRecordFailure(t *testing.T) {
+	t.Parallel()
+	orch, ctrl, registry, _ := newTestOrchWithAIMD(t)
+
+	const prov = NameMusicBrainz
+	registry.Register(&mockProvider{
+		name: prov,
+		getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+			return nil, &ErrProviderUnavailable{
+				Provider:   prov,
+				Cause:      fmt.Errorf("429 Too Many Requests"),
+				RetryAfter: 5 * time.Second,
+			}
+		},
+		getImgFn: func(_ context.Context, _ string) ([]ImageResult, error) {
+			return nil, nil
+		},
+	})
+
+	cache := make(map[ProviderName]*providerResult)
+	var mu sync.Mutex
+	_ = orch.getProviderResult(context.Background(), prov, "mbid-test", "Artist Name", nil, cache, &mu)
+
+	// lastDecrease must be non-zero -- RecordFailure must have been called.
+	if aimdLastDecrease(ctrl, prov).IsZero() {
+		t.Fatalf("rate-limit error did not trigger RecordFailure; lastDecrease is still zero")
+	}
+}
+
+// TestAIMDSingleSignalPerProviderCall verifies that getProviderResult emits
+// exactly ONE AIMD signal (not two) even when both GetArtist and GetImages
+// succeed. Emitting two RecordSuccess calls would halve the effective
+// aimdSuccessThreshold and allow a fail+success to cancel out.
+func TestAIMDSingleSignalPerProviderCall(t *testing.T) {
+	t.Parallel()
+	orch, ctrl, registry, _ := newTestOrchWithAIMD(t)
+
+	const prov = NameFanartTV
+	registry.Register(&mockProvider{
+		name: prov,
+		getArtFn: func(_ context.Context, _ string) (*ArtistMetadata, error) {
+			return &ArtistMetadata{Name: "Artist"}, nil
+		},
+		getImgFn: func(_ context.Context, _ string) ([]ImageResult, error) {
+			return []ImageResult{{URL: "http://example.com/img.jpg"}}, nil
+		},
+	})
+
+	// Drive one full getProviderResult call.
+	cache := make(map[ProviderName]*providerResult)
+	var mu sync.Mutex
+	_ = orch.getProviderResult(context.Background(), prov, "mbid-test", "Artist Name", nil, cache, &mu)
+
+	// successCount must be exactly 1 (one RecordSuccess fired, not two).
+	got := aimdSuccessCount(ctrl, prov)
+	if got != 1 {
+		t.Fatalf("expected exactly 1 AIMD success signal, got %d", got)
+	}
 }
 
 // TestApplyTagSliceField_VocabFilter verifies the orchestrator tag-merge path

--- a/internal/provider/settings.go
+++ b/internal/provider/settings.go
@@ -722,6 +722,57 @@ func (s *SettingsService) DeleteRateLimit(ctx context.Context, name ProviderName
 	return nil
 }
 
+// rateLimitCeilingSettingKey returns the settings table key for a provider's
+// AIMD rate-limit ceiling.
+func rateLimitCeilingSettingKey(name ProviderName) string {
+	return fmt.Sprintf("provider.%s.rate_limit_ceiling", name)
+}
+
+// GetRateLimitCeiling returns the configured AIMD rate-limit ceiling (requests
+// per second) for a provider. Returns 0 if no ceiling is configured.
+func (s *SettingsService) GetRateLimitCeiling(ctx context.Context, name ProviderName) (float64, error) {
+	key := rateLimitCeilingSettingKey(name)
+	var value string
+	err := s.db.QueryRowContext(ctx, "SELECT value FROM settings WHERE key = ?", key).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("reading rate limit ceiling for %s: %w", name, err)
+	}
+	ceiling, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing rate limit ceiling for %s: %w", name, err)
+	}
+	return ceiling, nil
+}
+
+// SetRateLimitCeiling stores an AIMD rate-limit ceiling (requests per second)
+// for a provider.
+func (s *SettingsService) SetRateLimitCeiling(ctx context.Context, name ProviderName, ceiling float64) error {
+	key := rateLimitCeilingSettingKey(name)
+	value := strconv.FormatFloat(ceiling, 'f', -1, 64)
+	_, err := s.db.ExecContext(ctx,
+		"INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = ?, updated_at = datetime('now')",
+		key, value, value,
+	)
+	if err != nil {
+		return fmt.Errorf("storing rate limit ceiling for %s: %w", name, err)
+	}
+	return nil
+}
+
+// DeleteRateLimitCeiling removes the AIMD rate-limit ceiling for a provider,
+// reverting to the default (aimdDefaultCeilingMultiplier * floor).
+func (s *SettingsService) DeleteRateLimitCeiling(ctx context.Context, name ProviderName) error {
+	key := rateLimitCeilingSettingKey(name)
+	_, err := s.db.ExecContext(ctx, "DELETE FROM settings WHERE key = ?", key)
+	if err != nil {
+		return fmt.Errorf("deleting rate limit ceiling for %s: %w", name, err)
+	}
+	return nil
+}
+
 // fieldVerbositySettingKey returns the settings table key for a single
 // field's verbosity selection for a provider.
 // Format: "provider.<name>.field_verbosity.<field>"

--- a/internal/provider/settings_test.go
+++ b/internal/provider/settings_test.go
@@ -1323,3 +1323,65 @@ func TestGetFieldVerbosity_CorruptStoredValue(t *testing.T) {
 		t.Errorf("verbosity for a corrupt stored value = %q, want the default %q", got, VerbosityIntro)
 	}
 }
+
+// TestRateLimitCeilingRoundTrip verifies that SetRateLimitCeiling persists a
+// value that GetRateLimitCeiling can read back, and that DeleteRateLimitCeiling
+// removes it so a subsequent get returns 0.
+func TestRateLimitCeilingRoundTrip(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	enc := setupTestEncryptor(t)
+	svc := NewSettingsService(db, enc)
+	ctx := context.Background()
+
+	const prov = NameMusicBrainz
+	const want = 12.5
+
+	// Initially unset: should return 0 with no error.
+	got, err := svc.GetRateLimitCeiling(ctx, prov)
+	if err != nil {
+		t.Fatalf("GetRateLimitCeiling (unset): %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("GetRateLimitCeiling (unset): expected 0, got %v", got)
+	}
+
+	// Set a ceiling.
+	if err := svc.SetRateLimitCeiling(ctx, prov, want); err != nil {
+		t.Fatalf("SetRateLimitCeiling: %v", err)
+	}
+
+	// Read it back.
+	got, err = svc.GetRateLimitCeiling(ctx, prov)
+	if err != nil {
+		t.Fatalf("GetRateLimitCeiling (after set): %v", err)
+	}
+	if got != want {
+		t.Fatalf("GetRateLimitCeiling: expected %v, got %v", want, got)
+	}
+
+	// Overwrite with a new value.
+	const want2 = 20.0
+	if err := svc.SetRateLimitCeiling(ctx, prov, want2); err != nil {
+		t.Fatalf("SetRateLimitCeiling (overwrite): %v", err)
+	}
+	got, err = svc.GetRateLimitCeiling(ctx, prov)
+	if err != nil {
+		t.Fatalf("GetRateLimitCeiling (after overwrite): %v", err)
+	}
+	if got != want2 {
+		t.Fatalf("GetRateLimitCeiling (overwrite): expected %v, got %v", want2, got)
+	}
+
+	// Delete should revert to 0.
+	if err := svc.DeleteRateLimitCeiling(ctx, prov); err != nil {
+		t.Fatalf("DeleteRateLimitCeiling: %v", err)
+	}
+	got, err = svc.GetRateLimitCeiling(ctx, prov)
+	if err != nil {
+		t.Fatalf("GetRateLimitCeiling (after delete): %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("GetRateLimitCeiling (after delete): expected 0, got %v", got)
+	}
+}


### PR DESCRIPTION
## What

Adds adaptive **AIMD** (additive-increase / multiplicative-decrease) rate limiting with hysteresis for external providers (`internal/provider/aimd.go`). The controller adapts each provider's effective request rate based on live success/rate-limit signals:

- **Additive increase**: after `aimdSuccessThreshold` (10) consecutive successes, bump the limit by `aimdIncrement` (0.5 req/s), capped at a per-provider ceiling.
- **Multiplicative decrease**: on a rate-limit signal, halve the limit (`aimdDecreaseFactor` 0.5), floored at the configured `defaultRateLimits` floor (never to 0).
- **Hysteresis**: a second rate-limit signal within `aimdHysteresisCooldown` (30s) does not decrease again, avoiding thrash on a 429 burst.
- New per-provider setting `provider.<name>.rate_limit_ceiling`; startup loads ceilings for all providers (default `10×` floor).

Hooks are wired into the provider-call paths in `orchestrator.go` (`getProviderResult`, `FetchImages`, `Search`, `SearchForLinking`), reusing the existing `Clock` from `retry.go`.

## Why

`#1747` — providers throttle / return 429+Retry-After under load. A static rate limit either wastes headroom or trips throttling; AIMD backs off on rate-limit signals and ramps back up on sustained success.

## Design notes (from review)

- **Only rate-limit/unavailable errors signal AIMD.** `RecordFailure` fires solely when the error `errors.As` a `*ErrProviderUnavailable` (429/Retry-After) — an ordinary not-found / auth / parse / context-cancel error does **not** throttle a healthy provider.
- **Exactly one AIMD signal per provider call** — `getProviderResult` accumulates across GetArtist + GetImages and emits one composite signal (failure wins).
- **Never wedges to zero** — even for a provider with no configured floor, the limit is floored at `aimdIncrement`.
- Controller is `sync.RWMutex`-guarded; all orchestrator calls are nil-guarded.

## Known limitation (tracked: #2055)

When a `ScraperExecutor` is configured, `FetchMetadata` short-circuits before these hooks, so the **executor refresh path** (the production refresh) is not yet AIMD-instrumented. This PR covers the search / identify / image / direct-metadata paths; instrumenting the executor is the follow-up **#2055** (a code comment marks the gap).

## Test plan

- `go build ./... && go vet ./...` — clean (whole module; all 53 `NewOrchestrator` callers updated to pass `nil`).
- `go test -race ./internal/provider/` — clean, 0 data races.
- Patch coverage 79.25% (> 75% gate). Tests assert: one-signal-per-call, ordinary-error-does-not-record-failure, multiplicative decrease floored, hysteresis cooldown, and two-key concurrent init under `-race`.

Closes #1747
