### PR TITLE
test(bruno): parity smoke requests for connection library import/populate/scan (#2049)

### DIFF
--- a/api/bruno/connections/import-libraries.bru
+++ b/api/bruno/connections/import-libraries.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Import Libraries (Sentinel 404)
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{apiBase}}/connections/{{connectionId}}/libraries/import
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  connectionId is the all-zeros-style sentinel UUID that is guaranteed not to
+  exist in the CI database. The handler verifies the connection exists before
+  touching the request body, so a non-existent connection yields a
+  deterministic 404 with an error envelope.
+}
+
+tests {
+  test("returns 404 for sentinel connectionId", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope reports connection not found", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.equal("connection not found");
+  });
+}

--- a/api/bruno/connections/populate-library.bru
+++ b/api/bruno/connections/populate-library.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Populate Library (Sentinel 404)
+  type: http
+  seq: 14
+}
+
+post {
+  url: {{apiBase}}/connections/{{connectionId}}/libraries/{{libraryId}}/populate
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  connectionId is the sentinel UUID guaranteed not to exist in the CI
+  database. The handler verifies the connection exists before the library
+  lookup, so a non-existent connection yields a deterministic 404 with an
+  error envelope regardless of the libraryId value.
+}
+
+tests {
+  test("returns 404 for sentinel connectionId", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope reports connection not found", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.equal("connection not found");
+  });
+}

--- a/api/bruno/connections/scan-library.bru
+++ b/api/bruno/connections/scan-library.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Scan Library (Sentinel 404)
+  type: http
+  seq: 15
+}
+
+post {
+  url: {{apiBase}}/connections/{{connectionId}}/libraries/{{libraryId}}/scan
+  body: none
+  auth: none
+}
+
+headers {
+  Cookie: session={{sessionToken}}
+}
+
+docs {
+  connectionId is the sentinel UUID guaranteed not to exist in the CI
+  database. The handler verifies the connection exists before the library
+  lookup, so a non-existent connection yields a deterministic 404 with an
+  error envelope regardless of the libraryId value.
+}
+
+tests {
+  test("returns 404 for sentinel connectionId", function() {
+    expect(res.status).to.equal(404);
+  });
+
+  test("error envelope reports connection not found", function() {
+    expect(res.body).to.be.an("object");
+    expect(res.body.error).to.equal("connection not found");
+  });
+}

--- a/api/bruno/environments/ci.bru
+++ b/api/bruno/environments/ci.bru
@@ -4,7 +4,7 @@ vars {
   sessionToken:
   adminUser: ci-admin
   adminPassword: ci-ephemeral-pw
-  libraryId:
+  libraryId: 00000000-0000-0000-0000-000000000009
   artistId: 00000000-0000-0000-0000-000000000000
   aliasId: 00000000-0000-0000-0000-000000000001
   notificationId: 00000000-0000-0000-0000-000000000002

--- a/api/bruno/environments/local.bru
+++ b/api/bruno/environments/local.bru
@@ -4,7 +4,7 @@ vars {
   sessionToken:
   adminUser: admin
   adminPassword: changeme123
-  libraryId:
+  libraryId: 00000000-0000-0000-0000-000000000009
   artistId: 00000000-0000-0000-0000-000000000000
   aliasId: 00000000-0000-0000-0000-000000000001
   notificationId: 00000000-0000-0000-0000-000000000002

--- a/api/bruno/parity-ignore.json
+++ b/api/bruno/parity-ignore.json
@@ -336,18 +336,6 @@
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },
   {
-    "route": "POST /api/v1/connections/{}/libraries/import",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "POST /api/v1/connections/{}/libraries/{}/populate",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
-    "route": "POST /api/v1/connections/{}/libraries/{}/scan",
-    "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
-  },
-  {
     "route": "POST /api/v1/connections/{}/platform-settings/disable",
     "reason": "Not yet covered by the Bruno CI smoke collection (baseline gap recorded for #1765). Add a Bruno request when contract-testing this route, then remove this entry."
   },


### PR DESCRIPTION
## Summary

- Adds Bruno route-parity smoke requests for three previously ignore-listed connection library-management routes and removes them from the parity ignore baseline, chipping down the `#2049` backlog opportunistically.
- Routes now covered: `POST /connections/{}/libraries/import`, `POST /connections/{}/libraries/{}/populate`, `POST /connections/{}/libraries/{}/scan`. Each asserts the sentinel `404 "connection not found"` (the connection-id lookup precedes body/library resolution in all three handlers, so a nonexistent sentinel connection id 404s deterministically — same pattern as the existing `discover-libraries.bru`).
- Test-collection-only change (`api/bruno/**`); no product code touched.

## Linked issue

Part of #2049

(The issue is a running "chip down opportunistically" register; this PR covers the next un-covered chunk. Phase 1/2 were already merged via #2054.)

## Pre-flight checklist

- [x] Pre-push gate green locally (`scripts/check-bruno-parity.sh` PASS; `go build ./...` clean).
- [x] Code review pass complete (lead + adversarial diff verify: the 3 un-ignored routes match the 3 added requests; sentinel `libraryId` addition confirmed safe against the create-library-first ordering).
- [x] Commits squashed into a single logical commit.
- [x] At least one label set.
- [x] Docs label decision: `docs: not-required` — test-collection-only, no user-visible behavior change.
- [ ] Screenshot — N/A (no UI change).
- [ ] OpenAPI — N/A (no request/response shape change).
- [ ] `templ generate` — N/A (no `.templ`).

## Test plan

- [x] `bash scripts/check-bruno-parity.sh` PASS — 267 API routes, 164 Bruno requests, 105 ignore-listed; every route covered or ignored, no stale requests.
- [ ] `go test -race ./...` — N/A for the collection change (runs via the pre-push hook on push).
- Manual UAT: the live Bruno suite run (server-required) is lead-owned; the static route-parity check is the gate here.
- Reviewer follow-ups:
  - [ ] Confirm the sentinel `libraryId` (`...0009`) added to both environments doesn't collide with the create-library flow (it does not — `create-library.bru` seq 1 overwrites `libraryId` before get/update/delete consume it).
