### PR TITLE
refactor(rule): reduce RunAllScoped cognitive complexity

### DIFF
--- a/internal/rule/fixer.go
+++ b/internal/rule/fixer.go
@@ -719,6 +719,32 @@ func (acc *runForArtistAccum) mergeOutcome(out violationOutcome, result *RunResu
 	}
 }
 
+// mergeIntoContrib folds one violation's delta into acc and contrib for
+// the RunAllScoped pass path, where per-artist results accumulate into an
+// artistContribution (merged under a mutex by the walker) rather than
+// directly into a *RunResult.
+func (acc *runForArtistAccum) mergeIntoContrib(out violationOutcome, contrib *artistContribution) {
+	if out.fr != nil {
+		contrib.results = append(contrib.results, *out.fr)
+		contrib.fixesAttempted++
+	}
+	if out.persistFailed {
+		acc.persistOK = false
+	}
+	if out.fixed {
+		contrib.fixesSucceeded++
+		acc.artistDirty = true
+		if out.imageFix {
+			acc.fixedImageTypes = append(acc.fixedImageTypes, out.imageType)
+		} else {
+			acc.metadataFixed = true
+		}
+	}
+	if out.resolvedRow != nil {
+		acc.resolvedRows = append(acc.resolvedRows, out.resolvedRow)
+	}
+}
+
 // runForArtistFiltered is the shared body of RunForArtist and
 // RunImageRulesForArtist. An empty categoryFilter runs every violation; a
 // non-empty value runs only violations whose Category matches exactly.
@@ -1077,6 +1103,74 @@ func (p *Pipeline) allowedRulesForCategory(ctx context.Context, a *artist.Artist
 	return allowedIDs, true
 }
 
+// processArtistForRunAll is the per-artist work unit for RunAllScoped.
+// It evaluates the artist, dispatches every violation through the
+// automation-mode strategies (reusing processManualViolation /
+// processAutoFixViolation, the same helpers runForArtistFiltered uses),
+// then finalizes health (#699), deferred resolved rows (#983), pass rows,
+// and platform publishing. The returned artistContribution is merged into
+// the shared RunResult by walkArtistsWithMark under a mutex, keeping this
+// hot path lock-free. rules_evaluated_at is NOT stamped here;
+// walkArtistsWithMark owns that step so the timestamp aligns with the
+// per-iteration startedAt captured by iterateArtistsByScope.
+func (p *Pipeline) processArtistForRunAll(ctx context.Context, a *artist.Artist) (artistContribution, bool) {
+	var contrib artistContribution
+	acc := &runForArtistAccum{persistOK: true}
+	// startedAt captured pre-Evaluate so every rule_results row written
+	// during this pass shares a timestamp (issue #699).
+	startedAt := time.Now().UTC()
+
+	// Issue #1133: per-artist EvaluationContext for fetch coalescing.
+	// Shadows the outer ctx so every downstream call inside this method
+	// inherits the coalescer without a rename.
+	ctx, counters := p.withEvalContext(ctx, a)
+	defer p.logEvalCounters(a, counters)
+
+	eval, err := p.engine.Evaluate(ctx, a)
+	if err != nil {
+		p.logger.Warn("evaluating artist", "artist", a.Name, "error", err)
+		return contrib, false
+	}
+
+	for j := range eval.Violations {
+		v := &eval.Violations[j]
+		contrib.violationsFound++
+		// getCachedRule is pipeline-level and RWMutex-guarded, safe for
+		// concurrent artist workers (issue #1730).
+		r, lookupErr := p.getCachedRule(ctx, v.RuleID)
+		if lookupErr != nil {
+			p.logger.Warn("fetching rule for violation", "rule_id", v.RuleID, "artist", a.Name, "error", lookupErr)
+			acc.persistOK = false
+			continue
+		}
+		acc.mergeIntoContrib(p.dispatchViolation(ctx, a, v, r), &contrib)
+	}
+
+	// Issue #699: derive pass/fail from the POST-fix evaluation so rules
+	// repaired during this pass are recorded as passed=1 in the same run.
+	postEval, persistOKHealth := p.updateHealthScore(ctx, a, acc.artistDirty)
+	if !persistOKHealth {
+		acc.persistOK = false
+	}
+	// Issue #983: only resolve violations once the artist row persisted
+	// cleanly. A failed Update leaves the mutation in memory; marking the
+	// violation resolved anyway would silently drop the fix.
+	if persistOKHealth && !p.finalizeResolvedRows(ctx, a, acc.resolvedRows) {
+		acc.persistOK = false
+	}
+	if postEval != nil {
+		postViolated := make(map[string]struct{}, len(postEval.Violations))
+		for j := range postEval.Violations {
+			postViolated[postEval.Violations[j].RuleID] = struct{}{}
+		}
+		if !p.persistPassResults(ctx, a, postEval.RulesConsidered, postViolated, startedAt, nil) {
+			acc.persistOK = false
+		}
+	}
+	p.publishAccumulated(ctx, a, acc.metadataFixed, acc.fixedImageTypes)
+	return contrib, acc.persistOK
+}
+
 // RunAll evaluates all enabled rules against eligible artists and attempts
 // fixes. Defaults to incremental scope -- only artists flagged as dirty are
 // processed. Use RunAllScoped(ctx, RunScopeAll) for a forced full sweep.
@@ -1088,8 +1182,6 @@ func (p *Pipeline) RunAll(ctx context.Context) (*RunResult, error) {
 // by scope (incremental or all). The result reports both the number of
 // artists processed and the total eligible count so progress UIs can show
 // "evaluating 12 of 800 (788 unchanged)".
-//
-//nolint:gocognit // Full-sweep pipeline (cog 77): rule registry walk, per-rule artist iteration with scope-aware source, evaluate-fix-persist + #983 deferred resolved-status writes, automation-mode dispatch, per-rule and global counters; the rule-major iteration order is required so that all violations of a given rule see a coherent before/after view of the artist within a single pipeline pass. Refactor tracked in #1542.
 func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult, error) {
 	result := &RunResult{Scope: scope.String()}
 	// passStart drives the pass_wall_clock_ms telemetry emitted at the end so
@@ -1106,8 +1198,8 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 	// Issue #1134 (M54 W3): pass-scoped provider-fetch cache. Construct a
 	// PassContext for the lifetime of this RunAllScoped invocation and
 	// plumb it onto the context so every per-artist EvaluationContext built
-	// inside processArtist finds it via passContextFromContext. When an
-	// artist is re-evaluated later in the same pass (e.g. dirtied by a
+	// inside processArtistForRunAll finds it via passContextFromContext. When
+	// an artist is re-evaluated later in the same pass (e.g. dirtied by a
 	// prior fix), its new EvaluationContext will find the cached provider
 	// payload in the PassContext instead of issuing a fresh network call.
 	// The PassContext falls out of scope when this function returns; there
@@ -1127,207 +1219,7 @@ func (p *Pipeline) RunAllScoped(ctx context.Context, scope RunScope) (*RunResult
 	}
 
 	processArtist := func(a *artist.Artist) (artistContribution, bool) {
-		// contrib accumulates this artist's counters/results locally instead
-		// of mutating the shared run-level result, so walkArtistsWithMark
-		// can run artists concurrently and merge under a mutex. Issue #1730.
-		var contrib artistContribution
-		var perArtistMetadata bool
-		var perArtistImages []string
-		var perArtistDirty bool
-		// resolvedRows collects violation upserts that should land with
-		// Status=ViolationStatusResolved. Issue #983: deferred until
-		// AFTER updateHealthScore persists the mutated artist so a
-		// failed artist Update does not silently mark the violation
-		// resolved while the actual fix never reached the DB.
-		var resolvedRows []*RuleViolation
-		// See RunRuleScoped's processArtist: persistOK gates the
-		// rules_evaluated_at stamp so a transient DB failure keeps the
-		// artist in the dirty set for retry instead of masking dropped
-		// violations until the next mutation.
-		persistOK := true
-		// startedAt captured pre-Evaluate so every rule_results pass row
-		// written during this pass shares a timestamp (issue #699).
-		startedAt := time.Now().UTC()
-
-		// Issue #1133: per-artist EvaluationContext for fetch coalescing.
-		// Shadows the outer ctx so every downstream call inside this
-		// closure inherits the coalescer without an artistCtx rename.
-		ctx, counters := p.withEvalContext(ctx, a)
-		defer p.logEvalCounters(a, counters)
-
-		eval, err := p.engine.Evaluate(ctx, a)
-		if err != nil {
-			p.logger.Warn("evaluating artist", "artist", a.Name, "error", err)
-			return contrib, false
-		}
-
-		for j := range eval.Violations {
-			v := &eval.Violations[j]
-			contrib.violationsFound++
-
-			// Look up rule to determine automation mode. getCachedRule uses
-			// the pipeline-level ruleCache (RWMutex-guarded), so it is safe
-			// to share across concurrent artist workers. Issue #1730.
-			r, lookupErr := p.getCachedRule(ctx, v.RuleID)
-			if lookupErr != nil {
-				p.logger.Warn("fetching rule for violation", "rule_id", v.RuleID, "artist", a.Name, "error", lookupErr)
-				persistOK = false
-				continue
-			}
-
-			// Manual mode: discover candidates but never auto-apply.
-			// Only invoke fixers that support candidate discovery
-			// without side effects.
-			if r.AutomationMode == AutomationModeManual {
-				fixer := p.findFixer(v)
-				if !v.Fixable || fixer == nil || !supportsCandidateDiscovery(fixer) {
-					rv := &RuleViolation{
-						RuleID:     v.RuleID,
-						ArtistID:   a.ID,
-						ArtistName: a.Name,
-						Severity:   v.Severity,
-						Message:    v.Message,
-						Fixable:    v.Fixable && fixer != nil,
-						Status:     ViolationStatusOpen,
-					}
-					if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
-						p.logger.Warn("persisting manual-mode violation", "rule_id", v.RuleID, "artist", a.Name, "error", err)
-						persistOK = false
-					}
-					continue
-				}
-
-				v.Config.DiscoveryOnly = true
-				fr := p.attemptFix(ctx, a, v)
-				contrib.results = append(contrib.results, *fr)
-				contrib.fixesAttempted++
-
-				status := ViolationStatusOpen
-				if len(fr.Candidates) > 0 {
-					status = ViolationStatusPendingChoice
-				}
-
-				rv := &RuleViolation{
-					RuleID:     v.RuleID,
-					ArtistID:   a.ID,
-					ArtistName: a.Name,
-					Severity:   v.Severity,
-					Message:    v.Message,
-					Fixable:    true,
-					Status:     status,
-					Candidates: fr.Candidates,
-				}
-				if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
-					p.logger.Warn("persisting manual-mode violation", "rule_id", v.RuleID, "artist", a.Name, "error", err)
-					persistOK = false
-				}
-				continue
-			}
-
-			// Auto mode (default): persist unfixable as open, attempt fix for fixable
-			if !v.Fixable {
-				rv := &RuleViolation{
-					RuleID:     v.RuleID,
-					ArtistID:   a.ID,
-					ArtistName: a.Name,
-					Severity:   v.Severity,
-					Message:    v.Message,
-					Fixable:    false,
-					Status:     ViolationStatusOpen,
-				}
-				if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
-					p.logger.Warn("persisting unfixable violation", "rule_id", v.RuleID, "artist", a.Name, "error", err)
-					persistOK = false
-				}
-				continue
-			}
-
-			fr := p.attemptFix(ctx, a, v)
-			contrib.results = append(contrib.results, *fr)
-			contrib.fixesAttempted++
-
-			// Issue #983: defer the resolved upsert until AFTER
-			// updateHealthScore persists the mutated artist. See the
-			// matching comment in RunRuleScoped.processArtist.
-			if fr.Fixed {
-				contrib.fixesSucceeded++
-				perArtistDirty = true
-				if fr.ImageType != "" {
-					perArtistImages = append(perArtistImages, fr.ImageType)
-				} else {
-					perArtistMetadata = true
-				}
-				// Issue #1106: emit a Recent Activity entry. See the
-				// matching comment + helper docstring in
-				// RunRuleScoped.processArtist.
-				p.recordRuleFixHistory(ctx, a.ID, fr)
-				resolvedRows = append(resolvedRows, &RuleViolation{
-					RuleID:     v.RuleID,
-					ArtistID:   a.ID,
-					ArtistName: a.Name,
-					Severity:   v.Severity,
-					Message:    v.Message,
-					Fixable:    true,
-					Candidates: fr.Candidates,
-				})
-				continue
-			}
-
-			status := ViolationStatusOpen
-			if len(fr.Candidates) > 0 {
-				status = ViolationStatusPendingChoice
-			}
-			rv := &RuleViolation{
-				RuleID:     v.RuleID,
-				ArtistID:   a.ID,
-				ArtistName: a.Name,
-				Severity:   v.Severity,
-				Message:    v.Message,
-				Fixable:    true,
-				Status:     status,
-				Candidates: fr.Candidates,
-			}
-			if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
-				p.logger.Warn("persisting fix result violation", "rule_id", v.RuleID, "artist", a.Name, "error", err)
-				persistOK = false
-			}
-		}
-
-		// Issue #699 propagation fix: derive the pass/fail skip-set from
-		// the POST-fix evaluation returned by updateHealthScore so rules
-		// repaired during this pass are recorded as passed=1 in the same
-		// run. Using the pre-fix violation snapshot would suppress them
-		// until the next evaluation.
-		postEval, persistOKHealth := p.updateHealthScore(ctx, a, perArtistDirty)
-		if !persistOKHealth {
-			persistOK = false
-		}
-		// Issue #983: only resolve violations once the artist row
-		// persisted cleanly. A failed Update leaves the mutation in
-		// memory; marking the violation resolved anyway would silently
-		// drop the fix.
-		if persistOKHealth {
-			now := time.Now().UTC()
-			for _, rv := range resolvedRows {
-				rv.Status = ViolationStatusResolved
-				rv.ResolvedAt = &now
-				if err := p.ruleService.UpsertViolation(ctx, rv); err != nil {
-					p.logger.Warn("persisting resolved violation", "rule_id", rv.RuleID, "artist", a.Name, "error", err)
-					persistOK = false
-				}
-			}
-		}
-		if postEval != nil {
-			postViolated := make(map[string]struct{}, len(postEval.Violations))
-			for j := range postEval.Violations {
-				postViolated[postEval.Violations[j].RuleID] = struct{}{}
-			}
-			if !p.persistPassResults(ctx, a, postEval.RulesConsidered, postViolated, startedAt, nil) {
-				persistOK = false
-			}
-		}
-		p.publishAccumulated(ctx, a, perArtistMetadata, perArtistImages)
-		return contrib, persistOK
+		return p.processArtistForRunAll(ctx, a)
 	}
 
 	// RunAll covers every enabled rule, so it owns rules_evaluated_at:

--- a/internal/rule/fixer_runall_test.go
+++ b/internal/rule/fixer_runall_test.go
@@ -1,8 +1,88 @@
 package rule
 
 import (
+	"context"
 	"testing"
+
+	"github.com/sydlexius/stillwater/internal/artist"
 )
+
+// TestProcessArtistForRunAll_EvaluateError covers the early-return branch in
+// processArtistForRunAll where the engine's Evaluate fails. The integration
+// tests never inject an engine error, so this drives the unit directly: with a
+// cold rule cache, closing the DB forces cachedRules -> List to error, which
+// Evaluate propagates. The method must bail with (contrib{}, false) and zero
+// violations recorded.
+func TestProcessArtistForRunAll_EvaluateError(t *testing.T) {
+	db := setupTestDB(t)
+	artistSvc := artist.NewService(db)
+	ruleSvc := NewService(db)
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	p := NewPipeline(engine, artistSvc, ruleSvc, nil, nil, testLogger())
+
+	// Close before any Evaluate so the engine rule cache stays cold; the next
+	// cachedRules call hits the closed DB and errors.
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing db: %v", err)
+	}
+
+	a := &artist.Artist{Name: "Eval Err", Path: t.TempDir()}
+	contrib, persistOK := p.processArtistForRunAll(context.Background(), a)
+	if persistOK {
+		t.Error("persistOK = true; want false when Evaluate errors")
+	}
+	if contrib.violationsFound != 0 {
+		t.Errorf("violationsFound = %d; want 0 on the Evaluate-error early return", contrib.violationsFound)
+	}
+}
+
+// TestProcessArtistForRunAll_RuleLookupError covers the getCachedRule-error
+// branch inside the per-violation loop. Evaluate is warmed first (engine rule
+// cache populated, violations confirmed) so the post-close Evaluate still
+// succeeds from cache; closing the DB afterward makes the pipeline-level
+// getCachedRule -> GetByID error, driving acc.persistOK false via the continue
+// branch. The trailing persist steps (health, resolved rows, pass results) also
+// fail against the closed DB, reinforcing persistOK == false.
+func TestProcessArtistForRunAll_RuleLookupError(t *testing.T) {
+	db := setupTestDB(t)
+	artistSvc := artist.NewService(db)
+	ruleSvc := NewService(db)
+	engine := NewEngine(ruleSvc, db, nil, nil, testLogger())
+	p := NewPipeline(engine, artistSvc, ruleSvc, nil, nil, testLogger())
+
+	// Seed the default rules so Evaluate has enabled rules to check; a no-NFO
+	// artist reliably violates RuleNFOExists, a field-based rule that still
+	// fires after the DB is closed (the rule set comes from the warm cache).
+	if err := ruleSvc.SeedDefaults(context.Background()); err != nil {
+		t.Fatalf("seeding default rules: %v", err)
+	}
+	a := &artist.Artist{Name: "Lookup Err", SortName: "Lookup Err", NFOExists: false, Path: t.TempDir()}
+	if err := artistSvc.Create(context.Background(), a); err != nil {
+		t.Fatalf("creating artist: %v", err)
+	}
+
+	// Warm the engine rule cache and confirm the artist violates at least one
+	// rule, so the per-violation loop runs after the DB is closed.
+	eval, err := engine.Evaluate(context.Background(), a)
+	if err != nil {
+		t.Fatalf("warm-up Evaluate: %v", err)
+	}
+	if len(eval.Violations) == 0 {
+		t.Fatal("expected the bare artist to violate at least one rule")
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing db: %v", err)
+	}
+
+	contrib, persistOK := p.processArtistForRunAll(context.Background(), a)
+	if persistOK {
+		t.Error("persistOK = true; want false when getCachedRule errors")
+	}
+	if contrib.violationsFound == 0 {
+		t.Error("violationsFound = 0; want the warmed-cache Evaluate to still surface violations")
+	}
+}
 
 // TestMergeIntoContrib exercises every branch of the mergeIntoContrib helper,
 // which is the per-violation merge path used by processArtistForRunAll. The

--- a/internal/rule/fixer_runall_test.go
+++ b/internal/rule/fixer_runall_test.go
@@ -1,0 +1,64 @@
+package rule
+
+import (
+	"testing"
+)
+
+// TestMergeIntoContrib exercises every branch of the mergeIntoContrib helper,
+// which is the per-violation merge path used by processArtistForRunAll. The
+// imageFix and persistFailed branches cannot be reached by the integration
+// tests in fixer_parallel_test.go (they require a successful image fix or a
+// DB error in the upsert path respectively), so this unit test covers them
+// directly.
+func TestMergeIntoContrib(t *testing.T) {
+	t.Run("fr_nil_persistFailed", func(t *testing.T) {
+		acc := &runForArtistAccum{persistOK: true}
+		var contrib artistContribution
+		acc.mergeIntoContrib(violationOutcome{persistFailed: true}, &contrib)
+		if acc.persistOK {
+			t.Error("persistOK should be false after persistFailed outcome")
+		}
+		if contrib.fixesAttempted != 0 || contrib.fixesSucceeded != 0 {
+			t.Error("no fixer counters should increment for a nil-fr outcome")
+		}
+	})
+
+	t.Run("fixed_imageFix", func(t *testing.T) {
+		acc := &runForArtistAccum{persistOK: true}
+		var contrib artistContribution
+		fr := &FixResult{RuleID: "img_rule", Fixed: true, ImageType: "thumb"}
+		rv := &RuleViolation{RuleID: "img_rule"}
+		acc.mergeIntoContrib(violationOutcome{
+			fr: fr, fixed: true, imageFix: true, imageType: "thumb",
+			resolvedRow: rv,
+		}, &contrib)
+		if !acc.artistDirty {
+			t.Error("artistDirty should be set on a successful fix")
+		}
+		if len(acc.fixedImageTypes) != 1 || acc.fixedImageTypes[0] != "thumb" {
+			t.Errorf("fixedImageTypes = %v, want [thumb]", acc.fixedImageTypes)
+		}
+		if acc.metadataFixed {
+			t.Error("metadataFixed should not be set for an image fix")
+		}
+		if contrib.fixesSucceeded != 1 {
+			t.Errorf("fixesSucceeded = %d, want 1", contrib.fixesSucceeded)
+		}
+		if len(acc.resolvedRows) != 1 || acc.resolvedRows[0] != rv {
+			t.Error("resolvedRow should be stashed in acc.resolvedRows")
+		}
+	})
+
+	t.Run("fixed_metadata", func(t *testing.T) {
+		acc := &runForArtistAccum{persistOK: true}
+		var contrib artistContribution
+		fr := &FixResult{RuleID: "bio_rule", Fixed: true}
+		acc.mergeIntoContrib(violationOutcome{fr: fr, fixed: true}, &contrib)
+		if !acc.metadataFixed {
+			t.Error("metadataFixed should be set for a non-image fix")
+		}
+		if len(acc.fixedImageTypes) != 0 {
+			t.Error("fixedImageTypes should be empty for a metadata fix")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Reduce the cognitive complexity of `RunAllScoped` (the full-sweep rule pipeline) in `internal/rule/fixer.go` from 77 to under the gocognit threshold of 30, with zero behavior change. Per-rule and per-artist stages are extracted into named helpers so the parent becomes a thin orchestration loop.

**Behavior preserved:** the rule-major iteration order is unchanged (all violations of a given rule see a coherent before/after view of the artist within one pass), the #983 deferred resolved-status write ordering is preserved, and automation-mode dispatch + per-rule/global counters + context-cancellation checkpoints are intact. The `//nolint:gocognit` directive on `RunAllScoped` is removed.

## Linked issue
Closes #1542. Sub-issue of #1540 (M55.5 Dead Code Hunt).

## Pre-flight checklist
- [x] Pre-push gate green (via the hook on push).
- [x] Behavior-preserving refactor; public API unchanged.
- [x] Label set; `docs: not-required` (internal refactor).
- [ ] Screenshot / UAT: N/A.
- [x] OpenAPI / templ: N/A.

## Test plan
- [x] `go test ./internal/rule/` passes (no deletions/weakened assertions); added unit tests for the extracted helpers.
- [x] `golangci-lint run ./internal/rule/...` 0 issues; `//nolint:gocognit` removed from `RunAllScoped`, lint passes without it.
- [x] `go build ./... && go vet ./...` clean.
