### PR TITLE
fix(openapi): broaden discogs 409 to oneOf, scope deezer 409 to ConflictWriteBlock (#2059)

### DIFF
--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -11530,7 +11530,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/ConflictWriteBlock"
         "500":
           description: Failed to link Deezer ID
           content:
@@ -11732,7 +11732,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                oneOf:
+                  - $ref: "#/components/schemas/ConflictWriteBlock"
+                  - type: object
+                    required: [error, field, reason]
+                    properties:
+                      error:
+                        type: string
+                        enum: [field_locked]
+                      field:
+                        type: string
+                        enum: [discogs_id]
+                      reason:
+                        type: string
         "500":
           description: Failed to link Discogs ID
           content:


### PR DESCRIPTION
## Summary

Align two provider "match-by-name" link 409 schemas with their actual handler behavior (spec-only, no handler changes):

- `POST /artists/{id}/discogs/link` 409 broadened from the generic `Error` to `oneOf(ConflictWriteBlock, field_locked)` with `field` enum `[discogs_id]` -- `discogs_id` IS a lockable field, so the handler can return either variant.
- `POST /artists/{id}/deezer/link` 409 scoped to `ConflictWriteBlock` only -- `deezer_id` is NOT a lockable field, so there is no `field_locked` path.

Deferred from #2057 (#1830) to avoid touching sibling endpoints outside that PR's scope. Both handlers verified before editing.

## Linked issue

Closes #2059

## Pre-flight checklist

- [x] Pre-push gate green locally (full suite via pre-push hook)
- [x] OpenAPI consistency (`TestOpenAPIConsistency`) passes
- [x] Commits squashed (single commit)
- [x] Label(s) set
- [x] OpenAPI spec updated to match handlers
- [ ] Screenshot for UI change (N/A -- spec-only)
- [ ] UAT performed for user-visible changes (N/A -- spec-only, no behavior change)

## Test plan

- [x] `make check-openapi` / `TestOpenAPIConsistency` passes
- [x] `go build ./...` clean
- [ ] Reviewer: confirm the discogs `field` enum and the deezer single-variant 409 match the handlers
