### PR TITLE
chore(test): cover settings/docs routes in Bruno; shrink parity baseline

### DIFF
--- a/api/bruno/docs/api-docs.bru
+++ b/api/bruno/docs/api-docs.bru
@@ -1,0 +1,21 @@
+meta {
+  name: API Docs
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{apiBase}}/docs
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is HTML", function() {
+    expect(res.headers["content-type"]).to.include("text/html");
+  });
+}

--- a/api/bruno/docs/openapi-yaml.bru
+++ b/api/bruno/docs/openapi-yaml.bru
@@ -1,0 +1,21 @@
+meta {
+  name: OpenAPI Spec
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{apiBase}}/docs/openapi.yaml
+  body: none
+  auth: none
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is YAML", function() {
+    expect(res.headers["content-type"]).to.include("application/yaml");
+  });
+}

--- a/api/bruno/notifications/badge.bru
+++ b/api/bruno/notifications/badge.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Notification Badge
+  type: http
+  seq: 12
+}
+
+get {
+  url: {{apiBase}}/notifications/badge
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/api/bruno/parity-ignore.json
+++ b/api/bruno/parity-ignore.json
@@ -56,10 +56,6 @@
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
-    "route": "DELETE /api/v1/settings/cache",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "DELETE /api/v1/updates/skips/{}",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
@@ -176,14 +172,6 @@
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
-    "route": "GET /api/v1/docs",
-    "reason": "Static API-docs/OpenAPI-spec endpoint; documentation surface, not part of the JSON API contract under smoke test."
-  },
-  {
-    "route": "GET /api/v1/docs/openapi.yaml",
-    "reason": "Static API-docs/OpenAPI-spec endpoint; documentation surface, not part of the JSON API contract under smoke test."
-  },
-  {
     "route": "GET /api/v1/events/stream",
     "reason": "Server-Sent Events stream: a long-lived push connection, not a JSON request/response contract Bruno can assert."
   },
@@ -205,10 +193,6 @@
   },
   {
     "route": "GET /api/v1/logs/files",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/notifications/badge",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
@@ -241,26 +225,6 @@
   },
   {
     "route": "GET /api/v1/scraper/providers",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/settings/cache/stats",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/settings/logging",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/settings/maintenance/status",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/settings/nfo-output",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/settings/vocab",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
@@ -456,14 +420,6 @@
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
-    "route": "POST /api/v1/settings/maintenance/optimize",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "POST /api/v1/settings/maintenance/vacuum",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "POST /api/v1/setup/restore",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
@@ -521,22 +477,6 @@
   },
   {
     "route": "PUT /api/v1/scraper/config/connections/{}",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "PUT /api/v1/settings/logging",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "PUT /api/v1/settings/maintenance/schedule",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "PUT /api/v1/settings/nfo-output",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "PUT /api/v1/settings/vocab",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {

--- a/api/bruno/settings/cache-clear.bru
+++ b/api/bruno/settings/cache-clear.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Cache Clear
+  type: http
+  seq: 17
+}
+
+delete {
+  url: {{apiBase}}/settings/cache
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is JSON", function() {
+    expect(res.headers["content-type"]).to.include("application/json");
+  });
+
+  test("should return deletion summary", function() {
+    expect(res.body.files_deleted).to.be.a("number");
+    expect(res.body.bytes_freed).to.be.a("number");
+  });
+}

--- a/api/bruno/settings/cache-stats.bru
+++ b/api/bruno/settings/cache-stats.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Cache Stats
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{apiBase}}/settings/cache/stats
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is JSON", function() {
+    expect(res.headers["content-type"]).to.include("application/json");
+  });
+
+  test("should return cache size metrics", function() {
+    expect(res.body.size_bytes).to.be.a("number");
+    expect(res.body.file_count).to.be.a("number");
+    expect(res.body.artist_count).to.be.a("number");
+  });
+}

--- a/api/bruno/settings/get-logging.bru
+++ b/api/bruno/settings/get-logging.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Get Logging Config
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{apiBase}}/settings/logging
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is JSON", function() {
+    expect(res.headers["content-type"]).to.include("application/json");
+  });
+
+  test("should return logging config", function() {
+    expect(res.body.level).to.be.a("string");
+    expect(res.body.format).to.be.a("string");
+  });
+}

--- a/api/bruno/settings/maintenance-optimize.bru
+++ b/api/bruno/settings/maintenance-optimize.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Maintenance Optimize
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{apiBase}}/settings/maintenance/optimize
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is JSON", function() {
+    expect(res.headers["content-type"]).to.include("application/json");
+  });
+
+  test("should return optimized status", function() {
+    expect(res.body.status).to.equal("optimized");
+  });
+}

--- a/api/bruno/settings/maintenance-schedule.bru
+++ b/api/bruno/settings/maintenance-schedule.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Maintenance Schedule
+  type: http
+  seq: 12
+}
+
+put {
+  url: {{apiBase}}/settings/maintenance/schedule
+  body: json
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+body:json {
+  {
+    "enabled": false,
+    "interval_hours": 24
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is JSON", function() {
+    expect(res.headers["content-type"]).to.include("application/json");
+  });
+
+  test("should return updated status", function() {
+    expect(res.body.status).to.equal("updated");
+  });
+}

--- a/api/bruno/settings/maintenance-status.bru
+++ b/api/bruno/settings/maintenance-status.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Maintenance Status
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{apiBase}}/settings/maintenance/status
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is JSON", function() {
+    expect(res.headers["content-type"]).to.include("application/json");
+  });
+
+  test("should return db size metrics", function() {
+    expect(res.body.db_file_size).to.be.a("number");
+    expect(res.body.page_count).to.be.a("number");
+  });
+}

--- a/api/bruno/settings/maintenance-vacuum.bru
+++ b/api/bruno/settings/maintenance-vacuum.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Maintenance Vacuum
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{apiBase}}/settings/maintenance/vacuum
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is JSON", function() {
+    expect(res.headers["content-type"]).to.include("application/json");
+  });
+
+  test("should return vacuumed status", function() {
+    expect(res.body.status).to.equal("vacuumed");
+  });
+}

--- a/api/bruno/settings/nfo-output.bru
+++ b/api/bruno/settings/nfo-output.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Get NFO Output Settings
+  type: http
+  seq: 13
+}
+
+get {
+  url: {{apiBase}}/settings/nfo-output
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is JSON", function() {
+    expect(res.headers["content-type"]).to.include("application/json");
+  });
+
+  test("should return NFO field map", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body).to.have.property("default_behavior");
+    expect(res.body.genre_sources).to.be.an("array");
+  });
+}

--- a/api/bruno/settings/update-logging.bru
+++ b/api/bruno/settings/update-logging.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Update Logging Config
+  type: http
+  seq: 8
+}
+
+put {
+  url: {{apiBase}}/settings/logging
+  body: json
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+body:json {
+  {
+    "level": "info",
+    "format": "text"
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is JSON", function() {
+    expect(res.headers["content-type"]).to.include("application/json");
+  });
+
+  test("should return updated config", function() {
+    expect(res.body.level).to.be.a("string");
+    expect(res.body.format).to.be.a("string");
+  });
+}

--- a/api/bruno/settings/update-nfo-output.bru
+++ b/api/bruno/settings/update-nfo-output.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Update NFO Output Settings
+  type: http
+  seq: 14
+}
+
+put {
+  url: {{apiBase}}/settings/nfo-output
+  body: json
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+body:json {
+  {
+    "default_behavior": true,
+    "moods_as_styles": false,
+    "genre_sources": ["genres"]
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is JSON", function() {
+    expect(res.headers["content-type"]).to.include("application/json");
+  });
+
+  test("should return updated field map", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.genre_sources).to.be.an("array");
+  });
+}

--- a/api/bruno/settings/update-vocab.bru
+++ b/api/bruno/settings/update-vocab.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Update Vocab Config
+  type: http
+  seq: 16
+}
+
+put {
+  url: {{apiBase}}/settings/vocab
+  body: json
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+body:json {
+  {
+    "exclude": [],
+    "max_genres": 0,
+    "max_styles": 0,
+    "max_moods": 0
+  }
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is JSON", function() {
+    expect(res.headers["content-type"]).to.include("application/json");
+  });
+
+  test("should return updated status", function() {
+    expect(res.body.status).to.equal("updated");
+  });
+}

--- a/api/bruno/settings/vocab.bru
+++ b/api/bruno/settings/vocab.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Get Vocab Config
+  type: http
+  seq: 15
+}
+
+get {
+  url: {{apiBase}}/settings/vocab
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("response is JSON", function() {
+    expect(res.headers["content-type"]).to.include("application/json");
+  });
+
+  test("should return vocab config", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.exclude).to.be.an("array");
+  });
+}


### PR DESCRIPTION
## Summary

- Adds 15 Bruno requests covering the settings surface and read-only singletons: cache stats/clear, logging (GET+PUT), maintenance status/optimize/vacuum/schedule, NFO output (GET+PUT), vocab (GET+PUT), docs, docs/openapi.yaml, and notifications/badge.
- Removes 15 entries from `api/bruno/parity-ignore.json`, shrinking the baseline from 136 to 121 (266 routes / 147 Bruno / 121 ignore-listed).
- No Go code changed; pure test-infra. No user-visible behavior change.

## Linked issue

Part of #2049

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`), or run via `/prep-pr` / `/pr-review-toolkit:review-pr` which invokes it.
- [x] Code review pass complete (`/prep-pr` or `/pr-review-toolkit:review-pr`); critical and important findings fixed before pushing.
- [x] Commits squashed into clean, logical commits before the first push (Copilot reviews the diff at PR open).
- [x] At least one label set on `gh pr create --label ...` (the CI label gate fails without one).
- [x] Docs label decision made: `docs: not-required` -- test/CI-only PR, no user-visible behavioral change.
- [ ] ~~Screenshot attached for any UI change.~~ N/A - no UI change.
- [ ] ~~UAT performed for user-visible changes (run the binary, not just the test suite).~~ N/A - acceptance is automated via `make bruno-ci`; no user-visible change.
- [ ] ~~OpenAPI spec updated if any request or response shape changed (`make check-openapi`).~~ N/A - no request/response shape change.
- [ ] ~~`templ generate` re-run and `*_templ.go` committed if any `.templ` file changed.~~ N/A - no `.templ` files touched.

## Test plan

- [x] `go test -race ./...` passes locally (0 FAIL / 0 RACE).
- [x] `bash scripts/pre-push-gate.sh` passes locally (exit 0).
- [x] `make bruno-ci` green: 154 requests / 314 tests pass; parity guard reports 266 routes / 147 Bruno / 121 ignore-listed (down from 136).
- [ ] ~~Manual UAT steps~~ N/A - test-infra only; `make bruno-ci` is the acceptance criterion.
- [ ] Reviewer follow-ups (acknowledged non-blocking from hostile review):
  - `notifications/badge.bru` asserts HTTP 200 only -- acceptable for an HTMX fragment endpoint with no JSON body to assert.
  - `update-logging` and `update-nfo-output` assert response shape rather than echo the request body -- acceptable at smoke level; these settings endpoints return a canonical representation, not a round-trip echo.

**Skipped (remain in parity-ignore with reasons):**
- `DELETE /api/v1/settings/backup/{filename}` -- requires a real backup file to exist; not safe to seed in CI.
- `GET /api/v1/events/stream` -- SSE; blocks Bruno indefinitely.
- `POST /api/v1/onboarding/reset` -- disrupts CI onboarding state.
- `POST /api/v1/setup/restore` -- destructive; not safe in automated runs.
