### PR TITLE
chore(openapi): explicit discriminator on error-discriminated oneOf responses

### DIFF
--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -321,34 +321,58 @@ components:
         always carries a `conflicts` array (possibly empty); the
         `merge_in_progress` variant never carries `conflicts`.
       oneOf:
-        - type: object
-          description: >-
-            Pre-flight walk found same-name album collisions; nothing was
-            moved. The conflicts list enumerates each one with both the
-            survivor-side existing path and the would-be loser source.
-          properties:
-            error:
-              type: string
-              enum: [collisions]
-            survivor_id:
-              type: string
-            survivor_path:
-              type: string
-            conflicts:
-              type: array
-              items:
-                $ref: "#/components/schemas/MergeConflict"
-          required: [error, conflicts]
-        - type: object
-          description: >-
-            Another merge is already in flight for some group; the caller
-            should back off and retry shortly. No filesystem or database
-            state was touched by this request.
-          properties:
-            error:
-              type: string
-              enum: [merge_in_progress]
-          required: [error]
+        - $ref: "#/components/schemas/MergeCollisionConflict"
+        - $ref: "#/components/schemas/MergeInProgressError"
+      discriminator:
+        propertyName: error
+        mapping:
+          collisions: "#/components/schemas/MergeCollisionConflict"
+          merge_in_progress: "#/components/schemas/MergeInProgressError"
+    MergeCollisionConflict:
+      type: object
+      description: >-
+        Pre-flight walk found same-name album collisions; nothing was
+        moved. The conflicts list enumerates each one with both the
+        survivor-side existing path and the would-be loser source.
+      properties:
+        error:
+          type: string
+          enum: [collisions]
+        survivor_id:
+          type: string
+        survivor_path:
+          type: string
+        conflicts:
+          type: array
+          items:
+            $ref: "#/components/schemas/MergeConflict"
+      required: [error, conflicts]
+    MergeInProgressError:
+      type: object
+      description: >-
+        Another merge is already in flight for some group; the caller
+        should back off and retry shortly. No filesystem or database
+        state was touched by this request.
+      properties:
+        error:
+          type: string
+          enum: [merge_in_progress]
+      required: [error]
+    FieldLockedError:
+      type: object
+      description: >-
+        Returned when attempting to modify a user-locked field. Shared
+        across link endpoints, so `field` is a plain string rather than an
+        endpoint-specific enum since the discriminator operates on `error`.
+      properties:
+        error:
+          type: string
+          enum: [field_locked]
+        field:
+          type: string
+        reason:
+          type: string
+      required: [error, field, reason]
     ConflictWriteBlock:
       type: object
       description: >
@@ -12013,17 +12037,13 @@ paths:
               schema:
                 oneOf:
                   - $ref: "#/components/schemas/ConflictWriteBlock"
-                  - type: object
-                    required: [error, field, reason]
-                    properties:
-                      error:
-                        type: string
-                        enum: [field_locked]
-                      field:
-                        type: string
-                        enum: [discogs_id]
-                      reason:
-                        type: string
+                  - $ref: "#/components/schemas/FieldLockedError"
+                discriminator:
+                  propertyName: error
+                  mapping:
+                    field_locked: "#/components/schemas/FieldLockedError"
+                    nfo_write_blocked: "#/components/schemas/ConflictWriteBlock"
+                    round_trip_write_blocked: "#/components/schemas/ConflictWriteBlock"
         "500":
           description: Failed to link Discogs ID
           content:
@@ -12228,17 +12248,13 @@ paths:
               schema:
                 oneOf:
                   - $ref: "#/components/schemas/ConflictWriteBlock"
-                  - type: object
-                    required: [error, field, reason]
-                    properties:
-                      error:
-                        type: string
-                        enum: [field_locked]
-                      field:
-                        type: string
-                        enum: [audiodb_id]
-                      reason:
-                        type: string
+                  - $ref: "#/components/schemas/FieldLockedError"
+                discriminator:
+                  propertyName: error
+                  mapping:
+                    field_locked: "#/components/schemas/FieldLockedError"
+                    nfo_write_blocked: "#/components/schemas/ConflictWriteBlock"
+                    round_trip_write_blocked: "#/components/schemas/ConflictWriteBlock"
         "500":
           description: Failed to link TheAudioDB ID
           content:


### PR DESCRIPTION
## Summary

- Adds an explicit OpenAPI `discriminator: propertyName: error` to the error-discriminated `oneOf` response schemas (the `field_locked` vs `*_write_blocked` 409s on `POST /artists/{id}/discogs/link` and `POST /artists/{id}/audiodb/link`, and the merge-collisions response), backed by three new named component schemas (`FieldLockedError`, `MergeCollisionConflict`, `MergeInProgressError`).
- **Spec-only change — no runtime or handler behavior changes.** It improves generated-client codegen and docs clarity, matching the discriminator pattern already used elsewhere in the spec (e.g. `/connections/{id}/platform-settings`).
- Reviewers, look first at the discriminator **mappings**: each `error` value maps to the correct arm (`field_locked` → `FieldLockedError`; `nfo_write_blocked`/`round_trip_write_blocked` → `ConflictWriteBlock`; `image_write_blocked` intentionally omitted for these two endpoints, which only gate NFO writes per `handlers_discogs.go:160` / `handlers_audiodb.go:166`).

## Linked issue

Closes #2077

## Pre-flight checklist

- [x] Pre-push gate green locally (whole-module `go build ./...` / `go vet ./...` / `go test ./...` 71/71, `golangci-lint` 0 issues; `-race` runs via the pre-push hook on push).
- [x] Code review pass complete (lead adversarial review of the full diff; caught + skipped a stale CR-plan claim about a nonexistent "bare Error ref drift").
- [x] Commits squashed into a single logical commit before first push.
- [x] At least one label set on `gh pr create --label`.
- [x] Docs label decision: `docs: not-required` — internal API-spec consistency, no user-visible behavior change.
- [ ] Screenshot — N/A (no UI change).
- [x] OpenAPI spec updated (`make check-openapi` / `TestOpenAPIConsistency` PASS — this PR *is* the spec change).
- [ ] `templ generate` — N/A (no `.templ` changed).

## Test plan

- [x] `make check-openapi` (`TestOpenAPIConsistency`) PASS.
- [x] Whole-module `go test ./...` — 71/71 packages pass (includes the kin-openapi runtime request/response validation tests).
- [ ] Manual UAT — N/A (spec-only, no runtime behavior change).
- Reviewer follow-ups:
  - [ ] Confirm no other error-discriminated `oneOf` site was missed (the implementer swept all 11 `oneOf` sites in the spec; only these were `error`-value-discriminated — the rest are query-param type unions).
