### PR TITLE
feat(provider): instrument ScraperExecutor refresh path with AIMD (#2055)

### DIFF
--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -730,7 +730,7 @@ func (a *Application) wireProviders(ctx context.Context) error {
 	if err := a.scraperService.SeedDefaults(ctx); err != nil {
 		return fmt.Errorf("seeding default scraper config: %w", err)
 	}
-	scraperExecutor := scraper.NewExecutor(a.scraperService, a.providerRegistry, a.providerSettings, logger)
+	scraperExecutor := scraper.NewExecutor(a.scraperService, a.providerRegistry, a.providerSettings, logger, aimdCtrl)
 	a.orchestrator.SetExecutor(scraperExecutor)
 
 	return nil

--- a/internal/provider/aimd.go
+++ b/internal/provider/aimd.go
@@ -198,9 +198,9 @@ func (c *AIMDController) SetCeiling(name ProviderName, ceiling rate.Limit) {
 	s.ceiling = ceiling
 }
 
-// GetCurrentLimit returns the active rate limit for a provider, initializing
-// state lazily if needed. Primarily used in tests that must assert AIMD signal
-// effects without access to unexported aimdState.
+// GetCurrentLimit returns the provider's current AIMD rate limit, initializing
+// state lazily if needed. The fast path uses an RLock; the first-touch init
+// falls back to a write lock with a double-checked re-read.
 func (c *AIMDController) GetCurrentLimit(name ProviderName) rate.Limit {
 	c.mu.RLock()
 	if s, ok := c.states[name]; ok {

--- a/internal/provider/aimd.go
+++ b/internal/provider/aimd.go
@@ -198,6 +198,25 @@ func (c *AIMDController) SetCeiling(name ProviderName, ceiling rate.Limit) {
 	s.ceiling = ceiling
 }
 
+// GetCurrentLimit returns the active rate limit for a provider, initializing
+// state lazily if needed. Primarily used in tests that must assert AIMD signal
+// effects without access to unexported aimdState.
+func (c *AIMDController) GetCurrentLimit(name ProviderName) rate.Limit {
+	c.mu.RLock()
+	if s, ok := c.states[name]; ok {
+		v := s.currentLimit
+		c.mu.RUnlock()
+		return v
+	}
+	c.mu.RUnlock()
+
+	// State not yet initialized -- take the write lock, re-check, then init.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	s := c.stateFor(name) // stateFor handles the already-initialized case
+	return s.currentLimit
+}
+
 // GetCeiling returns the current ceiling for a provider, initializing state
 // lazily if needed. The fast path uses an RLock; the first-touch init falls
 // back to a write lock with a double-checked re-read.

--- a/internal/provider/aimd_test.go
+++ b/internal/provider/aimd_test.go
@@ -364,9 +364,9 @@ func TestAIMDGetCurrentLimit(t *testing.T) {
 	}
 }
 
-// TestRateLimitErrorHelpers exercises IsRateLimitError / RetryAfterDuration and
-// their package-internal aliases isRateLimitError / retryAfterDuration against
-// (a) an *ErrProviderUnavailable carrying a Retry-After and (b) ordinary errors.
+// TestRateLimitErrorHelpers exercises IsRateLimitError / RetryAfterDuration
+// against (a) an *ErrProviderUnavailable carrying a Retry-After and (b) ordinary
+// errors.
 func TestRateLimitErrorHelpers(t *testing.T) {
 	t.Parallel()
 
@@ -378,14 +378,8 @@ func TestRateLimitErrorHelpers(t *testing.T) {
 	if !IsRateLimitError(unavailable) {
 		t.Error("IsRateLimitError(*ErrProviderUnavailable): expected true")
 	}
-	if !isRateLimitError(unavailable) {
-		t.Error("isRateLimitError(*ErrProviderUnavailable): expected true")
-	}
 	if got := RetryAfterDuration(unavailable); got != retry {
 		t.Errorf("RetryAfterDuration(*ErrProviderUnavailable): expected %v, got %v", retry, got)
-	}
-	if got := retryAfterDuration(unavailable); got != retry {
-		t.Errorf("retryAfterDuration(*ErrProviderUnavailable): expected %v, got %v", retry, got)
 	}
 
 	// (b) Ordinary errors are NOT rate-limit signals and carry no backoff.
@@ -396,14 +390,8 @@ func TestRateLimitErrorHelpers(t *testing.T) {
 		if IsRateLimitError(ordinary) {
 			t.Errorf("IsRateLimitError(%v): expected false", ordinary)
 		}
-		if isRateLimitError(ordinary) {
-			t.Errorf("isRateLimitError(%v): expected false", ordinary)
-		}
 		if got := RetryAfterDuration(ordinary); got != 0 {
 			t.Errorf("RetryAfterDuration(%v): expected 0, got %v", ordinary, got)
-		}
-		if got := retryAfterDuration(ordinary); got != 0 {
-			t.Errorf("retryAfterDuration(%v): expected 0, got %v", ordinary, got)
 		}
 	}
 }

--- a/internal/provider/aimd_test.go
+++ b/internal/provider/aimd_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -314,6 +315,95 @@ func TestAIMDConcurrencyTwoKeys(t *testing.T) {
 		}
 		if got > ceiling {
 			t.Errorf("provider %s: limit %v above ceiling %v", n, got, ceiling)
+		}
+	}
+}
+
+// TestAIMDGetCurrentLimit verifies GetCurrentLimit across BOTH lock paths: the
+// lazy-init write-lock path (first touch of a fresh provider) and the
+// already-initialized fast path (RLock). It also confirms the returned value
+// tracks AIMD signal effects (a success ramp and a multiplicative decrease).
+func TestAIMDGetCurrentLimit(t *testing.T) {
+	t.Parallel()
+	clk := newFakeClock(time.Now())
+	ctrl := newTestAIMD(clk)
+	name := NameMusicBrainz // floor = 1 req/s, ceiling = 10
+	floor := defaultRateLimits[name]
+
+	// Lazy-init path: a fresh provider has no state slot, so GetCurrentLimit must
+	// take the write lock, initialize via stateFor, and return the floor.
+	if got := ctrl.GetCurrentLimit(name); got != floor {
+		t.Fatalf("fresh GetCurrentLimit (lazy-init/write-lock path): expected floor %v, got %v", floor, got)
+	}
+
+	// Fast path: the slot now exists, so a second call reads it under the RLock
+	// and returns the same value.
+	if got := ctrl.GetCurrentLimit(name); got != floor {
+		t.Fatalf("initialized GetCurrentLimit (RLock fast path): expected floor %v, got %v", floor, got)
+	}
+
+	// One additive increase: aimdSuccessThreshold successes raise the limit by
+	// aimdIncrement. The fast path must report the elevated value.
+	for range aimdSuccessThreshold {
+		ctrl.RecordSuccess(name)
+	}
+	wantUp := floor + aimdIncrement
+	if got := ctrl.GetCurrentLimit(name); got != wantUp {
+		t.Fatalf("GetCurrentLimit after success ramp: expected %v, got %v", wantUp, got)
+	}
+
+	// One multiplicative decrease: the limit halves, floored at the provider
+	// default. The fast path must report the post-failure value.
+	ctrl.RecordFailure(name, 0)
+	wantDown := rate.Limit(float64(wantUp) * aimdDecreaseFactor)
+	if wantDown < floor {
+		wantDown = floor
+	}
+	if got := ctrl.GetCurrentLimit(name); got != wantDown {
+		t.Fatalf("GetCurrentLimit after failure: expected %v, got %v", wantDown, got)
+	}
+}
+
+// TestRateLimitErrorHelpers exercises IsRateLimitError / RetryAfterDuration and
+// their package-internal aliases isRateLimitError / retryAfterDuration against
+// (a) an *ErrProviderUnavailable carrying a Retry-After and (b) ordinary errors.
+func TestRateLimitErrorHelpers(t *testing.T) {
+	t.Parallel()
+
+	// (a) An *ErrProviderUnavailable is a rate-limit signal and exposes its
+	// server-advised backoff.
+	const retry = 7 * time.Second
+	unavailable := &ErrProviderUnavailable{Provider: NameMusicBrainz, RetryAfter: retry}
+
+	if !IsRateLimitError(unavailable) {
+		t.Error("IsRateLimitError(*ErrProviderUnavailable): expected true")
+	}
+	if !isRateLimitError(unavailable) {
+		t.Error("isRateLimitError(*ErrProviderUnavailable): expected true")
+	}
+	if got := RetryAfterDuration(unavailable); got != retry {
+		t.Errorf("RetryAfterDuration(*ErrProviderUnavailable): expected %v, got %v", retry, got)
+	}
+	if got := retryAfterDuration(unavailable); got != retry {
+		t.Errorf("retryAfterDuration(*ErrProviderUnavailable): expected %v, got %v", retry, got)
+	}
+
+	// (b) Ordinary errors are NOT rate-limit signals and carry no backoff.
+	for _, ordinary := range []error{
+		&ErrNotFound{Provider: NameMusicBrainz, ID: "x"},
+		errors.New("some plain error"),
+	} {
+		if IsRateLimitError(ordinary) {
+			t.Errorf("IsRateLimitError(%v): expected false", ordinary)
+		}
+		if isRateLimitError(ordinary) {
+			t.Errorf("isRateLimitError(%v): expected false", ordinary)
+		}
+		if got := RetryAfterDuration(ordinary); got != 0 {
+			t.Errorf("RetryAfterDuration(%v): expected 0, got %v", ordinary, got)
+		}
+		if got := retryAfterDuration(ordinary); got != 0 {
+			t.Errorf("retryAfterDuration(%v): expected 0, got %v", ordinary, got)
 		}
 	}
 }

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -150,10 +150,10 @@ func (o *Orchestrator) SetExecutor(e ScraperExecutor) {
 //nolint:gocognit // Per-field provider iteration in priority order with provider-ID enrichment carry-forward between fields; this is the legacy non-scraper path retained for callers that have no scraper config, and its semantics must match ScrapeAll's outcome on a parallel diagram.
 func (o *Orchestrator) FetchMetadata(ctx context.Context, mbid, name string, providerIDs map[ProviderName]string) (*FetchResult, error) {
 	if o.executor != nil {
-		// NOTE: the ScraperExecutor (scraper.Executor.ScrapeAll) is the production
-		// refresh path and bypasses all AIMD instrumentation below. Wiring AIMD
-		// signals into the executor is tracked as a follow-up; do not instrument it
-		// in this PR.
+		// The ScraperExecutor (scraper.Executor.ScrapeAll) is the production
+		// refresh path. It records AIMD signals internally via its own
+		// AIMDController reference (the same instance as o.aimd), so no
+		// additional instrumentation is needed here.
 		return o.executor.ScrapeAll(ctx, mbid, name, "global", providerIDs)
 	}
 
@@ -392,15 +392,20 @@ func (o *Orchestrator) Search(ctx context.Context, name string) ([]ArtistSearchR
 	return allResults, nil
 }
 
-// isRateLimitError reports whether err is a provider-rate-limit / transient-
+// IsRateLimitError reports whether err is a provider-rate-limit / transient-
 // unavailability signal that the AIMD controller should react to. Only
 // *ErrProviderUnavailable qualifies: it carries 429/503/Retry-After semantics.
 // Ordinary errors (ErrNotFound, auth/401, JSON parse, context cancellation)
 // must NOT drive an AIMD decrease.
-func isRateLimitError(err error) bool {
+func IsRateLimitError(err error) bool {
 	var unavailable *ErrProviderUnavailable
 	return errors.As(err, &unavailable)
 }
+
+// isRateLimitError is the package-internal alias used by the orchestrator's own
+// getProviderResult. Callers outside the package (e.g. scraper.Executor) use
+// the exported IsRateLimitError.
+func isRateLimitError(err error) bool { return IsRateLimitError(err) }
 
 // retryAfterAttr returns a slog attribute carrying the server-advised backoff
 // from an *ErrProviderUnavailable, or an empty (elided) attribute when the error
@@ -416,17 +421,21 @@ func retryAfterAttr(err error) slog.Attr {
 	return slog.Attr{}
 }
 
-// retryAfterDuration extracts the RetryAfter duration from an
+// RetryAfterDuration extracts the RetryAfter duration from an
 // *ErrProviderUnavailable, returning 0 when the error is not of that type or
 // carries no hint. Used to pass the server-advised backoff to the AIMD
 // controller so it can log it alongside the multiplicative decrease.
-func retryAfterDuration(err error) time.Duration {
+func RetryAfterDuration(err error) time.Duration {
 	var unavailable *ErrProviderUnavailable
 	if errors.As(err, &unavailable) {
 		return unavailable.RetryAfter
 	}
 	return 0
 }
+
+// retryAfterDuration is the package-internal alias used by the orchestrator's
+// own getProviderResult. Callers outside the package use RetryAfterDuration.
+func retryAfterDuration(err error) time.Duration { return RetryAfterDuration(err) }
 
 // availableProviders returns only the registered providers whose API keys are
 // configured (or that do not require a key). This prevents the orchestrator

--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -346,8 +346,8 @@ func (o *Orchestrator) FetchImages(ctx context.Context, mbid string, providerIDs
 			result.Errors = append(result.Errors, fmt.Sprintf("%s: image fetch failed", p.Name()))
 			// Only signal AIMD on rate-limit / provider-unavailable errors.
 			// Ordinary errors (not-found, auth, JSON parse) are not AIMD signals.
-			if o.aimd != nil && isRateLimitError(err) {
-				o.aimd.RecordFailure(p.Name(), retryAfterDuration(err))
+			if o.aimd != nil && IsRateLimitError(err) {
+				o.aimd.RecordFailure(p.Name(), RetryAfterDuration(err))
 			}
 			continue
 		}
@@ -378,8 +378,8 @@ func (o *Orchestrator) Search(ctx context.Context, name string) ([]ArtistSearchR
 				retryAfterAttr(err))
 			// Only signal AIMD on rate-limit / provider-unavailable errors.
 			// Ordinary errors (not-found, auth, JSON parse) are not AIMD signals.
-			if o.aimd != nil && isRateLimitError(err) {
-				o.aimd.RecordFailure(p.Name(), retryAfterDuration(err))
+			if o.aimd != nil && IsRateLimitError(err) {
+				o.aimd.RecordFailure(p.Name(), RetryAfterDuration(err))
 			}
 			continue
 		}
@@ -401,11 +401,6 @@ func IsRateLimitError(err error) bool {
 	var unavailable *ErrProviderUnavailable
 	return errors.As(err, &unavailable)
 }
-
-// isRateLimitError is the package-internal alias used by the orchestrator's own
-// getProviderResult. Callers outside the package (e.g. scraper.Executor) use
-// the exported IsRateLimitError.
-func isRateLimitError(err error) bool { return IsRateLimitError(err) }
 
 // retryAfterAttr returns a slog attribute carrying the server-advised backoff
 // from an *ErrProviderUnavailable, or an empty (elided) attribute when the error
@@ -432,10 +427,6 @@ func RetryAfterDuration(err error) time.Duration {
 	}
 	return 0
 }
-
-// retryAfterDuration is the package-internal alias used by the orchestrator's
-// own getProviderResult. Callers outside the package use RetryAfterDuration.
-func retryAfterDuration(err error) time.Duration { return RetryAfterDuration(err) }
 
 // availableProviders returns only the registered providers whose API keys are
 // configured (or that do not require a key). This prevents the orchestrator
@@ -590,7 +581,7 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 					retryAfterAttr(err))
 				pr.err = err
 				// Record the first rate-limit error for the composite AIMD signal.
-				if isRateLimitError(err) && aimdRateLimitErr == nil {
+				if IsRateLimitError(err) && aimdRateLimitErr == nil {
 					aimdRateLimitErr = err
 				}
 			}
@@ -631,7 +622,7 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 				// when the provider was merely unreachable.
 				pr.imageErr = err
 				// Record the first rate-limit error for the composite AIMD signal.
-				if isRateLimitError(err) && aimdRateLimitErr == nil {
+				if IsRateLimitError(err) && aimdRateLimitErr == nil {
 					aimdRateLimitErr = err
 				}
 			}
@@ -649,7 +640,7 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 	// AIMD signals and neither case fires for them.
 	if o.aimd != nil {
 		if aimdRateLimitErr != nil {
-			o.aimd.RecordFailure(name, retryAfterDuration(aimdRateLimitErr))
+			o.aimd.RecordFailure(name, RetryAfterDuration(aimdRateLimitErr))
 		} else if aimdGotResult {
 			o.aimd.RecordSuccess(name)
 		}
@@ -1298,8 +1289,8 @@ func (o *Orchestrator) SearchForLinking(ctx context.Context, name string, provid
 			})
 			// Only signal AIMD on rate-limit / provider-unavailable errors.
 			// Ordinary errors (not-found, auth, JSON parse) are not AIMD signals.
-			if o.aimd != nil && isRateLimitError(err) {
-				o.aimd.RecordFailure(provName, retryAfterDuration(err))
+			if o.aimd != nil && IsRateLimitError(err) {
+				o.aimd.RecordFailure(provName, RetryAfterDuration(err))
 			}
 			continue
 		}

--- a/internal/scraper/executor.go
+++ b/internal/scraper/executor.go
@@ -17,6 +17,7 @@ type Executor struct {
 	service          *Service
 	registry         *provider.Registry
 	providerSettings *provider.SettingsService
+	aimd             *provider.AIMDController // may be nil; when nil, AIMD signals are skipped
 	logger           *slog.Logger
 }
 
@@ -30,12 +31,16 @@ type FieldResult struct {
 	Err          error                   `json:"-"`
 }
 
-// NewExecutor creates a new scraper executor.
-func NewExecutor(service *Service, registry *provider.Registry, settings *provider.SettingsService, logger *slog.Logger) *Executor {
+// NewExecutor creates a new scraper executor. aimd may be nil; when nil,
+// adaptive rate-limiting signals are skipped and the executor behaves exactly
+// as before. In production, pass the same AIMDController instance used by the
+// Orchestrator so both code paths share per-provider rate-limit state.
+func NewExecutor(service *Service, registry *provider.Registry, settings *provider.SettingsService, logger *slog.Logger, aimd *provider.AIMDController) *Executor {
 	return &Executor{
 		service:          service,
 		registry:         registry,
 		providerSettings: settings,
+		aimd:             aimd,
 		logger:           logger.With(slog.String("component", "scraper-executor")),
 	}
 }
@@ -367,6 +372,17 @@ func (e *Executor) getProviderResult(
 
 	pr := &providerResult{}
 
+	// aimdRateLimitErr records the first rate-limit / provider-unavailable error
+	// encountered across both GetArtist and GetImages within this single provider
+	// call. It is used to emit exactly ONE AIMD signal at the end of the function:
+	// RecordFailure if a rate-limit error was seen, RecordSuccess if results were
+	// returned without a rate-limit error. Ordinary errors (ErrNotFound, auth/401,
+	// JSON parse, context cancellation) are not AIMD signals.
+	var aimdRateLimitErr error
+	// aimdGotResult is true when at least one of GetArtist or GetImages returned
+	// a useful (non-error) result. Used to decide whether RecordSuccess is warranted.
+	aimdGotResult := false
+
 	// Lookup precedence: provider-specific ID > MBID > artist name.
 	usedProviderID := false
 	id := mbid
@@ -413,9 +429,14 @@ func (e *Executor) getProviderResult(
 					slog.String("provider", string(name)),
 					slog.String("error", err.Error()))
 				pr.err = err
+				// Record the first rate-limit error for the composite AIMD signal.
+				if provider.IsRateLimitError(err) && aimdRateLimitErr == nil {
+					aimdRateLimitErr = err
+				}
 			}
 		} else {
 			pr.meta = meta
+			aimdGotResult = true
 		}
 	}
 
@@ -448,9 +469,28 @@ func (e *Executor) getProviderResult(
 				// marked as attempted. This prevents clearing existing image data
 				// when the provider was merely unreachable.
 				pr.imageErr = err
+				// Record the first rate-limit error for the composite AIMD signal.
+				if provider.IsRateLimitError(err) && aimdRateLimitErr == nil {
+					aimdRateLimitErr = err
+				}
 			}
 		} else {
 			pr.images = images
+			aimdGotResult = true
+		}
+	}
+
+	// Emit exactly ONE AIMD signal per provider call:
+	//   - RecordFailure when a rate-limit / provider-unavailable error was seen.
+	//   - RecordSuccess when at least one sub-call (GetArtist or GetImages)
+	//     returned a useful result and no rate-limit error was recorded.
+	// Ordinary errors (ErrNotFound, auth, JSON parse, context cancel) are NOT
+	// AIMD signals and neither case fires for them.
+	if e.aimd != nil {
+		if aimdRateLimitErr != nil {
+			e.aimd.RecordFailure(name, provider.RetryAfterDuration(aimdRateLimitErr))
+		} else if aimdGotResult {
+			e.aimd.RecordSuccess(name)
 		}
 	}
 

--- a/internal/scraper/executor_test.go
+++ b/internal/scraper/executor_test.go
@@ -1522,9 +1522,12 @@ func newExecutorTestAIMD() *provider.AIMDController {
 }
 
 // newSingleFieldConfig returns a minimal ScraperConfig with one enabled field
-// (biography) sourced from the given primary provider in a single-entry chain.
-func newSingleFieldConfig(t *testing.T, ctx context.Context, svc *Service, prov provider.ProviderName) {
+// (biography) sourced from AudioDB as the primary provider in a single-entry
+// chain. AudioDB is the canonical provider for the AIMD executor tests (its
+// 0.5 req/s floor makes the expected limits easy to pin exactly).
+func newSingleFieldConfig(t *testing.T, ctx context.Context, svc *Service) {
 	t.Helper()
+	const prov = provider.NameAudioDB
 	cfg := &ScraperConfig{
 		Scope: ScopeGlobal,
 		Fields: []FieldConfig{
@@ -1569,7 +1572,7 @@ func TestExecutorAIMD_RateLimitErrorCallsRecordFailure(t *testing.T) {
 		},
 	})
 
-	newSingleFieldConfig(t, ctx, svc, provider.NameAudioDB)
+	newSingleFieldConfig(t, ctx, svc)
 
 	aimdCtrl := newExecutorTestAIMD()
 	exec := NewExecutor(svc, registry, settings, logger, aimdCtrl)
@@ -1583,6 +1586,15 @@ func TestExecutorAIMD_RateLimitErrorCallsRecordFailure(t *testing.T) {
 		}
 	}
 	primedLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
+	// AudioDB floor = 0.5 req/s (see defaultRateLimits in internal/provider).
+	// Priming drives 11 success signals: the 10th crosses the success threshold
+	// for exactly ONE additive increase (+0.5 increment), so the primed limit is
+	// exactly 1.0. Pinning the EXACT value (not merely ">floor") proves the
+	// executor emits exactly one success signal per ScrapeAll: a double-signal
+	// bug would have crossed the threshold twice and landed at 1.5.
+	if got := float64(primedLimit); got != 1.0 {
+		t.Fatalf("expected primed limit exactly 1.0 (one additive increase); got %.3f", got)
+	}
 
 	// Flip to failure mode. The hysteresis cooldown is 30s; since our test
 	// clock uses a fixed time, hysteresis never fires for a FIRST decrease.
@@ -1592,9 +1604,12 @@ func TestExecutorAIMD_RateLimitErrorCallsRecordFailure(t *testing.T) {
 	}
 
 	gotLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
-	if gotLimit >= primedLimit {
-		t.Errorf("expected AIMD limit to decrease after rate-limit error; primed=%.3f got=%.3f",
-			float64(primedLimit), float64(gotLimit))
+	// One rate-limit error => exactly one multiplicative decrease: 1.0 * 0.5 =
+	// 0.5, floored at the 0.5 AudioDB default. Pinning the exact post-value
+	// proves the decrease fired and lands where the AIMD constants predict.
+	if got := float64(gotLimit); got != 0.5 {
+		t.Errorf("expected exact AIMD limit 0.5 after rate-limit error; primed=%.3f got=%.3f",
+			float64(primedLimit), got)
 	}
 }
 
@@ -1616,16 +1631,20 @@ func TestExecutorAIMD_SuccessCallsRecordSuccess(t *testing.T) {
 		},
 	})
 
-	newSingleFieldConfig(t, ctx, svc, provider.NameAudioDB)
+	newSingleFieldConfig(t, ctx, svc)
 
 	aimdCtrl := newExecutorTestAIMD()
 	initialLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
+	// AudioDB floor = 0.5 req/s; a fresh controller starts there.
+	if got := float64(initialLimit); got != 0.5 {
+		t.Fatalf("expected initial AudioDB limit 0.5, got %.3f", got)
+	}
 
 	exec := NewExecutor(svc, registry, settings, logger, aimdCtrl)
 
 	// Drive 11 successful calls. The AIMD threshold is 10 consecutive successes,
 	// so the 10th call triggers one additive increase and the 11th resets the
-	// counter; the limit must be strictly greater than the initial after this loop.
+	// counter.
 	const calls = 11
 	for i := range calls {
 		_, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
@@ -1635,9 +1654,14 @@ func TestExecutorAIMD_SuccessCallsRecordSuccess(t *testing.T) {
 	}
 
 	gotLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
-	if gotLimit <= initialLimit {
-		t.Errorf("expected AIMD limit to increase after %d successes; initial=%.3f got=%.3f",
-			calls, float64(initialLimit), float64(gotLimit))
+	// 11 ScrapeAll calls => 11 success signals IF the executor emits exactly ONE
+	// per provider invocation. From the 0.5 floor, the 10th signal crosses the
+	// threshold for one additive increase (+0.5) => exactly 1.0. A double-signal
+	// bug (one per sub-call) would yield 22 signals => two increases => 1.5, so
+	// pinning the EXACT value proves the one-signal-per-invocation invariant.
+	if got := float64(gotLimit); got != 1.0 {
+		t.Errorf("expected exact AIMD limit 1.0 after %d one-signal invocations; initial=%.3f got=%.3f",
+			calls, float64(initialLimit), got)
 	}
 }
 
@@ -1654,10 +1678,172 @@ func TestExecutorAIMD_NilController(t *testing.T) {
 		},
 	})
 
-	newSingleFieldConfig(t, ctx, svc, provider.NameAudioDB)
+	newSingleFieldConfig(t, ctx, svc)
 
 	exec := NewExecutor(svc, registry, settings, logger, nil) // nil AIMD
 	if _, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil); err != nil {
 		t.Fatalf("ScrapeAll with nil aimd panicked or errored: %v", err)
+	}
+}
+
+// TestExecutorAIMD_ImagesRateLimitCallsRecordFailure verifies the composite
+// signal's GetImages path: GetArtist succeeds but GetImages returns an
+// *ErrProviderUnavailable. getProviderResult must still net a RecordFailure
+// because a rate-limit error was seen in EITHER sub-call, so the limit
+// multiplicatively decreases.
+func TestExecutorAIMD_ImagesRateLimitCallsRecordFailure(t *testing.T) {
+	registry, settings, svc, logger := setupExecutorTest(t)
+	ctx := context.Background()
+
+	// imgFail flips only GetImages between success and rate-limited.
+	var imgFail bool
+
+	registry.Register(&mockProvider{
+		name: provider.NameAudioDB,
+		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+			return &provider.ArtistMetadata{
+				Biography: "A long enough biography to clear the junk filter, definitely more than fifty characters here.",
+			}, nil
+		},
+		getImgFn: func(_ context.Context, _ string) ([]provider.ImageResult, error) {
+			if imgFail {
+				return nil, &provider.ErrProviderUnavailable{
+					Provider:   provider.NameAudioDB,
+					RetryAfter: 3 * time.Second,
+				}
+			}
+			return nil, nil
+		},
+	})
+
+	newSingleFieldConfig(t, ctx, svc)
+
+	aimdCtrl := newExecutorTestAIMD()
+	exec := NewExecutor(svc, registry, settings, logger, aimdCtrl)
+
+	// Prime above the AudioDB floor (one additive increase => 1.0) with both
+	// sub-calls succeeding.
+	const primeRounds = 11
+	for i := range primeRounds {
+		if _, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil); err != nil {
+			t.Fatalf("prime ScrapeAll %d: %v", i, err)
+		}
+	}
+	primedLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
+	if got := float64(primedLimit); got != 1.0 {
+		t.Fatalf("expected primed limit 1.0, got %.3f", got)
+	}
+
+	// Flip GetImages to rate-limited. GetArtist still succeeds, but the composite
+	// signal must be a RecordFailure: exactly one decrease, 1.0 * 0.5 = 0.5.
+	imgFail = true
+	if _, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil); err != nil {
+		t.Fatalf("images-fail ScrapeAll: %v", err)
+	}
+	gotLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
+	if got := float64(gotLimit); got != 0.5 {
+		t.Errorf("expected exact limit 0.5 after GetImages rate-limit; primed=%.3f got=%.3f",
+			float64(primedLimit), got)
+	}
+}
+
+// TestExecutorAIMD_NotFoundEmitsNoSignal verifies that an ordinary error
+// (ErrNotFound from both sub-calls) is NOT an AIMD signal: neither RecordFailure
+// nor RecordSuccess fires, so the current limit is byte-for-byte unchanged.
+func TestExecutorAIMD_NotFoundEmitsNoSignal(t *testing.T) {
+	registry, settings, svc, logger := setupExecutorTest(t)
+	ctx := context.Background()
+
+	registry.Register(&mockProvider{
+		name: provider.NameAudioDB,
+		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+			return nil, &provider.ErrNotFound{Provider: provider.NameAudioDB, ID: "mbid-1234"}
+		},
+		getImgFn: func(_ context.Context, _ string) ([]provider.ImageResult, error) {
+			return nil, &provider.ErrNotFound{Provider: provider.NameAudioDB, ID: "mbid-1234"}
+		},
+	})
+
+	newSingleFieldConfig(t, ctx, svc)
+
+	aimdCtrl := newExecutorTestAIMD()
+	// Reading the limit first initializes lazy state at the AudioDB floor (0.5).
+	initialLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
+	exec := NewExecutor(svc, registry, settings, logger, aimdCtrl)
+
+	// Drive enough rounds that a spurious success signal would cross the success
+	// threshold (10) and change the limit. ErrNotFound is an ordinary error, so
+	// NO signal fires and the limit must be unchanged.
+	const rounds = 11
+	for i := range rounds {
+		if _, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil); err != nil {
+			t.Fatalf("ScrapeAll %d: %v", i, err)
+		}
+	}
+	gotLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
+	if gotLimit != initialLimit {
+		t.Errorf("expected AIMD limit unchanged after ErrNotFound rounds; initial=%.3f got=%.3f",
+			float64(initialLimit), float64(gotLimit))
+	}
+}
+
+// TestExecutorAIMD_CompositeRateLimitWinsOverSuccess verifies first-rate-limit-
+// error-wins precedence: GetArtist returns a rate-limit error while GetImages
+// succeeds. The composite signal records the rate-limit error, so a RecordFailure
+// wins over the GetImages success and the limit decreases.
+func TestExecutorAIMD_CompositeRateLimitWinsOverSuccess(t *testing.T) {
+	registry, settings, svc, logger := setupExecutorTest(t)
+	ctx := context.Background()
+
+	// artFail flips only GetArtist between success and rate-limited.
+	var artFail bool
+
+	registry.Register(&mockProvider{
+		name: provider.NameAudioDB,
+		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+			if artFail {
+				return nil, &provider.ErrProviderUnavailable{
+					Provider:   provider.NameAudioDB,
+					RetryAfter: 2 * time.Second,
+				}
+			}
+			return &provider.ArtistMetadata{
+				Biography: "A biography long enough to pass the junk filter, definitely more than fifty characters in length.",
+			}, nil
+		},
+		getImgFn: func(_ context.Context, _ string) ([]provider.ImageResult, error) {
+			// GetImages always succeeds, returning one image so a useful result
+			// is recorded for the composite-success branch.
+			return []provider.ImageResult{{Type: provider.ImageThumb, URL: "http://example/img.jpg"}}, nil
+		},
+	})
+
+	newSingleFieldConfig(t, ctx, svc)
+
+	aimdCtrl := newExecutorTestAIMD()
+	exec := NewExecutor(svc, registry, settings, logger, aimdCtrl)
+
+	const primeRounds = 11
+	for i := range primeRounds {
+		if _, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil); err != nil {
+			t.Fatalf("prime ScrapeAll %d: %v", i, err)
+		}
+	}
+	primedLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
+	if got := float64(primedLimit); got != 1.0 {
+		t.Fatalf("expected primed limit 1.0, got %.3f", got)
+	}
+
+	// GetArtist rate-limits while GetImages still succeeds. The composite signal
+	// records the FIRST rate-limit error seen, so RecordFailure wins over the
+	// GetImages success: exactly one decrease, 1.0 * 0.5 = 0.5.
+	artFail = true
+	if _, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil); err != nil {
+		t.Fatalf("composite ScrapeAll: %v", err)
+	}
+	gotLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
+	if got := float64(gotLimit); got != 0.5 {
+		t.Errorf("expected exact limit 0.5 (rate-limit wins over success); primed=%.3f got=%.3f",
+			float64(primedLimit), got)
 	}
 }

--- a/internal/scraper/executor_test.go
+++ b/internal/scraper/executor_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/sydlexius/stillwater/internal/encryption"
 	"github.com/sydlexius/stillwater/internal/provider"
@@ -122,7 +123,7 @@ func TestExecutorErrNotFoundMarksFieldAttempted(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	exec := NewExecutor(svc, registry, settings, logger)
+	exec := NewExecutor(svc, registry, settings, logger, nil)
 
 	result, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
 	if err != nil {
@@ -190,7 +191,7 @@ func TestExecutorPopulatedFields_DistinguishesAttemptedFromPopulated(t *testing.
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	exec := NewExecutor(svc, registry, settings, logger)
+	exec := NewExecutor(svc, registry, settings, logger, nil)
 	result, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
 	if err != nil {
 		t.Fatalf("ScrapeAll: %v", err)
@@ -241,7 +242,7 @@ func TestExecutorPopulatedFields_RecordsFieldWhenProviderReturnsData(t *testing.
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	exec := NewExecutor(svc, registry, settings, logger)
+	exec := NewExecutor(svc, registry, settings, logger, nil)
 	result, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
 	if err != nil {
 		t.Fatalf("ScrapeAll: %v", err)
@@ -294,7 +295,7 @@ func TestExecutorGetImagesTimeoutDoesNotMarkImageFieldAttempted(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	exec := NewExecutor(svc, registry, settings, logger)
+	exec := NewExecutor(svc, registry, settings, logger, nil)
 
 	result, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
 	if err != nil {
@@ -341,7 +342,7 @@ func TestExecutorGetImagesErrNotFoundMarksImageFieldAttempted(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	exec := NewExecutor(svc, registry, settings, logger)
+	exec := NewExecutor(svc, registry, settings, logger, nil)
 
 	result, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
 	if err != nil {
@@ -394,7 +395,7 @@ func TestExecutorGetImagesDataMarksImageFieldAttempted(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	exec := NewExecutor(svc, registry, settings, logger)
+	exec := NewExecutor(svc, registry, settings, logger, nil)
 
 	result, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
 	if err != nil {
@@ -467,7 +468,7 @@ func TestExecutorFallbackChainImageTimeout(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	exec := NewExecutor(svc, registry, settings, logger)
+	exec := NewExecutor(svc, registry, settings, logger, nil)
 
 	result, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
 	if err != nil {
@@ -523,7 +524,7 @@ func TestExecutorNetworkErrorDoesNotMarkFieldAttempted(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	exec := NewExecutor(svc, registry, settings, logger)
+	exec := NewExecutor(svc, registry, settings, logger, nil)
 
 	result, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
 	if err != nil {
@@ -845,7 +846,7 @@ func TestExecutorHonorsConfiguredPriority(t *testing.T) {
 		t.Fatalf("SetPriority: %v", err)
 	}
 
-	exec := NewExecutor(svc, registry, settings, logger)
+	exec := NewExecutor(svc, registry, settings, logger, nil)
 	result, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
 	if err != nil {
 		t.Fatalf("ScrapeAll: %v", err)
@@ -922,7 +923,7 @@ func TestExecutorPriorityFallbackPreservesUnlistedProviders(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	exec := NewExecutor(svc, registry, settings, logger)
+	exec := NewExecutor(svc, registry, settings, logger, nil)
 	result, err := exec.ScrapeAll(ctx, "mbid-x", "Test Artist", ScopeGlobal, nil)
 	if err != nil {
 		t.Fatalf("ScrapeAll: %v", err)
@@ -1014,7 +1015,7 @@ func TestExecutorPriorityFallback_AllDisabledSkipsField(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	exec := NewExecutor(svc, registry, settings, logger)
+	exec := NewExecutor(svc, registry, settings, logger, nil)
 	result, err := exec.ScrapeAll(ctx, "mbid-x", "Test Artist", ScopeGlobal, nil)
 	if err != nil {
 		t.Fatalf("ScrapeAll: %v", err)
@@ -1200,7 +1201,7 @@ func TestScrapeAll_LocalizesGenresFromMetadataLanguage(t *testing.T) {
 		t.Fatalf("SaveConfig: %v", err)
 	}
 
-	exec := NewExecutor(svc, registry, settings, logger)
+	exec := NewExecutor(svc, registry, settings, logger, nil)
 	ctx := provider.WithMetadataLanguages(context.Background(), []string{"ja"})
 	result, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
 	if err != nil {
@@ -1496,5 +1497,167 @@ func TestEffectiveFieldOrdering_NonEmpty_Unchanged(t *testing.T) {
 		if gotChain.Providers[i] != p {
 			t.Errorf("Providers[%d]: want %q, got %q", i, p, gotChain.Providers[i])
 		}
+	}
+}
+
+// --- AIMD executor path tests -------------------------------------------------
+
+// executorTestClock is a minimal provider.Clock for executor AIMD tests. It
+// always returns a fixed time so hysteresis cooldowns do not interfere.
+type executorTestClock struct{ t time.Time }
+
+func (c executorTestClock) Now() time.Time                                 { return c.t }
+func (c executorTestClock) Sleep(_ context.Context, _ time.Duration) error { return nil }
+
+// newExecutorTestAIMD returns an AIMDController backed by a real RateLimiterMap
+// and a fixed-time clock. The fixed time ensures that repeated RecordFailure
+// calls within one test are NOT silently absorbed by the hysteresis guard
+// (which requires time.Now() to advance by aimdHysteresisCooldown = 30s).
+// For failure tests we call RecordFailure only once; for success tests we
+// drive aimdSuccessThreshold (10) calls without triggering hysteresis.
+func newExecutorTestAIMD() *provider.AIMDController {
+	rlm := provider.NewRateLimiterMap()
+	clk := executorTestClock{t: time.Now()}
+	return provider.NewAIMDController(rlm, clk)
+}
+
+// newSingleFieldConfig returns a minimal ScraperConfig with one enabled field
+// (biography) sourced from the given primary provider in a single-entry chain.
+func newSingleFieldConfig(t *testing.T, ctx context.Context, svc *Service, prov provider.ProviderName) {
+	t.Helper()
+	cfg := &ScraperConfig{
+		Scope: ScopeGlobal,
+		Fields: []FieldConfig{
+			{Field: FieldBiography, Primary: prov, Enabled: true, Category: CategoryMetadata},
+		},
+		FallbackChains: []FallbackChain{
+			{Category: CategoryMetadata, Providers: []provider.ProviderName{prov}},
+		},
+	}
+	if err := svc.SaveConfig(ctx, ScopeGlobal, cfg, nil); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+}
+
+// TestExecutorAIMD_RateLimitErrorCallsRecordFailure verifies that when
+// getProviderResult receives an *ErrProviderUnavailable from GetArtist, it
+// drives RecordFailure on the AIMD controller, which multiplicatively decreases
+// the provider's current rate limit.
+//
+// Setup: prime the limit above the floor via aimdSuccessThreshold successful
+// calls (using a switchable mock), then flip the mock to rate-limit mode.
+// This ensures the decrease has room to move below the initial elevated limit.
+func TestExecutorAIMD_RateLimitErrorCallsRecordFailure(t *testing.T) {
+	registry, settings, svc, logger := setupExecutorTest(t)
+	ctx := context.Background()
+
+	// failMode gates the provider between "success" and "rate-limited" behavior.
+	var failMode bool
+
+	registry.Register(&mockProvider{
+		name: provider.NameAudioDB,
+		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+			if failMode {
+				return nil, &provider.ErrProviderUnavailable{
+					Provider:   provider.NameAudioDB,
+					RetryAfter: 5 * time.Second,
+				}
+			}
+			return &provider.ArtistMetadata{
+				Biography: "A long enough biography for the junk filter, definitely more than fifty characters long.",
+			}, nil
+		},
+	})
+
+	newSingleFieldConfig(t, ctx, svc, provider.NameAudioDB)
+
+	aimdCtrl := newExecutorTestAIMD()
+	exec := NewExecutor(svc, registry, settings, logger, aimdCtrl)
+
+	// Prime: drive aimdSuccessThreshold (10) + 1 successful calls so the limit
+	// rises above the floor. The 10th call triggers one additive increase.
+	const primeRounds = 11
+	for i := range primeRounds {
+		if _, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil); err != nil {
+			t.Fatalf("prime ScrapeAll %d: %v", i, err)
+		}
+	}
+	primedLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
+
+	// Flip to failure mode. The hysteresis cooldown is 30s; since our test
+	// clock uses a fixed time, hysteresis never fires for a FIRST decrease.
+	failMode = true
+	if _, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil); err != nil {
+		t.Fatalf("failure ScrapeAll: %v", err)
+	}
+
+	gotLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
+	if gotLimit >= primedLimit {
+		t.Errorf("expected AIMD limit to decrease after rate-limit error; primed=%.3f got=%.3f",
+			float64(primedLimit), float64(gotLimit))
+	}
+}
+
+// TestExecutorAIMD_SuccessCallsRecordSuccess verifies that when getProviderResult
+// returns a valid result (no error), it drives RecordSuccess on the AIMD
+// controller. After aimdSuccessThreshold (10) consecutive successes the limit
+// increases; the test drives 11 ScrapeAll calls to guarantee a threshold crossing.
+func TestExecutorAIMD_SuccessCallsRecordSuccess(t *testing.T) {
+	registry, settings, svc, logger := setupExecutorTest(t)
+	ctx := context.Background()
+
+	// Register a provider that always returns valid metadata.
+	registry.Register(&mockProvider{
+		name: provider.NameAudioDB,
+		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+			return &provider.ArtistMetadata{
+				Biography: "A biography that is long enough to pass the junk filter for test purposes, definitely more than 50 chars.",
+			}, nil
+		},
+	})
+
+	newSingleFieldConfig(t, ctx, svc, provider.NameAudioDB)
+
+	aimdCtrl := newExecutorTestAIMD()
+	initialLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
+
+	exec := NewExecutor(svc, registry, settings, logger, aimdCtrl)
+
+	// Drive 11 successful calls. The AIMD threshold is 10 consecutive successes,
+	// so the 10th call triggers one additive increase and the 11th resets the
+	// counter; the limit must be strictly greater than the initial after this loop.
+	const calls = 11
+	for i := range calls {
+		_, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil)
+		if err != nil {
+			t.Fatalf("ScrapeAll call %d: %v", i, err)
+		}
+	}
+
+	gotLimit := aimdCtrl.GetCurrentLimit(provider.NameAudioDB)
+	if gotLimit <= initialLimit {
+		t.Errorf("expected AIMD limit to increase after %d successes; initial=%.3f got=%.3f",
+			calls, float64(initialLimit), float64(gotLimit))
+	}
+}
+
+// TestExecutorAIMD_NilController verifies that a nil AIMDController does not
+// panic -- the executor must guard every signal with a nil check.
+func TestExecutorAIMD_NilController(t *testing.T) {
+	registry, settings, svc, logger := setupExecutorTest(t)
+	ctx := context.Background()
+
+	registry.Register(&mockProvider{
+		name: provider.NameAudioDB,
+		getArtFn: func(_ context.Context, _ string) (*provider.ArtistMetadata, error) {
+			return nil, &provider.ErrProviderUnavailable{Provider: provider.NameAudioDB}
+		},
+	})
+
+	newSingleFieldConfig(t, ctx, svc, provider.NameAudioDB)
+
+	exec := NewExecutor(svc, registry, settings, logger, nil) // nil AIMD
+	if _, err := exec.ScrapeAll(ctx, "mbid-1234", "Test Artist", ScopeGlobal, nil); err != nil {
+		t.Fatalf("ScrapeAll with nil aimd panicked or errored: %v", err)
 	}
 }


### PR DESCRIPTION
## What

Instruments the **production scraper refresh path** -- `scraper.Executor.ScrapeAll` (via `getProviderResult`) -- with AIMD rate-limit signals. The executor now records per-provider success / rate-limit feedback into the **same** `AIMDController` instance the orchestrator uses, so both code paths share per-provider rate-limit state instead of diverging.

Previously, when a `ScraperExecutor` was configured, `Orchestrator.FetchMetadata` short-circuited to `executor.ScrapeAll` **before** any AIMD hooks ran. Per `reference_dual_metadata_path.md` the executor is the live **refresh** path in production, so the primary refresh path was uninstrumented: 429 / Retry-After signals during a refresh never fed AIMD.

## Why

Follow-up to **#1747** (AIMD controller, merged as PR #2056). #1747 instrumented the orchestrator search / identify / image / direct-metadata paths but explicitly left the executor refresh path as a tracked gap (a code comment marked it). This PR closes that gap so adaptive back-off / ramp-up applies to the production refresh path too.

## Key changes

- **`NewExecutor` now takes a `*provider.AIMDController`** (nil-safe). When nil, AIMD signals are skipped and the executor behaves exactly as before -- backward compatible.
- **`getProviderResult` emits exactly one composite AIMD signal per invocation**, mirroring the orchestrator's discipline: it accumulates across `GetArtist` + `GetImages`, records the first rate-limit / provider-unavailable error, and at the end fires either `RecordFailure` (a rate-limit error was seen) or `RecordSuccess` (a useful result with no rate-limit error). Ordinary errors (`ErrNotFound`, auth, JSON parse, context cancel) are **not** AIMD signals.
- **Exported `IsRateLimitError` / `RetryAfterDuration`** from `internal/provider` (with package-internal aliases retained for the orchestrator's own `getProviderResult`), so the scraper package can reuse the same rate-limit-error classification.
- **New `GetCurrentLimit`** on `AIMDController` -- lazily initializes state, primarily for tests asserting AIMD signal effects without reaching into unexported `aimdState`.
- **`main.go` wires the shared controller** -- `wireProviders` passes the same `aimdCtrl` to `NewExecutor` that the orchestrator already uses.
- Updated the `FetchMetadata` short-circuit comment to reflect that the executor now records AIMD signals internally.

## Test plan

- `go build ./... && go vet ./...` -- clean.
- `go test -race ./internal/provider/ ./internal/scraper/` -- clean, 0 data races.
- Patch coverage **90.38%** (> gate).
- New tests pin the **exactly-one-signal invariant** via exact `GetCurrentLimit` values, plus coverage for `GetCurrentLimit`, the exported rate-limit helpers (`IsRateLimitError` / `RetryAfterDuration`), and the executor images / not-found / composite paths.

Closes #2055


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated adaptive rate-limiting into the scraper, enabling intelligent adjustment of request rates based on provider feedback and automatic backoff on rate-limit responses.

* **Tests**
  * Added comprehensive test coverage for rate-limit detection, backoff behavior, and edge cases across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->