### PR TITLE
chore: finish drift-coverage guards (#2009 #2,#5,#6,#7,#9,#10,#12)

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage
-FROM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
+FROM golang:1.26.4-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS builder
 
 RUN apk add --no-cache curl libstdc++ libgcc
 

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -559,14 +559,10 @@ func wireInfraServices(ctx context.Context, a *Application, db *sql.DB, cfg *con
 // scanner, bulk executor, FSCache invalidator, health subscriber, and dirty
 // subscriber. All services wired here must be initialized before this call.
 func wireEventSubscriptions(a *Application) {
-	for _, eventType := range []event.Type{
-		event.ArtistNew, event.MetadataFixed, event.ReviewNeeded,
-		event.RuleViolation, event.BulkCompleted, event.ScanCompleted,
-		event.LidarrArtistAdd, event.LidarrDownload,
-		event.EmbyArtistUpdate, event.EmbyLibraryScan,
-		event.JellyfinArtistUpdate, event.JellyfinLibraryScan,
-		event.FSDirCreated, event.FSDirRemoved, event.FSUnexpectedWrite,
-	} {
+	// event.WebhookEventTypes is the single source of truth for the
+	// webhook-eligible event set; the API validates subscriptions and openapi
+	// documents the enum against the same list (#2009 #6).
+	for _, eventType := range event.WebhookEventTypes {
 		a.eventBus.Subscribe(eventType, a.webhookDispatcher.HandleEvent)
 	}
 	a.scannerService.SetEventBus(a.eventBus)

--- a/cmd/stillwater/main.go
+++ b/cmd/stillwater/main.go
@@ -562,7 +562,7 @@ func wireEventSubscriptions(a *Application) {
 	// event.WebhookEventTypes is the single source of truth for the
 	// webhook-eligible event set; the API validates subscriptions and openapi
 	// documents the enum against the same list (#2009 #6).
-	for _, eventType := range event.WebhookEventTypes {
+	for _, eventType := range event.WebhookEventTypes() {
 		a.eventBus.Subscribe(eventType, a.webhookDispatcher.HandleEvent)
 	}
 	a.scannerService.SetEventBus(a.eventBus)

--- a/internal/api/handlers_sse.go
+++ b/internal/api/handlers_sse.go
@@ -344,41 +344,45 @@ func buildActivityRecentMsg(data map[string]any) string {
 	return strVal(data, "text")
 }
 
-// SubscribeToEventBus registers event bus handlers that convert internal events
-// into SSE events and broadcast them to all connected clients.
-//
-// The mappings slice is flat by design: every per-event message builder
-// lives at file scope (buildScanCompletedMsg etc.) so this function stays
-// under the gocognit lint threshold. Adding a new event type means
-// declaring a build*Msg helper and appending one entry below.
-func (h *SSEHub) SubscribeToEventBus(bus *event.Bus) {
-	mappings := []sseEventMapping{
-		{event.ScanCompleted, "Scan completed", buildScanCompletedMsg},
-		{event.RuleViolation, "New rule violation", buildRuleViolationMsg},
-		{event.BulkCompleted, "Bulk operation completed", buildBulkCompletedMsg},
-		{event.ArtistNew, "New artist discovered", nil},
-		{event.ArtistUpdated, "Artist updated", nil},
-		{event.MetadataFixed, "Metadata fixed", buildMetadataFixedMsg},
-		{event.ConflictChanged, "Conflict state changed", buildConflictChangedMsg},
-		// OperationProgress carries its own structured fields (op_id, label,
-		// processed, total, status) for the ProgressPill renderer. The
-		// Title/Message text is only used as a fallback for clients that
-		// surface unknown events as plain toasts.
-		{event.OperationProgress, "Operation progress", buildOperationProgressMsg},
-		// ConnectionPushFailed Data carries the structured connection +
-		// error_class + artist_name fields; the raw transport error is
-		// deliberately NOT in Data. See internal/publish/notifier.go.
-		{event.ConnectionPushFailed, "Platform push failed", buildConnectionPushFailedMsg},
-		// M55 next-channel events. These are low-volume cross-tab / dashboard
-		// signals; their consumers read the structured Data, so the Title is
-		// only a plain-toast fallback. logs.line / logs.throttled are NOT here
-		// (emitted on the dedicated logs stream in #1338).
-		{event.ActivityRecent, "Recent activity", buildActivityRecentMsg},
-		{event.SettingsChanged, "Settings changed", nil},
-		{event.DashboardActionResolved, "Action resolved", nil},
-	}
+// sseEventMappings is the flat list of event types the SSE hub forwards to
+// browser clients, with their fallback title and optional message builder.
+// Flat by design: every per-event message builder lives at file scope
+// (buildScanCompletedMsg etc.) so SubscribeToEventBus stays under the gocognit
+// lint threshold -- adding a new event type means declaring a build*Msg helper
+// and appending one entry here. Hoisted to package scope so the drift guard
+// (#2009 #12) can assert it stays in sync with event.SSEForwardedTypes and the
+// SSE catalog doc. logs.line / logs.throttled are intentionally absent here --
+// they stream on the dedicated logs endpoint (#1338) -- but are still part of
+// event.SSEForwardedTypes.
+var sseEventMappings = []sseEventMapping{
+	{event.ScanCompleted, "Scan completed", buildScanCompletedMsg},
+	{event.RuleViolation, "New rule violation", buildRuleViolationMsg},
+	{event.BulkCompleted, "Bulk operation completed", buildBulkCompletedMsg},
+	{event.ArtistNew, "New artist discovered", nil},
+	{event.ArtistUpdated, "Artist updated", nil},
+	{event.MetadataFixed, "Metadata fixed", buildMetadataFixedMsg},
+	{event.ConflictChanged, "Conflict state changed", buildConflictChangedMsg},
+	// OperationProgress carries its own structured fields (op_id, label,
+	// processed, total, status) for the ProgressPill renderer. The
+	// Title/Message text is only a fallback for clients that surface unknown
+	// events as plain toasts.
+	{event.OperationProgress, "Operation progress", buildOperationProgressMsg},
+	// ConnectionPushFailed Data carries the structured connection +
+	// error_class + artist_name fields; the raw transport error is
+	// deliberately NOT in Data. See internal/publish/notifier.go.
+	{event.ConnectionPushFailed, "Platform push failed", buildConnectionPushFailedMsg},
+	// M55 next-channel events: low-volume cross-tab / dashboard signals whose
+	// consumers read the structured Data, so the Title is a plain-toast fallback.
+	{event.ActivityRecent, "Recent activity", buildActivityRecentMsg},
+	{event.SettingsChanged, "Settings changed", nil},
+	{event.DashboardActionResolved, "Action resolved", nil},
+}
 
-	for _, m := range mappings {
+// SubscribeToEventBus registers event bus handlers that convert internal events
+// into SSE events and broadcast them to all connected clients. The forwarded
+// set is sseEventMappings (kept in sync with event.SSEForwardedTypes).
+func (h *SSEHub) SubscribeToEventBus(bus *event.Bus) {
+	for _, m := range sseEventMappings {
 		m := m // capture loop variable
 		bus.Subscribe(m.eventType, func(e event.Event) {
 			msg := ""

--- a/internal/api/handlers_webhook.go
+++ b/internal/api/handlers_webhook.go
@@ -41,6 +41,20 @@ func (r *Router) handleGetWebhook(w http.ResponseWriter, req *http.Request) {
 }
 
 // handleCreateWebhook registers a new outbound webhook.
+// firstInvalidWebhookEvent returns the first entry of events that is not a
+// subscribable webhook event type (event.WebhookEventTypes), with false.
+// Returns ("", true) when every entry is valid, including an empty/nil list.
+// Validating here rejects a typo'd subscription at the API boundary instead of
+// silently storing an event that the dispatcher will never fire (#2009 #6).
+func firstInvalidWebhookEvent(events []string) (string, bool) {
+	for _, e := range events {
+		if !event.IsWebhookEvent(e) {
+			return e, false
+		}
+	}
+	return "", true
+}
+
 // POST /api/v1/webhooks
 func (r *Router) handleCreateWebhook(w http.ResponseWriter, req *http.Request) {
 	var body struct {
@@ -60,6 +74,11 @@ func (r *Router) handleCreateWebhook(w http.ResponseWriter, req *http.Request) {
 		body.URL = req.FormValue("url")
 		body.Type = req.FormValue("type")
 		body.Enabled = true
+	}
+
+	if bad, ok := firstInvalidWebhookEvent(body.Events); !ok {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown webhook event type: " + bad})
+		return
 	}
 
 	wh := &webhook.Webhook{
@@ -114,6 +133,10 @@ func (r *Router) handleUpdateWebhook(w http.ResponseWriter, req *http.Request) {
 		existing.Type = body.Type
 	}
 	if body.Events != nil {
+		if bad, ok := firstInvalidWebhookEvent(body.Events); !ok {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "unknown webhook event type: " + bad})
+			return
+		}
 		existing.Events = body.Events
 	}
 	if body.Enabled != nil {

--- a/internal/api/handlers_webhook_validation_test.go
+++ b/internal/api/handlers_webhook_validation_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/webhook"
+)
+
+func webhookValidationRouter(t *testing.T) *Router {
+	t.Helper()
+	r, _ := testRouter(t)
+	r.webhookService = webhook.NewService(r.db)
+	return r
+}
+
+// TestHandleCreateWebhook_RejectsUnknownEvent: a subscription naming an event
+// type not in event.WebhookEventTypes is rejected at the API boundary (400),
+// rather than silently stored and never fired (#2009 #6).
+func TestHandleCreateWebhook_RejectsUnknownEvent(t *testing.T) {
+	t.Parallel()
+	r := webhookValidationRouter(t)
+
+	body := `{"name":"wh","url":"https://example.test/hook","type":"generic","events":["artist.new","bogus.event"]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.handleCreateWebhook(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "bogus.event") {
+		t.Errorf("error response should name the bad event; body: %s", w.Body.String())
+	}
+}
+
+// TestHandleCreateWebhook_AcceptsValidEvents: a subscription using only
+// canonical event types is created (201).
+func TestHandleCreateWebhook_AcceptsValidEvents(t *testing.T) {
+	t.Parallel()
+	r := webhookValidationRouter(t)
+
+	body := `{"name":"wh","url":"https://example.test/hook","type":"generic","events":["artist.new","metadata.fixed"]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.handleCreateWebhook(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+}
+
+// TestHandleUpdateWebhook_RejectsUnknownEvent: the same validation applies on
+// update.
+func TestHandleUpdateWebhook_RejectsUnknownEvent(t *testing.T) {
+	t.Parallel()
+	r := webhookValidationRouter(t)
+
+	// Seed a valid webhook directly via the service.
+	wh := &webhook.Webhook{Name: "wh", URL: "https://example.test/hook", Type: "generic", Events: []string{"artist.new"}, Enabled: true}
+	if err := r.webhookService.Create(context.Background(), wh); err != nil {
+		t.Fatalf("seeding webhook: %v", err)
+	}
+
+	body := `{"events":["scan.completed","not.a.real.event"]}`
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/webhooks/"+wh.ID, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.SetPathValue("id", wh.ID)
+	w := httptest.NewRecorder()
+	r.handleUpdateWebhook(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "not.a.real.event") {
+		t.Errorf("error response should name the bad event; body: %s", w.Body.String())
+	}
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -653,6 +653,22 @@ components:
           description: Event types this webhook subscribes to.
           items:
             type: string
+            enum:
+              - artist.new
+              - metadata.fixed
+              - review.needed
+              - rule.violation
+              - bulk.completed
+              - scan.completed
+              - lidarr.artist.add
+              - lidarr.download
+              - emby.artist.update
+              - emby.library.scan
+              - jellyfin.artist.update
+              - jellyfin.library.scan
+              - fs.dir.created
+              - fs.dir.removed
+              - fs.unexpected.write
         enabled:
           type: boolean
           description: Whether this webhook is active and will fire on matching events.
@@ -6574,6 +6590,22 @@ paths:
                   type: array
                   items:
                     type: string
+                    enum:
+                      - artist.new
+                      - metadata.fixed
+                      - review.needed
+                      - rule.violation
+                      - bulk.completed
+                      - scan.completed
+                      - lidarr.artist.add
+                      - lidarr.download
+                      - emby.artist.update
+                      - emby.library.scan
+                      - jellyfin.artist.update
+                      - jellyfin.library.scan
+                      - fs.dir.created
+                      - fs.dir.removed
+                      - fs.unexpected.write
                 enabled:
                   type: boolean
               required: [name, url]
@@ -6641,6 +6673,22 @@ paths:
                   type: array
                   items:
                     type: string
+                    enum:
+                      - artist.new
+                      - metadata.fixed
+                      - review.needed
+                      - rule.violation
+                      - bulk.completed
+                      - scan.completed
+                      - lidarr.artist.add
+                      - lidarr.download
+                      - emby.artist.update
+                      - emby.library.scan
+                      - jellyfin.artist.update
+                      - jellyfin.library.scan
+                      - fs.dir.created
+                      - fs.dir.removed
+                      - fs.unexpected.write
                 enabled:
                   type: boolean
       responses:

--- a/internal/api/openapi_route_coverage_test.go
+++ b/internal/api/openapi_route_coverage_test.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/sydlexius/stillwater/internal/filesystem"
 )
 
 // openapi_route_coverage_test.go is #2009 #5: a bidirectional route<->spec
@@ -57,7 +59,10 @@ func writeRouteIgnore(path string, keys []string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, append(data, '\n'), 0o644)
+	// Route the in-place rewrite of the tracked fixture through the repo's
+	// atomic tmp/bak/rename helper so an interrupted regeneration can't leave
+	// testdata/openapi-route-ignore.json truncated or invalid.
+	return filesystem.WriteFileAtomic(path, append(data, '\n'), 0o644)
 }
 
 func TestOpenAPIRouteCoverage(t *testing.T) {

--- a/internal/api/openapi_route_coverage_test.go
+++ b/internal/api/openapi_route_coverage_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// openapi_route_coverage_test.go is #2009 #5: a bidirectional route<->spec
+// coverage guard.
+//
+//   - spec -> router (a documented operation with no route) is already enforced
+//     by TestOperationIDCoverage (its unmappedOps check), so it is not
+//     duplicated here.
+//
+//   - router -> spec (a registered /api/v1 route with NO openapi operation) had
+//     no guard: a new endpoint could ship undocumented. TestOpenAPIRouteCoverage
+//     closes that direction using the same router-AST and spec parsers as the
+//     operationId coverage test.
+//
+// It uses a ratchet baseline (testdata/openapi-route-ignore.json) seeded with
+// the routes undocumented at the time of writing -- health/docs/meta endpoints
+// and any pre-existing gaps -- mirroring the openapi-coverage-baseline.json and
+// Bruno parity-ignore.json patterns. A NEW undocumented /api/v1 route fails;
+// shrinking the baseline (documenting a route) is surfaced as a stale entry.
+//
+// Regenerate the baseline after an intentional change:
+//
+//	SW_UPDATE_ROUTE_IGNORE=1 go test ./internal/api/ -run TestOpenAPIRouteCoverage
+
+const routeIgnorePath = "testdata/openapi-route-ignore.json"
+
+func loadRouteIgnore(path string) (map[string]bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]bool{}, nil
+		}
+		return nil, err
+	}
+	var list []string
+	if err := json.Unmarshal(data, &list); err != nil {
+		return nil, err
+	}
+	m := make(map[string]bool, len(list))
+	for _, k := range list {
+		m[k] = true
+	}
+	return m, nil
+}
+
+func writeRouteIgnore(path string, keys []string) error {
+	sort.Strings(keys)
+	data, err := json.MarshalIndent(keys, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}
+
+func TestOpenAPIRouteCoverage(t *testing.T) {
+	t.Parallel()
+
+	ops, err := loadSpecOperations("openapi.yaml")
+	if err != nil {
+		t.Fatalf("loading openapi.yaml: %v", err)
+	}
+	routes, err := loadRouterBindings("router.go")
+	if err != nil {
+		t.Fatalf("loading router.go: %v", err)
+	}
+
+	// Spec keys are bare paths; router keys carry the /api/v1 prefix that the
+	// spec's server base URL implies (same convention as TestOperationIDCoverage).
+	specSet := make(map[string]bool, len(ops))
+	for _, op := range ops {
+		specSet[op.Method+" /api/v1"+op.Path] = true
+	}
+
+	// Every /api/v1 router binding that has no matching spec operation.
+	var undocumented []string
+	for key := range routes {
+		_, route, ok := strings.Cut(key, " ")
+		if !ok || !strings.HasPrefix(route, "/api/v1") {
+			continue // non-API routes (/, /static/, /register) are out of scope
+		}
+		if !specSet[key] {
+			undocumented = append(undocumented, key)
+		}
+	}
+	sort.Strings(undocumented)
+
+	if os.Getenv("SW_UPDATE_ROUTE_IGNORE") != "" {
+		if err := writeRouteIgnore(routeIgnorePath, undocumented); err != nil {
+			t.Fatalf("writing route ignore baseline: %v", err)
+		}
+		t.Logf("regenerated %s with %d undocumented routes", routeIgnorePath, len(undocumented))
+		return
+	}
+
+	ignore, err := loadRouteIgnore(routeIgnorePath)
+	if err != nil {
+		t.Fatalf("loading route ignore baseline: %v", err)
+	}
+
+	// New gaps: undocumented routes not in the baseline.
+	var newGaps []string
+	have := make(map[string]bool, len(undocumented))
+	for _, k := range undocumented {
+		have[k] = true
+		if !ignore[k] {
+			newGaps = append(newGaps, k)
+		}
+	}
+	if len(newGaps) > 0 {
+		t.Errorf("%d /api/v1 route(s) registered in router.go have no openapi.yaml operation. Document them in the spec, or (if intentionally undocumented) regenerate the baseline with SW_UPDATE_ROUTE_IGNORE=1:\n  %s",
+			len(newGaps), strings.Join(newGaps, "\n  "))
+	}
+
+	// Stale baseline entries: now documented (or removed). Keep the ratchet tight.
+	var stale []string
+	for k := range ignore {
+		if !have[k] {
+			stale = append(stale, k)
+		}
+	}
+	if len(stale) > 0 {
+		sort.Strings(stale)
+		t.Errorf("%d entr(y/ies) in %s are now documented or gone. Regenerate with SW_UPDATE_ROUTE_IGNORE=1:\n  %s",
+			len(stale), routeIgnorePath, strings.Join(stale, "\n  "))
+	}
+}

--- a/internal/api/sse_catalog_drift_test.go
+++ b/internal/api/sse_catalog_drift_test.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/event"
+)
+
+// sseEventIDRE matches a dotted lower-case event identifier in a markdown
+// backtick span, e.g. `artist.new`, `dashboard.action-resolved`.
+var sseEventIDRE = regexp.MustCompile("`([a-z][a-z]+\\.[a-z._-]+)`")
+
+// TestSSECatalogMatchesForwardedSet guards #2009 #12: the SSE event catalog doc
+// must list exactly the events the server forwards to SSE clients
+// (event.SSEForwardedTypes). The doc is hand-maintained; without this guard a
+// new forwarded event (or a removed one) silently diverges from the catalog
+// integrators rely on.
+func TestSSECatalogMatchesForwardedSet(t *testing.T) {
+	// internal/api -> ../.. is the repo root.
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolving repo root: %v", err)
+	}
+	docPath := filepath.Join(root, "docs", "site", "src", "contributing", "architecture", "sse-events.md")
+	data, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("reading SSE catalog %s: %v", docPath, err)
+	}
+
+	docSet := map[string]bool{}
+	for _, m := range sseEventIDRE.FindAllSubmatch(data, -1) {
+		docSet[string(m[1])] = true
+	}
+
+	wantSet := map[string]bool{}
+	for _, ty := range event.SSEForwardedTypes {
+		wantSet[string(ty)] = true
+	}
+
+	var inDocNotForwarded, forwardedNotInDoc []string
+	for id := range docSet {
+		if !wantSet[id] {
+			inDocNotForwarded = append(inDocNotForwarded, id)
+		}
+	}
+	for id := range wantSet {
+		if !docSet[id] {
+			forwardedNotInDoc = append(forwardedNotInDoc, id)
+		}
+	}
+	sort.Strings(inDocNotForwarded)
+	sort.Strings(forwardedNotInDoc)
+
+	if len(forwardedNotInDoc) > 0 {
+		t.Errorf("event(s) in SSEForwardedTypes missing from the SSE catalog doc (%s) -- add them: %v", docPath, forwardedNotInDoc)
+	}
+	if len(inDocNotForwarded) > 0 {
+		t.Errorf("event id(s) in the SSE catalog doc that are NOT in SSEForwardedTypes -- remove them or add to the forwarded set: %v", inDocNotForwarded)
+	}
+}
+
+// TestSSEHubForwardsCanonicalSet ties the hub code to the canonical set: the
+// events wired in sseEventMappings, plus the two that stream on the dedicated
+// logs endpoint (#1338), must equal event.SSEForwardedTypes. A new hub mapping
+// not added to the canonical set/catalog fails here, and vice versa.
+func TestSSEHubForwardsCanonicalSet(t *testing.T) {
+	covered := map[string]bool{}
+	for _, m := range sseEventMappings {
+		covered[string(m.eventType)] = true
+	}
+	// Forwarded on the dedicated logs stream, not via the hub mappings.
+	covered[string(event.LogsLine)] = true
+	covered[string(event.LogsThrottled)] = true
+
+	wantSet := map[string]bool{}
+	for _, ty := range event.SSEForwardedTypes {
+		wantSet[string(ty)] = true
+	}
+
+	var extra, missing []string
+	for id := range covered {
+		if !wantSet[id] {
+			extra = append(extra, id)
+		}
+	}
+	for id := range wantSet {
+		if !covered[id] {
+			missing = append(missing, id)
+		}
+	}
+	sort.Strings(extra)
+	sort.Strings(missing)
+
+	if len(extra) > 0 {
+		t.Errorf("SSE hub forwards event(s) not in event.SSEForwardedTypes -- add them to the canonical set + catalog: %v", extra)
+	}
+	if len(missing) > 0 {
+		t.Errorf("event.SSEForwardedTypes contains event(s) neither in sseEventMappings nor the logs stream -- wire them or remove from the set: %v", missing)
+	}
+}

--- a/internal/api/testdata/openapi-coverage-baseline.json
+++ b/internal/api/testdata/openapi-coverage-baseline.json
@@ -9,7 +9,6 @@
   "clearResolvedViolations",
   "clobberCheck",
   "createPlatform",
-  "createWebhook",
   "deleteLogFiles",
   "deletePlatform",
   "deleteProviderKey",
@@ -64,6 +63,5 @@
   "updateConnectionScraperConfig",
   "updateLogging",
   "updateMaintenanceSchedule",
-  "updateScraperConfig",
-  "updateWebhook"
+  "updateScraperConfig"
 ]

--- a/internal/api/testdata/openapi-coverage.json
+++ b/internal/api/testdata/openapi-coverage.json
@@ -242,7 +242,7 @@
     "method": "POST",
     "path": "/webhooks",
     "handler": "handleCreateWebhook",
-    "covered": false
+    "covered": true
   },
   {
     "operationId": "cropImage",
@@ -1782,7 +1782,7 @@
     "method": "PUT",
     "path": "/webhooks/{id}",
     "handler": "handleUpdateWebhook",
-    "covered": false
+    "covered": true
   },
   {
     "operationId": "uploadImage",

--- a/internal/api/testdata/openapi-route-ignore.json
+++ b/internal/api/testdata/openapi-route-ignore.json
@@ -1,0 +1,12 @@
+[
+  "DELETE /api/v1/users/invites/{id}",
+  "DELETE /api/v1/users/{id}",
+  "GET /api/v1/artists/{id}/fields/{field}/history/fragment",
+  "GET /api/v1/connections/{id}/conflict-detail",
+  "GET /api/v1/users",
+  "GET /api/v1/users/invites",
+  "GET /api/v1/users/{id}",
+  "PATCH /api/v1/users/{id}",
+  "POST /api/v1/users/invites",
+  "POST /api/v1/users/register"
+]

--- a/internal/api/webhook_events_drift_test.go
+++ b/internal/api/webhook_events_drift_test.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sydlexius/stillwater/internal/event"
+	"gopkg.in/yaml.v3"
+)
+
+// TestWebhookEventEnumMatchesRegistry guards #2009 #6: the openapi.yaml Webhook
+// schema `events` enum must match event.WebhookEventTypes exactly (same values,
+// same order). The registry is the single source of truth (main.go subscribes
+// the dispatcher and handlers_webhook.go validates against it); this keeps the
+// published contract from drifting away from what the server actually accepts
+// and dispatches.
+func TestWebhookEventEnumMatchesRegistry(t *testing.T) {
+	data, err := os.ReadFile("openapi.yaml")
+	if err != nil {
+		t.Fatalf("reading openapi.yaml: %v", err)
+	}
+	var doc struct {
+		Components struct {
+			Schemas struct {
+				Webhook struct {
+					Properties struct {
+						Events struct {
+							Items struct {
+								Enum []string `yaml:"enum"`
+							} `yaml:"items"`
+						} `yaml:"events"`
+					} `yaml:"properties"`
+				} `yaml:"Webhook"`
+			} `yaml:"schemas"`
+		} `yaml:"components"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parsing openapi.yaml: %v", err)
+	}
+
+	got := doc.Components.Schemas.Webhook.Properties.Events.Items.Enum
+	want := event.WebhookEventStrings()
+	if len(got) == 0 {
+		t.Fatal("openapi Webhook.events.items.enum is empty -- the enum is missing or the schema path changed")
+	}
+	if len(got) != len(want) {
+		t.Fatalf("openapi Webhook events enum has %d values, registry has %d:\n  openapi: %v\n  registry: %v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("openapi Webhook events enum[%d] = %q, registry = %q (regenerate the enum from event.WebhookEventTypes)", i, got[i], want[i])
+		}
+	}
+}
+
+// TestFirstInvalidWebhookEvent exercises the API-boundary validation predicate
+// used by the create/update webhook handlers.
+func TestFirstInvalidWebhookEvent(t *testing.T) {
+	t.Run("all valid", func(t *testing.T) {
+		if bad, ok := firstInvalidWebhookEvent(event.WebhookEventStrings()); !ok {
+			t.Errorf("firstInvalidWebhookEvent(all valid) = (%q, false); want ('', true)", bad)
+		}
+	})
+	t.Run("empty list", func(t *testing.T) {
+		if _, ok := firstInvalidWebhookEvent(nil); !ok {
+			t.Error("firstInvalidWebhookEvent(nil) = (_, false); want (_, true) -- empty subscription is allowed")
+		}
+	})
+	t.Run("one invalid", func(t *testing.T) {
+		bad, ok := firstInvalidWebhookEvent([]string{"artist.new", "totally.bogus", "metadata.fixed"})
+		if ok || bad != "totally.bogus" {
+			t.Errorf("firstInvalidWebhookEvent = (%q, %v); want ('totally.bogus', false)", bad, ok)
+		}
+	})
+}

--- a/internal/event/sse_events.go
+++ b/internal/event/sse_events.go
@@ -1,0 +1,32 @@
+package event
+
+// SSEForwardedTypes is the canonical set of event types that are forwarded to
+// connected SSE clients -- the "forwarded" half of the internal-vs-forwarded
+// split (#2009 #12). Every other event.Type is internal-only (consumed by
+// in-process subscribers such as the FSCache invalidator, health/dirty
+// subscribers, or the webhook dispatcher) and is deliberately NOT streamed to
+// browsers.
+//
+// Most of these are forwarded by the SSE hub (SSEHub.SubscribeToEventBus in
+// internal/api/handlers_sse.go); LogsLine and LogsThrottled are forwarded on
+// the dedicated logs stream (#1338) instead. This set is the source of truth
+// for the SSE event catalog doc
+// (docs/site/src/contributing/architecture/sse-events.md), kept in lockstep by
+// TestSSECatalogMatchesForwardedSet, and for the hub coverage check
+// (TestSSEHubForwardsCanonicalSet).
+var SSEForwardedTypes = []Type{
+	ScanCompleted,
+	RuleViolation,
+	BulkCompleted,
+	ArtistNew,
+	ArtistUpdated,
+	MetadataFixed,
+	ConflictChanged,
+	OperationProgress,
+	ConnectionPushFailed,
+	ActivityRecent,
+	SettingsChanged,
+	DashboardActionResolved,
+	LogsLine,
+	LogsThrottled,
+}

--- a/internal/event/webhook_events.go
+++ b/internal/event/webhook_events.go
@@ -1,6 +1,8 @@
 package event
 
-// WebhookEventTypes is the canonical, ordered set of event types a webhook may
+import "slices"
+
+// webhookEventTypes is the canonical, ordered set of event types a webhook may
 // subscribe to. It is the single source of truth for three places that
 // previously held independent copies and could silently drift (#2009 #6):
 //
@@ -13,8 +15,11 @@ package event
 //     lockstep by a drift test.
 //
 // Keep the order meaningful (grouped by domain); openapi enum order is asserted
-// to match.
-var WebhookEventTypes = []Type{
+// to match. It is unexported so the registry cannot be mutated (reordered or
+// appended) from another package, which would silently change webhook
+// validation and the openapi enum ordering; callers read it via the accessors
+// below, each of which returns a fresh copy.
+var webhookEventTypes = []Type{
 	ArtistNew, MetadataFixed, ReviewNeeded,
 	RuleViolation, BulkCompleted, ScanCompleted,
 	LidarrArtistAdd, LidarrDownload,
@@ -23,9 +28,15 @@ var WebhookEventTypes = []Type{
 	FSDirCreated, FSDirRemoved, FSUnexpectedWrite,
 }
 
+// WebhookEventTypes returns the canonical, ordered set of subscribable webhook
+// event types. It returns a copy, so callers cannot mutate the registry.
+func WebhookEventTypes() []Type {
+	return slices.Clone(webhookEventTypes)
+}
+
 // IsWebhookEvent reports whether s is a subscribable webhook event type.
 func IsWebhookEvent(s string) bool {
-	for _, t := range WebhookEventTypes {
+	for _, t := range webhookEventTypes {
 		if string(t) == s {
 			return true
 		}
@@ -33,10 +44,10 @@ func IsWebhookEvent(s string) bool {
 	return false
 }
 
-// WebhookEventStrings returns WebhookEventTypes as a string slice, in order.
+// WebhookEventStrings returns the registry as a string slice, in order.
 func WebhookEventStrings() []string {
-	out := make([]string, len(WebhookEventTypes))
-	for i, t := range WebhookEventTypes {
+	out := make([]string, len(webhookEventTypes))
+	for i, t := range webhookEventTypes {
 		out[i] = string(t)
 	}
 	return out

--- a/internal/event/webhook_events.go
+++ b/internal/event/webhook_events.go
@@ -1,0 +1,43 @@
+package event
+
+// WebhookEventTypes is the canonical, ordered set of event types a webhook may
+// subscribe to. It is the single source of truth for three places that
+// previously held independent copies and could silently drift (#2009 #6):
+//
+//   - cmd/stillwater/main.go subscribes the webhook dispatcher to exactly these
+//     types (an event not in this list can never reach a webhook);
+//   - internal/api/handlers_webhook.go validates subscription requests against
+//     it (IsWebhookEvent), rejecting unknown event types instead of silently
+//     accepting a typo that would never fire;
+//   - internal/api/openapi.yaml documents these as the `events` enum, kept in
+//     lockstep by a drift test.
+//
+// Keep the order meaningful (grouped by domain); openapi enum order is asserted
+// to match.
+var WebhookEventTypes = []Type{
+	ArtistNew, MetadataFixed, ReviewNeeded,
+	RuleViolation, BulkCompleted, ScanCompleted,
+	LidarrArtistAdd, LidarrDownload,
+	EmbyArtistUpdate, EmbyLibraryScan,
+	JellyfinArtistUpdate, JellyfinLibraryScan,
+	FSDirCreated, FSDirRemoved, FSUnexpectedWrite,
+}
+
+// IsWebhookEvent reports whether s is a subscribable webhook event type.
+func IsWebhookEvent(s string) bool {
+	for _, t := range WebhookEventTypes {
+		if string(t) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// WebhookEventStrings returns WebhookEventTypes as a string slice, in order.
+func WebhookEventStrings() []string {
+	out := make([]string, len(WebhookEventTypes))
+	for i, t := range WebhookEventTypes {
+		out[i] = string(t)
+	}
+	return out
+}

--- a/internal/event/webhook_events_test.go
+++ b/internal/event/webhook_events_test.go
@@ -1,0 +1,35 @@
+package event
+
+import "testing"
+
+func TestIsWebhookEvent(t *testing.T) {
+	// Every canonical type is accepted.
+	for _, ty := range WebhookEventTypes {
+		if !IsWebhookEvent(string(ty)) {
+			t.Errorf("IsWebhookEvent(%q) = false; want true (it is in WebhookEventTypes)", ty)
+		}
+	}
+	// Non-subscribable / unknown types are rejected.
+	for _, bad := range []string{
+		"", "bogus.event", "test",
+		string(SettingsChanged), // emitted internally but NOT webhook-subscribable
+		string(LogsLine),        // SSE-only
+		"ARTIST.NEW",            // case-sensitive
+	} {
+		if IsWebhookEvent(bad) {
+			t.Errorf("IsWebhookEvent(%q) = true; want false", bad)
+		}
+	}
+}
+
+func TestWebhookEventStrings(t *testing.T) {
+	got := WebhookEventStrings()
+	if len(got) != len(WebhookEventTypes) {
+		t.Fatalf("WebhookEventStrings() len = %d, want %d", len(got), len(WebhookEventTypes))
+	}
+	for i, ty := range WebhookEventTypes {
+		if got[i] != string(ty) {
+			t.Errorf("WebhookEventStrings()[%d] = %q, want %q (order must match WebhookEventTypes)", i, got[i], ty)
+		}
+	}
+}

--- a/internal/event/webhook_events_test.go
+++ b/internal/event/webhook_events_test.go
@@ -4,9 +4,9 @@ import "testing"
 
 func TestIsWebhookEvent(t *testing.T) {
 	// Every canonical type is accepted.
-	for _, ty := range WebhookEventTypes {
+	for _, ty := range WebhookEventTypes() {
 		if !IsWebhookEvent(string(ty)) {
-			t.Errorf("IsWebhookEvent(%q) = false; want true (it is in WebhookEventTypes)", ty)
+			t.Errorf("IsWebhookEvent(%q) = false; want true (it is in WebhookEventTypes())", ty)
 		}
 	}
 	// Non-subscribable / unknown types are rejected.
@@ -24,12 +24,13 @@ func TestIsWebhookEvent(t *testing.T) {
 
 func TestWebhookEventStrings(t *testing.T) {
 	got := WebhookEventStrings()
-	if len(got) != len(WebhookEventTypes) {
-		t.Fatalf("WebhookEventStrings() len = %d, want %d", len(got), len(WebhookEventTypes))
+	want := WebhookEventTypes()
+	if len(got) != len(want) {
+		t.Fatalf("WebhookEventStrings() len = %d, want %d", len(got), len(want))
 	}
-	for i, ty := range WebhookEventTypes {
+	for i, ty := range want {
 		if got[i] != string(ty) {
-			t.Errorf("WebhookEventStrings()[%d] = %q, want %q (order must match WebhookEventTypes)", i, got[i], ty)
+			t.Errorf("WebhookEventStrings()[%d] = %q, want %q (order must match WebhookEventTypes())", i, got[i], ty)
 		}
 	}
 }

--- a/internal/i18n/drift_test.go
+++ b/internal/i18n/drift_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -58,7 +59,23 @@ func TestLocaleCompleteness(t *testing.T) {
 	root := repoRoot(t)
 	en := loadLocaleKeys(t, root, "en")
 
-	for _, loc := range []string{"fr", "ja"} {
+	// Discover the non-English locales from the locales directory rather than
+	// hard-coding them: a newly added locale file must be checked automatically,
+	// otherwise this guard recreates the duplicate-truth problem it exists to
+	// prevent (a new locale silently unguarded until someone edits this slice).
+	localesDir := filepath.Join(root, "internal", "i18n", "locales")
+	entries, err := os.ReadDir(localesDir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", localesDir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		loc := strings.TrimSuffix(entry.Name(), ".json")
+		if loc == "en" {
+			continue // en is the canonical key set, not a target.
+		}
 		t.Run(loc, func(t *testing.T) {
 			var orphans []string
 			for k := range loadLocaleKeys(t, root, loc) {
@@ -80,6 +97,23 @@ func TestLocaleCompleteness(t *testing.T) {
 // built keys (t(ctx, "prefix."+x)) are intentionally out of scope.
 var templKeyRE = regexp.MustCompile(`\bt\(ctx,\s*"([^"]+)"\)`)
 
+// stripLineComments removes `//` line comments from templ source so that an
+// example call written in a doc comment (e.g. `// fetched via t(ctx, "key")`)
+// is not mistaken for a real translation call. A `//` immediately preceded by
+// `:` is treated as part of a URL (https://...), not a comment.
+func stripLineComments(src []byte) []byte {
+	lines := strings.Split(string(src), "\n")
+	for i, line := range lines {
+		for j := 0; j+1 < len(line); j++ {
+			if line[j] == '/' && line[j+1] == '/' && (j == 0 || line[j-1] != ':') {
+				lines[i] = line[:j]
+				break
+			}
+		}
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
 // TestTranslationKeysDefined guards #2009 #9 (the used-but-undefined direction):
 // every string-literal key passed to t(ctx, "...") in a templ source must exist
 // in en.json. A missing key renders the bare key string in the UI -- a visible,
@@ -94,31 +128,39 @@ func TestTranslationKeysDefined(t *testing.T) {
 	root := repoRoot(t)
 	en := loadLocaleKeys(t, root, "en")
 
-	templDir := filepath.Join(root, "web", "templates")
 	missing := map[string][]string{} // key -> files referencing it
 
-	err := filepath.WalkDir(templDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() || filepath.Ext(path) != ".templ" {
-			return nil
-		}
-		src, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		rel, _ := filepath.Rel(root, path)
-		for _, m := range templKeyRE.FindAllSubmatch(src, -1) {
-			key := string(m[1])
-			if _, ok := en[key]; !ok {
-				missing[key] = append(missing[key], rel)
+	// Scan every templ surface, not just web/templates: web/components holds
+	// reusable templ fragments that also call t(ctx, "..."), so an undefined key
+	// there would otherwise ship unguarded.
+	for _, templDir := range []string{
+		filepath.Join(root, "web", "templates"),
+		filepath.Join(root, "web", "components"),
+	} {
+		err := filepath.WalkDir(templDir, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
 			}
+			if d.IsDir() || filepath.Ext(path) != ".templ" {
+				return nil
+			}
+			src, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			rel, _ := filepath.Rel(root, path)
+			src = stripLineComments(src)
+			for _, m := range templKeyRE.FindAllSubmatch(src, -1) {
+				key := string(m[1])
+				if _, ok := en[key]; !ok {
+					missing[key] = append(missing[key], rel)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walking %s: %v", templDir, err)
 		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walking %s: %v", templDir, err)
 	}
 
 	if len(missing) > 0 {

--- a/internal/i18n/drift_test.go
+++ b/internal/i18n/drift_test.go
@@ -1,0 +1,134 @@
+package i18n
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"testing"
+)
+
+// drift_test.go holds the two i18n drift guards from the 2026-06-15 audit
+// (#2009 #9 and #10). They are deliberately filesystem-driven (reading the
+// locale JSON and the templ sources directly) rather than going through the
+// embedded bundle, so they assert the on-disk source of truth a contributor
+// edits, not a snapshot.
+
+// repoRoot returns the repository root relative to this package
+// (internal/i18n), so the guards can read web/templates and the locale files
+// regardless of where `go test` is invoked from.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	// internal/i18n -> ../.. is the repo root.
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolving repo root: %v", err)
+	}
+	return root
+}
+
+// loadLocaleKeys reads internal/i18n/locales/<loc>.json and returns its key set.
+func loadLocaleKeys(t *testing.T, root, loc string) map[string]struct{} {
+	t.Helper()
+	path := filepath.Join(root, "internal", "i18n", "locales", loc+".json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	keys := make(map[string]struct{}, len(m))
+	for k := range m {
+		keys[k] = struct{}{}
+	}
+	return keys
+}
+
+// TestLocaleCompleteness guards #2009 #10: every key in a non-English locale
+// must exist in en.json. en is the fallback and the canonical key set; a key
+// removed from en.json would otherwise become a silent orphan in fr/ja (the
+// fallback chain would return the bare key). The reverse direction is NOT
+// asserted -- fr/ja are intentionally partial (they translate a subset and
+// fall back to en for the rest), so a key present in en but absent from fr/ja
+// is expected, not drift.
+func TestLocaleCompleteness(t *testing.T) {
+	root := repoRoot(t)
+	en := loadLocaleKeys(t, root, "en")
+
+	for _, loc := range []string{"fr", "ja"} {
+		t.Run(loc, func(t *testing.T) {
+			var orphans []string
+			for k := range loadLocaleKeys(t, root, loc) {
+				if _, ok := en[k]; !ok {
+					orphans = append(orphans, k)
+				}
+			}
+			sort.Strings(orphans)
+			if len(orphans) > 0 {
+				t.Errorf("%s.json has %d key(s) not present in en.json (orphaned -- the fallback chain will return the bare key); remove them or add the key to en.json: %v",
+					loc, len(orphans), orphans)
+			}
+		})
+	}
+}
+
+// templKeyRE matches the canonical translation call in templ sources:
+// t(ctx, "some.key"). Only string-literal keys are extracted; dynamically
+// built keys (t(ctx, "prefix."+x)) are intentionally out of scope.
+var templKeyRE = regexp.MustCompile(`\bt\(ctx,\s*"([^"]+)"\)`)
+
+// TestTranslationKeysDefined guards #2009 #9 (the used-but-undefined direction):
+// every string-literal key passed to t(ctx, "...") in a templ source must exist
+// in en.json. A missing key renders the bare key string in the UI -- a visible,
+// user-facing defect that nothing else catches.
+//
+// Only the used-but-undefined direction is asserted as a hard failure. The
+// reverse (defined-but-unused) is deliberately omitted: keys are also consumed
+// from Go handlers and via dynamically constructed names, so a templ-only scan
+// would flag many false positives, and the maintainer prefers a precise guard
+// over a noisy one.
+func TestTranslationKeysDefined(t *testing.T) {
+	root := repoRoot(t)
+	en := loadLocaleKeys(t, root, "en")
+
+	templDir := filepath.Join(root, "web", "templates")
+	missing := map[string][]string{} // key -> files referencing it
+
+	err := filepath.WalkDir(templDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".templ" {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(root, path)
+		for _, m := range templKeyRE.FindAllSubmatch(src, -1) {
+			key := string(m[1])
+			if _, ok := en[key]; !ok {
+				missing[key] = append(missing[key], rel)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", templDir, err)
+	}
+
+	if len(missing) > 0 {
+		keys := make([]string, 0, len(missing))
+		for k := range missing {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			t.Errorf("translation key %q used in %v is not defined in en.json (renders as the bare key in the UI)", k, missing[k])
+		}
+	}
+}

--- a/scripts/check-tool-versions.sh
+++ b/scripts/check-tool-versions.sh
@@ -95,6 +95,17 @@ require() {
 # Each extraction ends in `|| true` so a grep miss (exit 1) does not abort the
 # script under `set -e`/`pipefail`; an empty result is reported by require().
 
+# Go: the go.mod `go` directive and the Dockerfile golang base-image tag must
+# pin the same version, so the release image builds on the same toolchain as
+# CI / local dev (#2009 #7). The Dockerfile also @sha256-pins the image (the
+# real reproducibility guarantee), but the tag must still read the correct
+# patch for humans and for this guard to catch a go.mod bump that forgot the
+# Dockerfile. No auto-fixer: bump go.mod + the Dockerfile tag together, then
+# re-pin the digest.
+go_mod=$(grep -oE '^go[[:space:]]+[0-9.]+' go.mod | grep -oE '[0-9.]+' | head -1 || true)
+go_docker=$(grep -oE 'golang:[0-9.]+' build/docker/Dockerfile | grep -oE '[0-9.]+' | head -1 || true)
+require "go" "$go_mod" "$go_docker" "go.mod" "build/docker/Dockerfile"
+
 # Tailwind: the composite action (CI glibc x64 binary) and the Dockerfile (musl
 # binaries) pin the SAME TAILWIND_VERSION but DIFFERENT SHAs. Only the version is
 # a shared invariant, so assert just the version here; the SHAs intentionally

--- a/web/templates/next/prefs_layout_drift_test.go
+++ b/web/templates/next/prefs_layout_drift_test.go
@@ -1,0 +1,78 @@
+package next
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// jsDefaultOrderRE captures the contents of every
+// `var DEFAULT_ORDER = [ ... ];` array literal in prefs-drawer.js. The array
+// is declared in more than one function scope there, and each copy must match
+// the Go default order, so all occurrences are checked.
+var jsDefaultOrderRE = regexp.MustCompile(`var DEFAULT_ORDER\s*=\s*\[([^\]]*)\]`)
+
+// TestPrefsLayoutSectionOrderParity guards #2009 #2: the artist-detail section
+// order is declared in Go (defaultPrefsLayoutSections in prefs_drawer.templ) and
+// duplicated as DEFAULT_ORDER in web/static/js/prefs-drawer.js (used by the
+// reset button and the full-reset PATCH). A reorder or rename in one place that
+// is not mirrored in the other silently breaks reset/full-reset, with no guard
+// today. This asserts every JS DEFAULT_ORDER copy equals the Go order exactly.
+func TestPrefsLayoutSectionOrderParity(t *testing.T) {
+	// Go source of truth (in-package access to the unexported var).
+	want := make([]string, len(defaultPrefsLayoutSections))
+	for i, s := range defaultPrefsLayoutSections {
+		want[i] = s.ID
+	}
+
+	// web/templates/next -> ../../.. is the repo root.
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatalf("resolving repo root: %v", err)
+	}
+	jsPath := filepath.Join(root, "web", "static", "js", "prefs-drawer.js")
+	src, err := os.ReadFile(jsPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", jsPath, err)
+	}
+
+	matches := jsDefaultOrderRE.FindAllSubmatch(src, -1)
+	if len(matches) == 0 {
+		t.Fatalf("no `var DEFAULT_ORDER = [...]` literal found in %s -- did the JS rename it? Update this guard.", jsPath)
+	}
+
+	for i, m := range matches {
+		got := parseJSStringArray(string(m[1]))
+		if !equalStrings(got, want) {
+			t.Errorf("DEFAULT_ORDER copy #%d in prefs-drawer.js = %v, want %v (must match defaultPrefsLayoutSections in prefs_drawer.templ)", i+1, got, want)
+		}
+	}
+}
+
+// parseJSStringArray turns `'a', 'b', 'c'` (the inside of a JS array literal of
+// single- or double-quoted strings) into []string{"a","b","c"}.
+func parseJSStringArray(inner string) []string {
+	var out []string
+	for _, part := range strings.Split(inner, ",") {
+		s := strings.TrimSpace(part)
+		s = strings.Trim(s, `'"`)
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Finish the drift-coverage audit (#2009): add the remaining guards so the places where the same truth lives in 2+ representations can no longer silently diverge. Re-verified every item against current code first -- the 2026-06-15 audit was stale -- which changed the scope (details below).

**Guards added (HIGH + MEDIUM + LOW):**
- **#2** section-order Go/JS parity: `TestPrefsLayoutSectionOrderParity` asserts every `DEFAULT_ORDER` copy in prefs-drawer.js matches `defaultPrefsLayoutSections` (templ).
- **#5** router->openapi route coverage: `TestOpenAPIRouteCoverage` asserts every `/api/v1` route in router.go has an openapi operation (the spec->router direction is already covered by `TestOperationIDCoverage`). Ratchet baseline `testdata/openapi-route-ignore.json` (10 currently-undocumented routes).
- **#6** webhook event enum + validation: new `event.WebhookEventTypes` is the single source of truth; main.go subscribes from it, the create/update handlers reject unknown event types (400), and openapi.yaml gains the `events` enum. Drift guard asserts the enum == the registry.
- **#7** Dockerfile Go pin: tag -> `1.26.4-alpine` (same digest) + a `check-tool-versions.sh` rule asserting it matches go.mod.
- **#9** i18n used-but-undefined: `TestTranslationKeysDefined` asserts every literal `t(ctx,"...")` key in templ is in en.json.
- **#10** non-en locale completeness: `TestLocaleCompleteness` asserts every fr/ja key exists in en.json.
- **#12** SSE catalog parity: new `event.SSEForwardedTypes` (the internal-vs-forwarded marker); guards assert the catalog doc and the SSE hub mappings both match it.

**Scope corrections from the re-audit (the audit was ~2 weeks stale):**
- **#1** (prefs Go/JS defaults) was already done by the merged #2006 (`TestJSDefaultsMatchGoRegistry`) -- not re-implemented.
- **#3 / #4** (CI generators + doc-facts) shipped in #2141.
- **#7** was largely moot: the image is already @sha256-pinned; added the tag precision + guard as belt-and-suspenders.
- **#8** (applyPlatformGlyph dup) deferred per the issue's own note (until the stable artists page retires) -- LOW cosmetic dup, not a drift-of-truth.

With #1 (#2006), #3/#4 (#2141), and the above, every HIGH + MEDIUM guard is implemented and runs in CI, and every LOW item is implemented or explicitly deferred -- the acceptance criteria are met.

## Linked issue

Closes #2009.

## Pre-flight checklist
- [x] Pre-push gate green locally (via the pre-push hook on push).
- [x] Each new guard passes on current main (no pre-existing drift), and the webhook validation is covered end-to-end (predicate + HTTP 400 path).
- [x] Logical commits, one per guard.
- [x] Label set.
- [x] Docs label decision: `needs-docs-review` (webhook subscriptions now reject unknown event types; openapi.yaml enum updated).
- [x] OpenAPI: `events` enum added; `make check-openapi` consistent.
- [x] `go vet` / build clean; actionlint + hadolint clean on the workflow/Dockerfile changes.

## Test plan
- [x] New guards pass: i18n (completeness + undefined keys), section-order parity, route coverage, webhook enum/validation, SSE catalog, Dockerfile go-version check.
- [x] `go test ./internal/i18n/ ./internal/event/ ./internal/api/ ./web/templates/next/` green.
- [x] Existing webhook + SSE + openapi-consistency tests unaffected.

## Note
Large single PR by maintainer request (the remaining audit in one cycle). The guard tests run in the required CI Test job; the `check-tool-versions` go rule runs in the (advisory) tool-versions job + local hook.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook creation and updates now reject unknown event selections with clear `400 Bad Request` errors.
  * SSE and webhook subscriptions now rely on a single authoritative set of supported events, keeping behavior aligned with published documentation.
* **Documentation**
  * Updated API/OpenAPI webhook event options to only include valid, supported event names.
* **Tests**
  * Added automated drift/coverage checks to catch mismatches between API docs, runtime event registries, i18n translations, and UI preference ordering.
* **Chores**
  * Pinned the Go builder image to a specific Go patch version for CI consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->