### PR TITLE
refactor(provider/scraper): consolidate duplicate getProviderResult

### DIFF
--- a/internal/provider/orchestrator.go
+++ b/internal/provider/orchestrator.go
@@ -183,7 +183,7 @@ func (o *Orchestrator) FetchMetadata(ctx context.Context, mbid, name string, pro
 
 	// Cache provider results to avoid duplicate calls
 	var mu sync.Mutex
-	cache := make(map[ProviderName]*providerResult)
+	cache := make(map[ProviderName]*ProviderResult)
 
 	for _, pri := range priorities {
 		queried := false
@@ -492,16 +492,10 @@ func (o *Orchestrator) imageProvidersInPriorityOrder(ctx context.Context) ([]Pro
 	return ordered, nil
 }
 
-type providerResult struct {
-	meta            *ArtistMetadata
-	images          []ImageResult
-	err             error
-	imageErr        error // non-nil when GetImages returned a transient error (not ErrNotFound)
-	imagesAttempted bool  // true whenever GetImages was actually invoked, regardless of outcome
-}
-
-//nolint:gocognit // Per-provider cached fetch with lookup-precedence ladder (provider ID > MBID > name), name-based retry only when MBID-not-found AND the provider implements NameLookupProvider, plus ErrNotFound-vs-transient distinction for both GetArtist and GetImages so stale data is cleared on a definitive miss but preserved on a transient failure. Near-identical to scraper.Executor.getProviderResult (cog 34 each); the consolidation is a peripheral concern but worth tracking; refactor tracked in #1554.
-func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName, mbid string, artistName string, providerIDs map[ProviderName]string, cache map[ProviderName]*providerResult, mu *sync.Mutex) *providerResult {
+// getProviderResult fetches and caches results from a single provider.
+// Cache check and registry lookup happen here; the per-provider fetch logic
+// is shared with the scraper executor via FetchProviderResult.
+func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName, mbid string, artistName string, providerIDs map[ProviderName]string, cache map[ProviderName]*ProviderResult, mu *sync.Mutex) *ProviderResult {
 	mu.Lock()
 	if pr, ok := cache[name]; ok {
 		mu.Unlock()
@@ -511,141 +505,14 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 
 	p := o.registry.Get(name)
 	if p == nil {
-		pr := &providerResult{err: fmt.Errorf("provider %s not registered", name)}
+		pr := &ProviderResult{err: fmt.Errorf("provider %s not registered", name)}
 		mu.Lock()
 		cache[name] = pr
 		mu.Unlock()
 		return pr
 	}
 
-	pr := &providerResult{}
-
-	// aimdRateLimitErr records the first rate-limit / provider-unavailable error
-	// encountered across both GetArtist and GetImages within this single provider
-	// call. It is used to emit exactly ONE AIMD signal at the end of the function:
-	// RecordFailure if a rate-limit error was seen, RecordSuccess if results were
-	// returned without a rate-limit error. Ordinary errors (ErrNotFound, auth/401,
-	// JSON parse, context cancellation) are not AIMD signals.
-	var aimdRateLimitErr error
-	// aimdGotResult is true when at least one of GetArtist or GetImages returned
-	// a useful (non-error) result. Used to decide whether RecordSuccess is warranted.
-	aimdGotResult := false
-
-	// Lookup precedence: provider-specific ID > MBID > artist name.
-	// Providers like AudioDB, Discogs, and Deezer have their own numeric IDs
-	// that are more reliable than passing an MBID they may not recognize.
-	usedProviderID := false
-	id := mbid
-	if pid, ok := providerIDs[name]; ok && pid != "" {
-		id = pid
-		usedProviderID = true
-	} else if id == "" {
-		id = artistName
-	}
-
-	// queryID tracks the identifier actually passed to the most recent
-	// GetArtist call. It may differ from id after a name-based retry.
-	queryID := id
-
-	if id != "" {
-		meta, err := p.GetArtist(ctx, id)
-		// If we used an MBID (not a provider-specific ID) and the provider
-		// returned not-found, retry with the artist name -- but only for
-		// providers that support name lookups (e.g. Genius, Last.fm).
-		if err != nil && !usedProviderID && mbid != "" && artistName != "" {
-			var notFound *ErrNotFound
-			if errors.As(err, &notFound) {
-				if nlp, ok := p.(NameLookupProvider); ok && nlp.SupportsNameLookup() {
-					o.logger.Debug("retrying with artist name after MBID not-found",
-						slog.String("provider", string(name)),
-						slog.String("name", artistName))
-					queryID = artistName
-					meta, err = p.GetArtist(ctx, artistName)
-				}
-			}
-		}
-		if err != nil {
-			// ErrNotFound means the provider was reached and definitively said
-			// "no data". Treat this as a successful query (no error) so the
-			// field is marked as attempted and stale data can be cleared.
-			// Transient failures (timeouts, 5xx) remain as real errors.
-			var notFound *ErrNotFound
-			if errors.As(err, &notFound) {
-				o.logger.Debug("provider has no data for artist",
-					slog.String("provider", string(name)),
-					slog.String("id", queryID))
-			} else {
-				o.logger.Debug("provider GetArtist failed",
-					slog.String("provider", string(name)),
-					slog.String("error", ScrubError(err)),
-					retryAfterAttr(err))
-				pr.err = err
-				// Record the first rate-limit error for the composite AIMD signal.
-				if IsRateLimitError(err) && aimdRateLimitErr == nil {
-					aimdRateLimitErr = err
-				}
-			}
-		} else {
-			pr.meta = meta
-			aimdGotResult = true
-		}
-	}
-
-	// Fetch images using the same precedence: provider ID > MBID.
-	imgID := mbid
-	if pid, ok := providerIDs[name]; ok && pid != "" {
-		imgID = pid
-	}
-	if imgID != "" {
-		images, err := p.GetImages(ctx, imgID)
-		// Mark that GetImages was actually invoked regardless of outcome.
-		// This distinguishes "GetImages was called and returned ErrNotFound"
-		// (imagesAttempted=true, imageErr=nil) from "GetImages was never called
-		// because no ID was available" (imagesAttempted=false).
-		pr.imagesAttempted = true
-		if err != nil {
-			var notFound *ErrNotFound
-			if errors.As(err, &notFound) {
-				o.logger.Debug("provider has no images for artist",
-					slog.String("provider", string(name)),
-					slog.String("id", imgID))
-				// ErrNotFound means the provider was reached and definitively said
-				// "no images". Leave imageErr nil so image fields are marked as
-				// attempted and stale image data can be cleared.
-			} else {
-				o.logger.Warn("provider GetImages failed, preserving existing image data",
-					slog.String("provider", string(name)),
-					slog.String("error", ScrubError(err)),
-					retryAfterAttr(err))
-				// Transient failure: store in imageErr so image fields are NOT
-				// marked as attempted. This prevents clearing existing image data
-				// when the provider was merely unreachable.
-				pr.imageErr = err
-				// Record the first rate-limit error for the composite AIMD signal.
-				if IsRateLimitError(err) && aimdRateLimitErr == nil {
-					aimdRateLimitErr = err
-				}
-			}
-		} else {
-			pr.images = images
-			aimdGotResult = true
-		}
-	}
-
-	// Emit exactly ONE AIMD signal per provider call:
-	//   - RecordFailure when a rate-limit / provider-unavailable error was seen.
-	//   - RecordSuccess when at least one sub-call (GetArtist or GetImages)
-	//     returned a useful result and no rate-limit error was recorded.
-	// Ordinary errors (ErrNotFound, auth, JSON parse, context cancel) are NOT
-	// AIMD signals and neither case fires for them.
-	if o.aimd != nil {
-		if aimdRateLimitErr != nil {
-			o.aimd.RecordFailure(name, RetryAfterDuration(aimdRateLimitErr))
-		} else if aimdGotResult {
-			o.aimd.RecordSuccess(name)
-		}
-	}
-
+	pr := FetchProviderResult(ctx, p, name, mbid, artistName, providerIDs, o.logger, o.aimd)
 	mu.Lock()
 	cache[name] = pr
 	mu.Unlock()
@@ -665,7 +532,7 @@ func (o *Orchestrator) getProviderResult(ctx context.Context, name ProviderName,
 // Each helper below mirrors one arm of the original switch. `matched` follows
 // the original early-return semantics exactly: any case arm that took the
 // `return ...` statement counts as matched.
-type fieldApplier func(result *FetchResult, field string, pr *providerResult, source ProviderName) (populated, matched bool)
+type fieldApplier func(result *FetchResult, field string, pr *ProviderResult, source ProviderName) (populated, matched bool)
 
 // scalarFieldAccessor describes how to read/write one of the simple scalar
 // "set-if-empty" fields handled by applyField. The pattern is identical for
@@ -712,7 +579,7 @@ var scalarFieldAccessors = map[string]scalarFieldAccessor{
 // when meta has data and result is still empty. matched is true only when the
 // populate condition held, mirroring the original switch arms which only took
 // the early-return when both sides were ready.
-func applyScalarField(result *FetchResult, field string, pr *providerResult, source ProviderName) (populated, matched bool) {
+func applyScalarField(result *FetchResult, field string, pr *ProviderResult, source ProviderName) (populated, matched bool) {
 	acc, ok := scalarFieldAccessors[field]
 	if !ok {
 		return false, false
@@ -730,7 +597,7 @@ func applyScalarField(result *FetchResult, field string, pr *providerResult, sou
 // still empty, skipping known junk strings via IsJunkBiography. matched is
 // true only when the populate condition held (matching the original switch
 // arm's early-return semantics).
-func applyBiography(result *FetchResult, _ string, pr *providerResult, source ProviderName) (populated, matched bool) {
+func applyBiography(result *FetchResult, _ string, pr *ProviderResult, source ProviderName) (populated, matched bool) {
 	meta := pr.meta
 	if meta.Biography == "" || result.Metadata.Biography != "" || IsJunkBiography(meta.Biography) {
 		return false, false
@@ -780,7 +647,7 @@ var tagSliceFieldAccessors = map[string]tagSliceFieldAccessor{
 // merge in this path. When the config is nil (no setting stored) or the
 // exclude list is empty with no cap, the filter is a no-op and output is
 // identical to the pre-filter result.
-func applyTagSliceField(result *FetchResult, field string, pr *providerResult, source ProviderName) (populated, matched bool) {
+func applyTagSliceField(result *FetchResult, field string, pr *ProviderResult, source ProviderName) (populated, matched bool) {
 	acc, ok := tagSliceFieldAccessors[field]
 	if !ok {
 		return false, false
@@ -811,7 +678,7 @@ func applyTagSliceField(result *FetchResult, field string, pr *providerResult, s
 // applyMembers copies the members list from meta when result has none. The
 // members field is first-write-wins (no merge across providers) because each
 // provider returns a complete band roster.
-func applyMembers(result *FetchResult, _ string, pr *providerResult, source ProviderName) (populated, matched bool) {
+func applyMembers(result *FetchResult, _ string, pr *ProviderResult, source ProviderName) (populated, matched bool) {
 	meta := pr.meta
 	if len(meta.Members) == 0 || len(result.Metadata.Members) != 0 {
 		return false, false
@@ -825,7 +692,7 @@ func applyMembers(result *FetchResult, _ string, pr *providerResult, source Prov
 // non-individual type (group, orchestra, choir) also clears any previously
 // applied gender value and its provenance, mirroring the scraper-executor
 // normalization path.
-func applyType(result *FetchResult, _ string, pr *providerResult, source ProviderName) (populated, matched bool) {
+func applyType(result *FetchResult, _ string, pr *ProviderResult, source ProviderName) (populated, matched bool) {
 	meta := pr.meta
 	if meta.Type == "" || result.Metadata.Type != "" {
 		return false, false
@@ -842,7 +709,7 @@ func applyType(result *FetchResult, _ string, pr *providerResult, source Provide
 // applyGender copies gender from meta when result has none AND the accumulated
 // type either is empty (unknown) or refers to an individual.
 // Group/orchestra/choir types do not carry gender.
-func applyGender(result *FetchResult, _ string, pr *providerResult, source ProviderName) (populated, matched bool) {
+func applyGender(result *FetchResult, _ string, pr *ProviderResult, source ProviderName) (populated, matched bool) {
 	meta := pr.meta
 	if meta.Gender == "" || result.Metadata.Gender != "" {
 		return false, false
@@ -860,7 +727,7 @@ func applyGender(result *FetchResult, _ string, pr *providerResult, source Provi
 // the field source is recorded only for the first contributor so
 // MetadataSources reflects the highest-priority provider. matched mirrors the
 // original switch arm: only true when at least one matching image was found.
-func applyImageField(result *FetchResult, field string, pr *providerResult, source ProviderName) (populated, matched bool) {
+func applyImageField(result *FetchResult, field string, pr *ProviderResult, source ProviderName) (populated, matched bool) {
 	imgType := fieldToImageType(field)
 	found := false
 	for _, img := range pr.images {
@@ -895,7 +762,7 @@ var fieldAppliers = map[string]fieldApplier{
 // dispatchFieldApplier routes the field to its specific applier or to the
 // scalar / tag-slice generic helpers. Unknown fields return matched=false so
 // the caller falls through to the provider-ID merge tail.
-func dispatchFieldApplier(result *FetchResult, field string, pr *providerResult, source ProviderName) (populated, matched bool) {
+func dispatchFieldApplier(result *FetchResult, field string, pr *ProviderResult, source ProviderName) (populated, matched bool) {
 	if fn, ok := fieldAppliers[field]; ok {
 		return fn(result, field, pr, source)
 	}
@@ -979,7 +846,7 @@ func mergeProviderIDsAndExtras(result *FetchResult, meta *ArtistMetadata) {
 // canonical name, URLs, and aliases from meta into result. This preserves
 // the pre-refactor early-return / fall-through behavior exactly: a
 // successful field-specific apply does NOT trigger the ID/URL/alias merge.
-func applyField(result *FetchResult, field string, pr *providerResult, source ProviderName) bool {
+func applyField(result *FetchResult, field string, pr *ProviderResult, source ProviderName) bool {
 	if pr.meta == nil {
 		return false
 	}
@@ -1042,7 +909,7 @@ func (o *Orchestrator) FetchFieldFromProviders(ctx context.Context, mbid, name, 
 	}
 
 	var mu sync.Mutex
-	cache := make(map[ProviderName]*providerResult)
+	cache := make(map[ProviderName]*ProviderResult)
 	var results []FieldProviderResult
 
 	for _, provName := range providers {

--- a/internal/provider/orchestrator_test.go
+++ b/internal/provider/orchestrator_test.go
@@ -237,7 +237,7 @@ func TestFetchMetadata_MBNameAuthoritative_EmptyDoesNotClobber(t *testing.T) {
 
 // TestFetchMetadata_MBNameAuthoritative_MBErrorDoesNotClobber verifies the
 // override respects provider errors: when MB returns an error (timeout, 5xx,
-// unreachable), its cached providerResult has err != nil and the override
+// unreachable), its cached ProviderResult has err != nil and the override
 // must short-circuit, preserving a Name set by another provider. Without
 // this guard a transient MB outage would erase the artist's Name on every
 // affected refresh.
@@ -1482,7 +1482,7 @@ func TestApplyFieldDetailFields(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.field, func(t *testing.T) {
 			result := &FetchResult{Metadata: &ArtistMetadata{URLs: make(map[string]string)}}
-			pr := &providerResult{meta: &tc.meta}
+			pr := &ProviderResult{meta: &tc.meta}
 			if !applyField(result, tc.field, pr, NameMusicBrainz) {
 				t.Fatalf("applyField(%s) = false, want true", tc.field)
 			}
@@ -1494,7 +1494,7 @@ func TestApplyFieldDetailFields(t *testing.T) {
 				t.Errorf("applyField(%s) source = %v, want provider %s", tc.field, src, NameMusicBrainz)
 			}
 			// Second provider must not overwrite the first-match-wins value.
-			pr2 := &providerResult{meta: &ArtistMetadata{
+			pr2 := &ProviderResult{meta: &ArtistMetadata{
 				Gender: "Female", Type: "solo", YearsActive: "1999", Born: "x",
 				Died: "y", Disbanded: "z", Origin: "Canada",
 			}}
@@ -1517,7 +1517,7 @@ func TestApplyFieldGenderClearedOnNonIndividualType(t *testing.T) {
 	result := &FetchResult{Metadata: &ArtistMetadata{URLs: make(map[string]string)}}
 
 	// First apply gender from one provider.
-	prGender := &providerResult{meta: &ArtistMetadata{Gender: "Female"}}
+	prGender := &ProviderResult{meta: &ArtistMetadata{Gender: "Female"}}
 	if !applyField(result, "gender", prGender, NameMusicBrainz) {
 		t.Fatalf("applyField(gender) = false, want true")
 	}
@@ -1529,7 +1529,7 @@ func TestApplyFieldGenderClearedOnNonIndividualType(t *testing.T) {
 	}
 
 	// Now apply a non-individual type; gender and its provenance must clear.
-	prType := &providerResult{meta: &ArtistMetadata{Type: "group"}}
+	prType := &ProviderResult{meta: &ArtistMetadata{Type: "group"}}
 	if !applyField(result, "type", prType, NameWikidata) {
 		t.Fatalf("applyField(type) = false, want true")
 	}
@@ -1552,7 +1552,7 @@ func TestApplyFieldGenderRejectedWhenTypeNonIndividual(t *testing.T) {
 		Metadata: &ArtistMetadata{Type: "group", URLs: make(map[string]string)},
 		Sources:  []FieldSource{{Field: "type", Provider: NameMusicBrainz}},
 	}
-	pr := &providerResult{meta: &ArtistMetadata{Gender: "Male"}}
+	pr := &ProviderResult{meta: &ArtistMetadata{Gender: "Male"}}
 	if applyField(result, "gender", pr, NameWikidata) {
 		t.Errorf("applyField(gender) = true with non-individual type, want false")
 	}
@@ -1575,8 +1575,8 @@ func TestApplyFieldGenderPreservedForIndividualTypes(t *testing.T) {
 	for _, typ := range []string{"solo", "person", "character"} {
 		t.Run("gender_first_type="+typ, func(t *testing.T) {
 			result := &FetchResult{Metadata: &ArtistMetadata{URLs: make(map[string]string)}}
-			applyField(result, "gender", &providerResult{meta: &ArtistMetadata{Gender: "Female"}}, NameMusicBrainz)
-			applyField(result, "type", &providerResult{meta: &ArtistMetadata{Type: typ}}, NameWikidata)
+			applyField(result, "gender", &ProviderResult{meta: &ArtistMetadata{Gender: "Female"}}, NameMusicBrainz)
+			applyField(result, "type", &ProviderResult{meta: &ArtistMetadata{Type: typ}}, NameWikidata)
 			if result.Metadata.Gender != "Female" {
 				t.Errorf("Gender = %q, want Female (type %q must preserve gender)", result.Metadata.Gender, typ)
 			}
@@ -1589,7 +1589,7 @@ func TestApplyFieldGenderPreservedForIndividualTypes(t *testing.T) {
 				Metadata: &ArtistMetadata{Type: typ, URLs: make(map[string]string)},
 				Sources:  []FieldSource{{Field: "type", Provider: NameMusicBrainz}},
 			}
-			if !applyField(result, "gender", &providerResult{meta: &ArtistMetadata{Gender: "Male"}}, NameWikidata) {
+			if !applyField(result, "gender", &ProviderResult{meta: &ArtistMetadata{Gender: "Male"}}, NameWikidata) {
 				t.Errorf("applyField(gender) = false for individual type %q, want true", typ)
 			}
 			if result.Metadata.Gender != "Male" {
@@ -1606,7 +1606,7 @@ func TestApplyFieldImageTypeFilter(t *testing.T) {
 		Metadata: &ArtistMetadata{URLs: make(map[string]string)},
 	}
 	// Provider has fanart images but no thumb images.
-	pr := &providerResult{
+	pr := &ProviderResult{
 		meta: &ArtistMetadata{Name: "Test"},
 		images: []ImageResult{
 			{URL: "http://example.com/fanart1.jpg", Type: ImageFanart, Source: "test"},
@@ -3320,7 +3320,7 @@ func TestAIMDOrdinaryErrorDoesNotTriggerRecordFailure(t *testing.T) {
 		t.Fatalf("SetAPIKey: %v", err)
 	}
 
-	cache := make(map[ProviderName]*providerResult)
+	cache := make(map[ProviderName]*ProviderResult)
 	var mu sync.Mutex
 	_ = orch.getProviderResult(context.Background(), prov, "mbid-test", "Artist Name", nil, cache, &mu)
 
@@ -3355,7 +3355,7 @@ func TestAIMDRateLimitErrorTriggerRecordFailure(t *testing.T) {
 		},
 	})
 
-	cache := make(map[ProviderName]*providerResult)
+	cache := make(map[ProviderName]*ProviderResult)
 	var mu sync.Mutex
 	_ = orch.getProviderResult(context.Background(), prov, "mbid-test", "Artist Name", nil, cache, &mu)
 
@@ -3385,7 +3385,7 @@ func TestAIMDSingleSignalPerProviderCall(t *testing.T) {
 	})
 
 	// Drive one full getProviderResult call.
-	cache := make(map[ProviderName]*providerResult)
+	cache := make(map[ProviderName]*ProviderResult)
 	var mu sync.Mutex
 	_ = orch.getProviderResult(context.Background(), prov, "mbid-test", "Artist Name", nil, cache, &mu)
 
@@ -3545,7 +3545,7 @@ func TestApplyTagSliceField_VocabFilter(t *testing.T) {
 			Metadata:         &ArtistMetadata{},
 			MetadataVocabCfg: &tagdict.VocabConfig{Exclude: []string{"junk*"}},
 		}
-		pr := &providerResult{meta: &ArtistMetadata{Genres: []string{"Rock", "junk tag", "Pop"}}}
+		pr := &ProviderResult{meta: &ArtistMetadata{Genres: []string{"Rock", "junk tag", "Pop"}}}
 
 		applyTagSliceField(result, "genres", pr, NameMusicBrainz)
 
@@ -3564,7 +3564,7 @@ func TestApplyTagSliceField_VocabFilter(t *testing.T) {
 			Metadata:         &ArtistMetadata{},
 			MetadataVocabCfg: &tagdict.VocabConfig{MaxGenres: 2},
 		}
-		pr := &providerResult{meta: &ArtistMetadata{Genres: []string{"Rock", "Pop", "Jazz", "Blues"}}}
+		pr := &ProviderResult{meta: &ArtistMetadata{Genres: []string{"Rock", "Pop", "Jazz", "Blues"}}}
 
 		applyTagSliceField(result, "genres", pr, NameMusicBrainz)
 

--- a/internal/provider/provider_result.go
+++ b/internal/provider/provider_result.go
@@ -1,0 +1,168 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+// ProviderResult caches a single provider's API response for one artist lookup.
+// Fields are unexported; use the accessor methods from external packages.
+type ProviderResult struct {
+	meta            *ArtistMetadata
+	images          []ImageResult
+	err             error
+	imageErr        error // non-nil when GetImages returned a transient error (not ErrNotFound)
+	imagesAttempted bool  // true whenever GetImages was actually invoked, regardless of outcome
+}
+
+// Meta returns the artist metadata retrieved from this provider, or nil on error or not-found.
+func (pr *ProviderResult) Meta() *ArtistMetadata { return pr.meta }
+
+// Images returns the image results retrieved from this provider.
+func (pr *ProviderResult) Images() []ImageResult { return pr.images }
+
+// Err returns any transient error that prevented metadata retrieval.
+// A nil Err with a nil Meta means the provider definitively reported no data (ErrNotFound).
+func (pr *ProviderResult) Err() error { return pr.err }
+
+// ImageErr returns any transient error that prevented image retrieval.
+// A nil ImageErr with ImagesAttempted==true means ErrNotFound (no images exist).
+func (pr *ProviderResult) ImageErr() error { return pr.imageErr }
+
+// ImagesAttempted reports whether GetImages was invoked for this provider.
+// When false, image fields must not be cleared (no ID was available to query).
+func (pr *ProviderResult) ImagesAttempted() bool { return pr.imagesAttempted }
+
+// FetchProviderResult executes the per-provider lookup-precedence ladder
+// (provider-specific ID > MBID > artist name), retries GetArtist with the
+// artist name when the provider reports MBID not-found and implements
+// NameLookupProvider, and enforces the ErrNotFound-vs-transient distinction
+// for both GetArtist and GetImages so callers can clear stale data on a
+// definitive miss while preserving it on a transient failure.
+//
+// p must be non-nil. aimd may be nil; when nil, AIMD signals are skipped.
+// Cache management and registry lookup are the caller's responsibility.
+func FetchProviderResult(
+	ctx context.Context,
+	p Provider,
+	name ProviderName,
+	mbid, artistName string,
+	providerIDs map[ProviderName]string,
+	logger *slog.Logger,
+	aimd *AIMDController,
+) *ProviderResult {
+	pr := &ProviderResult{}
+
+	var aimdRateLimitErr error
+	aimdGotResult := false
+
+	usedProviderID := false
+	id := mbid
+	if pid, ok := providerIDs[name]; ok && pid != "" {
+		id = pid
+		usedProviderID = true
+	} else if id == "" {
+		id = artistName
+	}
+
+	if id != "" {
+		meta, queryID, err := fetchArtist(ctx, p, name, id, mbid, artistName, usedProviderID, logger)
+		if err != nil {
+			var notFound *ErrNotFound
+			if errors.As(err, &notFound) {
+				logger.Debug("provider has no data for artist",
+					slog.String("provider", string(name)),
+					slog.String("id", queryID))
+			} else {
+				logger.Debug("provider GetArtist failed",
+					slog.String("provider", string(name)),
+					slog.String("error", ScrubError(err)),
+					retryAfterAttr(err))
+				pr.err = err
+				if IsRateLimitError(err) && aimdRateLimitErr == nil {
+					aimdRateLimitErr = err
+				}
+			}
+		} else {
+			pr.meta = meta
+			aimdGotResult = true
+		}
+	}
+
+	imgID := mbid
+	if pid, ok := providerIDs[name]; ok && pid != "" {
+		imgID = pid
+	}
+	if imgID != "" {
+		images, err := p.GetImages(ctx, imgID)
+		pr.imagesAttempted = true
+		if err != nil {
+			var notFound *ErrNotFound
+			if errors.As(err, &notFound) {
+				logger.Debug("provider has no images for artist",
+					slog.String("provider", string(name)),
+					slog.String("id", imgID))
+			} else {
+				logger.Warn("provider GetImages failed, preserving existing image data",
+					slog.String("provider", string(name)),
+					slog.String("error", ScrubError(err)),
+					retryAfterAttr(err))
+				pr.imageErr = err
+				if IsRateLimitError(err) && aimdRateLimitErr == nil {
+					aimdRateLimitErr = err
+				}
+			}
+		} else {
+			pr.images = images
+			aimdGotResult = true
+		}
+	}
+
+	emitAIMDSignal(aimd, name, aimdRateLimitErr, aimdGotResult)
+	return pr
+}
+
+// fetchArtist calls p.GetArtist(id) and, when the provider returns ErrNotFound
+// for an MBID-based lookup and supports name lookups, retries with artistName.
+// It returns the metadata, the query ID that produced the final result (used
+// only for logging), and the final error.
+func fetchArtist(
+	ctx context.Context,
+	p Provider,
+	name ProviderName,
+	id, mbid, artistName string,
+	usedProviderID bool,
+	logger *slog.Logger,
+) (meta *ArtistMetadata, queryID string, err error) {
+	queryID = id
+	meta, err = p.GetArtist(ctx, id)
+	if err != nil && !usedProviderID && mbid != "" && artistName != "" {
+		var notFound *ErrNotFound
+		if errors.As(err, &notFound) {
+			if nlp, ok := p.(NameLookupProvider); ok && nlp.SupportsNameLookup() {
+				logger.Debug("retrying with artist name after MBID not-found",
+					slog.String("provider", string(name)),
+					slog.String("name", artistName))
+				queryID = artistName
+				meta, err = p.GetArtist(ctx, artistName)
+			}
+		}
+	}
+	return meta, queryID, err
+}
+
+// emitAIMDSignal fires exactly one AIMD signal per provider call:
+// RecordFailure when a rate-limit error was seen, RecordSuccess when at least
+// one sub-call returned a useful result and no rate-limit error was recorded.
+// Ordinary errors (ErrNotFound, auth, context cancel) produce no signal.
+func emitAIMDSignal(aimd *AIMDController, name ProviderName, rateLimitErr error, gotResult bool) {
+	if aimd == nil {
+		return
+	}
+	if rateLimitErr != nil {
+		aimd.RecordFailure(name, RetryAfterDuration(rateLimitErr))
+	} else if gotResult {
+		aimd.RecordSuccess(name)
+	}
+}

--- a/internal/scraper/executor.go
+++ b/internal/scraper/executor.go
@@ -2,7 +2,6 @@ package scraper
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -344,8 +343,8 @@ type providerResult struct {
 }
 
 // getProviderResult fetches and caches results from a single provider.
-//
-//nolint:gocognit // Same per-provider lookup-precedence ladder and ErrNotFound-vs-transient distinction as provider.Orchestrator.getProviderResult (cog 34 each); kept as a near-duplicate so the scraper-aware path stays decoupled from the legacy orchestrator path during the executor migration. The consolidation belongs with the orchestrator twin; refactor tracked in #1554.
+// Cache check and registry lookup happen here; the per-provider fetch logic
+// is shared with the orchestrator via provider.FetchProviderResult.
 func (e *Executor) getProviderResult(
 	ctx context.Context,
 	name provider.ProviderName,
@@ -370,130 +369,14 @@ func (e *Executor) getProviderResult(
 		return pr
 	}
 
-	pr := &providerResult{}
-
-	// aimdRateLimitErr records the first rate-limit / provider-unavailable error
-	// encountered across both GetArtist and GetImages within this single provider
-	// call. It is used to emit exactly ONE AIMD signal at the end of the function:
-	// RecordFailure if a rate-limit error was seen, RecordSuccess if results were
-	// returned without a rate-limit error. Ordinary errors (ErrNotFound, auth/401,
-	// JSON parse, context cancellation) are not AIMD signals.
-	var aimdRateLimitErr error
-	// aimdGotResult is true when at least one of GetArtist or GetImages returned
-	// a useful (non-error) result. Used to decide whether RecordSuccess is warranted.
-	aimdGotResult := false
-
-	// Lookup precedence: provider-specific ID > MBID > artist name.
-	usedProviderID := false
-	id := mbid
-	if pid, ok := providerIDs[name]; ok && pid != "" {
-		id = pid
-		usedProviderID = true
-	} else if id == "" {
-		id = artistName
+	fetched := provider.FetchProviderResult(ctx, p, name, mbid, artistName, providerIDs, e.logger, e.aimd)
+	pr := &providerResult{
+		meta:            fetched.Meta(),
+		images:          fetched.Images(),
+		err:             fetched.Err(),
+		imageErr:        fetched.ImageErr(),
+		imagesAttempted: fetched.ImagesAttempted(),
 	}
-
-	// queryID tracks the identifier actually passed to the most recent
-	// GetArtist call. It may differ from id after a name-based retry.
-	queryID := id
-
-	if id != "" {
-		meta, err := p.GetArtist(ctx, id)
-		// If we used an MBID (not a provider-specific ID) and the provider
-		// returned not-found, retry with the artist name -- but only for
-		// providers that support name lookups (e.g. Genius, Last.fm).
-		if err != nil && !usedProviderID && mbid != "" && artistName != "" {
-			var notFound *provider.ErrNotFound
-			if errors.As(err, &notFound) {
-				if nlp, ok := p.(provider.NameLookupProvider); ok && nlp.SupportsNameLookup() {
-					e.logger.Debug("retrying with artist name after MBID not-found",
-						slog.String("provider", string(name)),
-						slog.String("name", artistName))
-					queryID = artistName
-					meta, err = p.GetArtist(ctx, artistName)
-				}
-			}
-		}
-		if err != nil {
-			// ErrNotFound means the provider was reached and definitively said
-			// "no data". Treat this as a successful query (no error) so the
-			// field is marked as attempted and stale data can be cleared.
-			// Transient failures (timeouts, 5xx) remain as real errors.
-			var notFound *provider.ErrNotFound
-			if errors.As(err, &notFound) {
-				e.logger.Debug("provider has no data for artist",
-					slog.String("provider", string(name)),
-					slog.String("id", queryID))
-			} else {
-				e.logger.Debug("provider GetArtist failed",
-					slog.String("provider", string(name)),
-					slog.String("error", err.Error()))
-				pr.err = err
-				// Record the first rate-limit error for the composite AIMD signal.
-				if provider.IsRateLimitError(err) && aimdRateLimitErr == nil {
-					aimdRateLimitErr = err
-				}
-			}
-		} else {
-			pr.meta = meta
-			aimdGotResult = true
-		}
-	}
-
-	// Fetch images using the same precedence: provider ID > MBID.
-	imgID := mbid
-	if pid, ok := providerIDs[name]; ok && pid != "" {
-		imgID = pid
-	}
-	if imgID != "" {
-		images, err := p.GetImages(ctx, imgID)
-		// Mark that GetImages was actually invoked regardless of outcome.
-		// This distinguishes "GetImages was called and returned ErrNotFound"
-		// (imagesAttempted=true, imageErr=nil) from "GetImages was never called
-		// because no ID was available" (imagesAttempted=false).
-		pr.imagesAttempted = true
-		if err != nil {
-			var notFound *provider.ErrNotFound
-			if errors.As(err, &notFound) {
-				e.logger.Debug("provider has no images for artist",
-					slog.String("provider", string(name)),
-					slog.String("id", imgID))
-				// ErrNotFound means the provider was reached and definitively said
-				// "no images". Leave imageErr nil so image fields are marked as
-				// attempted and stale image data can be cleared.
-			} else {
-				e.logger.Warn("provider GetImages failed, preserving existing image data",
-					slog.String("provider", string(name)),
-					slog.String("error", provider.ScrubError(err)))
-				// Transient failure: store in imageErr so image fields are NOT
-				// marked as attempted. This prevents clearing existing image data
-				// when the provider was merely unreachable.
-				pr.imageErr = err
-				// Record the first rate-limit error for the composite AIMD signal.
-				if provider.IsRateLimitError(err) && aimdRateLimitErr == nil {
-					aimdRateLimitErr = err
-				}
-			}
-		} else {
-			pr.images = images
-			aimdGotResult = true
-		}
-	}
-
-	// Emit exactly ONE AIMD signal per provider call:
-	//   - RecordFailure when a rate-limit / provider-unavailable error was seen.
-	//   - RecordSuccess when at least one sub-call (GetArtist or GetImages)
-	//     returned a useful result and no rate-limit error was recorded.
-	// Ordinary errors (ErrNotFound, auth, JSON parse, context cancel) are NOT
-	// AIMD signals and neither case fires for them.
-	if e.aimd != nil {
-		if aimdRateLimitErr != nil {
-			e.aimd.RecordFailure(name, provider.RetryAfterDuration(aimdRateLimitErr))
-		} else if aimdGotResult {
-			e.aimd.RecordSuccess(name)
-		}
-	}
-
 	mu.Lock()
 	cache[name] = pr
 	mu.Unlock()


### PR DESCRIPTION
## Summary

Consolidate the two near-duplicate `getProviderResult` functions (`(*Orchestrator).getProviderResult` in `internal/provider/orchestrator.go` and `(*Executor).getProviderResult` in `internal/scraper/executor.go`, both cog 34) into a single shared helper, eliminating an architectural-smell duplicate carried forward from the scraper migration.

- New shared `FetchProviderResult(...)` (+ a small `ProviderResult` accessor type) in `internal/provider/provider_result.go`, consumed by both call sites. No import cycle (scraper already depends on provider; provider does not depend on scraper).
- Both `//nolint:gocognit` directives on the old functions are removed; neither site trips gocognit at threshold 30.
- Net **-82 LOC** (210 insertions / 292 deletions across 4 files).

**Behavior preserved:** the per-provider lookup-precedence ladder (provider ID > MBID > name, with name-based retry only on MBID-not-found for `NameLookupProvider`s) is unchanged, and the **ErrNotFound-vs-transient distinction is kept intact** -- a definitive miss (`ErrNotFound`) clears stale data, a transient failure preserves it. Callers still branch on this; the two error classes are not collapsed.

## Linked issue

Closes #1554. Sub-issue of the #1540 gocognit refactor parent (M55.5 Dead Code Hunt).

## Pre-flight checklist
- [x] Pre-push gate green locally (via the pre-push hook on push).
- [x] Behavior-preserving refactor; public API unchanged.
- [x] Single squashed commit.
- [x] Label set.
- [x] Docs label decision: `docs: not-required` (internal refactor, no user-visible behavioral change).
- [ ] Screenshot: N/A (no UI change).
- [ ] UAT: N/A (internal refactor; covered by the existing provider + scraper suites).
- [x] OpenAPI: N/A (no request/response change).
- [x] `templ generate`: N/A (no `.templ` change).

## Test plan
- [x] `go test ./internal/provider/... ./internal/scraper/...` passes (no test deletions or weakened assertions).
- [x] `go test -race` clean on the affected packages.
- [x] `golangci-lint run ./internal/provider/... ./internal/scraper/...` -> 0 issues; both `//nolint:gocognit` directives removed and lint passes without them.
- [x] Patch coverage 92.86% (provider_result.go 91.2%, both call sites 100%) -- above the 75% floor.
- [x] `go build ./... && go vet ./...` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artist metadata and image fetching reliability across providers.
  * Better fallback behavior when a provider-specific lookup is unavailable, helping results populate more consistently.
  * Reduced duplicate fetch failures and preserved existing image data when only image retrieval is temporarily interrupted.
  * More consistent result handling should make field updates and comparison views behave more predictably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->