### PR TITLE
chore(gate): declare repo gate config in .gates.toml

### DIFF
--- a/.gates.toml
+++ b/.gates.toml
@@ -1,0 +1,6 @@
+# Read by gate-runner.py (cc-orchestrator >= v0.49.0).
+[prep_pr]
+gate = "bash scripts/pre-push-gate.sh"
+
+[merge_pr]
+coverage_advisory = true   # codecov.yml present


### PR DESCRIPTION
## Summary

- cc-orchestrator >= v0.49.0 reads a repo-root `.gates.toml` so `/prep-pr` and the pre-push hook run the *same declared* gate instead of relying on auto-detection. This declares Stillwater's existing umbrella (`scripts/pre-push-gate.sh`) explicitly and records the merge-time coverage-advisory signal.
- The file was authored locally ~2 weeks ago but the commit step was never landed, so it had been sitting untracked on `main`. This commits it as its own small change.
- No runtime/user-visible behavior change: the file is trusted repo config (like a Makefile), inert until the orchestrator runner is deployed here.

## Linked issue

(none -- tooling config; no tracked issue)

## Pre-flight checklist

- [x] Pre-push gate green locally (via the pre-push hook on push).
- [x] Single logical commit.
- [x] Labels set.
- [x] Docs label decision: `docs: not-required` (no user-visible behavioral change; repo tooling config).
- [x] Verified the runner resolves the config: `gate-runner.py` -> Form A delegate -> `bash scripts/pre-push-gate.sh`.

## Test plan

- [x] `.gates.toml` parses as valid TOML.
- [x] `gate-runner.py` loads it and resolves the delegate gate correctly.
- [x] Pre-push gate (`-race ./...`, a11y, provider-failure, Bruno parity) green on push.
- No Go code changed; no UAT applicable.