### PR TITLE
chore(gate): align local pre-push gate with CI (coverage + a11y + generators/doc-facts)

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -89,6 +89,14 @@ jobs:
         run: tailwindcss -i web/static/css/input.css -o web/static/css/styles.css --minify
 
       - name: Regenerate doc generators
+        # Must stay in lockstep with scripts/check-generated.sh: that script
+        # (run by the local pre-push hook) regenerates all generators, but CI
+        # only re-ran six, so a contributor without the hook could land stale
+        # gen-cli-reference / gen-envelope-changelog / gen-make-reference /
+        # gen-platform-profiles / gen-prefs-reference output past required
+        # checks (#2009 #3 -- the audit said 3 missing; two more were added to
+        # check-generated.sh since, so it is 5). Keep this list == the
+        # generators in check-generated.sh.
         run: |
           go run ./cmd/gen-provider-matrix
           go run ./cmd/gen-env-reference
@@ -96,6 +104,11 @@ jobs:
           go run ./cmd/gen-settings-reference
           go run ./cmd/gen-doc-anchors
           go run ./cmd/gen-ci-reference
+          go run ./cmd/gen-cli-reference
+          go run ./cmd/gen-envelope-changelog
+          go run ./cmd/gen-make-reference
+          go run ./cmd/gen-platform-profiles
+          go run ./cmd/gen-prefs-reference
 
       - name: Fail on stale generated files
         run: |
@@ -375,6 +388,43 @@ jobs:
               echo '```'
               echo ""
               echo "Drift details:"
+              echo '```'
+              echo "$output"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          }
+          echo "$output"
+
+  # ---------------------------------------------------------------------------
+  # Doc-facts drift
+  #
+  # Replicates the '=== Doc facts ===' check in scripts/pre-push-gate.sh, which
+  # the local pre-push hook runs but gate.yml did not -- so a contributor
+  # without the hook could land a stale hand-written doc fact (built-in rule
+  # count, envelope version, dev-setup Go version, SWAG upload limit) past
+  # required checks (#2009 #4). check-doc-facts.sh is a grep-only guard, so no
+  # Go toolchain is needed; always runs and always emits a terminal status.
+  # ---------------------------------------------------------------------------
+  doc-facts:
+    name: Doc Facts Drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Check hand-written doc facts
+        run: |
+          output=$(bash scripts/check-doc-facts.sh 2>&1) || {
+            echo "$output"
+            {
+              echo "## Doc Facts Drift -- FAILED"
+              echo ""
+              echo "A hand-written doc fact no longer matches its source of truth (built-in rule count, envelope version, dev-setup Go version, or SWAG upload limit). Reconcile the doc with the code, or update the assertion in scripts/check-doc-facts.sh."
+              echo ""
+              echo "Details:"
               echo '```'
               echo "$output"
               echo '```'

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -423,34 +423,71 @@ echo "OK"
 
 echo ""
 echo "=== Accessibility (axe-core) ==="
-# Opt-in only. `make test-a11y` builds the binary, boots an ephemeral server,
-# installs npm deps, downloads a Chromium browser, and runs the Playwright +
-# @axe-core/playwright rendered-contrast smoke tests -- minutes of work plus a
-# one-time browser download. That cost is inappropriate for every push, so the
-# check is gated behind RUN_A11Y and SKIPS by default. CI runs the same
-# target unconditionally in its dedicated a11y-test job, so default-skipping
-# here only trades local speed for the CI gate, never removes coverage.
-# Self-contained block (no shared state with other steps) to minimize merge
-# conflicts with sibling branches that also append to this gate.
-# Accept common truthy values (1/true/yes/on), case-insensitive, so
-# contributors can opt in with whichever convention they reach for; anything
-# else (incl. unset/empty) skips. ${RUN_A11Y:-} keeps `set -u` happy.
-# Strip all whitespace too, so a stray leading/trailing space (e.g.
-# RUN_A11Y=' true') still matches instead of silently skipping a11y.
+# Runs the axe-core rendered-contrast smoke when a11y-relevant files changed
+# since BASE, mirroring CI's changes filter (.github/workflows/ci.yml a11y
+# paths), so a WCAG regression is caught locally instead of only by the CI a11y
+# job (the #2139 gap, where a borderline /next/settings contrast failure passed
+# the local gate and only CI caught it). `make test-a11y` builds the binary,
+# boots an ephemeral server, and runs Playwright + @axe-core/playwright.
+#
+# Degrades gracefully (#2140), and stays self-contained (no shared state with
+# other steps) to minimize merge conflicts with sibling branches:
+#   - RUN_A11Y truthy (1/true/yes/on): force a RUN regardless of changed files.
+#   - RUN_A11Y falsy  (0/false/no/off): force a SKIP (escape hatch when the
+#     Playwright toolchain is unavailable and you must push anyway; CI still
+#     gates a11y).
+#   - RUN_A11Y unset (auto, the default): run iff a11y-relevant files changed
+#     AND the Playwright toolchain is installed; otherwise SKIP -- never FAIL --
+#     so a fresh clone without `npx playwright install` can still push, matching
+#     the oasdiff/python3 optional-tool SKIP pattern above.
 a11y_flag="$(printf '%s' "${RUN_A11Y:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+
+# a11y_changed: did this branch touch any file CI's a11y filter watches?
+a11y_changed() {
+  git diff --name-only "$BASE" HEAD 2>/dev/null \
+    | grep -qE '^(web/templates/|web/static/css/|web/static/js/|tests/a11y/|playwright\.config\.js|package(-lock)?\.json)|\.templ$'
+}
+# a11y_toolchain_ready: are the Playwright browser binaries available? make
+# test-a11y runs `npm ci` itself (so node deps are not the gating concern) but
+# never `npx playwright install`, so the BROWSER cache is the real dependency.
+# Its location is platform-specific -- ~/.cache (Linux/CI), ~/Library/Caches
+# (macOS), %LOCALAPPDATA% (Windows) -- and PLAYWRIGHT_BROWSERS_PATH overrides it,
+# so probe all of them rather than a single Linux path.
+a11y_toolchain_ready() {
+  command -v npx >/dev/null 2>&1 || return 1
+  for d in "${PLAYWRIGHT_BROWSERS_PATH:-}" "$HOME/.cache/ms-playwright" "$HOME/Library/Caches/ms-playwright" "${LOCALAPPDATA:-}/ms-playwright"; do
+    [ -n "$d" ] && [ -d "$d" ] && return 0
+  done
+  return 1
+}
+
+run_a11y=0
 case "$a11y_flag" in
+  0 | false | no | off)
+    echo "a11y: skipped (RUN_A11Y=${RUN_A11Y} forces opt-out; CI still gates a11y)"
+    ;;
   1 | true | yes | on)
-    if ! make test-a11y; then
-      echo ""
-      echo "FAIL: accessibility (axe-core) smoke tests reported failures (see output above)."
-      exit 1
-    fi
-    echo "OK"
+    run_a11y=1
     ;;
   *)
-    echo "a11y: skipped (set RUN_A11Y=1 to run; also accepts true/yes/on)"
+    if ! a11y_changed; then
+      echo "a11y: skipped (no a11y-relevant changes since BASE; set RUN_A11Y=1 to force)"
+    elif ! a11y_toolchain_ready; then
+      echo "a11y: skipped (Playwright browsers not installed -- run 'npx playwright install chromium' to enable locally; CI still gates a11y)"
+    else
+      run_a11y=1
+    fi
     ;;
 esac
+
+if [ "$run_a11y" -eq 1 ]; then
+  if ! make test-a11y; then
+    echo ""
+    echo "FAIL: accessibility (axe-core) smoke tests reported failures (see output above)."
+    exit 1
+  fi
+  echo "OK"
+fi
 
 echo "=== Bruno route parity check ==="
 # Verify every /api/v1 route registered in internal/api/router.go is either

--- a/scripts/pre-push-gate.sh
+++ b/scripts/pre-push-gate.sh
@@ -137,7 +137,25 @@ bash "$TOOL_VERSIONS_HELPER"
 
 echo ""
 echo "=== Tests ==="
-go test -race -count=1 -covermode=atomic -coverprofile="$COVER_OUT" ./...
+# -coverpkg=./... matches CI's methodology (.github/workflows/ci.yml): each test
+# binary is instrumented against every package, so a package exercised mainly by
+# other packages' integration tests (e.g. internal/connection via api/publish/
+# imagebridge) is credited that cross-package coverage. Without it the local
+# profile reads lower than CI and fails the floor locally while CI passes (#2062;
+# the avoidable extra test-writing on #1686/#1564). Costs extra instrumentation
+# time vs per-package coverage -- the tradeoff for floor numbers that match CI.
+go test -race -count=1 -covermode=atomic -coverpkg=./... -coverprofile="$COVER_OUT" ./...
+
+# Union the profile before the floor/patch checks consume it. A single
+# `go test ./... -coverpkg=./...` invocation emits each block once PER test
+# binary (every binary instruments every package), so the raw profile is
+# heavily duplicated. `go tool cover` dedups on read, but coverage-floor.sh and
+# patch-coverage.sh sum nstmts across duplicate blocks and would read every
+# package at ~1/N of its real coverage, failing the floor spuriously. gocovmerge
+# applies the same per-block UNION that CI runs across its 9 shards
+# (.github/workflows/ci.yml:575) so the local floor/patch numbers match CI.
+go tool gocovmerge "$COVER_OUT" > "$COVER_OUT.merged"
+mv "$COVER_OUT.merged" "$COVER_OUT"
 
 echo ""
 echo "=== Lint (diff-only) ==="
@@ -312,8 +330,9 @@ fi
 
 echo ""
 echo "=== Patch coverage ==="
-# Matches codecov.yml's 75% patch threshold. The script approximates the
-# same semantics locally so we catch gaps before push instead of learning
+# Matches codecov.yml's 78% patch threshold (codecov.yml:14). With -coverpkg on
+# the test run above, the local profile now uses the same cross-package
+# methodology as Codecov, so we catch patch gaps before push instead of learning
 # about them from a failing codecov check.
 #
 # patch-coverage.sh uses exit codes 0|1|2 (2 = config error). This wrapper
@@ -338,7 +357,7 @@ if [ ! -x "$PATCH_COVERAGE_HELPER" ]; then
   echo "pre-push-gate: patch-coverage.sh not found in scripts/ or ~/.claude/scripts/" >&2
   exit 1
 fi
-if COVER_OUT="$COVER_OUT" PATCH_COVERAGE_THRESHOLD=75 \
+if COVER_OUT="$COVER_OUT" PATCH_COVERAGE_THRESHOLD=78 \
     PATCH_COVERAGE_EXCLUDE="*_templ.go cmd/stillwater/main.go scripts/" \
     bash "$PATCH_COVERAGE_HELPER"; then
   :


### PR DESCRIPTION
## Summary

Close two local-vs-CI gaps in the pre-push gate so it catches what CI catches, before push instead of after. Both are "make the local gate match CI" and surfaced from the same M55 wind-down work (the coverage gap on #2137, the a11y gap on #2139), so they ship together.

**Coverage (#2062):**
- Add `-coverpkg=./...` to the local coverage test run so each test binary is instrumented against every package, matching CI. A package exercised mainly by other packages' integration tests (e.g. `internal/connection`) no longer reads low locally and fails the floor while CI passes.
- A single `go test ./... -coverpkg=./...` invocation emits each block once per test binary, so the raw profile is heavily duplicated; `go tool cover` dedups on read but `coverage-floor.sh`/`patch-coverage.sh` sum nstmts across duplicates and read every package at ~1/N. Union the profile through `go tool gocovmerge` -- the same per-block UNION CI applies across its 9 shards (`ci.yml:575`) -- before the floor/patch checks. **This step is not in the issue's proposed fix; without it the gate fails every floor (verified: raw profile floors all read ~1%, merged profile passes with several packages reading higher, matching CI).**
- Bump `PATCH_COVERAGE_THRESHOLD` 75 -> 78 to match `codecov.yml:14`; correct the stale "75%" comment.

**A11y (#2140):**
- The axe-core smoke was opt-in (`RUN_A11Y`), off by default, so a WCAG contrast regression on `/next/settings` reached CI on #2139 with the local gate green. Change the default to AUTO: run `make test-a11y` when a11y-relevant files changed since BASE (mirroring CI's changes filter), and SKIP -- never FAIL -- when the Playwright toolchain is absent, matching the oasdiff/python3 optional-tool SKIPs so a fresh clone still pushes. `RUN_A11Y` is kept as an explicit override (truthy forces a run, falsy forces a skip).
- Toolchain guard probes the Playwright **browser cache** (the real dependency -- `make test-a11y` runs `npm ci` itself but never `npx playwright install`), cross-platform: `~/.cache` (Linux/CI), `~/Library/Caches` (macOS), `%LOCALAPPDATA%` (Windows), and `PLAYWRIGHT_BROWSERS_PATH`.

**CI gate parity (#2009 items #3 + #4 -- same theme, other direction: CI catching what the local hook catches):**
- **#3:** `gate.yml`'s generated-files job re-ran only 6 of the 11 generators `check-generated.sh` runs, so a contributor without the local hook could land stale generated docs past required checks. Add the 5 it skipped (`gen-cli-reference`, `gen-envelope-changelog`, `gen-make-reference`, `gen-platform-profiles`, `gen-prefs-reference`). The audit named 3; two were added to check-generated.sh since. Lands in the already-required job -> effective immediately.
- **#4:** Add a `doc-facts` job running `check-doc-facts.sh` (rule count / envelope version / dev-setup Go version / SWAG upload limit), which the local gate ran but CI did not. Grep-only guard -> no Go toolchain (modeled on `tool-versions`). **The new `Doc Facts Drift` job must be added to branch-protection required contexts to BLOCK (maintainer action).**

## Linked issues

Closes #2062. Closes #2140. Part of #2009 (HIGH items #3, #4 only; remaining guards tracked for a follow-up).

## Pre-flight checklist
- [x] Pre-push gate green locally (via the pre-push hook on push) -- exercises the new `-coverpkg`/`gocovmerge` coverage path and the a11y auto-skip (scripts-only branch -> a11y correctly skips with "no a11y-relevant changes").
- [x] Behavior: tooling-only; no production code change.
- [x] Three logical commits (coverage, a11y, CI gate parity).
- [x] actionlint clean on the `gate.yml` change; the 5 added generators run with no drift; `check-doc-facts.sh` passes (rules=24, envelope=1.5, go=1.26.4, upload=25MB).
- [x] Label set.
- [x] Docs label decision: `docs: not-required` (developer tooling, no user-visible behavior).
- [x] OpenAPI / templ: N/A (no handler or `.templ` change).

## Test plan
- [x] Coverage: verified the raw single-invocation `-coverpkg` profile fails every floor (~1%) and the `gocovmerge`-unioned profile passes (`coverage-floor.sh` green, several packages reading higher to match CI); `patch-coverage.sh` reads the merged profile.
- [x] A11y detection self-tested: the path regex matches CI's a11y filter (web/templates, css/js, tests/a11y, playwright/package manifests, `**/*.templ`) and is FALSE for this scripts-only branch; graceful SKIP when Playwright is not installed; `make test-a11y` non-zero exit trips the existing FAIL path.
- [x] Runtime note: `-coverpkg` instrumentation adds measurable time to the local `-race` run (cross-package instrumentation of every test binary); the a11y step adds build + server boot + Playwright only when a11y files changed.

## Notes
Surfaced during M55 wind-down: #2137 (codecov/patch failed while the local gate passed) and #2139 (CI a11y failed while the local gate passed).
