### PR TITLE
chore(test): cover connections/providers/updates/scraper routes in Bruno

### DIFF
--- a/api/bruno/connections/clobber-check.bru
+++ b/api/bruno/connections/clobber-check.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Clobber Check
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{apiBase}}/connections/clobber-check
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return risks array", function() {
+    expect(res.body.risks).to.be.an("array");
+  });
+}

--- a/api/bruno/connections/get-conflict-detail.bru
+++ b/api/bruno/connections/get-conflict-detail.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get Conflict Detail
+  type: http
+  seq: 12
+}
+
+get {
+  url: {{apiBase}}/connections/{{connectionId}}/conflict-detail
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("returns 204 for unknown connection (HTMX fragment endpoint)", function() {
+    expect(res.status).to.equal(204);
+  });
+}

--- a/api/bruno/connections/get-conflict-detail.bru
+++ b/api/bruno/connections/get-conflict-detail.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{apiBase}}/connections/{{connectionId}}/conflict-detail
+  url: {{apiBase}}/connections/00000000-0000-0000-0000-000000000000/conflict-detail
   body: none
   auth: none
 }

--- a/api/bruno/connections/get-platform-settings.bru
+++ b/api/bruno/connections/get-platform-settings.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Platform Settings
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{apiBase}}/connections/{{connectionId}}/platform-settings
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("returns 404 for sentinel connectionId", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope reports connection not found", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.equal("connection not found");
+  });
+}

--- a/api/bruno/connections/get-platform-summary.bru
+++ b/api/bruno/connections/get-platform-summary.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Platform Summary
+  type: http
+  seq: 11
+}
+
+get {
+  url: {{apiBase}}/connections/{{connectionId}}/platform-summary
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("returns 404 for sentinel connectionId", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope reports connection not found", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.equal("connection not found");
+  });
+}

--- a/api/bruno/connections/populate-in-flight.bru
+++ b/api/bruno/connections/populate-in-flight.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Populate In-Flight
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{apiBase}}/connections/populate/in-flight
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return operations array", function() {
+    expect(res.body.operations).to.be.an("array");
+  });
+}

--- a/api/bruno/parity-ignore.json
+++ b/api/bruno/parity-ignore.json
@@ -152,26 +152,6 @@
     "reason": "OIDC browser-redirect endpoint: requires an external IdP round-trip; not exercisable from a headless Bruno run."
   },
   {
-    "route": "GET /api/v1/connections/clobber-check",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/connections/populate/in-flight",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/connections/{}/conflict-detail",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/connections/{}/platform-settings",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/connections/{}/platform-summary",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "GET /api/v1/events/stream",
     "reason": "Server-Sent Events stream: a long-lived push connection, not a JSON request/response contract Bruno can assert."
   },
@@ -196,14 +176,6 @@
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
-    "route": "GET /api/v1/providers/websearch",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/providers/{}/config",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "GET /api/v1/rules/run-all/status",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
@@ -216,31 +188,7 @@
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
-    "route": "GET /api/v1/scraper/config",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/scraper/config/connections/{}",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/scraper/providers",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "GET /api/v1/shared-filesystem/status",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/updates/config",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/updates/skips",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "GET /api/v1/updates/status",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {

--- a/api/bruno/providers/get-provider-config.bru
+++ b/api/bruno/providers/get-provider-config.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Get Provider Config
+  type: http
+  seq: 10
+}
+
+get {
+  url: {{apiBase}}/providers/wikipedia/config
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return provider config envelope", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.provider).to.equal("wikipedia");
+    expect(res.body.verbosity).to.be.an("object");
+  });
+}

--- a/api/bruno/providers/get-websearch.bru
+++ b/api/bruno/providers/get-websearch.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Get Web Search Providers
+  type: http
+  seq: 9
+}
+
+get {
+  url: {{apiBase}}/providers/websearch
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return providers array", function() {
+    expect(res.body.providers).to.be.an("array");
+  });
+}

--- a/api/bruno/scraper/get-config.bru
+++ b/api/bruno/scraper/get-config.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Scraper Config
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{apiBase}}/scraper/config
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return config object with fields array", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.fields).to.be.an("array");
+  });
+}

--- a/api/bruno/scraper/get-connection-config.bru
+++ b/api/bruno/scraper/get-connection-config.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Connection Scraper Config
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{apiBase}}/scraper/config/connections/{{connectionId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("returns 404 for sentinel connectionId", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope reports connection not found", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.equal("connection not found");
+  });
+}

--- a/api/bruno/scraper/list-providers.bru
+++ b/api/bruno/scraper/list-providers.bru
@@ -1,0 +1,25 @@
+meta {
+  name: List Scraper Providers
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{apiBase}}/scraper/providers
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return providers array", function() {
+    expect(res.body.providers).to.be.an("array");
+  });
+}

--- a/api/bruno/updates/get-update-config.bru
+++ b/api/bruno/updates/get-update-config.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Update Config
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{apiBase}}/updates/config
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return config object", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.channel).to.be.a("string");
+  });
+}

--- a/api/bruno/updates/get-update-skips.bru
+++ b/api/bruno/updates/get-update-skips.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Get Update Skips
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{apiBase}}/updates/skips
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return skipped_versions array", function() {
+    expect(res.body.skipped_versions).to.be.an("array");
+  });
+}

--- a/api/bruno/updates/get-update-status.bru
+++ b/api/bruno/updates/get-update-status.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Get Update Status
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{apiBase}}/updates/status
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+tests {
+  test("should return 200", function() {
+    expect(res.status).to.equal(200);
+  });
+
+  test("should return status object with state field", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.state).to.be.a("string");
+  });
+
+  test("should return skipped_versions array", function() {
+    expect(res.body.skipped_versions).to.be.an("array");
+  });
+}


### PR DESCRIPTION
## Summary

- Adds 13 Bruno requests covering the connections, providers, updates, and scraper READ surface, reducing the `parity-ignore.json` baseline from 121 to 108.
- Routes covered: connections (clobber-check, populate-in-flight, `{}/platform-settings` [404], `{}/platform-summary` [404], `{}/conflict-detail` [204]); providers (websearch, `{}/config`); updates (config, skips, status); scraper (config, list-providers, `config/connections/{}` [404]).
- Mutating routes in these groups (platform mutations, update apply/check, scraper/provider config writes) remain in parity-ignore; no API surface or behavior changes.

## Linked issue

Part of #2049

## Pre-flight checklist

- [x] Pre-push gate green locally (`bash scripts/pre-push-gate.sh`), or run via `/prep-pr` / `/pr-review-toolkit:review-pr` which invokes it.
- [x] Code review pass complete (`/prep-pr` or `/pr-review-toolkit:review-pr`); critical and important findings fixed before pushing.
- [x] Commits squashed into clean, logical commits before the first push (Copilot reviews the diff at PR open).
- [x] At least one label set on `gh pr create --label ...` (the CI label gate fails without one).
- [x] Docs label decision made: `docs: not-required` -- test-infra only, no user-visible behavioral change.
- N/A Screenshot attached for any UI change.
- N/A UAT performed for user-visible changes (no UI or behavior change; acceptance is automated via `make bruno-ci`).
- N/A OpenAPI spec updated if any request or response shape changed (no API changes).
- N/A `templ generate` re-run and `*_templ.go` committed if any `.templ` file changed (no `.templ` changes).

## Test plan

- [x] `make bruno-ci` passes: 167 requests / 340 tests GREEN.
- [x] Parity guard exit 0: 266 routes / 160 Bruno / 108 ignore-listed (down from 121).
- [x] `bash scripts/pre-push-gate.sh` passes locally (full gate exit 0).
- N/A Manual UAT steps: no user-visible surface changed.
- [ ] Reviewer follow-ups: hostile review noted one MINOR -- no explicit `Content-Type` assertions on responses. This is consistent with the existing collection style (other requests in the collection also omit content-type assertions); not treated as a defect, but flagging for awareness.

**Skipped (remain in parity-ignore):** all mutating POST/PUT/PATCH/DELETE routes in the connections, providers, updates, and scraper groups -- platform mutations, update apply/check, and scraper/provider config writes are deferred to a future slice.
