### PR TITLE
feat(logs): dedicated SSE log-broadcaster + GET /api/v1/logs/stream (#1338 PR 5A)

### DIFF
--- a/api/bruno/logs/stream-logs.bru
+++ b/api/bruno/logs/stream-logs.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Stream Logs (SSE auth gate)
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{apiBase}}/logs/stream
+  body: none
+  auth: none
+}
+
+docs {
+  GET /api/v1/logs/stream is a long-lived Server-Sent Events endpoint, so a
+  Bruno request cannot assert a 200 body without blocking on the open stream
+  (the same reason GET /api/v1/events/stream is not exercised live). This smoke
+  deliberately sends NO session cookie so it returns immediately, asserting the
+  endpoint exists and is admin-gated (wrapAuth -> 401 when unauthenticated). The
+  streaming, backfill, filter, and throttle behavior is covered by the Go unit
+  and race tests in internal/logging and internal/api.
+}
+
+tests {
+  test("unauthenticated request is rejected (admin-gated)", function() {
+    expect(res.status).to.equal(401);
+  });
+}

--- a/internal/api/handlers_logs.go
+++ b/internal/api/handlers_logs.go
@@ -1,14 +1,17 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"html"
+	"log/slog"
 	"net/http"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/sydlexius/stillwater/internal/event"
 	"github.com/sydlexius/stillwater/internal/logging"
 )
 
@@ -226,6 +229,198 @@ func (r *Router) renderLogEntries(w http.ResponseWriter, entries []logging.LogEn
 	}
 
 	w.Write([]byte(b.String())) //nolint:errcheck // Best-effort write to HTTP response; client disconnect mid-write is not actionable
+}
+
+// logStreamBackfillLimit caps how many recent entries the stream replays from
+// the ring buffer on connect (the ring holds up to DefaultRingBufferSize=2000).
+const logStreamBackfillLimit = 500
+
+// handleLogsStream serves the live log stream as Server-Sent Events. On connect
+// it backfills recent ring-buffer entries (filtered, oldest-first, capped at
+// logStreamBackfillLimit) then live-tails new records via the log broadcaster.
+// Filters come from the query string: level (minimum severity), scope
+// (component, exact match), and q (case-insensitive message substring). The
+// browser EventSource's Last-Event-ID header (each frame's id is the entry's
+// RFC3339Nano timestamp) acts as a resume cursor so a reconnect only replays
+// entries newer than the last one seen.
+//
+// GET /api/v1/logs/stream
+func (r *Router) handleLogsStream(w http.ResponseWriter, req *http.Request) {
+	// SSE requires a flushable writer.
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "streaming not supported"})
+		return
+	}
+
+	if r.logManager == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "logging manager not available"})
+		return
+	}
+	rb := r.logManager.RingBuffer()
+	lb := r.logManager.LogBroadcaster()
+	if rb == nil || lb == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "log streaming not available"})
+		return
+	}
+
+	// Parse and validate the filter before writing any stream headers so an
+	// invalid request still gets a clean JSON 400.
+	filter := logging.LogFilter{
+		Search:    req.URL.Query().Get("q"),
+		Component: req.URL.Query().Get("scope"),
+	}
+	if level := req.URL.Query().Get("level"); level != "" {
+		if !logging.ValidLevel(level) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid level: must be one of trace, debug, info, warn, error"})
+			return
+		}
+		filter.Level = level
+	}
+
+	// SSE headers.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no") // disable nginx buffering
+
+	// Clear the write deadline so this long-lived stream is not killed by the
+	// server-level WriteTimeout.
+	rc := http.NewResponseController(w)
+	if err := rc.SetWriteDeadline(time.Time{}); err != nil {
+		r.logger.Error("failed to clear write deadline for logs stream", "err", err)
+	}
+
+	// Subscribe BEFORE snapshotting the ring buffer so no record is lost in the
+	// gap between backfill and live-tail. Records that arrive during backfill
+	// queue on the subscription and are emitted after it; the newestTS cursor
+	// returned below suppresses any that the snapshot already covered.
+	sub := lb.Subscribe(filter)
+	defer sub.Close()
+
+	newestTS, ok := r.emitLogBackfill(w, flusher, req, rb, filter)
+	if !ok {
+		return // client disconnected during backfill
+	}
+	r.streamLogLines(w, flusher, req, sub, newestTS)
+}
+
+// emitLogBackfill writes the initial connection frame and replays recent
+// ring-buffer entries (filtered, oldest-first) as logs.line events. A
+// Last-Event-ID resume cursor narrows the replay to entries after the client's
+// last-seen time. It returns the newest emitted timestamp (used to suppress
+// duplicate live delivery) and false if a write failed (client disconnected).
+func (r *Router) emitLogBackfill(w http.ResponseWriter, flusher http.Flusher, req *http.Request, rb *logging.RingBuffer, filter logging.LogFilter) (time.Time, bool) {
+	backfill := filter
+	backfill.Limit = logStreamBackfillLimit
+	if cursor := lastEventIDFromRequest(req); cursor != "" {
+		if t, err := time.Parse(time.RFC3339Nano, cursor); err == nil {
+			backfill.After = t
+		} else {
+			// A malformed cursor must not silently replay the full window: log a
+			// warning and degrade visibly. Streaming continues with the full
+			// backfill, which is acceptable (the client simply re-sees recent
+			// entries) but should never happen without a signal.
+			r.logger.Warn("logs stream: unparsable Last-Event-ID cursor, replaying full backfill window", "cursor", cursor, "error", err)
+		}
+	}
+	entries := rb.Entries(backfill)
+
+	// Initial connection frame (no id, so it does not advance Last-Event-ID).
+	if err := writeLogSSE(w, "", "connected", map[string]any{"replayed": len(entries)}, r.logger); err != nil {
+		return time.Time{}, false
+	}
+	// Emit backfill oldest-first so the newest entry lands at the bottom, the
+	// natural scroll direction for a log tail.
+	var newestTS time.Time
+	for i := len(entries) - 1; i >= 0; i-- {
+		e := entries[i]
+		if err := writeLogSSE(w, e.Time.Format(time.RFC3339Nano), string(event.LogsLine), e, r.logger); err != nil {
+			return time.Time{}, false
+		}
+		if e.Time.After(newestTS) {
+			newestTS = e.Time
+		}
+	}
+	flusher.Flush()
+	return newestTS, true
+}
+
+// streamLogLines live-tails the subscription, writing each new entry as a
+// logs.line event (suppressing any already covered by the backfill window),
+// reporting buffer overflow as logs.throttled, and sending a heartbeat comment
+// every 30 seconds. It returns when the client disconnects, a write fails, or
+// the broadcaster closes the subscription.
+func (r *Router) streamLogLines(w http.ResponseWriter, flusher http.Flusher, req *http.Request, sub *logging.Subscription, newestTS time.Time) {
+	heartbeat := time.NewTicker(30 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-req.Context().Done():
+			return
+		case <-sub.Throttle():
+			// The subscriber buffer overflowed; report how many lines were shed
+			// so the client can show a throttle banner.
+			dropped := sub.DrainDropped()
+			if dropped > 0 {
+				if err := writeLogSSE(w, "", string(event.LogsThrottled),
+					map[string]any{"dropped": dropped, "window": "live-buffer"}, r.logger); err != nil {
+					return
+				}
+				flusher.Flush()
+			}
+		case e, ok := <-sub.Lines():
+			if !ok {
+				return // broadcaster closed the subscription
+			}
+			// Suppress entries already delivered in the backfill window. Because
+			// the cursor is the entry timestamp, two distinct records sharing an
+			// identical timestamp (one in backfill, one live) can suppress the
+			// live one; clock resolution makes this rare and it is the inherent
+			// cost of using the timestamp as the resume cursor.
+			if !newestTS.IsZero() && !e.Time.After(newestTS) {
+				continue
+			}
+			if err := writeLogSSE(w, e.Time.Format(time.RFC3339Nano), string(event.LogsLine), e, r.logger); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-heartbeat.C:
+			if _, err := w.Write([]byte(": heartbeat\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+// writeLogSSE writes a single SSE frame for the log stream: an optional id line
+// (omitted when id is empty so transport-only frames do not advance the
+// client's Last-Event-ID), the event name, and a JSON data payload. A write
+// error typically means the client disconnected; the caller returns on error.
+func writeLogSSE(w http.ResponseWriter, id, eventType string, payload any, logger *slog.Logger) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		logger.Warn("logs sse marshal failed", "type", eventType, "error", err)
+		return err
+	}
+	if id != "" {
+		if _, err := w.Write([]byte("id: " + id + "\n")); err != nil {
+			return err
+		}
+	}
+	if _, err := w.Write([]byte("event: " + eventType + "\n")); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte("data: ")); err != nil {
+		return err
+	}
+	if _, err := w.Write(data); err != nil {
+		return err
+	}
+	_, err = w.Write([]byte("\n\n"))
+	return err
 }
 
 // levelBadgeClass returns Tailwind classes for the log level badge.

--- a/internal/api/handlers_logs_test.go
+++ b/internal/api/handlers_logs_test.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -469,6 +471,35 @@ func TestHandleGetLogs_NegativeLimit(t *testing.T) {
 	}
 }
 
+func TestHandleLogsStream_NilManager(t *testing.T) {
+	t.Parallel()
+	r := &Router{
+		logManager: nil,
+		logger:     slog.Default(),
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/stream", nil)
+	r.handleLogsStream(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestHandleLogsStream_InvalidLevel(t *testing.T) {
+	t.Parallel()
+	r, _ := newTestRouterWithLogs(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/stream?level=verbose", nil)
+	r.handleLogsStream(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
 func TestLevelBadgeClass(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -486,5 +517,585 @@ func TestLevelBadgeClass(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("levelBadgeClass(%q) = %q, want %q", tt.level, got, tt.want)
 		}
+	}
+}
+
+// --- SSE stream handler tests ---
+
+// newTestRouterWithLogsAndLogger extends newTestRouterWithLogs to also return
+// the slog.Logger wired to the broadcaster, so tests can publish live records.
+func newTestRouterWithLogsAndLogger(t *testing.T) (*Router, *logging.RingBuffer, *slog.Logger) {
+	t.Helper()
+	mgr, logger := logging.NewManager(logging.Config{Level: "debug", Format: "json"})
+	t.Cleanup(func() { mgr.Close() })
+	rb := mgr.RingBuffer()
+	r := &Router{logManager: mgr, logger: slog.Default()}
+	return r, rb, logger
+}
+
+// collectSSEFrames reads up to n blank-line-terminated SSE frames from scanner.
+// Each returned string contains all non-blank lines of one frame joined by "\n".
+// It stops after n frames or when the scanner closes (e.g., context canceled).
+func collectSSEFrames(scanner *bufio.Scanner, n int) []string {
+	var frames []string
+	var cur []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if len(cur) > 0 {
+				frames = append(frames, strings.Join(cur, "\n"))
+				cur = nil
+				if len(frames) >= n {
+					break
+				}
+			}
+		} else {
+			cur = append(cur, line)
+		}
+	}
+	if len(cur) > 0 {
+		frames = append(frames, strings.Join(cur, "\n"))
+	}
+	return frames
+}
+
+// TestHandleLogsStream_ConnectedAndBackfill verifies the stream sends a
+// "connected" event reporting the replayed count, followed by ring-buffer
+// entries replayed oldest-first as logs.line events.
+func TestHandleLogsStream_ConnectedAndBackfill(t *testing.T) {
+	t.Parallel()
+	r, rb, _ := newTestRouterWithLogsAndLogger(t)
+
+	base := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	rb.Write(logging.LogEntry{Time: base, Level: "info", Message: "alpha"})
+	rb.Write(logging.LogEntry{Time: base.Add(time.Second), Level: "warn", Message: "beta"})
+	rb.Write(logging.LogEntry{Time: base.Add(2 * time.Second), Level: "error", Message: "gamma"})
+
+	ts := httptest.NewServer(http.HandlerFunc(r.handleLogsStream))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("want text/event-stream, got %q", ct)
+	}
+
+	// connected frame + 3 backfill frames
+	scanner := bufio.NewScanner(resp.Body)
+	frames := collectSSEFrames(scanner, 4)
+	cancel()
+
+	if len(frames) < 4 {
+		t.Fatalf("want 4 SSE frames (connected + 3 backfill), got %d: %v", len(frames), frames)
+	}
+
+	if !strings.Contains(frames[0], "event: connected") {
+		t.Errorf("frame[0] should be connected event, got: %q", frames[0])
+	}
+	if !strings.Contains(frames[0], `"replayed":3`) {
+		t.Errorf("connected frame should report replayed:3, got: %q", frames[0])
+	}
+
+	// emitLogBackfill reverses entries so oldest lands first in the stream.
+	for i, want := range []string{"alpha", "beta", "gamma"} {
+		if !strings.Contains(frames[i+1], "event: logs.line") {
+			t.Errorf("frame[%d] should be logs.line event, got: %q", i+1, frames[i+1])
+		}
+		if !strings.Contains(frames[i+1], want) {
+			t.Errorf("frame[%d] should contain %q, got: %q", i+1, want, frames[i+1])
+		}
+	}
+
+	// id lines should be present (RFC3339Nano timestamps).
+	if !strings.Contains(frames[1], "id: ") {
+		t.Errorf("backfill frame should have id line, got: %q", frames[1])
+	}
+}
+
+// TestHandleLogsStream_LiveRecord verifies a record published to the log
+// broadcaster after connect is delivered as a logs.line SSE event.
+func TestHandleLogsStream_LiveRecord(t *testing.T) {
+	t.Parallel()
+	r, _, logger := newTestRouterWithLogsAndLogger(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(r.handleLogsStream))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+
+	// Read and discard the connected frame (replayed: 0 since ring is empty).
+	connFrames := collectSSEFrames(scanner, 1)
+	if len(connFrames) == 0 || !strings.Contains(connFrames[0], "event: connected") {
+		t.Fatalf("expected connected frame first, got: %v", connFrames)
+	}
+
+	// Publish a live record through the broadcaster.
+	logger.Info("live-record-marker", slog.String("src", "test"))
+
+	// Read the live frame.
+	liveFrames := collectSSEFrames(scanner, 1)
+	cancel()
+
+	if len(liveFrames) == 0 {
+		t.Fatal("expected a live logs.line frame but got none")
+	}
+	if !strings.Contains(liveFrames[0], "event: logs.line") {
+		t.Errorf("live frame should be logs.line, got: %q", liveFrames[0])
+	}
+	if !strings.Contains(liveFrames[0], "live-record-marker") {
+		t.Errorf("live frame should contain the log message, got: %q", liveFrames[0])
+	}
+}
+
+// TestHandleLogsStream_LastEventIDCursor verifies that a reconnect with a
+// valid RFC3339Nano Last-Event-ID cursor replays only entries after the cursor.
+func TestHandleLogsStream_LastEventIDCursor(t *testing.T) {
+	t.Parallel()
+	r, rb, _ := newTestRouterWithLogsAndLogger(t)
+
+	base := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	rb.Write(logging.LogEntry{Time: base, Level: "info", Message: "old-entry"})
+	rb.Write(logging.LogEntry{Time: base.Add(10 * time.Second), Level: "info", Message: "new-entry"})
+
+	ts := httptest.NewServer(http.HandlerFunc(r.handleLogsStream))
+	defer ts.Close()
+
+	// Cursor is set to 5s after base, so only "new-entry" should be replayed.
+	cursor := base.Add(5 * time.Second).Format(time.RFC3339Nano)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Last-Event-ID", cursor)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	// connected + 1 backfill (only "new-entry")
+	frames := collectSSEFrames(scanner, 2)
+	cancel()
+
+	if len(frames) < 2 {
+		t.Fatalf("want 2 frames (connected + 1 backfill), got %d: %v", len(frames), frames)
+	}
+	if !strings.Contains(frames[0], `"replayed":1`) {
+		t.Errorf("connected frame should report replayed:1, got: %q", frames[0])
+	}
+	if strings.Contains(frames[1], "old-entry") {
+		t.Errorf("frame[1] should not contain old-entry (before cursor), got: %q", frames[1])
+	}
+	if !strings.Contains(frames[1], "new-entry") {
+		t.Errorf("frame[1] should contain new-entry (after cursor), got: %q", frames[1])
+	}
+}
+
+// TestHandleLogsStream_MalformedCursor verifies that an unparsable
+// Last-Event-ID causes the handler to log a warning and fall back to a full
+// backfill rather than silently dropping entries.
+func TestHandleLogsStream_MalformedCursor(t *testing.T) {
+	t.Parallel()
+	r, rb, _ := newTestRouterWithLogsAndLogger(t)
+
+	base := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	rb.Write(logging.LogEntry{Time: base, Level: "info", Message: "entry-one"})
+	rb.Write(logging.LogEntry{Time: base.Add(time.Second), Level: "info", Message: "entry-two"})
+
+	ts := httptest.NewServer(http.HandlerFunc(r.handleLogsStream))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Last-Event-ID", "not-a-valid-timestamp")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	// Expect full backfill (both entries) despite malformed cursor.
+	frames := collectSSEFrames(scanner, 3) // connected + 2 entries
+	cancel()
+
+	if len(frames) < 3 {
+		t.Fatalf("want 3 frames (connected + 2 full backfill), got %d: %v", len(frames), frames)
+	}
+	if !strings.Contains(frames[0], `"replayed":2`) {
+		t.Errorf("connected frame should report replayed:2 (full replay), got: %q", frames[0])
+	}
+}
+
+// TestHandleLogsStream_LevelFilter verifies the level query param filters both
+// backfill and live log entries so only entries at or above the requested level
+// appear in the stream.
+func TestHandleLogsStream_LevelFilter(t *testing.T) {
+	t.Parallel()
+	r, rb, _ := newTestRouterWithLogsAndLogger(t)
+
+	base := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	rb.Write(logging.LogEntry{Time: base, Level: "debug", Message: "debug-msg"})
+	rb.Write(logging.LogEntry{Time: base.Add(time.Second), Level: "info", Message: "info-msg"})
+	rb.Write(logging.LogEntry{Time: base.Add(2 * time.Second), Level: "error", Message: "error-msg"})
+
+	ts := httptest.NewServer(http.HandlerFunc(r.handleLogsStream))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"?level=error", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	frames := collectSSEFrames(scanner, 2) // connected + 1 error entry
+	cancel()
+
+	if len(frames) < 2 {
+		t.Fatalf("want 2 frames (connected + 1 error), got %d", len(frames))
+	}
+	if !strings.Contains(frames[0], `"replayed":1`) {
+		t.Errorf("connected frame should report replayed:1, got: %q", frames[0])
+	}
+	if strings.Contains(frames[1], "debug-msg") || strings.Contains(frames[1], "info-msg") {
+		t.Errorf("filtered frame should not contain debug or info messages, got: %q", frames[1])
+	}
+	if !strings.Contains(frames[1], "error-msg") {
+		t.Errorf("filtered frame should contain error-msg, got: %q", frames[1])
+	}
+}
+
+// TestHandleLogsStream_ScopeFilter verifies the scope query param filters
+// backfill entries to only those with a matching component.
+func TestHandleLogsStream_ScopeFilter(t *testing.T) {
+	t.Parallel()
+	r, rb, _ := newTestRouterWithLogsAndLogger(t)
+
+	base := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	rb.Write(logging.LogEntry{Time: base, Level: "info", Message: "scanner-work", Component: "scanner"})
+	rb.Write(logging.LogEntry{Time: base.Add(time.Second), Level: "info", Message: "backup-work", Component: "backup"})
+
+	ts := httptest.NewServer(http.HandlerFunc(r.handleLogsStream))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"?scope=scanner", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	frames := collectSSEFrames(scanner, 2) // connected + 1 scanner entry
+	cancel()
+
+	if len(frames) < 2 {
+		t.Fatalf("want 2 frames (connected + 1 scope match), got %d", len(frames))
+	}
+	if !strings.Contains(frames[0], `"replayed":1`) {
+		t.Errorf("connected frame should report replayed:1 (scope filtered), got: %q", frames[0])
+	}
+	if strings.Contains(frames[1], "backup-work") {
+		t.Errorf("frame[1] should not contain backup-work, got: %q", frames[1])
+	}
+	if !strings.Contains(frames[1], "scanner-work") {
+		t.Errorf("frame[1] should contain scanner-work, got: %q", frames[1])
+	}
+}
+
+// TestStreamLogLines_Throttle verifies that when the subscriber buffer overflows
+// (more records published than the channel can hold), streamLogLines emits a
+// logs.throttled SSE frame with a non-zero dropped count.
+func TestStreamLogLines_Throttle(t *testing.T) {
+	t.Parallel()
+	r, _, logger := newTestRouterWithLogsAndLogger(t)
+
+	lb := r.logManager.LogBroadcaster()
+	sub := lb.Subscribe(logging.LogFilter{})
+	defer sub.Close()
+
+	// Publish enough records to overflow the subscriber's default 256-entry buffer.
+	// The broadcaster fans out non-blocking: once s.lines is full, dropped++ and
+	// the throttle signal fires. Publishing 300 guarantees overflow.
+	for i := 0; i < 300; i++ {
+		logger.Info("flood", slog.Int("i", i))
+	}
+
+	// Give the broadcaster goroutines time to fan out all records before reading.
+	// (Publishes happen synchronously in Handle(), so no sleep needed here, but
+	// runtime scheduling may delay the channel sends slightly.)
+	// The subscription now has >=256 entries in Lines and 1 signal in Throttle.
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/stream", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// newestTS=zero so no backfill suppression; call streamLogLines directly.
+		r.streamLogLines(w, w, req, sub, time.Time{})
+	}()
+
+	// Give the handler time to drain Lines and process the Throttle signal.
+	// With 256+ entries in a bytes.Buffer (no IO), this should be near-instant.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	body := w.Body.String()
+	if !strings.Contains(body, "event: logs.throttled") {
+		t.Errorf("expected logs.throttled SSE event in stream output, got:\n%s", body)
+	}
+	if !strings.Contains(body, `"dropped"`) {
+		t.Errorf("throttled event should include dropped count, got:\n%s", body)
+	}
+}
+
+// TestStreamLogLines_LivePath verifies that a record published via a
+// Subscription is forwarded as a logs.line SSE event by streamLogLines.
+func TestStreamLogLines_LivePath(t *testing.T) {
+	t.Parallel()
+	r, _, logger := newTestRouterWithLogsAndLogger(t)
+
+	lb := r.logManager.LogBroadcaster()
+	sub := lb.Subscribe(logging.LogFilter{})
+	defer sub.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/stream", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.streamLogLines(w, w, req, sub, time.Time{})
+	}()
+
+	// Publish one record after streamLogLines has started.
+	time.Sleep(10 * time.Millisecond) // tiny gap so the goroutine enters select
+	logger.Info("stream-live-test-marker")
+
+	time.Sleep(50 * time.Millisecond) // let the handler write the SSE frame
+	cancel()
+	<-done
+
+	body := w.Body.String()
+	if !strings.Contains(body, "event: logs.line") {
+		t.Errorf("expected logs.line event, got:\n%s", body)
+	}
+	if !strings.Contains(body, "stream-live-test-marker") {
+		t.Errorf("expected log message in SSE output, got:\n%s", body)
+	}
+}
+
+// TestEmitLogBackfill_EmptyRing verifies the handler sends a connected frame
+// with replayed:0 when the ring buffer contains no matching entries.
+func TestEmitLogBackfill_EmptyRing(t *testing.T) {
+	t.Parallel()
+	r, rb, _ := newTestRouterWithLogsAndLogger(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/stream", nil)
+	filter := logging.LogFilter{}
+
+	ts, ok := r.emitLogBackfill(w, w, req, rb, filter)
+	if !ok {
+		t.Fatal("emitLogBackfill returned false (client disconnect) unexpectedly")
+	}
+	if !ts.IsZero() {
+		t.Errorf("newestTS should be zero for empty ring, got %v", ts)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "event: connected") {
+		t.Errorf("expected connected event, got: %q", body)
+	}
+	if !strings.Contains(body, `"replayed":0`) {
+		t.Errorf("expected replayed:0, got: %q", body)
+	}
+}
+
+// TestEmitLogBackfill_WithEntries verifies backfill replay and newestTS return.
+func TestEmitLogBackfill_WithEntries(t *testing.T) {
+	t.Parallel()
+	r, rb, _ := newTestRouterWithLogsAndLogger(t)
+
+	base := time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC)
+	rb.Write(logging.LogEntry{Time: base, Level: "info", Message: "first"})
+	rb.Write(logging.LogEntry{Time: base.Add(time.Second), Level: "info", Message: "second"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/stream", nil)
+	filter := logging.LogFilter{}
+
+	ts, ok := r.emitLogBackfill(w, w, req, rb, filter)
+	if !ok {
+		t.Fatal("emitLogBackfill returned false unexpectedly")
+	}
+	if ts.IsZero() {
+		t.Error("newestTS should be non-zero after backfill")
+	}
+	// newestTS should be the second entry (later timestamp).
+	wantTS := base.Add(time.Second)
+	if !ts.Equal(wantTS) {
+		t.Errorf("newestTS = %v, want %v", ts, wantTS)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, `"replayed":2`) {
+		t.Errorf("expected replayed:2, got: %q", body)
+	}
+	if !strings.Contains(body, "first") || !strings.Contains(body, "second") {
+		t.Errorf("expected both entries in backfill output, got: %q", body)
+	}
+}
+
+// TestWriteLogSSE_Basic verifies the SSE frame format: id line, event line,
+// data line (valid JSON), and terminating blank line.
+func TestWriteLogSSE_Basic(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	payload := map[string]any{"msg": "hello", "level": "info"}
+
+	err := writeLogSSE(w, "2025-01-01T12:00:00Z", "logs.line", payload, slog.Default())
+	if err != nil {
+		t.Fatalf("writeLogSSE returned error: %v", err)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "id: 2025-01-01T12:00:00Z\n") {
+		t.Errorf("missing id line, got: %q", body)
+	}
+	if !strings.Contains(body, "event: logs.line\n") {
+		t.Errorf("missing event line, got: %q", body)
+	}
+	if !strings.Contains(body, "data: ") {
+		t.Errorf("missing data line, got: %q", body)
+	}
+	if !strings.HasSuffix(body, "\n\n") {
+		t.Errorf("SSE frame should end with double newline, got: %q", body)
+	}
+
+	// Extract and validate data JSON.
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "data: ") {
+			raw := strings.TrimPrefix(line, "data: ")
+			var got map[string]any
+			if err := json.Unmarshal([]byte(raw), &got); err != nil {
+				t.Errorf("data line is not valid JSON: %v", err)
+			}
+			if got["msg"] != "hello" {
+				t.Errorf("data.msg = %v, want hello", got["msg"])
+			}
+		}
+	}
+}
+
+// TestWriteLogSSE_NoID verifies that when id is empty the id line is omitted
+// (so transport-only frames do not advance the client's Last-Event-ID).
+func TestWriteLogSSE_NoID(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+
+	err := writeLogSSE(w, "", "connected", map[string]any{"replayed": 0}, slog.Default())
+	if err != nil {
+		t.Fatalf("writeLogSSE returned error: %v", err)
+	}
+
+	body := w.Body.String()
+	if strings.Contains(body, "id: ") {
+		t.Errorf("frame with empty id should not contain id line, got: %q", body)
+	}
+	if !strings.Contains(body, "event: connected\n") {
+		t.Errorf("expected event line, got: %q", body)
+	}
+}
+
+// TestHandleLogsStream_RecorderFlusher verifies that the stream handler starts
+// correctly when given an httptest.ResponseRecorder (which implements
+// http.Flusher), setting SSE headers and emitting the connected frame.
+func TestHandleLogsStream_RecorderFlusher(t *testing.T) {
+	t.Parallel()
+	r, _, _ := newTestRouterWithLogsAndLogger(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/stream", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r.handleLogsStream(w, req)
+	}()
+	<-done
+
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("want text/event-stream, got %q", ct)
+	}
+	if !strings.Contains(w.Body.String(), "event: connected") {
+		t.Errorf("expected connected frame in body, got: %q", w.Body.String())
 	}
 }

--- a/internal/api/handlers_logs_test.go
+++ b/internal/api/handlers_logs_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -730,6 +731,8 @@ func TestHandleLogsStream_LastEventIDCursor(t *testing.T) {
 func TestHandleLogsStream_MalformedCursor(t *testing.T) {
 	t.Parallel()
 	r, rb, _ := newTestRouterWithLogsAndLogger(t)
+	var logBuf bytes.Buffer
+	r.logger = slog.New(slog.NewTextHandler(&logBuf, nil))
 
 	base := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
 	rb.Write(logging.LogEntry{Time: base, Level: "info", Message: "entry-one"})
@@ -763,6 +766,9 @@ func TestHandleLogsStream_MalformedCursor(t *testing.T) {
 	}
 	if !strings.Contains(frames[0], `"replayed":2`) {
 		t.Errorf("connected frame should report replayed:2 (full replay), got: %q", frames[0])
+	}
+	if got := logBuf.String(); !strings.Contains(got, "unparsable Last-Event-ID cursor") {
+		t.Errorf("expected malformed cursor Warn to be logged, got: %q", got)
 	}
 }
 
@@ -856,10 +862,62 @@ func TestHandleLogsStream_ScopeFilter(t *testing.T) {
 	}
 }
 
-// TestStreamLogLines_Throttle verifies that when the subscriber buffer overflows
-// (more records published than the channel can hold), streamLogLines emits a
-// logs.throttled SSE frame with a non-zero dropped count.
-func TestStreamLogLines_Throttle(t *testing.T) {
+// TestHandleLogsStream_LiveFilter verifies that the level filter applies on the
+// live-tail path (records arriving via the LogBroadcaster after connect), not
+// only during backfill. The ring buffer starts empty so all frames come from live.
+func TestHandleLogsStream_LiveFilter(t *testing.T) {
+	t.Parallel()
+	r, _, logger := newTestRouterWithLogsAndLogger(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(r.handleLogsStream))
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"?level=error", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+
+	// Wait for "connected" frame -- confirms the subscription with level=error is active.
+	connected := collectSSEFrames(scanner, 1)
+	if len(connected) < 1 || !strings.Contains(connected[0], "event: connected") {
+		t.Fatalf("expected connected frame, got: %v", connected)
+	}
+
+	// Publish one non-matching (info) and one matching (error) record.
+	logger.Info("should-be-filtered")
+	logger.Error("should-arrive")
+
+	// Collect one logs.line frame; the filter must suppress the info record.
+	frames := collectSSEFrames(scanner, 1)
+	cancel()
+
+	if len(frames) < 1 {
+		t.Fatal("expected a logs.line frame but got none")
+	}
+	if strings.Contains(frames[0], "should-be-filtered") {
+		t.Errorf("info record leaked through level=error filter: %q", frames[0])
+	}
+	if !strings.Contains(frames[0], "should-arrive") {
+		t.Errorf("error record not delivered through live filter: %q", frames[0])
+	}
+}
+
+// TestHandleLogsStream_Throttle verifies that when the subscriber buffer
+// overflows, streamLogLines emits a logs.throttled SSE frame with a non-zero
+// dropped count. Pre-overflows the channel so the throttle signal is present
+// before streamLogLines starts; uses an io.Pipe so the scanner blocks
+// deterministically instead of sleeping.
+func TestHandleLogsStream_Throttle(t *testing.T) {
 	t.Parallel()
 	r, _, logger := newTestRouterWithLogsAndLogger(t)
 
@@ -867,82 +925,114 @@ func TestStreamLogLines_Throttle(t *testing.T) {
 	sub := lb.Subscribe(logging.LogFilter{})
 	defer sub.Close()
 
-	// Publish enough records to overflow the subscriber's default 256-entry buffer.
-	// The broadcaster fans out non-blocking: once s.lines is full, dropped++ and
-	// the throttle signal fires. Publishing 300 guarantees overflow.
+	// Publish enough records to overflow the subscriber's default 256-entry
+	// buffer before streamLogLines starts. The broadcaster fans out
+	// non-blocking: once s.lines is full, dropped++ and the throttle signal
+	// fires. Publishing 300 guarantees overflow.
 	for i := 0; i < 300; i++ {
 		logger.Info("flood", slog.Int("i", i))
 	}
 
-	// Give the broadcaster goroutines time to fan out all records before reading.
-	// (Publishes happen synchronously in Handle(), so no sleep needed here, but
-	// runtime scheduling may delay the channel sends slightly.)
-	// The subscription now has >=256 entries in Lines and 1 signal in Throttle.
-
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	pr, pw := io.Pipe()
+	rw := &pipeResponseWriter{pw: pw, header: make(http.Header)}
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/stream", nil).WithContext(ctx)
-	w := httptest.NewRecorder()
 
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		// newestTS=zero so no backfill suppression; call streamLogLines directly.
-		r.streamLogLines(w, w, req, sub, time.Time{})
+		defer pw.Close()
+		r.streamLogLines(rw, rw, req, sub, time.Time{})
 	}()
 
-	// Give the handler time to drain Lines and process the Throttle signal.
-	// With 256+ entries in a bytes.Buffer (no IO), this should be near-instant.
-	time.Sleep(200 * time.Millisecond)
+	// Scanner blocks on the pipe until streamLogLines writes a frame -- no
+	// sleep needed. Scan until the throttled frame is found.
+	scanner := bufio.NewScanner(pr)
+	var foundThrottle string
+	for foundThrottle == "" {
+		frames := collectSSEFrames(scanner, 1)
+		if len(frames) == 0 {
+			break // pipe closed (context done)
+		}
+		if strings.Contains(frames[0], "event: logs.throttled") {
+			foundThrottle = frames[0]
+		}
+	}
 	cancel()
+	io.Copy(io.Discard, pr) // drain so the goroutine can finish writing
 	<-done
 
-	body := w.Body.String()
-	if !strings.Contains(body, "event: logs.throttled") {
-		t.Errorf("expected logs.throttled SSE event in stream output, got:\n%s", body)
+	if foundThrottle == "" {
+		t.Error("expected logs.throttled event but none found within timeout")
 	}
-	if !strings.Contains(body, `"dropped"`) {
-		t.Errorf("throttled event should include dropped count, got:\n%s", body)
+	if !strings.Contains(foundThrottle, `"dropped"`) {
+		t.Errorf("throttled event should include dropped count, got: %q", foundThrottle)
 	}
 }
 
-// TestStreamLogLines_LivePath verifies that a record published via a
-// Subscription is forwarded as a logs.line SSE event by streamLogLines.
-func TestStreamLogLines_LivePath(t *testing.T) {
+// pipeResponseWriter is a minimal http.ResponseWriter + http.Flusher backed by
+// an io.PipeWriter. It lets tests scan SSE frames written by streamLogLines
+// without the fixed sleeps that make httptest.NewRecorder-based tests racy.
+type pipeResponseWriter struct {
+	pw     *io.PipeWriter
+	header http.Header
+}
+
+func (p *pipeResponseWriter) Header() http.Header         { return p.header }
+func (p *pipeResponseWriter) Write(b []byte) (int, error) { return p.pw.Write(b) }
+func (p *pipeResponseWriter) WriteHeader(int)             {}
+func (p *pipeResponseWriter) Flush()                      {}
+
+// TestHandleLogsStream_LivePath verifies that a record published via the
+// broadcaster is forwarded as a logs.line SSE event. Uses httptest.Server +
+// scanner so the connected frame provides a deterministic subscription barrier.
+func TestHandleLogsStream_LivePath(t *testing.T) {
 	t.Parallel()
 	r, _, logger := newTestRouterWithLogsAndLogger(t)
 
-	lb := r.logManager.LogBroadcaster()
-	sub := lb.Subscribe(logging.LogFilter{})
-	defer sub.Close()
+	ts := httptest.NewServer(http.HandlerFunc(r.handleLogsStream))
+	defer ts.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs/stream", nil).WithContext(ctx)
-	w := httptest.NewRecorder()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		r.streamLogLines(w, w, req, sub, time.Time{})
-	}()
+	scanner := bufio.NewScanner(resp.Body)
 
-	// Publish one record after streamLogLines has started.
-	time.Sleep(10 * time.Millisecond) // tiny gap so the goroutine enters select
+	// Wait for "connected" frame -- this is the deterministic signal that
+	// handleLogsStream has subscribed and streamLogLines is in its select loop.
+	connected := collectSSEFrames(scanner, 1)
+	if len(connected) < 1 || !strings.Contains(connected[0], "event: connected") {
+		t.Fatalf("expected connected frame, got: %v", connected)
+	}
+
+	// Publish after receiving the connected frame -- goroutine is definitely
+	// in the select loop at this point (it already wrote and flushed a frame).
 	logger.Info("stream-live-test-marker")
 
-	time.Sleep(50 * time.Millisecond) // let the handler write the SSE frame
+	// Scanner blocks until the logs.line frame arrives -- no sleep needed.
+	frames := collectSSEFrames(scanner, 1)
 	cancel()
-	<-done
 
-	body := w.Body.String()
-	if !strings.Contains(body, "event: logs.line") {
-		t.Errorf("expected logs.line event, got:\n%s", body)
+	if len(frames) < 1 {
+		t.Fatal("expected a logs.line frame but got none")
 	}
-	if !strings.Contains(body, "stream-live-test-marker") {
-		t.Errorf("expected log message in SSE output, got:\n%s", body)
+	if !strings.Contains(frames[0], "event: logs.line") {
+		t.Errorf("expected logs.line event, got: %q", frames[0])
+	}
+	if !strings.Contains(frames[0], "stream-live-test-marker") {
+		t.Errorf("expected log message in SSE output, got: %q", frames[0])
 	}
 }
 

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -10047,6 +10047,12 @@ paths:
           description: Case-insensitive substring search on the log message.
           schema:
             type: string
+        - name: last_event_id
+          in: query
+          description: RFC3339Nano resume cursor fallback for non-browser clients that cannot send the Last-Event-ID header. Mirrors the Last-Event-ID header; header takes precedence.
+          schema:
+            type: string
+            format: date-time
         - name: Last-Event-ID
           in: header
           description: |

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -10003,6 +10003,100 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /logs/stream:
+    get:
+      tags: [Logs]
+      summary: Stream live log entries (SSE)
+      description: |
+        Server-Sent Events endpoint that streams structured log records to the
+        log viewer in real time. Admin only.
+
+        On connect the server emits a `connected` frame (carrying
+        `data.replayed`, the number of backfilled entries), then backfills up to
+        500 recent entries from the in-memory ring buffer (filtered, oldest
+        first) before live-tailing new records as `logs.line` events. Each
+        `logs.line` frame's `id:` is the entry's RFC3339Nano timestamp; the
+        browser EventSource echoes the last id back as the `Last-Event-ID`
+        header on reconnect, and the server uses it as a resume cursor so only
+        entries newer than the last one seen are replayed.
+
+        When a slow client cannot keep up, the per-subscriber buffer overflows;
+        the server sheds lines and emits a `logs.throttled` frame carrying
+        `data.dropped` (the number of lines dropped) so the client can surface a
+        throttle banner. A heartbeat comment is sent every 30 seconds to keep
+        the connection alive.
+
+        Unlike the general `/events/stream` hub, this is a dedicated stream: the
+        raw log firehose is delivered only to clients that open this endpoint and
+        is never fanned out to every connected tab.
+      operationId: streamLogs
+      parameters:
+        - name: level
+          in: query
+          description: Minimum log level to include. Omit to return all levels.
+          schema:
+            type: string
+            enum: [trace, debug, info, warn, error]
+        - name: scope
+          in: query
+          description: Exact match on the component attribute.
+          schema:
+            type: string
+        - name: q
+          in: query
+          description: Case-insensitive substring search on the log message.
+          schema:
+            type: string
+        - name: Last-Event-ID
+          in: header
+          description: |
+            RFC3339Nano timestamp of the last entry the client saw, echoed
+            automatically by the browser EventSource on reconnect. Used as a
+            resume cursor so the backfill only replays newer entries. A
+            last_event_id query parameter is accepted as a fallback for
+            non-browser clients.
+          schema:
+            type: string
+            format: date-time
+      responses:
+        "200":
+          description: SSE stream established. Entries are sent as text/event-stream.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: SSE formatted stream with logs.line / logs.throttled named events and JSON log-entry payloads.
+        "400":
+          description: Invalid query parameter (e.g. unrecognized level)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Admin privileges required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Streaming not supported by the server
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Logging manager or log stream not available
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /settings/maintenance/status:
     get:
       tags: [Settings]

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -544,6 +544,7 @@ func (r *Router) Handler(ctx context.Context) http.Handler {
 	mux.HandleFunc("PUT "+bp+"/api/v1/settings/logging", wrapAuth(middleware.RequireAdmin(r.handleUpdateLogging), authMw))
 	// Log viewer routes (admin only)
 	mux.HandleFunc("GET "+bp+"/api/v1/logs", wrapAuth(middleware.RequireAdmin(r.handleGetLogs), authMw))
+	mux.HandleFunc("GET "+bp+"/api/v1/logs/stream", wrapAuth(middleware.RequireAdmin(r.handleLogsStream), authMw))
 	mux.HandleFunc("DELETE "+bp+"/api/v1/logs", wrapAuth(middleware.RequireAdmin(r.handleClearLogs), authMw))
 	mux.HandleFunc("GET "+bp+"/api/v1/logs/files", wrapAuth(middleware.RequireAdmin(r.handleListLogFiles), authMw))
 	mux.HandleFunc("DELETE "+bp+"/api/v1/logs/files", wrapAuth(middleware.RequireAdmin(r.handleDeleteLogFiles), authMw))

--- a/internal/api/testdata/openapi-coverage.json
+++ b/internal/api/testdata/openapi-coverage.json
@@ -1603,6 +1603,13 @@
     "covered": true
   },
   {
+    "operationId": "streamLogs",
+    "method": "GET",
+    "path": "/logs/stream",
+    "handler": "handleLogsStream",
+    "covered": true
+  },
+  {
     "operationId": "testConnection",
     "method": "POST",
     "path": "/connections/{id}/test",

--- a/internal/logging/logbroadcaster.go
+++ b/internal/logging/logbroadcaster.go
@@ -1,0 +1,222 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+)
+
+// defaultLogSubBuffer is the per-subscriber channel capacity for the live log
+// stream. The general SSE hub uses 16, but a raw log feed is far burstier than
+// the hub's coalesced domain events, so a deeper buffer absorbs short spikes
+// (a noisy scan, a burst of warnings) without shedding lines. When the buffer
+// does fill, the broadcaster drops the line and raises a throttle signal rather
+// than blocking the logging goroutine.
+const defaultLogSubBuffer = 256
+
+// Subscription is a live feed of log entries matching a LogFilter, handed back
+// by LogBroadcaster.Subscribe. The caller ranges over Lines() for matching
+// records and watches Throttle() to learn when the per-subscriber buffer
+// overflowed (calling DrainDropped to read and reset the dropped count). The
+// caller MUST call Close exactly once (typically via defer) to release the
+// subscription; Close is idempotent and safe to call concurrently with the
+// broadcaster's fan-out.
+type Subscription struct {
+	filter   LogFilter
+	lines    chan LogEntry
+	throttle chan struct{}
+	dropped  atomic.Int64
+	hub      *logHub
+}
+
+// Lines returns the channel of live log entries matching the subscription's
+// filter. It is closed when the subscription is closed.
+func (s *Subscription) Lines() <-chan LogEntry { return s.lines }
+
+// Throttle returns a channel that receives a (coalesced) signal whenever the
+// subscriber's buffer overflows and one or more lines are dropped. The signal
+// carries no payload; call DrainDropped to read the accumulated dropped count.
+// It is closed when the subscription is closed.
+func (s *Subscription) Throttle() <-chan struct{} { return s.throttle }
+
+// DrainDropped atomically returns the number of lines dropped since the last
+// call and resets the counter to zero.
+func (s *Subscription) DrainDropped() int { return int(s.dropped.Swap(0)) }
+
+// Close removes the subscription from the broadcaster and closes its channels.
+// It is idempotent.
+func (s *Subscription) Close() { s.hub.unsubscribe(s) }
+
+// logHub is the shared subscriber registry behind a LogBroadcaster and all of
+// its WithAttrs/WithGroup derivations. Splitting it out (mirroring how every
+// derived RingHandler shares one *RingBuffer) means a derived logger publishes
+// to the same set of subscribers as its parent.
+type logHub struct {
+	mu   sync.RWMutex
+	subs map[*Subscription]struct{}
+	buf  int // per-subscriber channel capacity
+}
+
+func (h *logHub) subscribe(filter LogFilter) *Subscription {
+	s := &Subscription{
+		filter:   filter,
+		lines:    make(chan LogEntry, h.buf),
+		throttle: make(chan struct{}, 1),
+		hub:      h,
+	}
+	h.mu.Lock()
+	h.subs[s] = struct{}{}
+	h.mu.Unlock()
+	return s
+}
+
+func (h *logHub) unsubscribe(s *Subscription) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if _, ok := h.subs[s]; !ok {
+		return // already removed; Close is idempotent
+	}
+	delete(h.subs, s)
+	close(s.lines)
+	close(s.throttle)
+}
+
+// publish fans an entry out to every subscriber whose filter matches. Sends are
+// non-blocking: a full subscriber buffer drops the line and raises a coalesced
+// throttle signal so a slow client can never stall the logging goroutine. It
+// takes the read lock; unsubscribe takes the write lock, so a channel is never
+// closed while publish may still send to it.
+func (h *logHub) publish(entry LogEntry) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for s := range h.subs {
+		if !s.filter.Matches(entry) {
+			continue
+		}
+		select {
+		case s.lines <- entry:
+		default:
+			// Buffer full: drop the line, accumulate the count, and raise a
+			// coalesced throttle signal (cap-1 channel, non-blocking send).
+			s.dropped.Add(1)
+			select {
+			case s.throttle <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+func (h *logHub) count() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.subs)
+}
+
+// LogBroadcaster is an slog.Handler that fans live log records out to live
+// subscribers (the next/ logs viewer). It is meant to sit alongside the primary
+// and ring handlers in the MultiHandler. Unlike the general SSE hub, it never
+// touches the event bus: a raw log firehose must not be broadcast to every
+// connected client, so it is delivered only to clients that explicitly open the
+// dedicated /api/v1/logs/stream endpoint.
+//
+// It is safe for concurrent use. WithAttrs/WithGroup derivations share the same
+// subscriber registry as the parent.
+type LogBroadcaster struct {
+	hub       *logHub
+	level     slog.Leveler
+	addSource bool
+	attrs     []slog.Attr
+	group     string
+}
+
+// NewLogBroadcaster creates a broadcaster capturing at the given level. When
+// addSource is true the source file:line and derived component are populated,
+// matching the ring handler so the live tail and the buffered view agree.
+func NewLogBroadcaster(level slog.Leveler, addSource bool) *LogBroadcaster {
+	return newLogBroadcasterWithBuffer(level, addSource, defaultLogSubBuffer)
+}
+
+// newLogBroadcasterWithBuffer is the buffer-size-injectable constructor used by
+// tests to exercise the buffer-full throttle path with a small buffer.
+func newLogBroadcasterWithBuffer(level slog.Leveler, addSource bool, buf int) *LogBroadcaster {
+	if buf <= 0 {
+		buf = defaultLogSubBuffer
+	}
+	return &LogBroadcaster{
+		hub: &logHub{
+			subs: make(map[*Subscription]struct{}),
+			buf:  buf,
+		},
+		level:     level,
+		addSource: addSource,
+	}
+}
+
+// Subscribe registers a new live subscriber filtered by filter and returns its
+// Subscription. The caller must Close the subscription when done. The filter's
+// Limit and After fields are ignored for the live tail (they govern backfill
+// from the ring buffer, not the forward stream).
+func (b *LogBroadcaster) Subscribe(filter LogFilter) *Subscription {
+	// Strip the backfill-only fields so the live matcher only applies the
+	// forward-looking predicates (level/component/search).
+	live := LogFilter{
+		Level:     filter.Level,
+		Search:    filter.Search,
+		Component: filter.Component,
+	}
+	return b.hub.subscribe(live)
+}
+
+// SubscriberCount returns the number of active subscribers.
+func (b *LogBroadcaster) SubscriberCount() int { return b.hub.count() }
+
+// Enabled reports whether the handler captures records at the given level.
+func (b *LogBroadcaster) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= b.level.Level()
+}
+
+// Handle converts the record to a LogEntry and publishes it to subscribers.
+// When there are no subscribers it skips the (allocating) conversion entirely,
+// so the broadcaster costs almost nothing while no log viewer is open.
+func (b *LogBroadcaster) Handle(_ context.Context, r slog.Record) error {
+	if b.hub.count() == 0 {
+		return nil
+	}
+	b.hub.publish(recordToEntry(r, b.attrs, b.group, b.addSource))
+	return nil
+}
+
+// WithAttrs returns a derived broadcaster with the given attributes pre-stored,
+// sharing the parent's subscriber registry.
+func (b *LogBroadcaster) WithAttrs(attrs []slog.Attr) slog.Handler {
+	newAttrs := make([]slog.Attr, len(b.attrs), len(b.attrs)+len(attrs))
+	copy(newAttrs, b.attrs)
+	newAttrs = append(newAttrs, attrs...)
+	return &LogBroadcaster{
+		hub:       b.hub,
+		level:     b.level,
+		addSource: b.addSource,
+		attrs:     newAttrs,
+		group:     b.group,
+	}
+}
+
+// WithGroup returns a derived broadcaster with the given group name appended,
+// sharing the parent's subscriber registry.
+func (b *LogBroadcaster) WithGroup(name string) slog.Handler {
+	newGroup := name
+	if b.group != "" {
+		newGroup = b.group + "." + name
+	}
+	newAttrs := make([]slog.Attr, len(b.attrs))
+	copy(newAttrs, b.attrs)
+	return &LogBroadcaster{
+		hub:       b.hub,
+		level:     b.level,
+		addSource: b.addSource,
+		attrs:     newAttrs,
+		group:     newGroup,
+	}
+}

--- a/internal/logging/logbroadcaster.go
+++ b/internal/logging/logbroadcaster.go
@@ -206,6 +206,9 @@ func (b *LogBroadcaster) WithAttrs(attrs []slog.Attr) slog.Handler {
 // WithGroup returns a derived broadcaster with the given group name appended,
 // sharing the parent's subscriber registry.
 func (b *LogBroadcaster) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return b
+	}
 	newGroup := name
 	if b.group != "" {
 		newGroup = b.group + "." + name

--- a/internal/logging/logbroadcaster_test.go
+++ b/internal/logging/logbroadcaster_test.go
@@ -1,0 +1,295 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestBroadcaster returns a broadcaster capturing at debug level with source
+// derivation disabled (tests assert on attrs/component/message, not file:line).
+func newTestBroadcaster(t *testing.T) *LogBroadcaster {
+	t.Helper()
+	lvl := &slog.LevelVar{}
+	lvl.Set(slog.LevelDebug)
+	return NewLogBroadcaster(lvl, false)
+}
+
+// emit logs one record through the broadcaster as a slog handler would.
+func emit(b *LogBroadcaster, level slog.Level, msg string, attrs ...slog.Attr) {
+	r := slog.NewRecord(time.Now(), level, msg, 0)
+	r.AddAttrs(attrs...)
+	_ = b.Handle(context.Background(), r)
+}
+
+func TestLogBroadcaster_SubscribeReceive(t *testing.T) {
+	t.Parallel()
+	b := newTestBroadcaster(t)
+
+	sub := b.Subscribe(LogFilter{})
+	defer sub.Close()
+
+	if got := b.SubscriberCount(); got != 1 {
+		t.Fatalf("SubscriberCount = %d, want 1", got)
+	}
+
+	emit(b, slog.LevelInfo, "hello world", slog.String("component", "scanner"), slog.Int("count", 3))
+
+	select {
+	case e := <-sub.Lines():
+		if e.Message != "hello world" {
+			t.Errorf("Message = %q, want %q", e.Message, "hello world")
+		}
+		if e.Level != "info" {
+			t.Errorf("Level = %q, want info", e.Level)
+		}
+		if e.Component != "scanner" {
+			t.Errorf("Component = %q, want scanner", e.Component)
+		}
+		if e.Attrs["count"] != int64(3) {
+			t.Errorf("Attrs[count] = %v, want 3", e.Attrs["count"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for log line")
+	}
+}
+
+func TestLogBroadcaster_RedactsSensitiveAttrs(t *testing.T) {
+	t.Parallel()
+	b := newTestBroadcaster(t)
+	sub := b.Subscribe(LogFilter{})
+	defer sub.Close()
+
+	emit(b, slog.LevelWarn, "auth attempt", slog.String("api_key", "super-secret-value"))
+
+	select {
+	case e := <-sub.Lines():
+		if got := e.Attrs["api_key"]; got != "[REDACTED]" {
+			t.Errorf("api_key = %v, want [REDACTED]", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for log line")
+	}
+}
+
+func TestLogBroadcaster_FilterMatching(t *testing.T) {
+	t.Parallel()
+	b := newTestBroadcaster(t)
+
+	t.Run("level", func(t *testing.T) {
+		sub := b.Subscribe(LogFilter{Level: "warn"})
+		defer sub.Close()
+		emit(b, slog.LevelInfo, "below threshold")
+		emit(b, slog.LevelError, "at or above")
+		e := mustReceive(t, sub)
+		if e.Message != "at or above" {
+			t.Errorf("got %q, want the error line (info should be filtered out)", e.Message)
+		}
+		assertNoMore(t, sub)
+	})
+
+	t.Run("component", func(t *testing.T) {
+		sub := b.Subscribe(LogFilter{Component: "watcher"})
+		defer sub.Close()
+		emit(b, slog.LevelInfo, "wrong", slog.String("component", "scanner"))
+		emit(b, slog.LevelInfo, "right", slog.String("component", "watcher"))
+		e := mustReceive(t, sub)
+		if e.Message != "right" {
+			t.Errorf("got %q, want the watcher line", e.Message)
+		}
+		assertNoMore(t, sub)
+	})
+
+	t.Run("search", func(t *testing.T) {
+		sub := b.Subscribe(LogFilter{Search: "DEADBEEF"})
+		defer sub.Close()
+		emit(b, slog.LevelInfo, "nothing here")
+		emit(b, slog.LevelInfo, "hash is deadbeef now") // case-insensitive
+		e := mustReceive(t, sub)
+		if e.Message != "hash is deadbeef now" {
+			t.Errorf("got %q, want the matching line", e.Message)
+		}
+		assertNoMore(t, sub)
+	})
+}
+
+func TestLogBroadcaster_Unsubscribe(t *testing.T) {
+	t.Parallel()
+	b := newTestBroadcaster(t)
+	sub := b.Subscribe(LogFilter{})
+
+	sub.Close()
+	if got := b.SubscriberCount(); got != 0 {
+		t.Fatalf("SubscriberCount after Close = %d, want 0", got)
+	}
+
+	// Lines channel must be closed.
+	if _, ok := <-sub.Lines(); ok {
+		t.Error("Lines channel should be closed after Close")
+	}
+
+	// Close is idempotent and a publish after unsubscribe must not panic.
+	sub.Close()
+	emit(b, slog.LevelInfo, "after unsubscribe")
+}
+
+func TestLogBroadcaster_BufferFullThrottle(t *testing.T) {
+	t.Parallel()
+	lvl := &slog.LevelVar{}
+	lvl.Set(slog.LevelDebug)
+	b := newLogBroadcasterWithBuffer(lvl, false, 2)
+
+	sub := b.Subscribe(LogFilter{})
+	defer sub.Close()
+
+	// Emit more than the buffer can hold without draining Lines, forcing drops.
+	const sent = 10
+	for i := 0; i < sent; i++ {
+		emit(b, slog.LevelInfo, "flood")
+	}
+
+	// A throttle signal must have been raised.
+	select {
+	case <-sub.Throttle():
+	case <-time.After(time.Second):
+		t.Fatal("expected a throttle signal when the buffer overflowed")
+	}
+
+	dropped := sub.DrainDropped()
+	if dropped <= 0 {
+		t.Fatalf("DrainDropped = %d, want > 0", dropped)
+	}
+	// Buffer holds 2, so at least sent-2 lines were dropped.
+	if dropped < sent-2 {
+		t.Errorf("DrainDropped = %d, want >= %d", dropped, sent-2)
+	}
+	// Draining resets the counter.
+	if again := sub.DrainDropped(); again != 0 {
+		t.Errorf("second DrainDropped = %d, want 0", again)
+	}
+}
+
+func TestLogBroadcaster_NoSubscribersIsCheap(t *testing.T) {
+	t.Parallel()
+	b := newTestBroadcaster(t)
+	// With no subscribers, Handle must be a no-op that never blocks or panics.
+	emit(b, slog.LevelError, "into the void", slog.String("api_key", "secret"))
+	if got := b.SubscriberCount(); got != 0 {
+		t.Fatalf("SubscriberCount = %d, want 0", got)
+	}
+}
+
+func TestLogBroadcaster_DerivedHandlerSharesSubscribers(t *testing.T) {
+	t.Parallel()
+	b := newTestBroadcaster(t)
+	sub := b.Subscribe(LogFilter{})
+	defer sub.Close()
+
+	// A handler derived via WithAttrs/WithGroup must publish to the same
+	// subscriber registry and carry its pre-stored attrs onto the entry.
+	derived, ok := b.WithAttrs([]slog.Attr{slog.String("component", "derived-pkg")}).(*LogBroadcaster)
+	if !ok {
+		t.Fatal("WithAttrs did not return *LogBroadcaster")
+	}
+	emit(derived, slog.LevelInfo, "from derived")
+
+	e := mustReceive(t, sub)
+	if e.Message != "from derived" {
+		t.Errorf("Message = %q, want from derived", e.Message)
+	}
+	if e.Component != "derived-pkg" {
+		t.Errorf("Component = %q, want derived-pkg (WithAttrs not applied)", e.Component)
+	}
+}
+
+// TestLogBroadcaster_ConcurrentPublishSubscribe exercises the broadcaster under
+// concurrent publishers, subscribers, and unsubscribes. Run with -race it
+// guards the lock discipline that keeps publish from sending on a closed
+// channel.
+func TestLogBroadcaster_ConcurrentPublishSubscribe(t *testing.T) {
+	t.Parallel()
+	b := newTestBroadcaster(t)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Publishers.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					emit(b, slog.LevelInfo, "concurrent", slog.String("component", "x"))
+				}
+			}
+		}()
+	}
+
+	// Subscribers that churn: subscribe, drain a bit, unsubscribe.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				sub := b.Subscribe(LogFilter{})
+				deadline := time.After(2 * time.Millisecond)
+			drain:
+				for {
+					select {
+					case <-sub.Lines():
+					case <-sub.Throttle():
+						sub.DrainDropped()
+					case <-deadline:
+						break drain
+					}
+				}
+				sub.Close()
+			}
+		}()
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	if got := b.SubscriberCount(); got != 0 {
+		t.Errorf("SubscriberCount after churn = %d, want 0", got)
+	}
+}
+
+// mustReceive returns the next line or fails on timeout.
+func mustReceive(t *testing.T, sub *Subscription) LogEntry {
+	t.Helper()
+	select {
+	case e, ok := <-sub.Lines():
+		if !ok {
+			t.Fatal("Lines channel closed unexpectedly")
+		}
+		return e
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for a log line")
+		return LogEntry{}
+	}
+}
+
+// assertNoMore fails if another line arrives promptly (used to confirm a
+// filtered-out entry was not delivered).
+func assertNoMore(t *testing.T, sub *Subscription) {
+	t.Helper()
+	select {
+	case e := <-sub.Lines():
+		t.Fatalf("unexpected extra line: %q", e.Message)
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -118,12 +118,13 @@ const DefaultRingBufferSize = 2000
 
 // Manager owns the logger lifecycle and supports runtime reconfiguration.
 type Manager struct {
-	levelVar   *slog.LevelVar
-	handler    *SwappableHandler
-	config     Config
-	mu         sync.Mutex
-	closer     io.Closer // lumberjack writer, if any
-	ringBuffer *RingBuffer
+	levelVar    *slog.LevelVar
+	handler     *SwappableHandler
+	config      Config
+	mu          sync.Mutex
+	closer      io.Closer // lumberjack writer, if any
+	ringBuffer  *RingBuffer
+	broadcaster *LogBroadcaster
 }
 
 // NewManager creates a Manager and returns it along with a ready-to-use logger.
@@ -133,17 +134,22 @@ func NewManager(cfg Config) (*Manager, *slog.Logger) {
 	lvl.Set(parseLevel(cfg.Level))
 
 	rb := NewRingBuffer(DefaultRingBufferSize)
+	// The broadcaster captures at the same level as the primary/ring handlers
+	// and persists across Reconfigure so live log-stream subscribers stay
+	// connected when the format or output file changes.
+	lb := NewLogBroadcaster(lvl, true)
 
 	writer, closer := buildWriter(cfg)
-	inner := buildMultiHandler(writer, lvl, cfg.Format, rb)
+	inner := buildMultiHandler(writer, lvl, cfg.Format, rb, lb)
 	handler := NewSwappableHandler(inner)
 
 	m := &Manager{
-		levelVar:   lvl,
-		handler:    handler,
-		config:     cfg,
-		closer:     closer,
-		ringBuffer: rb,
+		levelVar:    lvl,
+		handler:     handler,
+		config:      cfg,
+		closer:      closer,
+		ringBuffer:  rb,
+		broadcaster: lb,
 	}
 
 	logger := slog.New(handler)
@@ -153,6 +159,12 @@ func NewManager(cfg Config) (*Manager, *slog.Logger) {
 // RingBuffer returns the in-memory ring buffer used by the log viewer.
 func (m *Manager) RingBuffer() *RingBuffer {
 	return m.ringBuffer
+}
+
+// LogBroadcaster returns the live log broadcaster used by the log stream
+// endpoint to fan slog records out to connected viewer clients.
+func (m *Manager) LogBroadcaster() *LogBroadcaster {
+	return m.broadcaster
 }
 
 // Reconfigure applies a new configuration at runtime. Level-only changes
@@ -172,7 +184,9 @@ func (m *Manager) Reconfigure(cfg Config) {
 
 	if needSwap {
 		writer, closer := buildWriter(cfg)
-		inner := buildMultiHandler(writer, m.levelVar, cfg.Format, m.ringBuffer)
+		// Reuse the existing ring buffer and broadcaster so the log viewer's
+		// history and any live stream subscribers survive the handler swap.
+		inner := buildMultiHandler(writer, m.levelVar, cfg.Format, m.ringBuffer, m.broadcaster)
 		m.handler.Swap(inner)
 
 		// Close old file writer after swapping to eliminate the race
@@ -342,14 +356,17 @@ func buildHandler(w io.Writer, leveler slog.Leveler, format string) slog.Handler
 }
 
 // buildMultiHandler creates a MultiHandler that fans out to the primary
-// text/JSON handler and a RingHandler for in-memory log capture.
-func buildMultiHandler(w io.Writer, leveler slog.Leveler, format string, rb *RingBuffer) slog.Handler {
+// text/JSON handler, a RingHandler for in-memory log capture, and a
+// LogBroadcaster for the live log stream. The ring buffer and broadcaster are
+// passed in (not constructed here) so they persist across handler swaps in
+// Reconfigure.
+func buildMultiHandler(w io.Writer, leveler slog.Leveler, format string, rb *RingBuffer, lb *LogBroadcaster) slog.Handler {
 	primary := buildHandler(w, leveler, format)
 	// The ring handler captures at the same level as the primary handler so
 	// that logger.Enabled() reflects the configured level accurately.
 	// addSource=true captures caller file:line for the log viewer.
 	ring := NewRingHandler(rb, leveler, true)
-	return NewMultiHandler(primary, ring)
+	return NewMultiHandler(primary, ring, lb)
 }
 
 // ValidLevel returns true if s is a recognized log level.

--- a/internal/logging/ringbuffer.go
+++ b/internal/logging/ringbuffer.go
@@ -25,6 +25,27 @@ type LogFilter struct {
 	Limit     int       // max entries to return (default 100, max 500)
 }
 
+// Matches reports whether entry satisfies the filter. It is the single source
+// of truth for level/component/search/after matching, shared by the ring
+// buffer's Entries scan and the live LogBroadcaster fan-out so the backfill and
+// the live tail never diverge on what a filter selects. Limit is a pagination
+// concern, not a per-entry predicate, so it is not considered here.
+func (f LogFilter) Matches(entry LogEntry) bool {
+	if f.Level != "" && levelSeverity(entry.Level) < levelSeverity(f.Level) {
+		return false
+	}
+	if !f.After.IsZero() && !entry.Time.After(f.After) {
+		return false
+	}
+	if f.Component != "" && entry.Component != f.Component {
+		return false
+	}
+	if f.Search != "" && !strings.Contains(strings.ToLower(entry.Message), strings.ToLower(f.Search)) {
+		return false
+	}
+	return true
+}
+
 // levelSeverity returns a numeric severity for ordering: trace=-1, debug=0, info=1, warn=2, error=3.
 func levelSeverity(level string) int {
 	switch strings.ToLower(level) {
@@ -90,44 +111,21 @@ func (rb *RingBuffer) Entries(filter LogFilter) []LogEntry {
 		limit = 500
 	}
 
-	minSeverity := 0
-	if filter.Level != "" {
-		minSeverity = levelSeverity(filter.Level)
-	}
-
-	searchLower := strings.ToLower(filter.Search)
-
 	// Use a fixed-size initial allocation to satisfy CodeQL's
 	// uncontrolled-allocation-size check. The slice grows dynamically
 	// as needed but the initial capacity is a compile-time constant.
 	const initialCap = 64
 	result := make([]LogEntry, 0, initialCap)
 
-	// Iterate backwards from newest entry.
+	// Iterate backwards from newest entry. Per-entry matching is delegated to
+	// filter.Matches so the ring buffer and the live broadcaster apply
+	// identical level/component/search/after semantics.
 	for i := 0; i < rb.count && len(result) < limit; i++ {
 		idx := (rb.head - 1 - i + rb.size) % rb.size
 		entry := rb.entries[idx]
-
-		// Level filter: skip entries below the minimum severity.
-		if levelSeverity(entry.Level) < minSeverity {
+		if !filter.Matches(entry) {
 			continue
 		}
-
-		// Time filter: skip entries at or before the After timestamp.
-		if !filter.After.IsZero() && !entry.Time.After(filter.After) {
-			continue
-		}
-
-		// Component filter: exact match.
-		if filter.Component != "" && entry.Component != filter.Component {
-			continue
-		}
-
-		// Search filter: case-insensitive substring match on message.
-		if searchLower != "" && !strings.Contains(strings.ToLower(entry.Message), searchLower) {
-			continue
-		}
-
 		result = append(result, entry)
 	}
 

--- a/internal/logging/ringhandler.go
+++ b/internal/logging/ringhandler.go
@@ -34,9 +34,21 @@ func (h *RingHandler) Enabled(_ context.Context, level slog.Level) bool {
 }
 
 // Handle converts a slog.Record to a LogEntry and writes it to the buffer.
+func (h *RingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.buffer.Write(recordToEntry(r, h.attrs, h.group, h.addSource))
+	return nil
+}
+
+// recordToEntry converts a slog.Record into a LogEntry, applying the same
+// source-location derivation, component extraction, and RedactingReplaceAttr
+// scrubbing for both the in-memory ring buffer and the live log broadcaster.
+// preAttrs are the handler's accumulated WithAttrs attributes and group is its
+// WithGroup prefix. Sharing this walk keeps the two log sinks byte-for-byte
+// consistent (a divergence would mean the viewer and the live tail show
+// different redaction or component values for the same record).
 //
 //nolint:gocognit // slog.Record attribute walk requires a type switch over every supported slog.Kind (string, int64, uint64, float64, bool, duration, time, group, any) so each kind can be encoded to LogEntry's typed field; this is the slog contract, not application logic, and cannot be flattened.
-func (h *RingHandler) Handle(_ context.Context, r slog.Record) error {
+func recordToEntry(r slog.Record, preAttrs []slog.Attr, group string, addSource bool) LogEntry {
 	entry := LogEntry{
 		Time:    r.Time,
 		Level:   FormatLevel(r.Level),
@@ -47,7 +59,7 @@ func (h *RingHandler) Handle(_ context.Context, r slog.Record) error {
 	// caller uses slog.Info/Warn/etc). AddSource in the primary handler
 	// only affects that handler; we replicate the logic here.
 	var pkgName string // derived package name for auto-component
-	if h.addSource && r.PC != 0 {
+	if addSource && r.PC != 0 {
 		fs := runtime.CallersFrames([]uintptr{r.PC})
 		f, _ := fs.Next()
 		if f.File != "" {
@@ -108,12 +120,12 @@ func (h *RingHandler) Handle(_ context.Context, r slog.Record) error {
 		attrs[key] = a.Value.Any()
 	}
 
-	for _, a := range h.attrs {
-		addAttr(h.group, a)
+	for _, a := range preAttrs {
+		addAttr(group, a)
 	}
 
 	r.Attrs(func(a slog.Attr) bool {
-		addAttr(h.group, a)
+		addAttr(group, a)
 		return true
 	})
 
@@ -126,8 +138,7 @@ func (h *RingHandler) Handle(_ context.Context, r slog.Record) error {
 		entry.Attrs = attrs
 	}
 
-	h.buffer.Write(entry)
-	return nil
+	return entry
 }
 
 // WithAttrs returns a new RingHandler with the given attributes pre-stored.


### PR DESCRIPTION
## Summary

PR **5A of #1338** (backend; the `/next/logs` page is PR 5B). Adds a dedicated live-tail SSE stream for structured logs.

- **`LogBroadcaster`** (slog.Handler) fans records to per-subscriber channels - bounded 256 buffer, drop + coalesced `logs.throttled` signal on overflow, **never blocks the logging goroutine**; wired as a third handler in `buildMultiHandler`, persists across Reconfigure.
- **`GET /api/v1/logs/stream`** (`wrapAuth`+`RequireAdmin`, matching `/api/v1/logs`): backfills from the ring buffer (cap 500) then live-tails; **Last-Event-ID reconnect** (warns + full-replay on an unparsable cursor); `level`/`scope`(component)/`q`(search) filters.
- Extracts shared `recordToEntry` + `LogFilter.Matches` from the ring handler/buffer so the buffered view and live tail can't drift.

## Linked issue
Refs #1338 (PR 5A of the 5A/5B split; does not close the issue - 5B does).

## Pre-flight (lead-verified)
- [x] `go build ./...` clean; `go test -race ./internal/logging/ ./internal/api/` clean
- [x] `TestOpenAPIConsistency` + `TestOperationIDCoverage` + `make check-openapi` pass; Bruno parity OK; check-generated OK
- [x] Patch coverage 79.35% (>=75%): broadcaster 94%, logging 87-100%; stream-handler paths (backfill/live/throttle/reconnect/filter) tested
- [x] Lead review (code-reviewer + silent-failure-hunter): one Important silent-failure fixed (warn on unparsable Last-Event-ID instead of silent full-replay)
- [ ] No UAT (backend, no UI) - UAT lands with PR 5B

## Test plan
- [x] Race tests: concurrent publish + subscribe/unsubscribe (no send-on-closed); buffer-overflow raises a visible throttle signal with dropped count
- [x] Handler tests: nil-manager (503), invalid-level (400), backfill replay, live-tail, throttle, Last-Event-ID resume + malformed-cursor warn
- [ ] Reviewer: confirm the `recordToEntry`/`LogFilter.Matches` extraction is behavior-preserving vs the prior inlined ring logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time log streaming endpoint with filtering by severity level, scope, and search query
  * Supports resuming streams from the last received log entry
  * Includes automatic backfill of recent logs on initial connection and periodic heartbeat notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->