### PR TITLE
chore(test): cover conflict/history/reports/foreign-files, shrink parity

### DIFF
--- a/api/bruno/conflicts/conflict-banner.bru
+++ b/api/bruno/conflicts/conflict-banner.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Get Conflict Banner
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{apiBase}}/config/conflict-banner
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  Returns the conflict-banner HTML fragment (text/html). When no conflicts
+  are detected the response body is the empty-state banner; when the
+  conflict detector is not configured the handler emits 204 No Content.
+  Either way the route is reachable and the status is 2xx.
+}
+
+tests {
+  test("returns 2xx", function() {
+    expect(res.status).to.be.oneOf([200, 204]);
+  });
+}

--- a/api/bruno/environments/ci.bru
+++ b/api/bruno/environments/ci.bru
@@ -17,4 +17,6 @@ vars {
   fieldName: biography
   imageType: thumb
   undoId: 00000000-0000-0000-0000-000000000006
+  foreignFileId: 00000000-0000-0000-0000-000000000007
+  allowlistId: 00000000-0000-0000-0000-000000000008
 }

--- a/api/bruno/environments/local.bru
+++ b/api/bruno/environments/local.bru
@@ -17,4 +17,6 @@ vars {
   fieldName: biography
   imageType: thumb
   undoId: 00000000-0000-0000-0000-000000000006
+  foreignFileId: 00000000-0000-0000-0000-000000000007
+  allowlistId: 00000000-0000-0000-0000-000000000008
 }

--- a/api/bruno/foreign-files/add-allowlist.bru
+++ b/api/bruno/foreign-files/add-allowlist.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Add Foreign File to Allowlist (Sentinel 404)
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{apiBase}}/foreign-files/{{foreignFileId}}/allowlist
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  foreignFileId is a sentinel UUID that is guaranteed not to exist in the
+  CI foreign-file ledger. The handler calls GetByID before adding to the
+  allowlist, so a missing row yields a deterministic 404 with an error
+  envelope. Exercises the route and its error path without requiring real
+  foreign-file data.
+}
+
+tests {
+  test("returns 404 for non-existent sentinel foreign-file row", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope is present", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.be.a("string");
+  });
+}

--- a/api/bruno/foreign-files/allowlist.bru
+++ b/api/bruno/foreign-files/allowlist.bru
@@ -1,0 +1,27 @@
+meta {
+  name: List Foreign-File Allowlist
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{apiBase}}/foreign-file-allowlist
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response has items array and count", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.items).to.be.an("array");
+    expect(res.body.count).to.be.a("number");
+  });
+}

--- a/api/bruno/foreign-files/allowlist.bru
+++ b/api/bruno/foreign-files/allowlist.bru
@@ -19,9 +19,12 @@ tests {
     expect(res.status).to.equal(200);
   });
 
-  test("response has items array and count", function() {
+  test("response has items array (or null on empty DB) and count", function() {
     expect(res.body).to.be.an("object");
-    expect(res.body.items).to.be.an("array");
+    var items = res.body.items;
+    var ok = items === null || Array.isArray(items);
+    expect(ok).to.equal(true);
     expect(res.body.count).to.be.a("number");
+    expect(res.body.count).to.equal(items === null ? 0 : items.length);
   });
 }

--- a/api/bruno/foreign-files/count.bru
+++ b/api/bruno/foreign-files/count.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Foreign Files Count Badge
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{apiBase}}/foreign-files/count
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  Returns an HTML sidebar count pill or nav link (text/html). On an empty
+  CI database the response body is empty (count <= 0 produces no output)
+  but the status is always 200. Admin role required; the CI session is
+  authenticated as admin so no 403 is expected.
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/api/bruno/foreign-files/delete-file.bru
+++ b/api/bruno/foreign-files/delete-file.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Delete Foreign File from Disk (Sentinel 404)
+  type: http
+  seq: 6
+}
+
+delete {
+  url: {{apiBase}}/foreign-files/{{foreignFileId}}/file
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  foreignFileId is a sentinel UUID that is guaranteed not to exist in the
+  CI foreign-file ledger. The handler calls GetByID before attempting the
+  disk delete, so a missing row yields a deterministic 404 with an error
+  envelope. Exercises the route and its error path without touching the
+  filesystem or requiring real foreign-file data.
+}
+
+tests {
+  test("returns 404 for non-existent sentinel foreign-file row", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope is present", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.be.a("string");
+  });
+}

--- a/api/bruno/foreign-files/dismiss.bru
+++ b/api/bruno/foreign-files/dismiss.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Dismiss All Foreign Files
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{apiBase}}/foreign-files/dismiss
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  Bulk-allowlists all currently-detected foreign files. On an empty CI
+  database the loop processes zero entries and renders an empty table
+  fragment (text/html). Always returns 200; admin role required and the CI
+  session is admin. No JSON body needed -- the endpoint reads the DB, not
+  the request body.
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/api/bruno/foreign-files/remove-allowlist.bru
+++ b/api/bruno/foreign-files/remove-allowlist.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Remove Foreign-File Allowlist Entry (Sentinel 404)
+  type: http
+  seq: 7
+}
+
+delete {
+  url: {{apiBase}}/foreign-file-allowlist/{{allowlistId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  allowlistId is a sentinel UUID that is guaranteed not to exist in the
+  CI foreign-file allowlist. The handler calls RemoveAllowlist which
+  returns ErrNotFound for a missing entry, yielding a deterministic 404
+  with an error envelope. Exercises the route and its error path without
+  requiring real allowlist data.
+}
+
+tests {
+  test("returns 404 for non-existent sentinel allowlist entry", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope is present", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.be.a("string");
+  });
+}

--- a/api/bruno/history/artist-history.bru
+++ b/api/bruno/history/artist-history.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Artist History (Sentinel 404)
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{apiBase}}/artists/{{artistId}}/history
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  artistId is the all-zeros sentinel UUID that is guaranteed not to exist in
+  the CI database. The handler verifies the artist exists before returning
+  history, so a non-existent artist yields a deterministic 404 with an error
+  envelope. This exercises the route without requiring seeded artist data.
+}
+
+tests {
+  test("returns 404 for non-existent sentinel artist", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope is present", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.be.a("string");
+  });
+}

--- a/api/bruno/history/revert-history.bru
+++ b/api/bruno/history/revert-history.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Revert History Entry (Sentinel 404)
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{apiBase}}/history/{{undoId}}/revert
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  undoId is the sentinel UUID (00000000-...-0006) that is guaranteed not to
+  exist in the CI history ledger. The handler looks up the change record
+  before reverting, so a non-existent change yields a deterministic 404 with
+  an error envelope. Exercises the route without requiring real history data.
+}
+
+tests {
+  test("returns 404 for non-existent sentinel history entry", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope is present", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.be.a("string");
+  });
+}

--- a/api/bruno/parity-ignore.json
+++ b/api/bruno/parity-ignore.json
@@ -36,14 +36,6 @@
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
-    "route": "DELETE /api/v1/foreign-file-allowlist/{}",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "DELETE /api/v1/foreign-files/{}/file",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "DELETE /api/v1/logs",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
@@ -124,10 +116,6 @@
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
-    "route": "GET /api/v1/artists/{}/history",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "GET /api/v1/artists/{}/images/fanart/list",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
@@ -168,10 +156,6 @@
     "reason": "OIDC browser-redirect endpoint: requires an external IdP round-trip; not exercisable from a headless Bruno run."
   },
   {
-    "route": "GET /api/v1/config/conflict-banner",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "GET /api/v1/connections/clobber-check",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
@@ -208,14 +192,6 @@
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
-    "route": "GET /api/v1/foreign-file-allowlist",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/foreign-files/count",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "GET /api/v1/images/random-backdrop",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
@@ -241,30 +217,6 @@
   },
   {
     "route": "GET /api/v1/providers/{}/config",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/reports/compliance/count",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/reports/compliance/export",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/reports/duplicates/count",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/reports/health/by-library",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/reports/metadata-completeness",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/reports/rule-pass-rates",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
@@ -494,18 +446,6 @@
   {
     "route": "POST /api/v1/connections/{}/verify-path-after-update",
     "reason": "Admin-gated per-connection HTMX toggle (Lidarr verify-after-PUT, #1685); sibling connection-toggle endpoints (stillwater-managed, features) are parity-ignored - no standalone Bruno request needed."
-  },
-  {
-    "route": "POST /api/v1/foreign-files/dismiss",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "POST /api/v1/foreign-files/{}/allowlist",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "POST /api/v1/history/{}/revert",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
     "route": "POST /api/v1/onboarding/reset",

--- a/api/bruno/reports/compliance-count.bru
+++ b/api/bruno/reports/compliance-count.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Compliance Count Badge
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{apiBase}}/reports/compliance/count
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  Returns an HTML sidebar count pill (text/html). On an empty CI database
+  the response body is empty (count <= 0 produces no output) but the status
+  is always 200. Admin role required; the CI session is authenticated as
+  admin so no 403 is expected.
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/api/bruno/reports/compliance-export.bru
+++ b/api/bruno/reports/compliance-export.bru
@@ -27,6 +27,6 @@ tests {
   });
 
   test("Content-Disposition is a CSV attachment", function() {
-    expect(res.headers['content-disposition']).to.equal('attachment; filename="compliance-report.csv"');
+    expect(res.headers['content-disposition']).to.match(/^attachment;.*filename="compliance-report\.csv"/i);
   });
 }

--- a/api/bruno/reports/compliance-export.bru
+++ b/api/bruno/reports/compliance-export.bru
@@ -25,4 +25,8 @@ tests {
   test("returns 200", function() {
     expect(res.status).to.equal(200);
   });
+
+  test("Content-Disposition is a CSV attachment", function() {
+    expect(res.headers['content-disposition']).to.equal('attachment; filename="compliance-report.csv"');
+  });
 }

--- a/api/bruno/reports/compliance-export.bru
+++ b/api/bruno/reports/compliance-export.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Compliance Report Export (CSV)
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{apiBase}}/reports/compliance/export
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  Streams a CSV download (Content-Disposition: attachment; filename="compliance-report.csv").
+  On an empty CI database the CSV contains only the header row. The route is
+  reachable and always returns 200; the body is text/csv, not JSON, so no
+  JSON shape assertions are made.
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/api/bruno/reports/duplicates-count.bru
+++ b/api/bruno/reports/duplicates-count.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Duplicates Count Badge
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{apiBase}}/reports/duplicates/count
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  Returns an HTML sidebar count pill (text/html). On an empty CI database
+  the response body is empty (count <= 0 produces no output) but the status
+  is always 200. Admin role required; the CI session is authenticated as
+  admin so no 403 is expected.
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/api/bruno/reports/duplicates-count.bru
+++ b/api/bruno/reports/duplicates-count.bru
@@ -25,4 +25,10 @@ tests {
   test("returns 200", function() {
     expect(res.status).to.equal(200);
   });
+
+  test("content-type is text/html when body non-empty", function() {
+    if (res.body && res.body.length > 0) {
+      expect(res.headers['content-type']).to.include('text/html');
+    }
+  });
 }

--- a/api/bruno/reports/health-by-library.bru
+++ b/api/bruno/reports/health-by-library.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Health Report by Library
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{apiBase}}/reports/health/by-library
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is an object with libraries and overall keys", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.libraries).to.be.an("array");
+    expect(res.body.overall).to.be.an("object");
+  });
+}

--- a/api/bruno/reports/health-by-library.bru
+++ b/api/bruno/reports/health-by-library.bru
@@ -19,6 +19,10 @@ tests {
     expect(res.status).to.equal(200);
   });
 
+  test("content-type is application/json", function() {
+    expect(res.headers['content-type']).to.include('application/json');
+  });
+
   test("response is an object with libraries and overall keys", function() {
     expect(res.body).to.be.an("object");
     expect(res.body.libraries).to.be.an("array");

--- a/api/bruno/reports/metadata-completeness.bru
+++ b/api/bruno/reports/metadata-completeness.bru
@@ -22,4 +22,20 @@ tests {
   test("response is an object", function() {
     expect(res.body).to.be.an("object");
   });
+
+  test("overall_score is a number", function() {
+    expect(res.body.overall_score).to.be.a("number");
+  });
+
+  test("total_artists is a number", function() {
+    expect(res.body.total_artists).to.be.a("number");
+  });
+
+  test("field_coverage is an array", function() {
+    expect(res.body.field_coverage).to.be.an("array");
+  });
+
+  test("lowest_completeness is an array", function() {
+    expect(res.body.lowest_completeness).to.be.an("array");
+  });
 }

--- a/api/bruno/reports/metadata-completeness.bru
+++ b/api/bruno/reports/metadata-completeness.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Metadata Completeness Report
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{apiBase}}/reports/metadata-completeness
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is an object", function() {
+    expect(res.body).to.be.an("object");
+  });
+}

--- a/api/bruno/reports/rule-pass-rates.bru
+++ b/api/bruno/reports/rule-pass-rates.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Rule Pass Rates Report
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{apiBase}}/reports/rule-pass-rates
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("returns 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response has rates array", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.rates).to.be.an("array");
+  });
+}


### PR DESCRIPTION
## Summary

- Adds 15 new Bruno request files covering the `conflicts/` (1), `history/` (2), `reports/` (6), and `foreign-files/` (6) route groups, chipping 15 routes out of the parity-ignore baseline (151 -> 136). The issue's original target baseline was 153; base `def3253b` already sat at 151 from prior drift.
- Fixes a nil-safe assertion bug introduced alongside the new files: allowlist items can be `null` on an empty DB, causing a false assertion failure in `foreign-files/allowlist.bru`.
- Strengthens `reports/metadata-completeness` and `reports/compliance-export` assertions per review nits (more specific field checks, tighter status validation).
- No Go source changes; all three commits are Bruno-collection, parity-baseline, and CI/local environment-file only.

## Linked issue

Part of #2049

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`), or run via `/prep-pr` / `/pr-review-toolkit:review-pr` which invokes it.
- [x] Code review pass complete (`/prep-pr` or `/pr-review-toolkit:review-pr`); critical and important findings fixed before pushing.
- [x] Commits squashed into clean, logical commits before the first push (Copilot reviews the diff at PR open).
- [x] At least one label set on `gh pr create --label ...` (the CI label gate fails without one).
- [x] Docs label decision made: `docs: not-required` -- test-infra only; no user-visible behavior change.
- [N/A] Screenshot attached for any UI change. -- No UI change.
- [N/A] UAT performed for user-visible changes (run the binary, not just the test suite). -- Test-infra PR; acceptance is automated via `make bruno-ci` (see Test plan).
- [N/A] OpenAPI spec updated if any request or response shape changed (`make check-openapi`). -- No API shape change; Bruno collection only.
- [N/A] `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed. -- No `.templ` files touched.

## Test plan

- [x] `go test -race ./...` passes locally -- 0 FAIL, 0 DATA RACE (gate-confirmed at HEAD 6e6a9309).
- [x] `bash scripts/pre-push-gate.sh` passes locally -- exit 0; lint 0 issues; OpenAPI PASS; generated files OK; provider-failure smoke 9/9.
- [x] `make bruno-ci` -- 139/139 requests, 271/271 tests green. This is the primary acceptance signal for a test-infra PR; no manual UAT steps apply.
- [x] Route-parity guard: 266 API routes / 132 Bruno requests / 136 ignore-listed (down from 151 at base; issue's original target was 153).
- [ ] Reviewer follow-ups:
  - Verify the nil-safe assertion in `foreign-files/allowlist.bru` looks correct for non-empty DB runs (the CI run uses an ephemeral empty DB, so the null path is the only one exercised there).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new report and status endpoints for conflict, foreign-file, history, and compliance views.
  * Added download support for compliance report exports as CSV.
  * Added count badges and summary views for duplicates, compliance, and foreign files.
  * Added health, metadata completeness, and rule pass-rate report views.

* **Bug Fixes**
  * Improved handling of missing or unavailable items so not-found states return consistent responses.
  * Added coverage for dismissing foreign files and reverting history entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->